### PR TITLE
make `TS.MGET` reply in the exact same format of `TS.MRANGE`

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1022,6 +1022,7 @@ int TSDB_mget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         } else {
             RedisModule_ReplyWithArray(ctx, 0);
         }
+        RedisModule_ReplyWithArray(ctx, 1);
         ReplyWithSeriesLastDatapoint(ctx, series);
         replylen++;
         RedisModule_CloseKey(key);

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -407,8 +407,8 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             assert r.execute_command('TS.CREATE', "key5_empty", "LABELS", "NODATA", "TRUE")
             # expect to received time-series k1 and k2
             expected_result = [
-                ["key4_empty", [], []],
-                ["key5_empty", [], []]
+                ["key4_empty", [], [[]]],
+                ["key5_empty", [], [[]]]
             ]
 
             actual_result = r.execute_command('TS.MGET', 'FILTER', 'NODATA=TRUE')
@@ -424,8 +424,8 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
 
             # expect to received time-series k1 and k2
             expected_result = [
-                [keys[0], [], [time_stamp, str(values[0])]],
-                [keys[1], [], [time_stamp, str(values[1])]]
+                [keys[0], [], [[time_stamp, str(values[0])]]],
+                [keys[1], [], [[time_stamp, str(values[1])]]]
             ]
 
             actual_result = r.execute_command('TS.MGET', 'FILTER', 'a=1')
@@ -433,7 +433,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
 
             # expect to received time-series k3 with labels
             expected_result_withlabels = [
-                [keys[2], [kvlabels[2]], [time_stamp, str(values[2])]]
+                [keys[2], [kvlabels[2]], [[time_stamp, str(values[2])]]]
             ]
             
             actual_result = r.execute_command('TS.MGET', 'WITHLABELS', 'FILTER', 'a!=1', 'b=1')
@@ -441,8 +441,8 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
 
             # expect to received time-series k1 and k2 with labels
             expected_result_withlabels = [
-                [keys[0], [kvlabels[0]], [time_stamp, str(values[0])]],
-                [keys[1], [kvlabels[1]], [time_stamp, str(values[1])]]
+                [keys[0], [kvlabels[0]], [[time_stamp, str(values[0])]]],
+                [keys[1], [kvlabels[1]], [[time_stamp, str(values[1])]]]
             ]
             
             actual_result = r.execute_command('TS.MGET', 'WITHLABELS', 'FILTER', 'a=1')


### PR DESCRIPTION
## pros/cons
- having the exact same reply helps all clients and makes us consistent and reduces clients code
- extra array with potential performance loss ( should be minimal since we always specificy array size and don't postpone it )

## the format now ( we need an extra array of size 1)
```
$ redis-cli TS.MGET FILTER metric=cpu 
1) 1) "test_TestClient_MultiGet_key1"
   2) (empty array)
   3) 1) (integer) 3
      2) "15"
2) 1) "test_TestClient_MultiGet_key2"
   2) (empty array)
   3) 1) (integer) 1
      2) "5"
```

## the format in compliance with `MRANGE`
```
$ redis-cli TS.MGET FILTER metric=cpu 
1) 1) "test_TestClient_MultiGet_key1"
   2) (empty array)
   3) 1) 1) (integer) 3
         2) "15"
2) 1) "test_TestClient_MultiGet_key2"
   2) (empty array)
   3) 1) 1) (integer) 1
         2) "5"
```