### PR TITLE
[add] added callgrind call graph profile rule to Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -132,8 +132,21 @@ VALGRIND_ARGS=\
 	--show-leak-kinds=all \
 	-v redis-server
 
+CALLGRIND_ARGS=\
+	--tool=callgrind \
+	--dump-instr=yes \
+	--simulate-cache=no \
+	--collect-jumps=yes \
+	--collect-atstart=yes \
+	--instr-atstart=yes \
+	-v redis-server --protected-mode no --save "" --appendonly no
+
+
 valgrind: $(TARGET)
 	$(SHOW)valgrind $(VALGRIND_ARGS) --loadmodule $(realpath $(TARGET)) $(REDIS_ARGS) --dir /tmp
+
+callgrind: $(TARGET)
+	$(SHOW)valgrind $(CALLGRIND_ARGS) --loadmodule $(realpath $(TARGET)) $(REDIS_ARGS) --dir /tmp
 
 $(UNITTESTS_RUNNER)	: $(TARGET) $(OBJECTS) $(TEST_OBJECTS)
 	$(SHOW)$(CC) $(LD_FLAGS) -o $@ $(OBJECTS) $(TEST_OBJECTS) $(LD_LIBS)


### PR DESCRIPTION
This is a simple PR with the intent to add callgrind call graph profile rule to Makefile.
make callgrind should enable you to launch valgrind's tool callgrind with the correct parameters. 