### PR TITLE
Added support for binary data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,5 +51,15 @@ pack:
 run:
 	@$(MAKE) -C src run
 
+valgrind:
+	@$(MAKE) -C src $@
+
+run:
+	@$(MAKE) -C src $@
+
+gdb:
+	@$(MAKE) -C src $@
+
+
 # deploy:
 #	@make -C src deploy

--- a/README.md
+++ b/README.md
@@ -119,6 +119,28 @@ OK
    2) "42"
 ```
 
+It is also possible to store binary data (with redis-cli, we illustrate this with character strings).
+For doing this, simply add the **BLOB** keyword when creating the key.
+Since creating the key is also feasible with TS.ADD, the **BLOB** keyword can be added as an option to this command, too.
+
+Aggregation works with binary data as well, but obviously, only types of "last" and "first" are supported in this case.
+
+```sh
+$ redis-cli
+127.0.0.1:6379> TS.CREATE blob1 BLOB
+OK
+127.0.0.1:6379> TS.ADD blob1 * value1
+(integer) 1600765694862
+127.0.0.1:6379> TS.ADD blob1 * value2
+(integer) 1600765708510
+127.0.0.1:6379> TS.RANGE blob1 - +
+1) 1) (integer) 1600765694862
+   2) "value1"
+2) 1) (integer) 1600765708510
+   2) "value2"
+
+```
+
 ### Client libraries
 
 Some languages have client libraries that provide support for RedisTimeSeries commands:

--- a/src/Makefile
+++ b/src/Makefile
@@ -116,6 +116,7 @@ CC_FLAGS += $(CC_FLAGS.coverage)
 LD_FLAGS += $(LD_FLAGS.coverage)
 
 _SOURCES=\
+	blob.c \
 	chunk.c \
 	compaction.c \
 	compressed_chunk.c \

--- a/src/blob.c
+++ b/src/blob.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018-2019 Redis Labs Ltd. and Contributors
+ * Copyright 2020 IoT.BzH
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
+
+#include "blob.h"
+
+#include "redismodule.h"
+
+#include <string.h>
+#include "rmutil/alloc.h"
+
+#define EMPTY_BLOB ""
+#define EMPTY_BLOB_SIZE 1
+
+TSBlob *NewBlob(const char *data, size_t len) {
+    TSBlob *blob = RedisModule_Calloc(1, sizeof(TSBlob));
+    if (data == NULL || len == 0)
+        return blob;
+
+    blob->len = len;
+    blob->data = RedisModule_Alloc(blob->len);
+    memcpy(blob->data, data, blob->len);
+    return blob;
+}
+
+TSBlob *CopyBlob(const TSBlob *src) {
+    TSBlob *blob = RedisModule_Alloc(sizeof(TSBlob));
+    blob->len = src->len;
+    blob->data = RedisModule_Alloc(blob->len);
+    memcpy(blob->data, src->data, blob->len);
+    return blob;
+}
+
+void FreeBlob(TSBlob *blob) {
+    if (blob->data)
+        RedisModule_Free(blob->data);
+    RedisModule_Free(blob);
+}
+
+void RedisModule_SaveBlob(RedisModuleIO *io, const TSBlob *blob) {
+    if (!blob) {
+        RedisModule_SaveStringBuffer(io, EMPTY_BLOB, EMPTY_BLOB_SIZE);
+        return;
+    }
+    RedisModule_SaveStringBuffer(io, blob->data, blob->len);
+}
+
+TSBlob *RedisModule_LoadBlob(RedisModuleIO *io) {
+    size_t len;
+    char *data = RedisModule_LoadStringBuffer(io, &len);
+    return NewBlob(data, len);
+}

--- a/src/blob.h
+++ b/src/blob.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018-2019 Redis Labs Ltd. and Contributors
+ * Copyright 2020 IoT.BzH
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
+#ifndef BLOB_H
+#define BLOB_H
+
+#include "redismodule.h"
+
+typedef struct
+{
+    size_t len;
+    char *data;
+} TSBlob;
+
+TSBlob *NewBlob(const char *data, size_t len);
+TSBlob *CopyBlob(const TSBlob *src);
+void FreeBlob(TSBlob *blob);
+
+void RedisModule_SaveBlob(RedisModuleIO *io, const TSBlob *blob);
+TSBlob *RedisModule_LoadBlob(RedisModuleIO *io);
+
+#endif /* BLOB_H */

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -17,6 +17,7 @@ typedef struct Chunk
     Sample *samples;
     unsigned int num_samples;
     size_t size;
+    bool isBlob;
 } Chunk;
 
 typedef struct ChunkIterator
@@ -28,7 +29,7 @@ typedef struct ChunkIterator
     int options;
 } ChunkIterator;
 
-Chunk_t *Uncompressed_NewChunk(size_t sampleCount);
+Chunk_t *Uncompressed_NewChunk(bool isBlob, size_t sampleCount);
 void Uncompressed_FreeChunk(Chunk_t *chunk);
 
 /**
@@ -68,7 +69,7 @@ ChunkResult Uncompressed_ChunkIteratorGetPrev(ChunkIter_t *iterator, Sample *sam
 void Uncompressed_FreeChunkIterator(ChunkIter_t *iter);
 
 // RDB
-void Uncompressed_SaveToRDB(Chunk_t *chunk, struct RedisModuleIO *io);
-void Uncompressed_LoadFromRDB(Chunk_t **chunk, struct RedisModuleIO *io);
+void Uncompressed_SaveToRDB(Chunk_t *chunk, struct RedisModuleIO *io, bool blob);
+void Uncompressed_LoadFromRDB(Chunk_t **chunk, struct RedisModuleIO *io, bool blob);
 
 #endif

--- a/src/compaction.c
+++ b/src/compaction.c
@@ -5,6 +5,9 @@
  */
 #include "compaction.h"
 
+#include "blob.h"
+#include "generic_chunk.h"
+
 #include <ctype.h>
 #include <math.h> // sqrt
 #include <string.h>
@@ -22,6 +25,13 @@ typedef struct SingleValueContext
     double value;
     char isResetted;
 } SingleValueContext;
+
+typedef struct BlobValueContext
+{
+    TSBlob *blob;
+    double count;
+    char isResetted;
+} BlobValueContext;
 
 typedef struct AvgContext
 {
@@ -66,6 +76,115 @@ void SingleValueWriteContext(void *contextPtr, RedisModuleIO *io) {
 void SingleValueReadContext(void *contextPtr, RedisModuleIO *io) {
     SingleValueContext *context = (SingleValueContext *)contextPtr;
     context->value = RedisModule_LoadDouble(io);
+}
+
+/* Blobs */
+
+static void BlobValueReset(void *contextPtr) {
+    BlobValueContext *context = (BlobValueContext *)contextPtr;
+    if (context->blob) {
+        FreeBlob(context->blob);
+        context->blob = NULL;
+    }
+    context->count = 0;
+    context->isResetted = TRUE;
+}
+
+static void *BlobValueCreateContext() {
+    BlobValueContext *context = (BlobValueContext *)RedisModule_Alloc(sizeof(BlobValueContext));
+    context->blob = NULL;
+    BlobValueReset(context);
+    return context;
+}
+
+static void BlobCountAppendValue(void *contextPtr, double val) {
+    BlobValueContext *context = (BlobValueContext *)contextPtr;
+    (void)val;
+
+    context->count++;
+    context->isResetted = FALSE;
+}
+
+static int BlobCountValueFinalize(void *contextPtr, double *val) {
+    BlobValueContext *context = (BlobValueContext *)contextPtr;
+
+    if (context->isResetted)
+        return TSDB_ERROR;
+
+    *val = context->count;
+    return TSDB_OK;
+}
+
+static void BlobCountWriteContext(void *contextPtr, RedisModuleIO *io) {
+    BlobValueContext *context = (BlobValueContext *)contextPtr;
+    RedisModule_SaveDouble(io, context->count);
+}
+
+static void BlobCountReadContext(void *contextPtr, RedisModuleIO *io) {
+    BlobValueContext *context = (BlobValueContext *)contextPtr;
+    context->count = RedisModule_LoadDouble(io);
+}
+
+static void BlobFirstAppendValue(void *contextPtr, double value) {
+    SampleValue val;
+    VALUE_DOUBLE(&val) = value;
+
+    BlobValueContext *context = (BlobValueContext *)contextPtr;
+
+    if (!context->isResetted)
+        return;
+
+    context->isResetted = false;
+    TSBlob *srcblob = VALUE_BLOB(&val);
+
+    if (context->blob)
+        FreeBlob(context->blob);
+
+    context->blob = CopyBlob(srcblob);
+}
+
+static void BlobLastAppendValue(void *contextPtr, double value) {
+    SampleValue val;
+    VALUE_DOUBLE(&val) = value;
+
+    BlobValueContext *context = (BlobValueContext *)contextPtr;
+
+    TSBlob *srcblob = VALUE_BLOB(&val);
+    if (context->blob)
+        FreeBlob(context->blob);
+
+    context->blob = CopyBlob(srcblob);
+    context->isResetted = false;
+}
+
+static int BlobValueFinalize(void *contextPtr, double *val) {
+    BlobValueContext *context = (BlobValueContext *)contextPtr;
+
+    if (context->isResetted)
+        return TSDB_ERROR;
+
+    TSBlob **blob = (TSBlob **)val;
+    *blob = CopyBlob(context->blob);
+    return TSDB_OK;
+}
+
+static void BlobValueDeleteContext(void *contextPtr) {
+    BlobValueContext *context = (BlobValueContext *)contextPtr;
+
+    if (context->blob)
+        FreeBlob(context->blob);
+
+    RedisModule_Free(context);
+}
+
+static void BlobValueWriteContext(void *contextPtr, RedisModuleIO *io) {
+    BlobValueContext *context = (BlobValueContext *)contextPtr;
+    RedisModule_SaveBlob(io, context->blob);
+}
+
+static void BlobValueReadContext(void *contextPtr, RedisModuleIO *io) {
+    BlobValueContext *context = (BlobValueContext *)contextPtr;
+    context->blob = RedisModule_LoadBlob(io);
 }
 
 void *AvgCreateContext() {
@@ -395,6 +514,30 @@ static AggregationClass aggLast = { .createContext = SingleValueCreateContext,
                                     .readContext = SingleValueReadContext,
                                     .resetContext = SingleValueReset };
 
+static AggregationClass blobAggCount = { .createContext = BlobValueCreateContext,
+                                         .appendValue = BlobCountAppendValue,
+                                         .freeContext = BlobValueDeleteContext,
+                                         .finalize = BlobCountValueFinalize,
+                                         .writeContext = BlobCountWriteContext,
+                                         .readContext = BlobCountReadContext,
+                                         .resetContext = BlobValueReset };
+
+static AggregationClass blobAggFirst = { .createContext = BlobValueCreateContext,
+                                         .appendValue = BlobFirstAppendValue,
+                                         .freeContext = BlobValueDeleteContext,
+                                         .finalize = BlobValueFinalize,
+                                         .writeContext = BlobValueWriteContext,
+                                         .readContext = BlobValueReadContext,
+                                         .resetContext = BlobValueReset };
+
+static AggregationClass blobAggLast = { .createContext = BlobValueCreateContext,
+                                        .appendValue = BlobLastAppendValue,
+                                        .freeContext = BlobValueDeleteContext,
+                                        .finalize = BlobValueFinalize,
+                                        .writeContext = BlobValueWriteContext,
+                                        .readContext = BlobValueReadContext,
+                                        .resetContext = BlobValueReset };
+
 static AggregationClass aggRange = { .createContext = MaxMinCreateContext,
                                      .appendValue = MaxMinAppendValue,
                                      .freeContext = rm_free,
@@ -402,6 +545,18 @@ static AggregationClass aggRange = { .createContext = MaxMinCreateContext,
                                      .writeContext = MaxMinWriteContext,
                                      .readContext = MaxMinReadContext,
                                      .resetContext = MaxMinReset };
+
+AggregationClass *BlobAggClass(AggregationClass *class) {
+    AggregationClass *blobClass = class;
+    if (class == &aggCount)
+        blobClass = &blobAggCount;
+    else if (class == &aggFirst)
+        blobClass = &blobAggFirst;
+    else if (class == &aggLast)
+        blobClass = &blobAggLast;
+
+    return blobClass;
+}
 
 int StringAggTypeToEnum(const char *agg_type) {
     return StringLenAggTypeToEnum(agg_type, strlen(agg_type));
@@ -472,10 +627,13 @@ const char *AggTypeEnumToString(TS_AGG_TYPES_T aggType) {
         case TS_AGG_VAR_S:
             return "VAR.S";
         case TS_AGG_COUNT:
+        case TS_AGG_BLOB_COUNT:
             return "COUNT";
         case TS_AGG_FIRST:
+        case TS_AGG_BLOB_FIRST:
             return "FIRST";
         case TS_AGG_LAST:
+        case TS_AGG_BLOB_LAST:
             return "LAST";
         case TS_AGG_RANGE:
             return "RANGE";
@@ -513,10 +671,43 @@ AggregationClass *GetAggClass(TS_AGG_TYPES_T aggType) {
             return &aggLast;
         case TS_AGG_RANGE:
             return &aggRange;
+        case TS_AGG_BLOB_COUNT:
+            return &blobAggCount;
+        case TS_AGG_BLOB_FIRST:
+            return &blobAggFirst;
+        case TS_AGG_BLOB_LAST:
+            return &blobAggLast;
         case TS_AGG_NONE:
         case TS_AGG_INVALID:
         case TS_AGG_TYPES_MAX:
             break;
     }
     return NULL;
+}
+
+// the only supported aggregation types for blob data
+
+bool IsCompactionBlobFriendly(TS_AGG_TYPES_T aggType) {
+    return (aggType == TS_AGG_NONE || aggType == TS_AGG_COUNT || aggType == TS_AGG_FIRST ||
+            aggType == TS_AGG_LAST);
+}
+
+// returns true if the aggregated result is of type blob
+
+bool aggClassIsBlob(const AggregationClass *class) {
+    return (class == &blobAggFirst || class == &blobAggLast);
+}
+
+TS_AGG_TYPES_T BlobAggType(TS_AGG_TYPES_T aggType) {
+    switch (aggType) {
+        case TS_AGG_COUNT:
+            return TS_AGG_BLOB_COUNT;
+        case TS_AGG_FIRST:
+            return TS_AGG_BLOB_FIRST;
+        case TS_AGG_LAST:
+            return TS_AGG_BLOB_LAST;
+        default:
+            break;
+    }
+    return aggType;
 }

--- a/src/compaction.h
+++ b/src/compaction.h
@@ -28,4 +28,10 @@ int RMStringLenAggTypeToEnum(RedisModuleString *aggTypeStr);
 int StringLenAggTypeToEnum(const char *agg_type, size_t len);
 const char *AggTypeEnumToString(TS_AGG_TYPES_T aggType);
 
+bool IsCompactionBlobFriendly(TS_AGG_TYPES_T aggType);
+
+AggregationClass *BlobAggClass(AggregationClass *class);
+bool aggClassIsBlob(const AggregationClass *class);
+TS_AGG_TYPES_T BlobAggType(TS_AGG_TYPES_T aggType);
+
 #endif

--- a/src/compressed_chunk.h
+++ b/src/compressed_chunk.h
@@ -14,7 +14,7 @@
 #include <sys/types.h> // u_int_t
 
 // Initialize compressed chunk
-Chunk_t *Compressed_NewChunk(size_t size);
+Chunk_t *Compressed_NewChunk(bool, size_t size);
 void Compressed_FreeChunk(Chunk_t *chunk);
 Chunk_t *Compressed_SplitChunk(Chunk_t *chunk);
 
@@ -36,8 +36,8 @@ timestamp_t Compressed_GetFirstTimestamp(Chunk_t *chunk);
 timestamp_t Compressed_GetLastTimestamp(Chunk_t *chunk);
 
 // RDB
-void Compressed_SaveToRDB(Chunk_t *chunk, struct RedisModuleIO *io);
-void Compressed_LoadFromRDB(Chunk_t **chunk, struct RedisModuleIO *io);
+void Compressed_SaveToRDB(Chunk_t *chunk, struct RedisModuleIO *io, bool blob);
+void Compressed_LoadFromRDB(Chunk_t **chunk, struct RedisModuleIO *io, bool blob);
 
 /* Used in tests */
 u_int64_t getIterIdx(ChunkIter_t *iter);

--- a/src/consts.h
+++ b/src/consts.h
@@ -44,7 +44,10 @@ typedef enum {
     TS_AGG_STD_S,
     TS_AGG_VAR_P,
     TS_AGG_VAR_S,
-    TS_AGG_TYPES_MAX // 13
+    TS_AGG_BLOB_COUNT,
+    TS_AGG_BLOB_FIRST,
+    TS_AGG_BLOB_LAST,
+    TS_AGG_TYPES_MAX // 16
 } TS_AGG_TYPES_T;
 
 
@@ -61,6 +64,7 @@ typedef enum DuplicatePolicy {
 
 /* Series struct options */
 #define SERIES_OPT_UNCOMPRESSED 0x1
+#define SERIES_OPT_BLOB 0x2
 
 /* Chunk enum */
 typedef enum {

--- a/src/generic_chunk.c
+++ b/src/generic_chunk.c
@@ -69,15 +69,15 @@ ChunkResult handleDuplicateSample(DuplicatePolicy policy, Sample oldSample, Samp
         case DP_LAST:
             return CR_OK;
         case DP_MIN:
-            if (oldSample.value < newSample->value)
-                newSample->value = oldSample.value;
+            if (VALUE_DOUBLE(&oldSample.value) < VALUE_DOUBLE(&newSample->value))
+                VALUE_DOUBLE(&newSample->value) = VALUE_DOUBLE(&oldSample.value);
             return CR_OK;
         case DP_MAX:
-            if (oldSample.value > newSample->value)
-                newSample->value = oldSample.value;
+            if (VALUE_DOUBLE(&oldSample.value) > VALUE_DOUBLE(&newSample->value))
+                VALUE_DOUBLE(&newSample->value) = VALUE_DOUBLE(&oldSample.value);
             return CR_OK;
         case DP_SUM:
-            newSample->value += oldSample.value;
+            VALUE_DOUBLE(&newSample->value) += VALUE_DOUBLE(&oldSample.value);
             return CR_OK;
         default:
             return CR_ERR;
@@ -156,4 +156,18 @@ DuplicatePolicy DuplicatePolicyFromString(const char *input, size_t len) {
         }
     }
     return DP_INVALID;
+}
+
+void updateSampleValue(bool isblob, SampleValue *dest, const SampleValue *src) {
+    if (!isblob) {
+        VALUE_DOUBLE(dest) = VALUE_DOUBLE(src);
+        return;
+    }
+
+    TSBlob *blob = VALUE_BLOB(dest);
+    if (blob->data) {
+        RedisModule_Free(blob->data);
+    }
+    blob->data = VALUE_BLOB(src)->data;
+    blob->len = VALUE_BLOB(src)->len;
 }

--- a/src/generic_chunk.h
+++ b/src/generic_chunk.h
@@ -7,6 +7,7 @@
 #ifndef GENERIC__CHUNK_H
 #define GENERIC__CHUNK_H
 
+#include "blob.h"
 #include "consts.h"
 
 #include <stdio.h>  // printf
@@ -16,12 +17,28 @@
 #include <rmutil/strings.h>
 
 struct RedisModuleIO;
+struct RedisModuleString;
+
+// Must fit in 64 bits
+typedef struct
+{
+    union
+    {
+        double value;
+        TSBlob *buf;
+    } d;
+} SampleValue;
 
 typedef struct Sample
 {
     timestamp_t timestamp;
-    double value;
+    SampleValue value;
 } Sample;
+
+#define VALUE_DOUBLE(sampleValue) ((sampleValue)->d.value)
+#define VALUE_BLOB(sampleValue) ((sampleValue)->d.buf)
+
+void updateSampleValue(bool blob, SampleValue *dest, const SampleValue *src);
 
 typedef void Chunk_t;
 typedef void ChunkIter_t;
@@ -43,6 +60,7 @@ typedef struct UpsertCtx
 {
     Sample sample;
     Chunk_t *inChunk; // original chunk
+    bool isBlob;
 } UpsertCtx;
 
 typedef struct ChunkIterFuncs
@@ -54,7 +72,7 @@ typedef struct ChunkIterFuncs
 
 typedef struct ChunkFuncs
 {
-    Chunk_t *(*NewChunk)(size_t sampleCount);
+    Chunk_t *(*NewChunk)(bool isBlob, size_t sampleCount);
     void (*FreeChunk)(Chunk_t *chunk);
     Chunk_t *(*SplitChunk)(Chunk_t *chunk);
 
@@ -70,8 +88,8 @@ typedef struct ChunkFuncs
     u_int64_t (*GetLastTimestamp)(Chunk_t *chunk);
     u_int64_t (*GetFirstTimestamp)(Chunk_t *chunk);
 
-    void (*SaveToRDB)(Chunk_t *chunk, struct RedisModuleIO *io);
-    void (*LoadFromRDB)(Chunk_t **chunk, struct RedisModuleIO *io);
+    void (*SaveToRDB)(Chunk_t *chunk, struct RedisModuleIO *io, bool blob);
+    void (*LoadFromRDB)(Chunk_t **chunk, struct RedisModuleIO *io, bool blob);
 } ChunkFuncs;
 
 ChunkResult handleDuplicateSample(DuplicatePolicy policy, Sample oldSample, Sample *newSample);

--- a/src/module.c
+++ b/src/module.c
@@ -52,14 +52,16 @@ int TSDB_info(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     int is_debug = RMUtil_ArgExists("DEBUG", argv, argc, 1);
     if (is_debug) {
-        RedisModule_ReplyWithArray(ctx, 13 * 2);
+        RedisModule_ReplyWithArray(ctx, 14 * 2);
     } else {
-        RedisModule_ReplyWithArray(ctx, 12 * 2);
+        RedisModule_ReplyWithArray(ctx, 13 * 2);
     }
 
     long long skippedSamples;
     long long firstTimestamp = getFirstValidTimestamp(series, &skippedSamples);
 
+    RedisModule_ReplyWithSimpleString(ctx, "type");
+    RedisModule_ReplyWithSimpleString(ctx, SeriesIsBlob(series) ? "blob" : "numeric");
     RedisModule_ReplyWithSimpleString(ctx, "totalSamples");
     RedisModule_ReplyWithLongLong(ctx, SeriesGetNumSamples(series) - skippedSamples);
     RedisModule_ReplyWithSimpleString(ctx, "memoryUsage");
@@ -98,6 +100,7 @@ int TSDB_info(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     }
 
     RedisModule_ReplyWithSimpleString(ctx, "rules");
+
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
     CompactionRule *rule = series->rules;
     int ruleCount = 0;
@@ -274,6 +277,7 @@ static int replyUngroupedMultiRange(RedisModuleCtx *ctx,
 }
 
 int TSDB_generic_mrange(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool rev) {
+    TS_AGG_TYPES_T agg_type = TS_AGG_NONE;
     RedisModule_AutoMemory(ctx);
 
     if (argc < 4) {
@@ -289,7 +293,8 @@ int TSDB_generic_mrange(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
     }
 
     AggregationClass *aggObject = NULL;
-    const int aggregationResult = parseAggregationArgs(ctx, argv, argc, &time_delta, &aggObject);
+    const int aggregationResult =
+        parseAggregationArgs(ctx, argv, argc, &time_delta, &aggObject, &agg_type);
     if (aggregationResult == TSDB_ERROR) {
         return REDISMODULE_ERR;
     }
@@ -333,6 +338,7 @@ int TSDB_generic_mrange(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
         if (reduce_location < 0 || (argc - groupby_location != 4)) {
             return RedisModule_WrongArity(ctx);
         }
+
         MultiSeriesReduceOp reducerOp;
         if (parseMultiSeriesReduceOp(RedisModule_StringPtrLen(argv[reduce_location + 1], NULL),
                                      &reducerOp) != TSDB_OK) {
@@ -369,6 +375,7 @@ int TSDB_mrevrange(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 }
 
 int TSDB_generic_range(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool rev) {
+    TS_AGG_TYPES_T agg_type = TS_AGG_NONE;
     RedisModule_AutoMemory(ctx);
 
     if (argc < 4) {
@@ -394,14 +401,20 @@ int TSDB_generic_range(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, 
     }
 
     AggregationClass *aggObject = NULL;
-    int aggregationResult = parseAggregationArgs(ctx, argv, argc, &time_delta, &aggObject);
+    int aggregationResult =
+        parseAggregationArgs(ctx, argv, argc, &time_delta, &aggObject, &agg_type);
     if (aggregationResult == TSDB_ERROR) {
         return REDISMODULE_ERR;
     }
 
-    ReplySeriesRange(ctx, series, start_ts, end_ts, aggObject, time_delta, count, rev);
+    if (SeriesIsBlob(series) && !IsCompactionBlobFriendly(agg_type)) {
+        RTS_ReplyGeneralError(ctx, "Aggregation type is not allowed with blob series");
+        return REDISMODULE_ERR;
+    }
 
+    ReplySeriesRange(ctx, series, start_ts, end_ts, aggObject, time_delta, count, rev);
     RedisModule_CloseKey(key);
+
     return REDISMODULE_OK;
 }
 
@@ -435,8 +448,10 @@ static void handleCompaction(RedisModuleCtx *ctx,
         Series *destSeries = RedisModule_ModuleTypeGetValue(key);
 
         double aggVal;
+
         if (rule->aggClass->finalize(rule->aggContext, &aggVal) == TSDB_OK) {
-            SeriesAddSample(destSeries, rule->startCurrentTimeBucket, aggVal);
+            SampleValue sValue = { .d.value = aggVal };
+            SeriesAddSample(destSeries, rule->startCurrentTimeBucket, sValue);
         }
         rule->aggClass->resetContext(rule->aggContext);
         rule->startCurrentTimeBucket = currentTimestamp;
@@ -448,7 +463,7 @@ static void handleCompaction(RedisModuleCtx *ctx,
 static int internalAdd(RedisModuleCtx *ctx,
                        Series *series,
                        api_timestamp_t timestamp,
-                       double value,
+                       SampleValue value,
                        DuplicatePolicy dp_override) {
     timestamp_t lastTS = series->lastTimestamp;
     uint64_t retention = series->retentionTime;
@@ -472,12 +487,30 @@ static int internalAdd(RedisModuleCtx *ctx,
         // handle compaction rules
         CompactionRule *rule = series->rules;
         while (rule != NULL) {
-            handleCompaction(ctx, series, rule, timestamp, value);
+            handleCompaction(ctx, series, rule, timestamp, VALUE_DOUBLE(&value));
             rule = rule->nextRule;
         }
     }
     RedisModule_ReplyWithLongLong(ctx, timestamp);
     return REDISMODULE_OK;
+}
+
+static int parseValue(RedisModuleCtx *ctx,
+                      bool isBlob,
+                      const RedisModuleString *valueStr,
+                      SampleValue *sampleValue) {
+    if (isBlob) {
+        size_t len;
+        const char *data = RedisModule_StringPtrLen(valueStr, &len);
+        VALUE_BLOB(sampleValue) = NewBlob(data, len);
+        return 0;
+    }
+
+    const char *valueCStr = RedisModule_StringPtrLen(valueStr, NULL);
+    if ((fast_double_parser_c_parse_number(valueCStr, &VALUE_DOUBLE(sampleValue)) == NULL)) {
+        return -1;
+    }
+    return 0;
 }
 
 static inline int add(RedisModuleCtx *ctx,
@@ -487,10 +520,7 @@ static inline int add(RedisModuleCtx *ctx,
                       RedisModuleString **argv,
                       int argc) {
     RedisModuleKey *key = RedisModule_OpenKey(ctx, keyName, REDISMODULE_READ | REDISMODULE_WRITE);
-    double value;
-    const char *valueCStr = RedisModule_StringPtrLen(valueStr, NULL);
-    if ((fast_double_parser_c_parse_number(valueCStr, &value) == NULL))
-        return RTS_ReplyGeneralError(ctx, "TSDB: invalid value");
+    SampleValue value;
 
     long long timestampValue;
     if ((RedisModule_StringToLongLong(timestampStr, &timestampValue) != REDISMODULE_OK)) {
@@ -508,16 +538,16 @@ static inline int add(RedisModuleCtx *ctx,
 
     Series *series = NULL;
     DuplicatePolicy dp = DP_NONE;
+    CreateCtx cCtx = { 0 };
 
     if (argv != NULL && RedisModule_KeyType(key) == REDISMODULE_KEYTYPE_EMPTY) {
         // the key doesn't exist, lets check we have enough information to create one
-        CreateCtx cCtx = { 0 };
+
         if (parseCreateArgs(ctx, argv, argc, &cCtx) != REDISMODULE_OK) {
-            return REDISMODULE_ERR;
+            RedisModule_CloseKey(key);
+            return RTS_ReplyGeneralError(ctx, "TSDB: unable to parse create arguments");
         }
 
-        CreateTsKey(ctx, keyName, &cCtx, &series, &key);
-        SeriesCreateRulesFromGlobalConfig(ctx, keyName, series, cCtx.labels, cCtx.labelsCount);
     } else if (RedisModule_ModuleTypeGetType(key) != SeriesType) {
         return RTS_ReplyGeneralError(ctx, "TSDB: the key is not a TSDB key");
     } else {
@@ -528,8 +558,24 @@ static inline int add(RedisModuleCtx *ctx,
             return REDISMODULE_ERR;
         }
     }
+
+    bool isBlob = false;
+    if ((cCtx.options & SERIES_OPT_BLOB) == SERIES_OPT_BLOB || (series && SeriesIsBlob(series)))
+        isBlob = true;
+
+    if (parseValue(ctx, isBlob, valueStr, &value) != 0) {
+        RedisModule_CloseKey(key);
+        return RTS_ReplyGeneralError(ctx, "TSDB: unable to parse value");
+    }
+
+    if (!series) {
+        CreateTsKey(ctx, keyName, &cCtx, &series, &key);
+        SeriesCreateRulesFromGlobalConfig(ctx, keyName, series, cCtx.labels, cCtx.labelsCount);
+    }
+
     int rv = internalAdd(ctx, series, timestamp, value, dp);
     RedisModule_CloseKey(key);
+
     return rv;
 }
 
@@ -755,6 +801,12 @@ int TSDB_createRule(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (!statusD) {
         return REDISMODULE_ERR;
     }
+
+    if (SeriesIsBlob(destSeries) && (aggType == TS_AGG_BLOB_COUNT || aggType == TS_AGG_COUNT))
+        return RTS_ReplyGeneralError(
+            ctx,
+            "TSDB: the destination key is of binary type and cannot hold an aggregation count");
+
     srcKeyName = RedisModule_CreateStringFromString(ctx, srcKeyName);
     if (!SeriesSetSrcRule(destSeries, srcKeyName)) {
         return RTS_ReplyGeneralError(ctx, "TSDB: the destination key already has a rule");
@@ -796,11 +848,17 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             return REDISMODULE_ERR;
         }
 
+        if ((cCtx.options & SERIES_OPT_BLOB) == SERIES_OPT_BLOB)
+            return RTS_ReplyGeneralError(ctx,
+                                         "TSDB: Creating blob is forbidden with this function");
+
         CreateTsKey(ctx, keyName, &cCtx, &series, &key);
         SeriesCreateRulesFromGlobalConfig(ctx, keyName, series, cCtx.labels, cCtx.labelsCount);
     }
 
     series = RedisModule_ModuleTypeGetValue(key);
+    if (SeriesIsBlob(series))
+        return RTS_ReplyGeneralError(ctx, "TSDB: Blobs are forbidden with this function");
 
     double incrby = 0;
     if (RMUtil_ParseArgs(argv, argc, 2, "d", &incrby) != REDISMODULE_OK) {
@@ -821,15 +879,16 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             ctx, "TSDB: for incrby/decrby, timestamp should be newer than the lastest one");
     }
 
-    double result = series->lastValue;
+    double result = VALUE_DOUBLE(&series->lastValue);
     RMUtil_StringToLower(argv[0]);
     if (RMUtil_StringEqualsC(argv[0], "ts.incrby")) {
         result += incrby;
     } else {
         result -= incrby;
     }
+    SampleValue sValue = { .d.value = result };
 
-    int rv = internalAdd(ctx, series, currentUpdatedTime, result, DP_LAST);
+    int rv = internalAdd(ctx, series, currentUpdatedTime, sValue, DP_LAST);
     RedisModule_ReplicateVerbatim(ctx);
     RedisModule_CloseKey(key);
     return rv;

--- a/src/query_language.c
+++ b/src/query_language.c
@@ -110,6 +110,10 @@ int parseCreateArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, Cre
         return TSDB_ERROR;
     }
 
+    if (RMUtil_ArgIndex("BLOB", argv, argc) > 0) {
+        cCtx->options |= SERIES_OPT_UNCOMPRESSED | SERIES_OPT_BLOB;
+    }
+
     return REDISMODULE_OK;
 }
 
@@ -157,7 +161,8 @@ int parseAggregationArgs(RedisModuleCtx *ctx,
                          RedisModuleString **argv,
                          int argc,
                          api_timestamp_t *time_delta,
-                         AggregationClass **agg_object) {
+                         AggregationClass **agg_object,
+                         TS_AGG_TYPES_T *type) {
     int agg_type;
     int result = _parseAggregationArgs(ctx, argv, argc, time_delta, &agg_type);
     if (result == TSDB_OK) {
@@ -166,6 +171,8 @@ int parseAggregationArgs(RedisModuleCtx *ctx,
             RTS_ReplyGeneralError(ctx, "TSDB: Failed to retrieve aggregation class");
             return TSDB_ERROR;
         }
+        if (type)
+            *type = agg_type;
         return TSDB_OK;
     } else {
         return result;

--- a/src/query_language.h
+++ b/src/query_language.h
@@ -37,7 +37,8 @@ int parseAggregationArgs(RedisModuleCtx *ctx,
                          RedisModuleString **argv,
                          int argc,
                          api_timestamp_t *time_delta,
-                         AggregationClass **agg_object);
+                         AggregationClass **agg_object,
+                         TS_AGG_TYPES_T *type);
 
 int parseRangeArguments(RedisModuleCtx *ctx,
                         Series *series,

--- a/src/reply.h
+++ b/src/reply.h
@@ -32,7 +32,7 @@ int ReplySeriesRange(RedisModuleCtx *ctx,
 
 void ReplyWithSeriesLabels(RedisModuleCtx *ctx, const Series *series);
 
-void ReplyWithSample(RedisModuleCtx *ctx, u_int64_t timestamp, double value);
+void ReplyWithSample(RedisModuleCtx *ctx, bool isBlob, u_int64_t timestamp, SampleValue value);
 
 void ReplyWithSeriesLastDatapoint(RedisModuleCtx *ctx, const Series *series);
 

--- a/src/series_iterator.c
+++ b/src/series_iterator.c
@@ -180,7 +180,7 @@ ChunkResult SeriesIteratorGetNextAggregated(SeriesIterator *iterator, Sample *cu
                 if (iterator->aggregation->finalize(iterator->aggregationContext, &value) ==
                     TSDB_OK) {
                     currentSample->timestamp = iterator->aggregationLastTimestamp;
-                    currentSample->value = value;
+                    VALUE_DOUBLE(&currentSample->value) = value; // WARNING here
                     hasSample = TRUE;
                     iterator->aggregation->resetContext(iterator->aggregationContext);
                 }
@@ -190,7 +190,8 @@ ChunkResult SeriesIteratorGetNextAggregated(SeriesIterator *iterator, Sample *cu
                 (internalSample.timestamp % iterator->aggregationTimeDelta);
         }
         iterator->aggregationIsFirstSample = FALSE;
-        iterator->aggregation->appendValue(iterator->aggregationContext, internalSample.value);
+        iterator->aggregation->appendValue(iterator->aggregationContext,
+                                           VALUE_DOUBLE(&internalSample.value));
         if (hasSample) {
             return CR_OK;
         }
@@ -204,7 +205,7 @@ ChunkResult SeriesIteratorGetNextAggregated(SeriesIterator *iterator, Sample *cu
             double value;
             if (iterator->aggregation->finalize(iterator->aggregationContext, &value) == TSDB_OK) {
                 currentSample->timestamp = iterator->aggregationLastTimestamp;
-                currentSample->value = value;
+                VALUE_DOUBLE(&currentSample->value) = value; // WARNING here
             }
             iterator->aggregationIsFinalized = TRUE;
             return CR_OK;

--- a/src/tsdb.h
+++ b/src/tsdb.h
@@ -43,7 +43,7 @@ typedef struct Series
     short options;
     CompactionRule *rules;
     timestamp_t lastTimestamp;
-    double lastValue;
+    SampleValue lastValue;
     Label *labels;
     RedisModuleString *keyName;
     size_t labelsCount;
@@ -90,10 +90,10 @@ int MultiSerieReduce(Series *dest,
                      AggregationClass *agg,
                      int64_t time_delta,
                      bool rev);
-int SeriesAddSample(Series *series, api_timestamp_t timestamp, double value);
+int SeriesAddSample(Series *series, api_timestamp_t timestamp, SampleValue value);
 int SeriesUpsertSample(Series *series,
                        api_timestamp_t timestamp,
-                       double value,
+                       SampleValue value,
                        DuplicatePolicy dp_override);
 int SeriesUpdateLastSample(Series *series);
 int SeriesDeleteRule(Series *series, RedisModuleString *destKey);
@@ -125,6 +125,8 @@ timestamp_t CalcWindowStart(timestamp_t timestamp, size_t window);
 // return first timestamp in retention window, and set `skipped` to number of samples outside of
 // retention
 timestamp_t getFirstValidTimestamp(Series *series, long long *skipped);
+
+bool SeriesIsBlob(const Series *series);
 
 CompactionRule *NewRule(RedisModuleString *destKey, int aggType, uint64_t timeBucket);
 

--- a/src/unittests_compressed_chunk.c
+++ b/src/unittests_compressed_chunk.c
@@ -23,11 +23,11 @@ MU_TEST(test_compressed_upsert) {
     float minV = 0.0;
     float maxV = 100.0;
     for (size_t chunk_size = 2; chunk_size < max_chunk_size; chunk_size += 64) {
-        CompressedChunk *chunk = Compressed_NewChunk(chunk_size);
+        CompressedChunk *chunk = Compressed_NewChunk(false, chunk_size);
         mu_assert(chunk != NULL, "create compressed chunk");
         for (size_t i = 1; i <= total_data_points; i++) {
             float value = minV + (float)rand() / ((float)RAND_MAX / maxV);
-            Sample sample = { .timestamp = i, .value = value };
+            Sample sample = { .timestamp = i, .value.d.value = value };
             total_upserts++;
             UpsertCtx uCtx = {
                 .inChunk = chunk,
@@ -46,10 +46,10 @@ MU_TEST(test_compressed_fail_appendInteger) {
     // ensureAddSample -> Compressed_AddSample -> Compressed_Append -> appendInteger
     srand((unsigned int)time(NULL));
     const size_t chunk_size = 4096; // 4096 bytes (data) chunck
-    CompressedChunk *chunk = Compressed_NewChunk(chunk_size);
+    CompressedChunk *chunk = Compressed_NewChunk(false, chunk_size);
     mu_assert(chunk != NULL, "create compressed chunk");
-    Sample s1 = { .timestamp = 10, .value = 5.0 };
-    Sample s2 = { .timestamp = 6, .value = 10.0 };
+    Sample s1 = { .timestamp = 10, .value.d.value = 5.0 };
+    Sample s2 = { .timestamp = 6, .value.d.value = 10.0 };
     Compressed_AddSample(chunk, &s1);
     mu_assert_int_eq(1, Compressed_ChunkNumOfSample(chunk));
     int size = 0;
@@ -68,7 +68,7 @@ MU_TEST(test_compressed_fail_appendInteger) {
     mu_assert_int_eq(6, Compressed_GetFirstTimestamp(chunk));
     mu_assert_int_eq(10, Compressed_GetLastTimestamp(chunk));
     for (size_t i = 0; i < 10; i++) {
-        s2.value = minV + (float)rand() / ((float)RAND_MAX / maxV);
+        VALUE_DOUBLE(&s2.value) = minV + (float)rand() / (float)(RAND_MAX / maxV);
         Compressed_UpsertSample(&uCtx, &size, DP_LAST);
         // ensure we're not adding more datapoints and only overwritting previous ones
         mu_assert_int_eq(2, Compressed_ChunkNumOfSample(chunk));
@@ -86,7 +86,8 @@ MU_TEST(test_compressed_fail_appendInteger) {
     mu_assert_int_eq(10, Compressed_GetLastTimestamp(chunk2));
 
     for (size_t i = 1; i < 6; i++) {
-        Sample s3 = { .timestamp = i, .value = minV + (float)rand() / ((float)RAND_MAX / maxV) };
+        Sample s3 = { .timestamp = i,
+                      .value.d.value = minV + (float)rand() / (float)(RAND_MAX / maxV) };
         UpsertCtx uCtxS3 = {
             .inChunk = chunk,
             .sample = s3,
@@ -104,7 +105,7 @@ MU_TEST(test_compressed_fail_appendInteger) {
 MU_TEST(test_Compressed_SplitChunk_empty) {
     srand((unsigned int)time(NULL));
     const size_t chunk_size = 4096; // 4096 bytes (data) chunck
-    CompressedChunk *chunk = Compressed_NewChunk(chunk_size);
+    CompressedChunk *chunk = Compressed_NewChunk(false, chunk_size);
     mu_assert(chunk != NULL, "create compressed chunk");
 
     CompressedChunk *chunk2 = Compressed_SplitChunk(chunk);
@@ -119,12 +120,12 @@ MU_TEST(test_Compressed_SplitChunk_empty) {
 MU_TEST(test_Compressed_SplitChunk_odd) {
     srand((unsigned int)time(NULL));
     const size_t chunk_size = 4096; // 4096 bytes (data) chunck
-    CompressedChunk *chunk = Compressed_NewChunk(chunk_size);
+    CompressedChunk *chunk = Compressed_NewChunk(false, chunk_size);
     mu_assert(chunk != NULL, "create compressed chunk");
 
-    Sample s1 = { .timestamp = 4, .value = 5.0 };
-    Sample s2 = { .timestamp = 50, .value = 10.0 };
-    Sample s3 = { .timestamp = 100, .value = 10.0 };
+    Sample s1 = { .timestamp = 4, .value.d.value = 5.0 };
+    Sample s2 = { .timestamp = 50, .value.d.value = 10.0 };
+    Sample s3 = { .timestamp = 100, .value.d.value = 10.0 };
     ChunkResult rv = Compressed_AddSample(chunk, &s1);
     mu_assert(rv == CR_OK, "add sample s1");
 
@@ -148,7 +149,7 @@ MU_TEST(test_Compressed_SplitChunk_odd) {
 MU_TEST(test_Compressed_SplitChunk_force_realloc) {
     srand((unsigned int)time(NULL));
     const size_t chunk_size = 4096; // 4096 bytes (data) chunck
-    CompressedChunk *chunk = Compressed_NewChunk(chunk_size);
+    CompressedChunk *chunk = Compressed_NewChunk(false, chunk_size);
     mu_assert(chunk != NULL, "create compressed chunk");
     ChunkResult rv = CR_OK;
     int64_t ts = 1;
@@ -157,7 +158,7 @@ MU_TEST(test_Compressed_SplitChunk_force_realloc) {
     // adding 1,3,5....
     while (rv != CR_END) {
         double tsv = ts * 1.0;
-        Sample s1 = { .timestamp = ts, .value = tsv };
+        Sample s1 = { .timestamp = ts, .value.d.value = tsv };
         rv = Compressed_AddSample(chunk, &s1);
         mu_assert(rv == CR_OK || rv == CR_END, "add sample");
         if (rv != CR_END) {
@@ -172,7 +173,7 @@ MU_TEST(test_Compressed_SplitChunk_force_realloc) {
     mu_assert_int_eq(chunk_size, chunk->size);
 
     // Now we're at the max of the chunck's capacity
-    Sample s3 = { .timestamp = 2, .value = 10.0 };
+    Sample s3 = { .timestamp = 2, .value.d.value = 10.0 };
     UpsertCtx uCtxS3 = {
         .inChunk = chunk,
         .sample = s3,

--- a/tests/flow/test_helper_classes.py
+++ b/tests/flow/test_helper_classes.py
@@ -168,9 +168,25 @@ class TSInfo(object):
     first_time_stamp = None
     chunk_size_bytes = None
     chunk_type = None
+    type = None
+
+    def __str__(self):
+        return "rules:" + str(self.rules) + \
+               ",labels:"+str(self.labels) +\
+               ",sourceKey:"+str(self.sourceKey)+\
+               ",chunk_count:"+str(self.chunk_count)+\
+               ",memory_usage:"+str(self.memory_usage)+\
+               ",total_samples:"+str(self.total_samples)+\
+               ",retention_msecs:"+str(self.retention_msecs)+\
+               ",last_time_stamp:"+str(self.last_time_stamp)+\
+               ",first_time_stamp:"+str(self.first_time_stamp)+\
+               ",chunk_size_bytes:"+str(self.chunk_size_bytes)+\
+               ",chunk_type:"+str(self.chunk_type)+\
+               ",type:"+str(self.type)
 
     def __init__(self, args):
         response = dict(zip(args[::2], args[1::2]))
+
         if b'rules' in response: self.rules = response[b'rules']
         if b'sourceKey' in response: self.sourceKey = response[b'sourceKey']
         if b'chunkCount' in response: self.chunk_count = response[b'chunkCount']
@@ -182,6 +198,7 @@ class TSInfo(object):
         if b'firstTimestamp' in response: self.first_time_stamp = response[b'firstTimestamp']
         if b'chunkSize' in response: self.chunk_size_bytes = response[b'chunkSize']
         if b'chunkType' in response: self.chunk_type = response[b'chunkType']
+        if b'type' in response: self.type = response[b'type']
 
     def __eq__(self, other):
         if not isinstance(other, TSInfo):
@@ -194,4 +211,5 @@ class TSInfo(object):
                self.retention_msecs == other.retention_msecs and \
                self.last_time_stamp == other.last_time_stamp and \
                self.first_time_stamp == other.first_time_stamp and \
-               self.chunk_size_bytes == other.chunk_size_bytes
+               self.chunk_size_bytes == other.chunk_size_bytes and \
+               self.type == other.type

--- a/tests/flow/test_ts_blob.py
+++ b/tests/flow/test_ts_blob.py
@@ -1,0 +1,143 @@
+import math
+import time
+
+import sys
+
+import pytest
+import redis
+from RLTest import Env
+from test_helper_classes import SAMPLE_SIZE, _get_ts_info
+
+def test_blob():
+
+    with Env().getConnection() as r:
+
+        r.execute_command('ts.create', 'blob1', 'BLOB')
+
+        assert b'blob' == _get_ts_info(r, 'blob1').type
+        r.execute_command('ts.add', 'blob2', 1, 'value1', 'BLOB')
+        assert b'blob' == _get_ts_info(r, 'blob1').type
+        res = r.execute_command('ts.range', 'blob2', '-', '+')
+
+        assert len(res) == 1
+        assert res[0][0] == 1
+        assert res[0][1] == b'value1'
+        r.execute_command('ts.add', 'blob2', 2, 'value2' )
+        r.execute_command('ts.add', 'blob2', 3, 'value3' )
+        res = r.execute_command('ts.range', 'blob2', '-', '+')
+
+        assert len(res) == 3
+        ### upsert ###
+        r.execute_command('ts.add', 'blob2', 2, 'new_value2')
+        res = r.execute_command('ts.range', 'blob2', '-', '+')
+
+        assert len(res) == 3
+
+        assert res[0][0] == 1
+        assert res[0][1] == b'value1'
+        assert res[1][0] == 2
+        assert res[1][1] == b'new_value2'
+        assert res[2][0] == 3
+        assert res[2][1] == b'value3'
+
+        ### aggregation count ###
+        res = r.execute_command('ts.range', 'blob2', '-', '+', 'AGGREGATION', 'count', 10)
+
+        assert res[0][1] == b'3'
+
+        ### Forbidden commands ###
+        forbidden = False;
+
+        try:
+            res = r.execute_command('ts.incrby', 'blob2', 1)
+        except:
+            forbidden = True;
+
+        assert forbidden == True
+
+        forbidden = False;
+
+        try:
+	        res = r.execute_command('ts.decrby', 'blob2', 1)
+        except:
+            forbidden = True;
+
+        assert forbidden == True
+
+	    ### downsampling ###
+        res = r.execute_command('ts.create', 'blob3', 'BLOB')
+        res = r.execute_command('ts.create', 'blob3_downsample_first', 'BLOB')
+        res = r.execute_command('ts.create', 'blob3_downsample_last', 'BLOB')
+        res = r.execute_command('ts.create', 'blob3_count', 'BLOB')
+
+        res = r.execute_command('ts.createrule', 'blob3', 'blob3_downsample_last', 'AGGREGATION', 'last', 3)
+        res = r.execute_command('ts.createrule', 'blob3', 'blob3_downsample_first', 'AGGREGATION', 'first', 3)
+
+        forbidden = False;
+
+        try:
+            res = r.execute_command('ts.createrule', 'blob3', 'blob3_count', 'AGGREGATION', 'count', 3)
+        except:
+            # must catch 'TSDB: the destination key is of binary type and cannot hold an aggregation count'
+            forbidden = True;
+
+        assert forbidden == True
+
+        # re-create it with scalar type
+        r.execute_command('del', 'blob3_count')
+        res = r.execute_command('ts.create', 'blob3_count')
+        res = r.execute_command('ts.createrule', 'blob3', 'blob3_count', 'AGGREGATION', 'count', 3)
+        # test save of empty aggregated count
+
+        for i in range(1,10):
+            r.execute_command('ts.add', 'blob3', i, 'value'+str(i) )
+
+        res = r.execute_command('ts.range', 'blob3_downsample_last', '-', '+')
+
+        assert res[0][0] == 0
+        assert res[0][1] == b'value2'
+
+        assert res[1][0] == 3
+        assert res[1][1] == b'value5'
+
+        assert res[2][0] == 6
+        assert res[2][1] == b'value8'
+
+        res = r.execute_command('ts.range', 'blob3_downsample_first', '-', '+')
+
+        assert res[0][0] == 0
+        assert res[0][1] == b'value1'
+
+        assert res[1][0] == 3
+        assert res[1][1] == b'value3'
+
+        assert res[2][0] == 6
+        assert res[2][1] == b'value6'
+
+        res = r.execute_command('ts.range', 'blob3_count', '-', '+')
+        assert len(res) == 3
+
+        # test save of empty blob
+        res = r.execute_command('ts.create', 'empty', 'BLOB')
+
+        # When server is started with slaves, a
+        # "Background save already in progress" can happen.
+
+        while True:
+            try:
+                res = r.execute_command('SAVE')
+            except Exception as err:
+                print(str(err), " -> retrying")
+                time.sleep(1);
+            else:
+                break;
+
+        r.execute_command('DUMP', 'blob3')
+        r.execute_command('del', 'blob3')
+
+        res = r.execute_command('ts.range', 'blob3_downsample_last', '-', '+')
+        ### Test after deletion of source (blob must be unchanged) ###
+
+        assert res[0][1] == b'value2'
+        assert res[1][1] == b'value5'
+        assert res[2][1] == b'value8'

--- a/tests/flow/test_ts_create.py
+++ b/tests/flow/test_ts_create.py
@@ -77,7 +77,7 @@ def test_uncompressed():
         assert [[1, b'3.5'], [2, b'4.5'], [3, b'5.5']] == \
                r.execute_command('ts.range not_compressed 0 -1')
         info = _get_ts_info(r, 'not_compressed')
-        assert info.total_samples == 3 and info.memory_usage == 4136
+        assert info.total_samples == 3 and info.memory_usage == 4144
 
         # rdb load
         data = r.execute_command('dump', 'not_compressed')
@@ -88,7 +88,7 @@ def test_uncompressed():
         assert [[1, b'3.5'], [2, b'4.5'], [3, b'5.5']] == \
                r.execute_command('ts.range not_compressed 0 -1')
         info = _get_ts_info(r, 'not_compressed')
-        assert info.total_samples == 3 and info.memory_usage == 4136
+        assert info.total_samples == 3 and info.memory_usage == 4144
         # test deletion
         assert r.delete('not_compressed')
 

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -245,6 +245,7 @@ def test_sanity():
         actual_result = r.execute_command('TS.range', 'tester', start_ts, start_ts + samples_count)
         assert expected_result == actual_result
         expected_result = [
+            b'type', b'numeric',
             b'totalSamples', 1500, b'memoryUsage', 1166,
             b'firstTimestamp', start_ts, b'chunkCount', 1,
             b'labels', [[b'name', b'brown'], [b'color', b'pink']],


### PR DESCRIPTION
The RedisTimeSeries API is cool, but makes a strong presumption on the
fact that the timestamped data is of type double, that allows simple
maths on aggregation functions. All the rest of the API (range
queries, labelling, downsampling, rules ... ) is of interest for
non-scalar data.
This commit adds support for binary data. In can coexist with
scalar data, so that the API remains 100% compatible.
Just like scalar time series, binary time series can be created wihh
TS.CREATE or TS.ADD, just by adding the 'BLOB' keyword in the command.

Aggregation is supported but obviously, performing maths on blob
in nonsense, so that only aggregation types of 'count', 'first'
and 'last' are allowed.

Persistence on disk is also supported.

The testsuite has been completed with the test of the new
features, and passes 100%

Signed-off-by: Thierry Bultel <thierry.bultel@iot.bzh>