### PR TITLE
TS.MRANGE option NOLABELS to reduce returned answer

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -251,7 +251,7 @@ But because m is pretty small, we can neglect it and look at the operation as O(
 Query a timestamp range across multiple keys by filters.
 
 ```sql
-TS.MRANGE fromTimestamp toTimestamp [COUNT count] [AGGREGATION aggregationType timeBucket] FILTER filter..
+TS.MRANGE fromTimestamp toTimestamp [COUNT count] [AGGREGATION aggregationType timeBucket] [NOLABELS] FILTER filter..
 ```
 
 * fromTimestamp - Start timestamp for the range query. `-` can be used to express the minimum possible timestamp (0).
@@ -263,8 +263,21 @@ Optional args:
 * count - Maximum number of returned results per timeseries
 * aggregationType - Aggregation type: avg, sum, min, max, range, count, first, last, std.p, std.s, var.p, var.s
 * timeBucket - Time bucket for aggregation in milliseconds
+* NOLABELS - Don't reply with the labels for each returned key. Instead an empty Array will be replied on the labels array position. It allows to reduce the returned reply size.
 
-#### Query by Filters Example
+#### Return Value
+
+Array-reply, specifically:
+
+The command returns the entries with labels matching the specified filter.
+The returned entries are complete, that means that the name, labels and all the values that match the range are returned. 
+
+The returned array will contain key1,labels1,values1,...,keyN,labelsN,valuesN, with labels and values being also of array data types. If the `NOLABELS` option is specified the labels array with be an empty Array for each of the returned keys.
+
+
+##### Examples
+
+##### Query by Filters Example
 
 ```sql
 127.0.0.1:6379> TS.MRANGE 1548149180000 1548149210000 AGGREGATION avg 5000 FILTER area_id=32 sensor_id!=1
@@ -292,6 +305,44 @@ Optional args:
          2) "3"
       2) 1) "area_id"
          2) "32"
+   3) 1) 1) (integer) 1548149180000
+         2) "26.199999999999999"
+      2) 1) (integer) 1548149185000
+         2) "27.399999999999999"
+      3) 1) (integer) 1548149190000
+         2) "24.800000000000001"
+      4) 1) (integer) 1548149195000
+         2) "23.199999999999999"
+      5) 1) (integer) 1548149200000
+         2) "25.199999999999999"
+      6) 1) (integer) 1548149205000
+         2) "28"
+      7) 1) (integer) 1548149210000
+         2) "20"
+```
+
+##### Query by Filters Example with NOLABELS option
+
+```sql
+127.0.0.1:6379> TS.MRANGE 1548149180000 1548149210000 AGGREGATION avg 5000 NOLABELS FILTER area_id=32 sensor_id!=1
+1) 1) "temperature:2:32"
+   2) (empty list or set)
+   3) 1) 1) (integer) 1548149180000
+         2) "27.600000000000001"
+      2) 1) (integer) 1548149185000
+         2) "23.800000000000001"
+      3) 1) (integer) 1548149190000
+         2) "24.399999999999999"
+      4) 1) (integer) 1548149195000
+         2) "24"
+      5) 1) (integer) 1548149200000
+         2) "25.600000000000001"
+      6) 1) (integer) 1548149205000
+         2) "25.800000000000001"
+      7) 1) (integer) 1548149210000
+         2) "21"
+2) 1) "temperature:3:32"
+   2) (empty list or set)
    3) 1) 1) (integer) 1548149180000
          2) "26.199999999999999"
       2) 1) (integer) 1548149185000


### PR DESCRIPTION
fixes #267 . 
- adds `NOLABELS` option to reduced the reply size ( usefull when we iterate over ts.mrange,etc... )
- documents the `NOLABELS` option
- documents the Return Value for `TS.MRANGE` 