### PR TITLE
Fix Documentation: Add Missing WITHLABELS

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -452,7 +452,7 @@ n = Number of time-series that match the filters
 
 ##### MGET Example with WITHLABELS option
 ```sql
-127.0.0.1:6379> TS.MGET FILTER area_id=32
+127.0.0.1:6379> TS.MGET WITHLABELS FILTER area_id=32
 1) 1) "temperature:2:32"
    2) 1) 1) "sensor_id"
          2) "2"


### PR DESCRIPTION
Fixes Missing WITHLABELS keyword in `MGET Example with WITHLABELS option` section