### PR TITLE
[fix] fixed lookup_intervals and parse_string_to_millisecs towards the correct data type and pointer type

### DIFF
--- a/src/parse_policies.c
+++ b/src/parse_policies.c
@@ -10,7 +10,7 @@
 #include "compaction.h"
 #include "parse_policies.h"
 
-static const int lookup_intervals[] = {
+static const uint64_t lookup_intervals[] = {
    ['m'] = 1,
    ['s'] = 1000,
    ['M'] = 1000*60,
@@ -18,7 +18,7 @@ static const int lookup_intervals[] = {
    ['d'] = 1000*60*60*24
 };
 
-int parse_string_to_millisecs(const char *timeStr, int *out){
+int parse_string_to_millisecs(const char *timeStr, uint64_t *out){
     char should_be_empty;
     unsigned char interval_type;
     int timeSize;


### PR DESCRIPTION
fixed lookup_intervals and parse_string_to_millisecs towards the correct data type and pointer type to avoid the following compile warnings:

```
parse_policies.c:51:51: warning: incompatible pointer types passing 'uint64_t *' (aka 'unsigned long long *') to parameter of type 'int *'
      [-Wincompatible-pointer-types]
             if (parse_string_to_millisecs(token, &rule->timeBucket) == FALSE) {
                                                  ^~~~~~~~~~~~~~~~~
parse_policies.c:21:57: note: passing argument to parameter 'out' here
int parse_string_to_millisecs(const char *timeStr, int *out){
                                                        ^
parse_policies.c:55:50: warning: incompatible pointer types passing 'uint64_t *' (aka 'unsigned long long *') to parameter of type 'int *'
      [-Wincompatible-pointer-types]
            if (parse_string_to_millisecs(token, &rule->retentionSizeMillisec) == FALSE) {
                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
parse_policies.c:21:57: note: passing argument to parameter 'out' here
int parse_string_to_millisecs(const char *timeStr, int *out){
                                                        ^
2 warnings generated.
```