### PR TITLE
fix: Error messages must contain all the error, including the initial error code (ERR)

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -1,6 +1,6 @@
 
 #pragma once
 
-#define ERR "ERR"
+#define RTS_ERR "ERR"
 #define RTS_ReplyError(ctx, err_type, msg) RedisModule_ReplyWithError(ctx, err_type " " msg);
-#define RTS_ReplyGeneralError(ctx, msg) RTS_ReplyError(ctx, ERR, msg);
+#define RTS_ReplyGeneralError(ctx, msg) RTS_ReplyError(ctx, RTS_ERR, msg);

--- a/src/common.h
+++ b/src/common.h
@@ -1,2 +1,6 @@
 
 #pragma once
+
+#define ERR "ERR"
+#define RTS_ReplyError(ctx, err_type, msg) RedisModule_ReplyWithError(ctx, err_type " " msg);
+#define RTS_ReplyGeneralError(ctx, msg) RTS_ReplyError(ctx, ERR, msg);

--- a/src/module.c
+++ b/src/module.c
@@ -700,7 +700,7 @@ static int internalAdd(RedisModuleCtx *ctx,
     timestamp_t lastTS = series->lastTimestamp;
     uint64_t retention = series->retentionTime;
     // ensure inside retention period.
-    if (retention && timestamp < lastTS && timestamp < lastTS - retention) {
+    if (retention && timestamp < lastTS && retention < lastTS - timestamp) {
         RTS_ReplyGeneralError(ctx, "TSDB: Timestamp is older than retention");
         return REDISMODULE_ERR;
     }

--- a/src/module.c
+++ b/src/module.c
@@ -5,6 +5,7 @@
  */
 #include "module.h"
 
+#include "common.h"
 #include "compaction.h"
 #include "config.h"
 #include "indexer.h"
@@ -12,7 +13,6 @@
 #include "redismodule.h"
 #include "tsdb.h"
 #include "version.h"
-#include "common.h"
 
 #include <ctype.h>
 #include <limits.h>


### PR DESCRIPTION
fixes #439 . This is important for clients properly parsing the RESP protocol