### PR TITLE
fix bug + silent compiler

### DIFF
--- a/src/compressed_chunk.c
+++ b/src/compressed_chunk.c
@@ -59,8 +59,8 @@ static void trimChunk(CompressedChunk *chunk, int minSize) {
 
     assert(excess >= 0); // else we have written beyond allocated memory
 
-    if (excess > 0) {
-        size_t newSize = max(chunk->size - excess + 2, minSize);
+    if (excess > 1) {
+        size_t newSize = max(chunk->size - excess + 1, minSize);
         chunk->data = realloc(chunk->data, newSize);
         chunk->size = newSize;
     }


### PR DESCRIPTION
fixes assertion fails on:
```
7328:M 24 Jun 2020 16:21:06.769 # Server initialized
7328:M 24 Jun 2020 16:21:06.769 * <timeseries> RedisTimeSeries version 999999, git_sha=9c78ee96394391790a0b8c029fbad0c45fa41ae9
7328:M 24 Jun 2020 16:21:06.769 * <timeseries> Redis version found by RedisTimeSeries : 6.0.5 - oss
7328:M 24 Jun 2020 16:21:06.769 * Module 'timeseries' loaded from bin/linux-x64-release/redistimeseries.so
7328:M 24 Jun 2020 16:21:06.770 * Ready to accept connections
redis-server: gorilla.c:450: readFloat: Assertion `leading + blocksize <= BINW' failed.
Aborted (core dumped)
```