### PR TITLE
Fixed CircleCI and Dockerhub problems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,10 +25,10 @@ commands:
           name: Package
           command: make pack BRANCH="$CIRCLE_BRANCH" INTO=/workspace/packages SHOW=1
       - persist_to_workspace:
-          root: /workspace/packages
+          root: /workspace
           paths:
-            - 'release/*.zip'
-            - 'branch/*.zip'
+            - 'packages/release/*.zip'
+            - 'packages/branch/*.zip'
       - store_test_results:
           path: /workspace/tests
   deploy:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ setup:
 	@python ./system-setup.py
 
 fetch:
-	@git submodule update --init --recursive
+	-@git submodule update --init --recursive
 
 build:
 	@make -C src all -j


### PR DESCRIPTION
- Dockerhub clones repo and submodules, and fails on subsequent clone: ignore (false) failure [known issue]
- CircleCI: fixed workspace package paths