### PR TITLE
[add] prevent deps folder changes to be tracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ venv/
 /VARIANT
 /BINDIR
 /tests/tests_report.xml
+/deps/


### PR DESCRIPTION
```
git clone --recursive https://github.com/RedisTimeSeries/RedisTimeSeries.git
cd RedisTimeSeries
git checkout 1447714fa93384f6ada5b4757225e04dad213c87
error: The following untracked working tree files would be overwritten by checkout:
	deps/readies/.gitignore
	deps/readies/LICENSE
	deps/readies/README.md
	deps/readies/bin/getdocker
	deps/readies/bin/getpy2
	deps/readies/bin/getredis5
	deps/readies/bin/platform
	deps/readies/bin/python2
	deps/readies/cetara/diag/gdb.c
	deps/readies/cetara/diag/gdb.h
	deps/readies/mk/bindirs.defs
	deps/readies/mk/bindirs.rules
	deps/readies/mk/build.defs
	deps/readies/mk/build.rules
	deps/readies/mk/cmake.defs
	deps/readies/mk/cmake.rules
	deps/readies/mk/common.defs
	deps/readies/mk/common.rules
	deps/readies/mk/configure.defs
	deps/readies/mk/configure.rules
	deps/readies/mk/defs
	deps/readies/mk/functions
	deps/readies/mk/help.defs
	deps/readies/mk/help.rules
	deps/readies/mk/main
	deps/readies/mk/rules
	deps/readies/mk/variant.defs
	deps/readies/mk/variant.rules
	deps/readies/paella/__init__.py
	deps/readies/paella/debug.py
	deps/readies/paella/docopt1.py
	deps/readies/paella/files.py
	deps/readies/paella/log.py
	deps/readies/paella/platform.py
	deps/readies/paella/setup.py
	deps/readies/paella/utils.py
	deps/readies/paella/utils2.py
	deps/readies/paella/utils3.py
	deps/readies/shibumi/functions
	deps/readies/shibumi/here
Please move or remove them before you switch branches.
Aborting
```
Preventing this issue by simply ignoring the deps folder on .gitignore

```
git clone https://github.com/RedisTimeSeries/RedisTimeSeries.git
cd RedisTimeSeries
git checkout setup.deps
git submodule init
git submodule update
git checkout 1447714fa93384f6ada5b4757225e04dad213c87
```