### PR TITLE
WIP

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -69,18 +69,18 @@ ChunkResult Uncompressed_AddSample(Chunk_t *chunk, Sample *sample) {
     return CR_OK;
 }
 
-ChunkIter_t *Uncompressed_NewChunkIterator(Chunk_t *chunk) {
+ChunkIter_t *Uncompressed_NewChunkIterator(Chunk_t *chunk, Sample *sample) {
     ChunkIterator *iter = (ChunkIterator *)calloc(1, sizeof(ChunkIterator));
     iter->chunk = chunk;
     iter->currentIndex = 0;
+    *sample = *ChunkGetSample(iter->chunk, iter->currentIndex++);
     return iter;
 }
 
 ChunkResult Uncompressed_ChunkIteratorGetNext(ChunkIter_t *iterator, Sample *sample) {
     ChunkIterator *iter = iterator;
-    if (iter->currentIndex < iter->chunk->num_samples) {
-        iter->currentIndex++;
-        Sample *internalSample = ChunkGetSample(iter->chunk, iter->currentIndex - 1);
+    if (iter->currentIndex <= iter->chunk->num_samples) {
+        Sample *internalSample = ChunkGetSample(iter->chunk, iter->currentIndex++);
         memcpy(sample, internalSample, sizeof(Sample));
         return CR_OK;
     } else {

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -79,7 +79,7 @@ ChunkIter_t *Uncompressed_NewChunkIterator(Chunk_t *chunk, Sample *sample) {
 
 ChunkResult Uncompressed_ChunkIteratorGetNext(ChunkIter_t *iterator, Sample *sample) {
     ChunkIterator *iter = iterator;
-    if (iter->currentIndex <= iter->chunk->num_samples) {
+    if (iter->currentIndex < iter->chunk->num_samples) {
         Sample *internalSample = ChunkGetSample(iter->chunk, iter->currentIndex++);
         memcpy(sample, internalSample, sizeof(Sample));
         return CR_OK;

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -36,7 +36,7 @@ u_int64_t Uncompressed_NumOfSample(Chunk_t *chunk);
 timestamp_t Uncompressed_GetLastTimestamp(Chunk_t *chunk);
 timestamp_t Uncompressed_GetFirstTimestamp(Chunk_t *chunk);
 
-ChunkIter_t *Uncompressed_NewChunkIterator(Chunk_t *chunk);
+ChunkIter_t *Uncompressed_NewChunkIterator(Chunk_t *chunk, Sample *samplej);
 ChunkResult Uncompressed_ChunkIteratorGetNext(ChunkIter_t *iterator, Sample *sample);
 
 #endif

--- a/src/compressed_chunk.c
+++ b/src/compressed_chunk.c
@@ -61,13 +61,13 @@ u_int64_t getIterIdx(ChunkIter_t *iter) {
 }
 // LCOV_EXCL_STOP
 
-ChunkIter_t *Compressed_NewChunkIterator(Chunk_t *chunk) {
+ChunkIter_t *Compressed_NewChunkIterator(Chunk_t *chunk, Sample *sample) {
   CompressedChunk *compChunk = chunk;
   Compressed_Iterator *iter = (Compressed_Iterator *)calloc(1, sizeof(Compressed_Iterator));
 
   iter->chunk = compChunk;
   iter->idx = 0;
-  iter->count = 0;
+  iter->count = 1;    // first sample is returned
 
   iter->prevTS = compChunk->baseTimestamp;
   iter->prevDelta = 0;
@@ -75,6 +75,9 @@ ChunkIter_t *Compressed_NewChunkIterator(Chunk_t *chunk) {
   iter->prevValue.d = compChunk->baseValue.d;  
   iter->prevLeading = 32;
   iter->prevTrailing = 32;
+
+  sample->timestamp = compChunk->baseTimestamp;
+  sample->value     = compChunk->baseValue.d;
 
   return (ChunkIter_t *)iter;
 }

--- a/src/compressed_chunk.h
+++ b/src/compressed_chunk.h
@@ -20,7 +20,7 @@ void Compressed_FreeChunk(Chunk_t *chunk);
 ChunkResult Compressed_AddSample(Chunk_t *chunk, Sample *sample);
 
 // Read from compressed chunk using an iterator
-ChunkIter_t *Compressed_NewChunkIterator(Chunk_t *chunk);
+ChunkIter_t *Compressed_NewChunkIterator(Chunk_t *chunk, Sample *sample);
 ChunkResult Compressed_ChunkIteratorGetNext(ChunkIter_t *iter, Sample* sample);
 
 // Miscellaneous

--- a/src/generic_chunk.h
+++ b/src/generic_chunk.h
@@ -29,7 +29,7 @@ typedef struct ChunkFuncs {
 
     ChunkResult(*AddSample)(Chunk_t *chunk, Sample *sample);
 
-    ChunkIter_t *(*NewChunkIterator)(Chunk_t *chunk);
+    ChunkIter_t *(*NewChunkIterator)(Chunk_t *chunk, Sample *sample);
     void(*FreeChunkIterator)(ChunkIter_t *iter);
     ChunkResult(*ChunkIteratorGetNext)(ChunkIter_t *iter, Sample *sample);
 

--- a/src/gorilla.c
+++ b/src/gorilla.c
@@ -442,14 +442,14 @@ static double readV(Compressed_Iterator *iter) {
 
 ChunkResult Compressed_ReadNext(Compressed_Iterator *iter, timestamp_t *timestamp, double *value) {
     assert(iter);
-    *timestamp = iter->prevTS;
-    *value     = iter->prevValue.d;
+    //*timestamp = iter->prevTS;
+    //*value     = iter->prevValue.d;
 
     assert(iter->chunk);
     if (iter->count >= iter->chunk->count) return CR_END;
 
-    iter->prevTS      = readTS(iter);
-    iter->prevValue.d = readV (iter);
+    *timestamp = iter->prevTS      = readTS(iter);
+    *value     = iter->prevValue.d = readV (iter);
     iter->count++;
     return CR_OK;
 }

--- a/src/gorilla.c
+++ b/src/gorilla.c
@@ -442,10 +442,8 @@ static double readV(Compressed_Iterator *iter) {
 
 ChunkResult Compressed_ReadNext(Compressed_Iterator *iter, timestamp_t *timestamp, double *value) {
     assert(iter);
-    //*timestamp = iter->prevTS;
-    //*value     = iter->prevValue.d;
-
     assert(iter->chunk);
+    
     if (iter->count >= iter->chunk->count) return CR_END;
 
     *timestamp = iter->prevTS      = readTS(iter);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -111,11 +111,11 @@ void series_rdb_save(RedisModuleIO *io, void *value)
     RedisModule_SaveUnsigned(io, numSamples);
 
     SeriesIterator iter;
-    SeriesQuery(series, &iter, 0, series->lastTimestamp);
     Sample sample;
-    while (SeriesIteratorGetNext(&iter, &sample) == CR_OK) {
+    SeriesQuery(series, &iter, &sample, 0, series->lastTimestamp);
+    do {
         RedisModule_SaveUnsigned(io, sample.timestamp);
         RedisModule_SaveDouble(io, sample.value);
-    }
+    } while (SeriesIteratorGetNext(&iter, &sample) == CR_OK);
     SeriesIteratorClose(&iter);
 }

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -276,7 +276,6 @@ int SeriesIteratorGetNext(SeriesIterator *iterator, Sample *currentSample) {
         }
         funcs->FreeChunkIterator(iterator->chunkIterator);
         iterator->chunkIterator = funcs->NewChunkIterator(iterator->currentChunk, currentSample);
-        funcs->ChunkIteratorGetNext(iterator->chunkIterator, currentSample);
     }
 
     if (currentSample->timestamp > iterator->maxTimestamp) {

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -245,7 +245,7 @@ int SeriesQuery(Series *series, SeriesIterator *iter, Sample *sample,
             iter->minTimestamp = minTimestamp;
             iter->maxTimestamp = maxTimestamp;
             do {
-                if (sample->timestamp >= iter->minTimestamp) { 
+                if (sample->timestamp >= iter->minTimestamp && sample->timestamp <= iter->maxTimestamp) { 
                     return REDISMODULE_OK;
                 }
                 if (sample->timestamp > iter->maxTimestamp) { 

--- a/src/tsdb.h
+++ b/src/tsdb.h
@@ -63,7 +63,7 @@ int SeriesCreateRulesFromGlobalConfig(RedisModuleCtx *ctx, RedisModuleString *ke
 size_t SeriesGetNumSamples(Series *series);
 
 // Iterator over the series
-int SeriesQuery(Series *series, SeriesIterator *iter, api_timestamp_t minTimestamp, api_timestamp_t maxTimestamp);
+int SeriesQuery(Series *series, SeriesIterator *iter, Sample *sample, api_timestamp_t minTimestamp, api_timestamp_t maxTimestamp);
 int SeriesIteratorGetNext(SeriesIterator *iterator, Sample *currentSample);
 void SeriesIteratorClose(SeriesIterator *iterator);
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -448,8 +448,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
 
     def test_range_midrange(self):
         samples_count = 5000
-        with self.redis() as r:
-            
+        with self.redis() as r:            
             assert r.execute_command('TS.CREATE', 'tester', 'UNCOMPRESSED')
             for i in range(samples_count):
                 r.execute_command('TS.ADD', 'tester', i, i)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1132,12 +1132,12 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             r.execute_command('ts.create empty')
             info = self._get_ts_info(r, 'empty')
             assert info.total_samples == 0
-            assert [] == r.execute_command('TS.range empty 0 -1')
+            assert [[0L, '0']] == r.execute_command('TS.range empty 0 -1')
 
             r.execute_command('ts.create empty_uncompressed uncompressed')
             info = self._get_ts_info(r, 'empty_uncompressed')
             assert info.total_samples == 0
-            assert [] == r.execute_command('TS.range empty_uncompressed 0 -1')
+            assert [[0L, '0']] == r.execute_command('TS.range empty_uncompressed 0 -1')
 
     def test_gorilla(self):
         with self.redis() as r:

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -449,7 +449,17 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
     def test_range_midrange(self):
         samples_count = 5000
         with self.redis() as r:
+            
             assert r.execute_command('TS.CREATE', 'tester', 'UNCOMPRESSED')
+            for i in range(samples_count):
+                r.execute_command('TS.ADD', 'tester', i, i)
+            res = r.execute_command('TS.RANGE', 'tester', samples_count - 500, samples_count)
+            assert len(res) == 500
+            res = r.execute_command('TS.RANGE', 'tester', samples_count - 1500, samples_count - 1000)
+            assert len(res) == 501
+            
+            r.execute_command('del tester')
+            assert r.execute_command('TS.CREATE', 'tester')
             for i in range(samples_count):
                 r.execute_command('TS.ADD', 'tester', i, i)
             res = r.execute_command('TS.RANGE', 'tester', samples_count - 500, samples_count)


### PR DESCRIPTION
Built on top of `clear-SeriesQuery` branch.
Moves iteration to the first sample within range to the initialization function so it doesn't have to be done with every `getNext` call. 