### PR TITLE
support of WITHLABELS optional argument on TS.MRANGE

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -248,10 +248,10 @@ But because m is pretty small, we can neglect it and look at the operation as O(
 
 ### TS.MRANGE
 
-Query a timestamp range across multiple keys by filters.
+Query a timestamp range across multiple time-series by filters.
 
 ```sql
-TS.MRANGE fromTimestamp toTimestamp [COUNT count] [AGGREGATION aggregationType timeBucket] FILTER filter..
+TS.MRANGE fromTimestamp toTimestamp [COUNT count] [AGGREGATION aggregationType timeBucket] [WITHLABELS] FILTER filter..
 ```
 
 * fromTimestamp - Start timestamp for the range query. `-` can be used to express the minimum possible timestamp (0).
@@ -260,14 +260,64 @@ TS.MRANGE fromTimestamp toTimestamp [COUNT count] [AGGREGATION aggregationType t
 
 Optional args:
 
-* count - Maximum number of returned results per timeseries
+* count - Maximum number of returned results per time-series.
 * aggregationType - Aggregation type: avg, sum, min, max, range, count, first, last, std.p, std.s, var.p, var.s
-* timeBucket - Time bucket for aggregation in milliseconds
+* timeBucket - Time bucket for aggregation in milliseconds.
+* WITHLABELS - Include in the reply the key-value pairs that represent metadata labels of the time-series. If this argument is not set, by default, an empty Array will be replied on the labels array position. 
 
-#### Query by Filters Example
+#### Return Value
 
+Array-reply, specifically:
+
+The command returns the entries with labels matching the specified filter.
+The returned entries are complete, that means that the name, labels and all the values that match the range are returned. 
+
+The returned array will contain key1,labels1,values1,...,keyN,labelsN,valuesN, with labels and values being also of array data types. By default, the labels array will be an empty Array for each of the returned time-series. If the `WITHLABELS` option is specified the labels Array will be filled with key-value pairs that represent metadata labels of the time-series.
+
+
+##### Examples
+
+##### Query by Filters Example
 ```sql
 127.0.0.1:6379> TS.MRANGE 1548149180000 1548149210000 AGGREGATION avg 5000 FILTER area_id=32 sensor_id!=1
+1) 1) "temperature:2:32"
+   2) (empty list or set)
+   3) 1) 1) (integer) 1548149180000
+         2) "27.600000000000001"
+      2) 1) (integer) 1548149185000
+         2) "23.800000000000001"
+      3) 1) (integer) 1548149190000
+         2) "24.399999999999999"
+      4) 1) (integer) 1548149195000
+         2) "24"
+      5) 1) (integer) 1548149200000
+         2) "25.600000000000001"
+      6) 1) (integer) 1548149205000
+         2) "25.800000000000001"
+      7) 1) (integer) 1548149210000
+         2) "21"
+2) 1) "temperature:3:32"
+   2) (empty list or set)
+   3) 1) 1) (integer) 1548149180000
+         2) "26.199999999999999"
+      2) 1) (integer) 1548149185000
+         2) "27.399999999999999"
+      3) 1) (integer) 1548149190000
+         2) "24.800000000000001"
+      4) 1) (integer) 1548149195000
+         2) "23.199999999999999"
+      5) 1) (integer) 1548149200000
+         2) "25.199999999999999"
+      6) 1) (integer) 1548149205000
+         2) "28"
+      7) 1) (integer) 1548149210000
+         2) "20"
+```
+
+##### Query by Filters Example with WITHLABELS option
+
+```sql
+127.0.0.1:6379> TS.MRANGE 1548149180000 1548149210000 AGGREGATION avg 5000 WITHLABELS FILTER area_id=32 sensor_id!=1
 1) 1) "temperature:2:32"
    2) 1) 1) "sensor_id"
          2) "2"

--- a/src/module.c
+++ b/src/module.c
@@ -406,12 +406,12 @@ int TSDB_mrange(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     }
 
     AggregationClass *aggObject = NULL;
-    int aggregationResult = parseAggregationArgs(ctx, argv, argc, &time_delta, &aggObject);
+    const int aggregationResult = parseAggregationArgs(ctx, argv, argc, &time_delta, &aggObject);
     if (aggregationResult == TSDB_ERROR) {
         return REDISMODULE_ERR;
     }
 
-    int filter_location = RMUtil_ArgIndex("FILTER", argv, argc);
+    const int filter_location = RMUtil_ArgIndex("FILTER", argv, argc);
     if (filter_location == -1) {
         return RedisModule_WrongArity(ctx);
     }
@@ -421,7 +421,8 @@ int TSDB_mrange(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return REDISMODULE_ERR;
     }
 
-    size_t query_count = argc - 1 - filter_location;
+    const size_t query_count = argc - 1 - filter_location;
+    const int withlabels_location = RMUtil_ArgIndex("WITHLABELS", argv, argc);
     QueryPredicate *queries = RedisModule_PoolAlloc(ctx, sizeof(QueryPredicate) * query_count);
     if (parseLabelListFromArgs(ctx, argv, filter_location + 1, query_count, queries) == TSDB_ERROR) {
         return RedisModule_ReplyWithError(ctx, "TSDB: failed parsing labels");
@@ -450,7 +451,11 @@ int TSDB_mrange(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         series = RedisModule_ModuleTypeGetValue(key);
         RedisModule_ReplyWithArray(ctx, 3);
         RedisModule_ReplyWithStringBuffer(ctx, currentKey, currentKeyLen);
-        ReplyWithSeriesLabels(ctx, series);
+        if (withlabels_location >= 0){
+            ReplyWithSeriesLabels(ctx, series);
+        } else {
+            RedisModule_ReplyWithArray(ctx, 0);
+        }    
         ReplySeriesRange(ctx, series, start_ts, end_ts, aggObject, time_delta, count);
         replylen++;
     }


### PR DESCRIPTION
**This PR includes default behaviour changes to `TS.MRANGE`.**
 fixes #267 .
By default, the labels array will be an empty Array for each of the returned time-series. If the `WITHLABELS` option is specified the labels Array will be filled with key-value pairs that represent metadata labels of the time-series.
This PR:
- adds `WITHLABELS` optional argument
- documents the added argument
- documents the Return Value for TS.MRANGE