### PR TITLE
[wip] wip on adding ts.revrange and ts.mrevrange

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -68,14 +68,23 @@ int ChunkAddSample(Chunk *chunk, Sample sample) {
     return 1;
 }
 
-ChunkIterator NewChunkIterator(Chunk* chunk) {
-    return (ChunkIterator){.chunk = chunk, .currentIndex = 0};
+ChunkIterator NewChunkIterator(Chunk* chunk,int rev) {
+    if(rev==0){
+        return (ChunkIterator){.chunk = chunk, .currentIndex = 0};
+    }else{
+        return (ChunkIterator){.chunk = chunk, .currentIndex = chunk->num_samples-1};
+    }
 }
 
-int ChunkIteratorGetNext(ChunkIterator *iter, Sample *sample) {
-    if (iter->currentIndex < iter->chunk->num_samples) {
+int ChunkIteratorGetNext(ChunkIterator *iter, Sample *sample,int rev) {
+    if (iter->currentIndex < iter->chunk->num_samples && (rev==0)) {
         iter->currentIndex++;
         Sample *internalSample = ChunkGetSample(iter->chunk, iter->currentIndex - 1);
+        memcpy(sample, internalSample, sizeof(Sample));
+        return 1;
+    } else if ( iter->currentIndex >= 0 && (rev==1) ) {
+        iter->currentIndex--;
+        Sample *internalSample = ChunkGetSample(iter->chunk, iter->currentIndex + 1);
         memcpy(sample, internalSample, sizeof(Sample));
         return 1;
     } else {

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -43,6 +43,6 @@ int ChunkNumOfSample(Chunk *chunk);
 timestamp_t ChunkGetLastTimestamp(Chunk *chunk);
 timestamp_t ChunkGetFirstTimestamp(Chunk *chunk);
 
-ChunkIterator NewChunkIterator(Chunk *chunk);
-int ChunkIteratorGetNext(ChunkIterator *iter, Sample* sample);
+ChunkIterator NewChunkIterator(Chunk *chunk, int rev);
+int ChunkIteratorGetNext(ChunkIterator *iter, Sample* sample, int rev);
 #endif

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -101,9 +101,9 @@ void series_rdb_save(RedisModuleIO *io, void *value)
     size_t numSamples = SeriesGetNumSamples(series);
     RedisModule_SaveUnsigned(io, numSamples);
 
-    SeriesIterator iter = SeriesQuery(series, 0, series->lastTimestamp);
+    SeriesIterator iter = SeriesQuery(series, 0, series->lastTimestamp,0);
     Sample sample;
-    while (SeriesIteratorGetNext(&iter, &sample) != 0) {
+    while (SeriesIteratorGetNext(&iter, &sample,0) != 0) {
         RedisModule_SaveUnsigned(io, sample.timestamp);
         RedisModule_SaveDouble(io, sample.data);
     }

--- a/src/tsdb.h
+++ b/src/tsdb.h
@@ -61,8 +61,8 @@ int SeriesCreateRulesFromGlobalConfig(RedisModuleCtx *ctx, RedisModuleString *ke
 size_t SeriesGetNumSamples(Series *series);
 
 // Iterator over the series
-SeriesIterator SeriesQuery(Series *series, api_timestamp_t minTimestamp, api_timestamp_t maxTimestamp);
-int SeriesIteratorGetNext(SeriesIterator *iterator, Sample *currentSample);
+SeriesIterator SeriesQuery(Series *series, api_timestamp_t minTimestamp, api_timestamp_t maxTimestamp, int rev);
+int SeriesIteratorGetNext(SeriesIterator *iterator, Sample *currentSample, int rev);
 void SeriesIteratorClose(SeriesIterator *iterator);
 
 CompactionRule *NewRule(RedisModuleString *destKey, int aggType, uint64_t timeBucket);


### PR DESCRIPTION
# description 
solves #254 
These commands are exactly like TS.RANGE and TS.MRANGE, but with the notable difference of returning the entries in reverse order, and also taking the start-end range in reverse order.

# ts.mrange and ts.mrevrange example
```
127.0.0.1:6379> ts.add test 1 2 LABELS metric cpu
(integer) 1
127.0.0.1:6379> ts.add test 2 4 
(integer) 2
127.0.0.1:6379> ts.add test 3 8 
(integer) 3
127.0.0.1:6379> ts.mrange - + FILTER metric=cpu
1) 1) "test"
   2) 1) 1) "metric"
         2) "cpu"
   3) 1) 1) (integer) 1
         2) "2"
      2) 1) (integer) 2
         2) "4"
      3) 1) (integer) 3
         2) "8"
127.0.0.1:6379> ts.mrevrange + - FILTER metric=cpu
1) 1) "test"
   2) 1) 1) "metric"
         2) "cpu"
   3) 1) 1) (integer) 3
         2) "8"
      2) 1) (integer) 2
         2) "4"
      3) 1) (integer) 1
         2) "2"
127.0.0.1:6379> ts.mrange - + COUNT 1 FILTER metric=cpu
1) 1) "test"
   2) 1) 1) "metric"
         2) "cpu"
   3) 1) 1) (integer) 1
         2) "2"
127.0.0.1:6379> ts.mrevrange + - COUNT 1 FILTER metric=cpu
1) 1) "test"
   2) 1) 1) "metric"
         2) "cpu"
   3) 1) 1) (integer) 3
         2) "8"
```

# ts.range and ts.revrange example

```
127.0.0.1:6379> ts.range test - +
1) 1) (integer) 1
   2) "2"
2) 1) (integer) 2
   2) "4"
3) 1) (integer) 3
   2) "8"
127.0.0.1:6379> ts.revrange test  + -
1) 1) (integer) 3
   2) "8"
2) 1) (integer) 2
   2) "4"
3) 1) (integer) 1
   2) "2"
127.0.0.1:6379> ts.revrange test  8 - count 1
1) 1) (integer) 3
   2) "8"
127.0.0.1:6379> ts.revrange test  8 - count 2
1) 1) (integer) 3
   2) "8"
2) 1) (integer) 2
   2) "4"
127.0.0.1:6379> ts.revrange test  8 0 count 2
1) 1) (integer) 3
   2) "8"
2) 1) (integer) 2
   2) "4"
127.0.0.1:6379> ts.revrange test  8 0 count 3
1) 1) (integer) 3
   2) "8"
2) 1) (integer) 2
   2) "4"
3) 1) (integer) 1
   2) "2"
```