### PR TITLE
max func instead of macro

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -41,9 +41,8 @@ typedef enum {
     TS_AGG_TYPES_MAX // 13
 } TS_AGG_TYPES_T;
 
-#define max(a,b) \
-   ({ __typeof__ (a) _a = (a); \
-       __typeof__ (b) _b = (b); \
-     _a > _b ? _a : _b; })
+inline u_int64_t max(u_int64_t a, u_int64_t b) {
+    return a > b ? a : b;
+}
 
 #endif

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -18,8 +18,7 @@
 static Series* lastDeletedSeries = NULL;
 
 Series *NewSeries(RedisModuleString *keyName, Label *labels, size_t labelsCount, uint64_t retentionTime,
-        short maxSamplesPerChunk, int uncompressed)
-{
+        short maxSamplesPerChunk, int uncompressed) {
     Series *newSeries = (Series *)malloc(sizeof(Series));
     newSeries->keyName = keyName;
     newSeries->chunks = RedisModule_CreateDict(NULL);
@@ -59,10 +58,8 @@ void SeriesTrim(Series * series) {
     timestamp_t minTimestamp = series->lastTimestamp > series->retentionTime ?
     		series->lastTimestamp - series->retentionTime : 0;
 
-    while (currentKey = RedisModule_DictNextC(iter, &keyLen, (void*)&currentChunk))
-    {
-        if (series->funcs->GetLastTimestamp(currentChunk) < minTimestamp)
-        {
+    while ((currentKey = RedisModule_DictNextC(iter, &keyLen, (void*)&currentChunk))) {
+        if (series->funcs->GetLastTimestamp(currentChunk) < minTimestamp) {
             RedisModule_DictDelC(series->chunks, currentKey, keyLen, NULL);
             // reseek iterator since we modified the dict, go to first element that is bigger than current key
             RedisModule_DictIteratorReseekC(iter, ">", currentKey, keyLen);


### PR DESCRIPTION
This will silence the compiler
We are using max in two places to compare integers so no need for this implementation.