### PR TITLE
[fix] fixed TS.MGET reply format. included WITHLABELS option support

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -410,12 +410,12 @@ n = Number of time-series that match the filters
 127.0.0.1:6379> TS.MGET FILTER area_id=32
 1) 1) "temperature:2:32"
    2) (empty list or set)
-      3) 1) 1) (integer) 1548149181000
-            2) "30"
+   3) 1) 1) (integer) 1548149181000
+         2) "30"
 2) 1) "temperature:3:32"
-    2) (empty list or set)
-      3) 1) 1) (integer) 1548149181000
-            2) "29"
+   2) (empty list or set)
+   3) 1) 1) (integer) 1548149181000
+         2) "29"
 ```
 
 ##### MGET Example with WITHLABELS option
@@ -426,15 +426,15 @@ n = Number of time-series that match the filters
          2) "2"
       2) 1) "area_id"
          2) "32"
-      3) 1) 1) (integer) 1548149181000
-            2) "30"
+   3) 1) 1) (integer) 1548149181000
+         2) "30"
 2) 1) "temperature:3:32"
    2) 1) 1) "sensor_id"
          2) "2"
       2) 1) "area_id"
          2) "32"
-      3) 1) 1) (integer) 1548149181000
-            2) "29"
+   3) 1) 1) (integer) 1548149181000
+         2) "29"
 ```
 
 ## General

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -379,12 +379,46 @@ TS.GET key
 Get the last samples matching the specific filter.
 
 ```sql
-TS.MGET FILTER filter...
+TS.MGET [WITHLABELS] FILTER filter...
 ```
 * filter - [See Filtering](#filtering)
 
-#### MGET Example
+Optional args:
 
+* WITHLABELS - Include in the reply the label-value pairs that represent metadata labels of the time-series. If this argument is not set, by default, an empty Array will be replied on the labels array position.
+
+#### Return Value
+
+Array-reply, specifically:
+
+The command returns the entries with labels matching the specified filter.
+The returned entries are complete, that means that the name, labels and all the last sample of the time-serie.
+
+The returned array will contain key1,labels1,lastsample1,...,keyN,labelsN,lastsampleN, with labels and lastsample being also of array data types. By default, the labels array will be an empty Array for each of the returned time-series. If the `WITHLABELS` option is specified the labels Array will be filled with label-value pairs that represent metadata labels of the time-series.
+
+
+#### Complexity
+
+TS.MGET complexity is O(n).
+
+n = Number of time-series that match the filters
+
+#### Examples
+
+##### MGET Example with default behaviour
+```sql
+127.0.0.1:6379> TS.MGET FILTER area_id=32
+1) 1) "temperature:2:32"
+   2) (empty list or set)
+      3) 1) 1) (integer) 1548149181000
+            2) "30"
+2) 1) "temperature:3:32"
+    2) (empty list or set)
+      3) 1) 1) (integer) 1548149181000
+            2) "29"
+```
+
+##### MGET Example with WITHLABELS option
 ```sql
 127.0.0.1:6379> TS.MGET FILTER area_id=32
 1) 1) "temperature:2:32"
@@ -392,15 +426,15 @@ TS.MGET FILTER filter...
          2) "2"
       2) 1) "area_id"
          2) "32"
-   3) (integer) 1548149181000
-   4) "30"
+      3) 1) 1) (integer) 1548149181000
+            2) "30"
 2) 1) "temperature:3:32"
    2) 1) 1) "sensor_id"
-         2) "3"
+         2) "2"
       2) 1) "area_id"
          2) "32"
-   3) (integer) 1548149181000
-   4) "29"
+      3) 1) 1) (integer) 1548149181000
+            2) "29"
 ```
 
 ## General

--- a/src/module.c
+++ b/src/module.c
@@ -28,6 +28,7 @@ static int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, api_timestamp_t
                      AggregationClass *aggObject, int64_t time_delta, long long maxResults);
 
 static void ReplyWithSeriesLabels(RedisModuleCtx *ctx, const Series *series);
+static void ReplyWithSeriesLastDatapoint(RedisModuleCtx *ctx, const Series *series);
 
 static int parseLabelsFromArgs(RedisModuleString **argv, int argc, size_t *label_count, Label **labels) {
     int pos = RMUtil_ArgIndex("LABELS", argv, argc);
@@ -301,6 +302,17 @@ void ReplyWithSeriesLabels(RedisModuleCtx *ctx, const Series *series) {
         RedisModule_ReplyWithArray(ctx, 2);
         RedisModule_ReplyWithString(ctx, series->labels[i].key);
         RedisModule_ReplyWithString(ctx, series->labels[i].value);
+    }
+}
+
+void ReplyWithSeriesLastDatapoint(RedisModuleCtx *ctx, const Series *series) {
+    if(SeriesGetNumSamples(series)==0){
+        RedisModule_ReplyWithArray(ctx, 0);
+    }
+    else {
+        RedisModule_ReplyWithArray(ctx, 2);
+        RedisModule_ReplyWithLongLong(ctx, series->lastTimestamp);
+        RedisModule_ReplyWithDouble(ctx, series->lastValue);
     }
 }
 
@@ -978,6 +990,7 @@ int TSDB_mget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return RedisModule_WrongArity(ctx);
     }
     size_t query_count = argc - 1 - filter_location;
+    const int withlabels_location = RMUtil_ArgIndex("WITHLABELS", argv, argc);
     QueryPredicate *queries = RedisModule_PoolAlloc(ctx, sizeof(QueryPredicate) * query_count);
     if (parseLabelListFromArgs(ctx, argv, filter_location + 1, query_count, queries) == TSDB_ERROR) {
         return RedisModule_ReplyWithError(ctx, "TSDB: failed parsing labels");
@@ -1002,12 +1015,14 @@ int TSDB_mget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                 continue;
             }
         series = RedisModule_ModuleTypeGetValue(key);
-
-        RedisModule_ReplyWithArray(ctx, 4);
+        RedisModule_ReplyWithArray(ctx, 3);
         RedisModule_ReplyWithStringBuffer(ctx, currentKey, currentKeyLen);
-        ReplyWithSeriesLabels(ctx, series);
-        RedisModule_ReplyWithLongLong(ctx, series->lastTimestamp);
-        RedisModule_ReplyWithDouble(ctx, series->lastValue);
+        if (withlabels_location >= 0){
+            ReplyWithSeriesLabels(ctx, series);
+        } else {
+            RedisModule_ReplyWithArray(ctx, 0);
+        }
+        ReplyWithSeriesLastDatapoint(ctx, series);
         replylen++;
         RedisModule_CloseKey(key);
     }

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -402,6 +402,19 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
         kvlabels = []
 
         with self.redis() as r:
+            # test for empty series
+            assert r.execute_command('TS.CREATE', "key4_empty", "LABELS", "NODATA", "TRUE")
+            assert r.execute_command('TS.CREATE', "key5_empty", "LABELS", "NODATA", "TRUE")
+            # expect to received time-series k1 and k2
+            expected_result = [
+                ["key4_empty", [], []],
+                ["key5_empty", [], []]
+            ]
+
+            actual_result = r.execute_command('TS.MGET', 'FILTER', 'NODATA=TRUE')
+            assert expected_result == actual_result
+
+            # test for series with data
             for i in range(num_of_keys):
                 assert r.execute_command('TS.CREATE', keys[i], 'LABELS', labels[i], '1')
                 kvlabels.append([labels[i], '1'])


### PR DESCRIPTION
fixes #315 
fixes #316 

- [fix] fixed TS.MGET reply format to match the one from other multi timeseries replies
- [add] include WITHLABELS optional argument. 
- [add] updated documentation and included complexity of command