### PR TITLE
remove unused default from switch

### DIFF
--- a/src/compaction.c
+++ b/src/compaction.c
@@ -445,7 +445,7 @@ const char *AggTypeEnumToString(int aggType) {
             return "LAST";
         case TS_AGG_RANGE:
             return "RANGE";
-        default:
+        default:    // covers TS_AGG_NONE/INVALID/MAX
             return "Unknown";
     }
 }
@@ -476,7 +476,7 @@ AggregationClass *GetAggClass(int aggType) {
             return &aggLast;
         case AGG_RANGE:
             return &aggRange;
-        default:
+        default:    // covers AGG_NONE
             return NULL;
     }
 }

--- a/src/compaction.c
+++ b/src/compaction.c
@@ -419,7 +419,7 @@ int StringLenAggTypeToEnum(const char *agg_type, size_t len) {
 	return result;
 }
 
-const char *AggTypeEnumToString(int aggType) {
+const char *AggTypeEnumToString(TS_AGG_TYPES_T aggType) {
     switch (aggType) {
         case TS_AGG_MIN:
             return "MIN";
@@ -445,38 +445,44 @@ const char *AggTypeEnumToString(int aggType) {
             return "LAST";
         case TS_AGG_RANGE:
             return "RANGE";
-        default:    // covers TS_AGG_NONE/INVALID/MAX
-            return "Unknown";
+        case TS_AGG_NONE:
+        case TS_AGG_INVALID:
+        case TS_AGG_TYPES_MAX:
+            break;
     }
+    return "Unknown";
 }
 
-AggregationClass *GetAggClass(int aggType) {
+AggregationClass *GetAggClass(TS_AGG_TYPES_T aggType) {
     switch (aggType) {
-        case AGG_MIN:
+        case TS_AGG_MIN:
             return &aggMin;
-        case AGG_MAX:
+        case TS_AGG_MAX:
             return &aggMax;
-        case AGG_AVG:
+        case TS_AGG_AVG:
             return &aggAvg;
-        case AGG_STD_P:
+        case TS_AGG_STD_P:
             return &aggStdP;
-        case AGG_STD_S:
+        case TS_AGG_STD_S:
             return &aggStdS;
-        case AGG_VAR_P:
+        case TS_AGG_VAR_P:
             return &aggVarP;
-        case AGG_VAR_S:
+        case TS_AGG_VAR_S:
             return &aggVarS;
-        case AGG_SUM:
+        case TS_AGG_SUM:
             return &aggSum;
-        case AGG_COUNT:
+        case TS_AGG_COUNT:
             return &aggCount;
-        case AGG_FIRST:
+        case TS_AGG_FIRST:
             return &aggFirst;
-        case AGG_LAST:
+        case TS_AGG_LAST:
             return &aggLast;
-        case AGG_RANGE:
+        case TS_AGG_RANGE:
             return &aggRange;
-        default:    // covers AGG_NONE
-            return NULL;
+        case TS_AGG_NONE:
+        case TS_AGG_INVALID:
+        case TS_AGG_TYPES_MAX:
+            break;
     }
+    return NULL;
 }

--- a/src/compaction.h
+++ b/src/compaction.h
@@ -10,21 +10,6 @@
 #include "consts.h"
 #include <rmutil/util.h>
 
-#define AGG_NONE 0
-#define AGG_MIN 1
-#define AGG_MAX 2
-#define AGG_SUM 3
-#define AGG_AVG 4
-#define AGG_COUNT 5
-#define AGG_FIRST 6
-#define AGG_LAST 7
-#define AGG_RANGE 8
-#define AGG_STD_P 9
-#define AGG_STD_S 10
-#define AGG_VAR_P 11
-#define AGG_VAR_S 12
-
-
 typedef struct AggregationClass
 {
     void *(*createContext)();
@@ -36,10 +21,10 @@ typedef struct AggregationClass
     double(*finalize)(void *context);
 } AggregationClass;
 
-AggregationClass *GetAggClass(int aggType);
+AggregationClass *GetAggClass(TS_AGG_TYPES_T aggType);
 int StringAggTypeToEnum(const char *agg_type);
 int RMStringLenAggTypeToEnum(RedisModuleString *aggTypeStr);
 int StringLenAggTypeToEnum(const char *agg_type, size_t len);
-const char *AggTypeEnumToString(int aggType);
+const char *AggTypeEnumToString(TS_AGG_TYPES_T aggType);
 
 #endif

--- a/src/generic_chunk.c
+++ b/src/generic_chunk.c
@@ -39,10 +39,10 @@ static ChunkFuncs comprChunk = {
     .GetFirstTimestamp = Compressed_GetFirstTimestamp
 };
 
-ChunkFuncs *GetChunkClass(int chunkType) {
+ChunkFuncs *GetChunkClass(CHUNK_TYPES_T chunkType) {
   switch (chunkType) {
-  case CHUNK_REGULAR:     return &regChunk;
-  case CHUNK_COMPRESSED:  return &comprChunk;
+    case CHUNK_REGULAR:     return &regChunk;
+    case CHUNK_COMPRESSED:  return &comprChunk;
   }
   return NULL;
 } 

--- a/src/generic_chunk.c
+++ b/src/generic_chunk.c
@@ -43,6 +43,6 @@ ChunkFuncs *GetChunkClass(int chunkType) {
   switch (chunkType) {
   case CHUNK_REGULAR:     return &regChunk;
   case CHUNK_COMPRESSED:  return &comprChunk;
-  default:                return NULL;
   }
+  return NULL;
 } 

--- a/src/generic_chunk.h
+++ b/src/generic_chunk.h
@@ -20,8 +20,10 @@ typedef struct Sample {
     double value;
 } Sample;
 
-#define CHUNK_REGULAR 0
-#define CHUNK_COMPRESSED 1
+typedef enum {
+    CHUNK_REGULAR,
+    CHUNK_COMPRESSED 
+} CHUNK_TYPES_T;
 
 typedef struct ChunkFuncs {
     Chunk_t *(*NewChunk)(size_t sampleCount);
@@ -39,6 +41,6 @@ typedef struct ChunkFuncs {
     u_int64_t(*GetFirstTimestamp)(Chunk_t *chunk);
 } ChunkFuncs;
 
-ChunkFuncs *GetChunkClass(int chunkClass);
+ChunkFuncs *GetChunkClass(CHUNK_TYPES_T chunkClass);
 
 #endif //GENERIC__CHUNK_H

--- a/src/module.c
+++ b/src/module.c
@@ -565,7 +565,7 @@ int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, api_timestamp_t start_
     }
     SeriesIteratorClose(&iterator);
 
-    if (aggObject != AGG_NONE) {
+    if (aggObject != TS_AGG_NONE) {
         if (arraylen != maxResults) {
             // reply last bucket of data
             ReplyWithAggValue(ctx, last_agg_timestamp, aggObject, context);

--- a/src/tsdb.h
+++ b/src/tsdb.h
@@ -16,7 +16,7 @@ typedef struct CompactionRule {
     RedisModuleString *destKey;
     timestamp_t timeBucket;
     AggregationClass *aggClass;
-    int aggType;
+    TS_AGG_TYPES_T aggType;
     void *aggContext;
     struct CompactionRule *nextRule;
     timestamp_t startCurrentTimeBucket;


### PR DESCRIPTION
```return NULL;``` is added to silence compiler