### PR TITLE
Streamline series iterator

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -517,13 +517,16 @@ int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, api_timestamp_t start_
     			max(start_ts, series->lastTimestamp - series->retentionTime) : start_ts;
     }
     SeriesIterator iterator = SeriesQuery(series, start_ts, end_ts);
+    if (iterator.chunkIterator == NULL) { 
+        return RedisModule_ReplyWithArray(ctx, 0);
+    }
 
     void *context = NULL;
     if (aggObject != NULL)
         context = aggObject->createContext();
     
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
-    while (SeriesIteratorGetNext(&iterator, &sample) != 0 &&
+    while (SeriesIteratorGetNext(&iterator, &sample) == CR_OK &&
                     (maxResults == -1 || arraylen < maxResults)) {
         if (aggObject == NULL) { // No aggregation whatssoever
             RedisModule_ReplyWithArray(ctx, 2);

--- a/src/module.c
+++ b/src/module.c
@@ -533,7 +533,7 @@ int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, api_timestamp_t start_
             return RedisModule_ReplyWithArray(ctx, 0);
         }
     }
-    SeriesIterator iterator;
+    SeriesIterator iterator = { 0 };
     if (SeriesQuery(series, &iterator, start_ts, end_ts) != REDISMODULE_OK) { 
         return RedisModule_ReplyWithArray(ctx, 0);
     }

--- a/src/module.c
+++ b/src/module.c
@@ -516,8 +516,8 @@ int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, api_timestamp_t start_
     	start_ts = series->lastTimestamp > series->retentionTime ?
     			max(start_ts, series->lastTimestamp - series->retentionTime) : start_ts;
     }
-    SeriesIterator iterator = SeriesQuery(series, start_ts, end_ts);
-    if (iterator.chunkIterator == NULL) { 
+    SeriesIterator iterator;
+    if (SeriesQuery(series, &iterator, start_ts, end_ts) != REDISMODULE_OK) { 
         return RedisModule_ReplyWithArray(ctx, 0);
     }
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -112,7 +112,7 @@ void series_rdb_save(RedisModuleIO *io, void *value)
 
     SeriesIterator iter = SeriesQuery(series, 0, series->lastTimestamp);
     Sample sample;
-    while (SeriesIteratorGetNext(&iter, &sample) != 0) {
+    while (SeriesIteratorGetNext(&iter, &sample) == CR_OK) {
         RedisModule_SaveUnsigned(io, sample.timestamp);
         RedisModule_SaveDouble(io, sample.value);
     }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -110,7 +110,7 @@ void series_rdb_save(RedisModuleIO *io, void *value)
     size_t numSamples = SeriesGetNumSamples(series);
     RedisModule_SaveUnsigned(io, numSamples);
 
-    SeriesIterator iter;
+    SeriesIterator iter = { 0 };
     SeriesQuery(series, &iter, 0, series->lastTimestamp);
     Sample sample;
     while (SeriesIteratorGetNext(&iter, &sample) == CR_OK) {

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -110,7 +110,8 @@ void series_rdb_save(RedisModuleIO *io, void *value)
     size_t numSamples = SeriesGetNumSamples(series);
     RedisModule_SaveUnsigned(io, numSamples);
 
-    SeriesIterator iter = SeriesQuery(series, 0, series->lastTimestamp);
+    SeriesIterator iter;
+    SeriesQuery(series, &iter, 0, series->lastTimestamp);
     Sample sample;
     while (SeriesIteratorGetNext(&iter, &sample) == CR_OK) {
         RedisModule_SaveUnsigned(io, sample.timestamp);

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -262,10 +262,10 @@ int SeriesIteratorGetNext(SeriesIterator *iterator, Sample *currentSample) {
         ChunkFuncs *funcs = iterator->series->funcs;
 
         ChunkResult res = funcs->ChunkIteratorGetNext(iterator->chunkIterator, currentSample);
-        if (res == CR_END) {    // Reached the end of the chunk
+        if (res == CR_END) { // Reached the end of the chunk
             if (!RedisModule_DictNextC(iterator->dictIter, NULL, (void*)&iterator->currentChunk)||
                 funcs->GetFirstTimestamp(currentChunk) > iterator->maxTimestamp) {
-                return CR_ERR;       // No more chunks or they out of range
+                break;       // No more chunks or they out of range
             }
             funcs->FreeChunkIterator(iterator->chunkIterator);
             iterator->chunkIterator = funcs->NewChunkIterator(iterator->currentChunk);
@@ -273,13 +273,14 @@ int SeriesIteratorGetNext(SeriesIterator *iterator, Sample *currentSample) {
         }
 
         if (currentSample->timestamp < iterator->minTimestamp) {
-            continue;           // Skip through initial samples 
+            continue;       // Skip through initial samples 
         } else if (currentSample->timestamp > iterator->maxTimestamp) {
-            return CR_ERR;           // Reach end of range requested
+            break;          // Reach end of range requested
         } else {
             return CR_OK;
         }
     }
+    return CR_ERR;
 }
 
 CompactionRule *SeriesAddRule(Series *series, RedisModuleString *destKeyStr, int aggType, uint64_t timeBucket) {

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -246,7 +246,8 @@ int SeriesQuery(Series *series, SeriesIterator *iter,
             iter->maxTimestamp = maxTimestamp;
             return REDISMODULE_OK;
         }
-    }    
+    }
+    SeriesIteratorClose(iter);
     return REDISMODULE_ERR;
 }
 
@@ -276,8 +277,11 @@ ChunkResult SeriesIteratorGetFirst(SeriesIterator *iterator, Sample *sample) {
 }
 
 void SeriesIteratorClose(SeriesIterator *iterator) {
-    iterator->series->funcs->FreeChunkIterator(iterator->chunkIterator);
-    RedisModule_DictIteratorStop(iterator->dictIter);
+    if (iterator->chunkIterator != NULL)
+        iterator->series->funcs->FreeChunkIterator(iterator->chunkIterator);
+    if (iterator->dictIter != NULL)
+        RedisModule_DictIteratorStop(iterator->dictIter);
+    *iterator = (SeriesIterator){ 0 };
 }
 
 ChunkResult SeriesIteratorGetNext(SeriesIterator *iterator, Sample *currentSample) {

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -257,14 +257,14 @@ void SeriesIteratorClose(SeriesIterator *iterator) {
 }
 
 int SeriesIteratorGetNext(SeriesIterator *iterator, Sample *currentSample) {
-    while (iterator->currentChunk != NULL) {
+    while (1) {
         Chunk_t *currentChunk = iterator->currentChunk;
         ChunkFuncs *funcs = iterator->series->funcs;
 
         ChunkResult res = funcs->ChunkIteratorGetNext(iterator->chunkIterator, currentSample);
         if (res == CR_END) {    // Reached the end of the chunk
             if (!RedisModule_DictNextC(iterator->dictIter, NULL, (void*)&iterator->currentChunk)||
-               funcs->GetFirstTimestamp(currentChunk) > iterator->maxTimestamp) {
+                funcs->GetFirstTimestamp(currentChunk) > iterator->maxTimestamp) {
                 return CR_ERR;       // No more chunks or they out of range
             }
             funcs->FreeChunkIterator(iterator->chunkIterator);

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -280,7 +280,6 @@ int SeriesIteratorGetNext(SeriesIterator *iterator, Sample *currentSample) {
             return CR_OK;
         }
     }
-    return CR_ERR;
 }
 
 CompactionRule *SeriesAddRule(Series *series, RedisModuleString *destKeyStr, int aggType, uint64_t timeBucket) {

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -228,16 +228,12 @@ SeriesIterator SeriesQuery(Series *series, api_timestamp_t minTimestamp, api_tim
     SeriesIterator iter;
     timestamp_t rax_key;
     iter.series = series;
+    
     // get the rightmost chunk whose base timestamp is smaller or equal to minTimestamp
     seriesEncodeTimestamp(&rax_key, minTimestamp);
     iter.dictIter = RedisModule_DictIteratorStartC(series->chunks, "<=", &rax_key, sizeof(rax_key));
+    RedisModule_DictNextC(iter.dictIter, NULL, (void*)&iter.currentChunk);
 
-    // if no such chunk exists, we will start the search from the first chunk
-    if (!RedisModule_DictNextC(iter.dictIter, NULL, (void*)&iter.currentChunk))
-    {
-        RedisModule_DictIteratorReseekC(iter.dictIter, "^", NULL, 0);
-        RedisModule_DictNextC(iter.dictIter, NULL, (void*)&iter.currentChunk);
-    }
     iter.chunkIteratorInitialized = FALSE;
     iter.chunkIterator = NULL;
     iter.minTimestamp = minTimestamp;

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -225,17 +225,27 @@ int SeriesAddSample(Series *series, api_timestamp_t timestamp, double value) {
 }
 
 SeriesIterator SeriesQuery(Series *series, api_timestamp_t minTimestamp, api_timestamp_t maxTimestamp) {
-    SeriesIterator iter;
+    SeriesIterator iter = { 0 };
     timestamp_t rax_key;
     iter.series = series;
+    ChunkFuncs *funcs = iter.series->funcs;
     
     // get the rightmost chunk whose base timestamp is smaller or equal to minTimestamp
     seriesEncodeTimestamp(&rax_key, minTimestamp);
     iter.dictIter = RedisModule_DictIteratorStartC(series->chunks, "<=", &rax_key, sizeof(rax_key));
     RedisModule_DictNextC(iter.dictIter, NULL, (void*)&iter.currentChunk);
+    
+    // iterate to the first relevant chunk
+    void *dictResult = (void *)TRUE;
+    while (dictResult) {
+        if (funcs->GetLastTimestamp(iter.currentChunk) < minTimestamp) {
+            dictResult = RedisModule_DictNextC(iter.dictIter, NULL, (void*)&iter.currentChunk);
+        } else {
+            iter.chunkIterator = funcs->NewChunkIterator(iter.currentChunk);
+            break;
+        }
+    }    
 
-    iter.chunkIteratorInitialized = FALSE;
-    iter.chunkIterator = NULL;
     iter.minTimestamp = minTimestamp;
     iter.maxTimestamp = maxTimestamp;
     return iter;
@@ -247,48 +257,30 @@ void SeriesIteratorClose(SeriesIterator *iterator) {
 }
 
 int SeriesIteratorGetNext(SeriesIterator *iterator, Sample *currentSample) {
-    Sample internalSample;
-    while (iterator->currentChunk != NULL)
-    {
+    while (iterator->currentChunk != NULL) {
         Chunk_t *currentChunk = iterator->currentChunk;
         ChunkFuncs *funcs = iterator->series->funcs;
-        if (funcs->GetLastTimestamp(currentChunk) < iterator->minTimestamp)
-        {
-            if (!RedisModule_DictNextC(iterator->dictIter, NULL, (void*)&iterator->currentChunk)) {
-                iterator->currentChunk = NULL;
-            }
-            iterator->chunkIteratorInitialized = FALSE;
-            continue;
-        }
-        else if (funcs->GetFirstTimestamp(currentChunk) > iterator->maxTimestamp)
-        {
-            break;
-        }
 
-        if (!iterator->chunkIteratorInitialized) 
-        {
+        ChunkResult res = funcs->ChunkIteratorGetNext(iterator->chunkIterator, currentSample);
+        if (res == CR_END) {    // Reached the end of the chunk
+            if (!RedisModule_DictNextC(iterator->dictIter, NULL, (void*)&iterator->currentChunk)||
+               funcs->GetFirstTimestamp(currentChunk) > iterator->maxTimestamp) {
+                return CR_ERR;       // No more chunks or they out of range
+            }
             funcs->FreeChunkIterator(iterator->chunkIterator);
             iterator->chunkIterator = funcs->NewChunkIterator(iterator->currentChunk);
-            iterator->chunkIteratorInitialized = TRUE;
+            continue;
         }
 
-        if (funcs->ChunkIteratorGetNext(iterator->chunkIterator, &internalSample) == CR_END) { // reached the end of the chunk
-            if (!RedisModule_DictNextC(iterator->dictIter, NULL, (void*)&iterator->currentChunk)) {
-                iterator->currentChunk = NULL;
-            }
-            iterator->chunkIteratorInitialized = FALSE;
-            continue;
-        }
-        if (internalSample.timestamp < iterator->minTimestamp) {
-            continue;
-        } else if (internalSample.timestamp > iterator->maxTimestamp) {
-            break;
+        if (currentSample->timestamp < iterator->minTimestamp) {
+            continue;           // Skip through initial samples 
+        } else if (currentSample->timestamp > iterator->maxTimestamp) {
+            return CR_ERR;           // Reach end of range requested
         } else {
-            memcpy(currentSample, &internalSample, sizeof(Sample));
-            return 1;
+            return CR_OK;
         }
     }
-    return 0;
+    return CR_ERR;
 }
 
 CompactionRule *SeriesAddRule(Series *series, RedisModuleString *destKeyStr, int aggType, uint64_t timeBucket) {

--- a/src/tsdb.h
+++ b/src/tsdb.h
@@ -64,7 +64,8 @@ size_t SeriesGetNumSamples(Series *series);
 
 // Iterator over the series
 int SeriesQuery(Series *series, SeriesIterator *iter, api_timestamp_t minTimestamp, api_timestamp_t maxTimestamp);
-int SeriesIteratorGetNext(SeriesIterator *iterator, Sample *currentSample);
+ChunkResult SeriesIteratorGetNext(SeriesIterator *iterator, Sample *currentSample);
+ChunkResult SeriesIteratorGetFirst(SeriesIterator *iterator, Sample *sample);
 void SeriesIteratorClose(SeriesIterator *iterator);
 
 CompactionRule *NewRule(RedisModuleString *destKey, int aggType, uint64_t timeBucket);

--- a/src/tsdb.h
+++ b/src/tsdb.h
@@ -42,7 +42,6 @@ typedef struct SeriesIterator {
     Series *series;
     RedisModuleDictIter *dictIter;
     Chunk_t *currentChunk;
-    int chunkIteratorInitialized;
     ChunkIter_t *chunkIterator;
     api_timestamp_t maxTimestamp;
     api_timestamp_t minTimestamp;

--- a/src/tsdb.h
+++ b/src/tsdb.h
@@ -63,7 +63,7 @@ int SeriesCreateRulesFromGlobalConfig(RedisModuleCtx *ctx, RedisModuleString *ke
 size_t SeriesGetNumSamples(Series *series);
 
 // Iterator over the series
-SeriesIterator SeriesQuery(Series *series, api_timestamp_t minTimestamp, api_timestamp_t maxTimestamp);
+int SeriesQuery(Series *series, SeriesIterator *iter, api_timestamp_t minTimestamp, api_timestamp_t maxTimestamp);
 int SeriesIteratorGetNext(SeriesIterator *iterator, Sample *currentSample);
 void SeriesIteratorClose(SeriesIterator *iterator);
 

--- a/tests/benchmark_compressed.py
+++ b/tests/benchmark_compressed.py
@@ -1,25 +1,30 @@
-import requests
 import redis
 import time
 
 redis = redis.Redis(host='localhost', port=6379, db=0)
 redis_pipe = redis.pipeline()
-redis.flushall()
 
 print "start benchmark"
 
 start_time = time.time()
 
+#name = str(time.time())
+name = "rts"
 num_sample = 1024 * 1024
-
-redis_pipe.execute_command('ts.create test')
+redis.execute_command('flushall')
+redis_pipe.execute_command('ts.create', name, 'uncompressed')
 
 for i in range(num_sample):
-  redis_pipe.execute_command('ts.add test', i, i)
-redis_pipe.execute()
+  redis_pipe.execute_command('ts.add', name, i, i)
+  if i % 999 == 0:
+    redis_pipe.execute()
+    
+print time.time() - start_time
+start_time = time.time()
 
-total_time = time.time() - start_time
+print "run range"
+for _ in range(50):
+  redis.execute_command('ts.range', name, 0, -1)
+  print ".",
 
-redis.execute_command('ts.range test 0 -1')
-
-print total_time
+print time.time() - start_time

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -446,6 +446,17 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
         with pytest.raises(redis.ResponseError) as excinfo:
             assert r.execute_command('TS.RANGE tester 0 -1 count number')
 
+    def test_range_midrange(self):
+        samples_count = 5000
+        with self.redis() as r:
+            assert r.execute_command('TS.CREATE', 'tester', 'UNCOMPRESSED')
+            for i in range(samples_count):
+                r.execute_command('TS.ADD', 'tester', i, i)
+            res = r.execute_command('TS.RANGE', 'tester', samples_count - 500, samples_count)
+            assert len(res) == 500
+            res = r.execute_command('TS.RANGE', 'tester', samples_count - 1500, samples_count - 1000)
+            assert len(res) == 501
+
     def test_range_with_agg_query(self):
         start_ts = 1488823384L
         samples_count = 1500

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -915,7 +915,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             actual_result = r.execute_command('TS.mrange', start_ts, start_ts + samples_count, 'COUNT', 3, 'AGGREGATION', 'LAST', 5, 'FILTER', 'generation=x')
             assert expected_result[0][2][:3] == actual_result[0][2]
             actual_result = r.execute_command('TS.mrange', start_ts + 1, start_ts + samples_count, 'AGGREGATION', 'COUNT', 5, 'FILTER', 'generation=x')
-            assert expected_result[0][2][1:9] == actual_result[0][2][:8]
+            assert expected_result[0][2][1:9] == actual_result[0][2][1:9]
             actual_result = r.execute_command('TS.mrange', start_ts, start_ts + samples_count, 'AGGREGATION', 'COUNT', 3, 'COUNT', 3, 'FILTER', 'generation=x')
             assert 3 == len(actual_result[0][2]) #just checking that agg count before count works
             actual_result = r.execute_command('TS.mrange', start_ts, start_ts + samples_count, 'COUNT', 3, 'AGGREGATION', 'COUNT', 3, 'FILTER', 'generation=x')


### PR DESCRIPTION
`RedisModule_DictIteratorReseekC(iter.dictIter, "^", NULL, 0);` is similar to `RedisModule_DictIteratorStartC(series->chunks, "<=", &rax_key, sizeof(rax_key));`
since we start anyway from the begining.