### PR TITLE
Deterministic retention query behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ RedisTimeSeries is a Redis Module adding a Time Series data structure to Redis.
 - Query by labels sets
 - Aggregated queries (Min, Max, Avg, Sum, Range, Count, First, Last) for any time bucket
 - Configurable max retention period
-- Compactions/Roll-ups - automatically updated aggregated timeseries
+- Compaction/Roll-ups - automatically updated aggregated timeseries
 - labels index - each key has labels which will allows query by labels
 
 ## Using with other tools metrics tools
@@ -33,7 +33,7 @@ Each sample is a tuple of the time and the value of 128 bits,
 You can either get RedisTimeSeries setup in a Docker container or on your own machine.
 
 ### Docker
-To quickly tryout RedisTimeSeries, launch an instance using docker:
+To quickly try out RedisTimeSeries, launch an instance using docker:
 ```sh
 docker run -p 6379:6379 -it --rm redislabs/redistimeseries
 ```
@@ -60,7 +60,7 @@ make all
 
 In your redis-server run: `loadmodule redistimeseries.so`
 
-For more infomation about modules, go to the [redis offical documentation](https://redis.io/topics/modules-intro).
+For more information about modules, go to the [redis official documentation](https://redis.io/topics/modules-intro).
 
 ## Give it a try
 
@@ -68,7 +68,7 @@ After you setup RedisTimeSeries, you can interact with it using redis-cli.
 
 Here we'll create a time series representing sensor temperature measurements. 
 After you create the time series, you can send temperature measurements.
-Then you can query the data for a time range on some aggreagation rule.
+Then you can query the data for a time range on some aggregation rule.
 
 ### With `redis-cli`
 ```sh

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -14,8 +14,8 @@ TS.CREATE key [RETENTION retentionSecs] [LABELS field value..]
 
 Optional args:
 
- * retentionSecs - Maximum age for samples compared to current time (in seconds)
-    * Default: The global retenion secs configuration of the database (by default, `0`)
+ * retentionSecs - Maximum age for samples compared to last event time (in seconds)
+    * Default: The global retention secs configuration of the database (by default, `0`)
     * When set to 0, the series is not trimmed at all
  * labels - Set of key-value pairs that represent metadata labels of the key
 
@@ -40,8 +40,8 @@ TS.ADD key timestamp value [RETENTION retentionSecs] [LABELS field value..]
 
 These arguments are optional because they can be set by TS.CREATE:
 
- * retentionSecs - Maximum age for samples compared to current time (in seconds)
-    * Default: The global retenion secs configuration of the database (by default, `0`)
+ * retentionSecs - Maximum age for samples compared to last event time (in seconds)
+    * Default: The global retention secs configuration of the database (by default, `0`)
     * When set to 0, the series is not trimmed at all
  * labels - Set of key-value pairs that represent metadata labels of the key
 
@@ -57,7 +57,7 @@ TS.ADD temperature:3:11 1548149181 30
 #### Complexity
 
 If a compaction rule exits on a timeseries, `TS.ADD` performance might be reduced.
-The complexity of `TS.ADD` is always O(M) when M is the amount of compactions rules or O(1) with no compaction.
+The complexity of `TS.ADD` is always O(M) when M is the amount of compaction rules or O(1) with no compaction.
 
 #### Notes
 
@@ -88,8 +88,8 @@ This command can be used as a counter or gauge that automatically gets history a
 Optional args:
 
 * time-bucket - Time bucket for resetting the current counter in seconds
-* retentionSecs - Maximum age for samples compared to current time (in seconds)
-  * Default: The global retenion secs configuration of the database (by default, `0`)
+* retentionSecs - Maximum age for samples compared to last event time (in seconds)
+  * Default: The global retention secs configuration of the database (by default, `0`)
   * When set to 0, the series is not trimmed at all
 * labels - Set of key-value pairs that represent metadata labels of the key
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -190,7 +190,7 @@ TS.MRANGE fromTimestamp toTimestamp [AGGREGATION aggregationType bucketSizeSecon
 
 * fromTimestamp - Start timestamp for range query
 * toTimestamp - End timestamp for range query
-* filters - Set of key-pair fitlers (`k=v`, `k!=v,` `k=` contains a key, `k!=` doesn't contain a key)
+* filters - Set of key-pair filters (`k=v`, `k!=v,` `k=` contains a key, `k!=` doesn't contain a key)
 
 Optional args:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ RedisTimeSeries is a Redis Module adding a Time Series data structure to Redis.
 - Query by labels sets
 - Aggregated queries (Min, Max, Avg, Sum, Range, Count, First, Last) for any time bucket
 - Configurable max retention period
-- Compactions/Roll-ups - automatically updated aggregated timeseries
+- Compaction/Roll-ups - automatically updated aggregated timeseries
 - labels index - each key has labels which will allows query by labels
 
 ## Using with other tools metrics tools
@@ -32,7 +32,7 @@ Each sample is a tuple of the time and the value of 128 bits,
 You can either get RedisTimeSeries setup in a Docker container or on your own machine.
 
 ### Docker
-To quickly tryout RedisTimeSeries, launch an instance using docker:
+To quickly try out RedisTimeSeries, launch an instance using docker:
 ```sh
 docker run -p 6379:6379 -it --rm redislabs/redistimeseries
 ```
@@ -59,7 +59,7 @@ make all
 
 In your redis-server run: `loadmodule redistimeseries.so`
 
-For more infomation about modules, go to the [redis offical documentation](https://redis.io/topics/modules-intro).
+For more information about modules, go to the [redis official documentation](https://redis.io/topics/modules-intro).
 
 ## Give it a try
 
@@ -67,7 +67,7 @@ After you setup RedisTimeSeries, you can interact with it using redis-cli.
 
 Here we'll create a time series representing sensor temperature measurements. 
 After you create the time series, you can send temperature measurements.
-Then you can query the data for a time range on some aggreagation rule.
+Then you can query the data for a time range on some aggregation rule.
 
 ### With `redis-cli`
 ```sh

--- a/src/module.c
+++ b/src/module.c
@@ -386,6 +386,8 @@ int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, api_timestamp_t start_
         AggregationClass *aggObject, int64_t time_delta) {
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
     long long arraylen = 0;
+
+    start_ts = max(start_ts, ChunkGetLastTimestamp(series->lastChunk) - series->retentionSecs);
     SeriesIterator iterator = SeriesQuery(series, start_ts, end_ts);
     Sample sample;
     void *context = NULL;

--- a/src/module.c
+++ b/src/module.c
@@ -387,7 +387,7 @@ int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, api_timestamp_t start_
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
     long long arraylen = 0;
 
-	// In case a retention is set shouldn't return chunks older than the retention 
+    // In case a retention is set shouldn't return chunks older than the retention 
     if(series->retentionSecs){ 
     	start_ts = max(start_ts, series->lastTimestamp - series->retentionSecs);
     }

--- a/src/module.c
+++ b/src/module.c
@@ -387,7 +387,10 @@ int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, api_timestamp_t start_
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
     long long arraylen = 0;
 
-    start_ts = max(start_ts, ChunkGetLastTimestamp(series->lastChunk) - series->retentionSecs);
+	// In case a retention is set shouldn't return chunks older than the retention 
+    if(series->retentionSecs){ 
+    	start_ts = max(start_ts, series->lastTimestamp - series->retentionSecs + 1);
+    }
     SeriesIterator iterator = SeriesQuery(series, start_ts, end_ts);
     Sample sample;
     void *context = NULL;

--- a/src/module.c
+++ b/src/module.c
@@ -389,7 +389,7 @@ int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, api_timestamp_t start_
 
 	// In case a retention is set shouldn't return chunks older than the retention 
     if(series->retentionSecs){ 
-    	start_ts = max(start_ts, series->lastTimestamp - series->retentionSecs + 1);
+    	start_ts = max(start_ts, series->lastTimestamp - series->retentionSecs);
     }
     SeriesIterator iterator = SeriesQuery(series, start_ts, end_ts);
     Sample sample;

--- a/src/tests/test_module.py
+++ b/src/tests/test_module.py
@@ -296,11 +296,11 @@ class RedisTimeseriesTests(ModuleTestCase(os.path.dirname(os.path.abspath(__file
         start_ts = 1488823384L
         samples_count = 1500
         with self.redis() as r:
-            assert r.execute_command('TS.CREATE', 'tester')
+            assert r.execute_command('TS.CREATE', 'tester', 'RETENTION', samples_count-100)
             self._insert_data(r, 'tester', start_ts, samples_count, 5)
 
             expected_result = [[start_ts+i, str(5)] for i in range(100, 151)]
-            actual_result = r.execute_command('TS.range', 'tester', start_ts+100, start_ts + 150)
+            actual_result = r.execute_command('TS.range', 'tester', start_ts+50, start_ts + 150)
             assert expected_result == actual_result
 
     def test_range_with_agg_query(self):

--- a/src/tests/test_module.py
+++ b/src/tests/test_module.py
@@ -244,27 +244,27 @@ class RedisTimeseriesTests(ModuleTestCase(os.path.dirname(os.path.abspath(__file
             expected_retention = 500
             expected_chunk_size = 100
             self._ts_alter_cmd(r, key, expected_retention, expected_chunk_size, expected_labels)
-            self._assert_alter_cmd(r, key, end_ts-500, end_ts, expected_data[-500:], expected_retention,
+            self._assert_alter_cmd(r, key, end_ts-501, end_ts, expected_data[-501:], expected_retention,
                                    expected_chunk_size, expected_labels)
             
             # test alter retention
             expected_retention = 200
             self._ts_alter_cmd(r, key, set_retention=expected_retention)
-            self._assert_alter_cmd(r, key, end_ts-200, end_ts, expected_data[-200:], expected_retention,
+            self._assert_alter_cmd(r, key, end_ts-201, end_ts, expected_data[-201:], expected_retention,
                                    expected_chunk_size, expected_labels)
             
             # test alter chunk size
             expected_chunk_size = 100
             expected_labels = [['A', '1'], ['B', '2'], ['C', '3']]
             self._ts_alter_cmd(r, key, set_chunk_size=expected_chunk_size)
-            self._assert_alter_cmd(r, key, end_ts-200, end_ts, expected_data[-200:], expected_retention,
+            self._assert_alter_cmd(r, key, end_ts-201, end_ts, expected_data[-201:], expected_retention,
                                    expected_chunk_size, expected_labels)
             
 
             # test alter labels
             expected_labels = [['A', '1']]
             self._ts_alter_cmd(r, key, expected_retention, set_labels=expected_labels)
-            self._assert_alter_cmd(r, key, end_ts-200, end_ts, expected_data[-200:], expected_retention,
+            self._assert_alter_cmd(r, key, end_ts-201, end_ts, expected_data[-201:], expected_retention,
                                    expected_chunk_size, expected_labels)
 
             # test indexer was updated
@@ -301,8 +301,8 @@ class RedisTimeseriesTests(ModuleTestCase(os.path.dirname(os.path.abspath(__file
             assert r.execute_command('TS.CREATE', 'tester', 'RETENTION', samples_count-100)
             self._insert_data(r, 'tester', start_ts, samples_count, 5)
 
-            expected_result = [[start_ts+i, str(5)] for i in range(100, 151)]
-            actual_result = r.execute_command('TS.range', 'tester', start_ts+50, start_ts + 150)
+            expected_result = [[start_ts+i, str(5)] for i in range(99, 151)]
+            actual_result = r.execute_command('TS.range', 'tester', start_ts+50, start_ts+150)
             assert expected_result == actual_result
 
     def test_range_with_agg_query(self):

--- a/src/tests/test_module.py
+++ b/src/tests/test_module.py
@@ -240,29 +240,31 @@ class RedisTimeseriesTests(ModuleTestCase(os.path.dirname(os.path.abspath(__file
             expected_data = [[start_ts + i, str(5)] for i in range(samples_count)]
 
             # test alter retention, chunk size and labels
-            expected_retention = 100
-            expected_chunk_size = 100
             expected_labels = [['A', '1'], ['B', '2'], ['C', '3']]
+            expected_retention = 500
+            expected_chunk_size = 100
             self._ts_alter_cmd(r, key, expected_retention, expected_chunk_size, expected_labels)
-            self._assert_alter_cmd(r, key, start_ts, end_ts, expected_data, expected_retention,
+            self._assert_alter_cmd(r, key, end_ts-500, end_ts, expected_data[-500:], expected_retention,
                                    expected_chunk_size, expected_labels)
-
+            
             # test alter retention
             expected_retention = 200
             self._ts_alter_cmd(r, key, set_retention=expected_retention)
-            self._assert_alter_cmd(r, key, start_ts, end_ts, expected_data, expected_retention,
+            self._assert_alter_cmd(r, key, end_ts-200, end_ts, expected_data[-200:], expected_retention,
                                    expected_chunk_size, expected_labels)
-
+            
             # test alter chunk size
-            expected_chunk_size = 500
+            expected_chunk_size = 100
+            expected_labels = [['A', '1'], ['B', '2'], ['C', '3']]
             self._ts_alter_cmd(r, key, set_chunk_size=expected_chunk_size)
-            self._assert_alter_cmd(r, key, start_ts, end_ts, expected_data, expected_retention,
+            self._assert_alter_cmd(r, key, end_ts-200, end_ts, expected_data[-200:], expected_retention,
                                    expected_chunk_size, expected_labels)
+            
 
             # test alter labels
             expected_labels = [['A', '1']]
             self._ts_alter_cmd(r, key, expected_retention, set_labels=expected_labels)
-            self._assert_alter_cmd(r, key, start_ts, end_ts, expected_data, expected_retention,
+            self._assert_alter_cmd(r, key, end_ts-200, end_ts, expected_data[-200:], expected_retention,
                                    expected_chunk_size, expected_labels)
 
             # test indexer was updated

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -45,7 +45,7 @@ void SeriesTrim(Series * series) {
     Chunk *currentChunk;
     void *currentKey;
     size_t keyLen;
-    timestamp_t minTimestamp = time(NULL) - series->retentionSecs;
+    timestamp_t minTimestamp = series->lastTimestamp - series->retentionSecs;
     while ((currentKey=RedisModule_DictNextC(iter, &keyLen, (void*)&currentChunk)))
     {
         if (ChunkGetLastTimestamp(currentChunk) < minTimestamp)


### PR DESCRIPTION
Always filter query result by max retention, this can be done simple by
using max(start_time, seriesMaxTimestamp - retention).