### PR TITLE
Fix typo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ You can either get RedisTimeSeries setup in the cloud, in a Docker container or 
 
 ### Redis Cloud
 
-RedisTimeSeries is available on all Redis Cloud managed services.  Redis Cloud Essentials offers a completely free managed databbases up to 30MB.
+RedisTimeSeries is available on all Redis Cloud managed services. Redis Cloud Essentials offers a completely free managed database up to 30MB.
 
 [Get started here](https://redislabs.com/try-free/)
 


### PR DESCRIPTION
Fixes a typo -- "databbases" should be "databases".