### PR TITLE
Avoid strange chars in $CIRCLE_BRANCH

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
             make test TEST_REPORT_DIR=/workspace/tests SHOW=1
       - run:
           name: Package
-          command: make pack BRANCH="$CIRCLE_BRANCH" INTO=/workspace/packages SHOW=1
+          command: make pack BRANCH="${CIRCLE_BRANCH//[^A-Za-z0-9._-]/_}" INTO=/workspace/packages SHOW=1
       - persist_to_workspace:
           root: /workspace
           paths:


### PR DESCRIPTION
e.g. CIRCLE_BRANCH="pull/190", which cannot be part of a valid filename.