### PR TITLE
[add] make usage of GetSeries across all module.c ( removes duplicate…

### DIFF
--- a/src/module.h
+++ b/src/module.h
@@ -16,7 +16,6 @@ extern RedisModuleType *SeriesType;
 int CreateTsKey(RedisModuleCtx *ctx, RedisModuleString *keyName, Label *labels, size_t labelsCounts,
                 long long retentionTime, long long maxSamplesPerChunk, int compressed, Series **series, RedisModuleKey **key);
 
-int GetSeries(RedisModuleCtx *ctx, RedisModuleString *keyName, Series **series);
-
+int GetSeries(RedisModuleCtx *ctx, RedisModuleString *keyName, RedisModuleKey **key, Series **serie, int mode);
 
 #endif

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -105,18 +105,22 @@ void CleanLastDeletedSeries(RedisModuleCtx *ctx, RedisModuleString *key){
     if(lastDeletedSeries != NULL && RedisModule_StringCompare(lastDeletedSeries->keyName, key) == 0) {
         CompactionRule *rule = lastDeletedSeries->rules;
         while (rule != NULL) {
+            RedisModuleKey *seriesKey;
             Series *dstSeries;
-            int status = GetSeries(ctx, rule->destKey, &dstSeries);
+            const int status = GetSeries(ctx, rule->destKey, &seriesKey, &dstSeries, REDISMODULE_READ|REDISMODULE_WRITE);
             if (status) {
                 SeriesDeleteSrcRule(dstSeries, lastDeletedSeries->keyName);
+                RedisModule_CloseKey(seriesKey);
             }
             rule = rule->nextRule;
         }
         if (lastDeletedSeries->srcKey) {
+            RedisModuleKey *seriesKey;
             Series *srcSeries;
-            int status = GetSeries(ctx, lastDeletedSeries->srcKey, &srcSeries);
+            const int status = GetSeries(ctx, lastDeletedSeries->srcKey, &seriesKey, &srcSeries, REDISMODULE_READ|REDISMODULE_WRITE);
             if (status) {
                 SeriesDeleteRule(srcSeries, lastDeletedSeries->keyName);
+                RedisModule_CloseKey(seriesKey);
             }
         }
     }


### PR DESCRIPTION
- make usage of `SeriesGetNumSamples` in `TS.INFO` ( no need to iterate over chunks ) and deleted `getTotalSample`.
- make usage of `GetSeries(RedisModuleCtx *ctx, RedisModuleString *keyName, RedisModuleKey **key, Series **series, int mode)` across the entire module.c file. This ensures all key opening checks and error replies are consistent across commands. 