### PR TITLE
Issue 376. Sample is first in chunk after one dictionary returns

### DIFF
--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -279,6 +279,12 @@ ChunkResult SeriesIteratorGetFirstInRange(SeriesIterator *iterator, Sample *samp
     if (res != CR_OK) { 
         return SeriesIteratorGetNext(iterator, sample);
     }
+
+    // No sample within range
+    if (sample->timestamp > iterator->maxTimestamp ||
+        sample->timestamp < iterator->minTimestamp) {
+        return CR_END;
+    } 
     return CR_OK;
 }
 

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -307,7 +307,7 @@ ChunkResult SeriesIteratorGetNext(SeriesIterator *iterator, Sample *currentSampl
             funcs->GetLastTimestamp (currentChunk) < iterator->minTimestamp) {
             return CR_END;       // No more chunks or they out of range
         }
-        funcs->FreeChunkIterator(iterator->chunkIterator, false);
+        funcs->FreeChunkIterator(iterator->chunkIterator, iterator->reverse);
         iterator->chunkIterator = funcs->NewChunkIterator(currentChunk, iterator->reverse);
         if(iterator->GetNext(iterator->chunkIterator, currentSample) != CR_OK) {
             return CR_END;

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -279,12 +279,6 @@ ChunkResult SeriesIteratorGetFirstInRange(SeriesIterator *iterator, Sample *samp
     if (res != CR_OK) { 
         return SeriesIteratorGetNext(iterator, sample);
     }
-
-    // No sample within range
-    if (sample->timestamp > iterator->maxTimestamp ||
-        sample->timestamp < iterator->minTimestamp) {
-        return CR_END;
-    } 
     return CR_OK;
 }
 

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -254,6 +254,8 @@ SeriesIterator SeriesQuery(Series *series, timestamp_t start_ts, timestamp_t end
         return (SeriesIterator){ 0 };
     }
 
+
+
     iter.chunkIterator = funcs->NewChunkIterator(iter.currentChunk, iter.reverse);
     return iter;
 }
@@ -274,9 +276,14 @@ ChunkResult SeriesIteratorGetFirstInRange(SeriesIterator *iterator, Sample *samp
         res = iterator->GetNext(iterator->chunkIterator, sample);
     }
 
+    // Sample can be 1st in the next chunk
+    if (res != CR_OK) { 
+        return SeriesIteratorGetNext(iterator, sample);
+    }
+
     // No sample within range
-    if (res != CR_OK || sample->timestamp > iterator->maxTimestamp ||
-                        sample->timestamp < iterator->minTimestamp) {
+    if (sample->timestamp > iterator->maxTimestamp ||
+        sample->timestamp < iterator->minTimestamp) {
         return CR_END;
     } 
     return CR_OK;

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1369,12 +1369,15 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
 
     def test_issue376(self):
         with self.redis() as r:
-            times = 500
+            times = 300
             r.execute_command('ts.create issue376 UNCOMPRESSED')
             for i in range(1, times):
                 r.execute_command('ts.add issue376', i * 5, i)
             for i in range(1, times):
-                range_res = r.execute_command('ts.range issue376', i * 5 - 1, i * 5 + 1)
+                range_res = r.execute_command('ts.range issue376', i * 5 - 1, i * 5 + 60)
+                assert len(range_res) > 0
+            for i in range(1, times):
+                range_res = r.execute_command('ts.revrange issue376', i * 5 - 1, i * 5 + 60)
                 assert len(range_res) > 0
 
 class GlobalConfigTests(ModuleTestCase(REDISTIMESERIES, 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1367,6 +1367,16 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             get_res = r.execute_command('ts.get issue358')[1]
             assert range_res == get_res
 
+    def test_issue376(self):
+        with self.redis() as r:
+            times = 500
+            r.execute_command('ts.create issue376 UNCOMPRESSED')
+            for i in range(1, times):
+                r.execute_command('ts.add issue376', i * 5, i)
+            for i in range(1, times):
+                range_res = r.execute_command('ts.range issue376', i * 5 - 1, i * 5 + 1)
+                assert len(range_res) > 0
+
 class GlobalConfigTests(ModuleTestCase(REDISTIMESERIES, 
         module_args=['COMPACTION_POLICY', 'max:1m:1d;min:10s:1h;avg:2h:10d;avg:3d:100d'])):
     def test_autocreate(self):


### PR DESCRIPTION
Fix #376 
Possible related to #379 
Dictionary returns 1st chunk `<=` from the timestamp requested but it might actually reside in the next chunk.