### PR TITLE
change max function + silence compiler warning

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -53,9 +53,8 @@ typedef enum {
   CR_END = 2  
 } ChunkResult;
 
-#define max(a,b) \
-   ({ __typeof__ (a) _a = (a); \
-       __typeof__ (b) _b = (b); \
-     _a > _b ? _a : _b; })
+inline u_int64_t max(u_int64_t a, u_int64_t b) {
+    return a > b ? a : b;
+}
 
 #endif

--- a/src/consts.h
+++ b/src/consts.h
@@ -53,8 +53,4 @@ typedef enum {
   CR_END = 2  
 } ChunkResult;
 
-inline u_int64_t max(u_int64_t a, u_int64_t b) {
-    return a > b ? a : b;
-}
-
 #endif

--- a/src/module.c
+++ b/src/module.c
@@ -30,6 +30,10 @@ static int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, api_timestamp_t
 static void ReplyWithSeriesLabels(RedisModuleCtx *ctx, const Series *series);
 static void ReplyWithSeriesLastDatapoint(RedisModuleCtx *ctx, const Series *series);
 
+static u_int64_t max(u_int64_t a, u_int64_t b) {
+    return a > b ? a : b;
+}
+
 static int parseLabelsFromArgs(RedisModuleString **argv, int argc, size_t *label_count, Label **labels) {
     int pos = RMUtil_ArgIndex("LABELS", argv, argc);
     int first_label_pos = pos + 1;

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -59,10 +59,8 @@ void SeriesTrim(Series * series) {
     timestamp_t minTimestamp = series->lastTimestamp > series->retentionTime ?
     		series->lastTimestamp - series->retentionTime : 0;
 
-    while (currentKey = RedisModule_DictNextC(iter, &keyLen, (void*)&currentChunk))
-    {
-        if (series->funcs->GetLastTimestamp(currentChunk) < minTimestamp)
-        {
+    while ((currentKey = RedisModule_DictNextC(iter, &keyLen, (void*)&currentChunk))) {
+        if (series->funcs->GetLastTimestamp(currentChunk) < minTimestamp) {
             RedisModule_DictDelC(series->chunks, currentKey, keyLen, NULL);
             // reseek iterator since we modified the dict, go to first element that is bigger than current key
             RedisModule_DictIteratorReseekC(iter, ">", currentKey, keyLen);


### PR DESCRIPTION
max is used for integers only. No need for this implementation.
Removes last compiler warnings.