### PR TITLE
Add Linux Mint support

### DIFF
--- a/deps/readies/paella/platform.py
+++ b/deps/readies/paella/platform.py
@@ -144,6 +144,8 @@ class OnPlatform:
                     self.suse()
                 elif dist == 'arch':
                     self.arch()
+                elif dist == 'linuxmint':
+                    self.linuxmint()
                 else:
                     assert(False), "Cannot determine installer"
             elif os == 'macosx':
@@ -200,4 +202,7 @@ class OnPlatform:
         pass
 
     def freebsd(self):
+        pass
+
+    def linuxmint(self):
         pass

--- a/deps/readies/paella/setup.py
+++ b/deps/readies/paella/setup.py
@@ -120,7 +120,7 @@ class Setup(OnPlatform):
         if self.os == 'linux':
             if self.dist == 'fedora':
                 self.dnf_install(packs, group=group, _try=_try)
-            elif self.dist == 'ubuntu' or self.dist == 'debian':
+            elif self.dist == 'ubuntu' or self.dist == 'debian' or self.dist == 'linuxmint':
                 self.apt_install(packs, group=group, _try=_try)
             elif self.dist == 'centos' or self.dist == 'redhat':
                 self.yum_install(packs, group=group, _try=_try)


### PR DESCRIPTION
I was taking Redis Labs - RU102JS course and it requires to setup this module. There were issues during setup on my Linux Mint 19.2 so I've fixed those. Hope there is some value in this contribution.