### PR TITLE
Support multiple duplicate sample policies (#521)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -21,8 +21,9 @@ Optional args:
    Adding this flag will keep data in an uncompressed form. Compression not only saves
    memory but usually improve performance due to lower number of memory accesses. 
  * CHUNK_SIZE - amount of memory, in bytes, allocated for data. Default: 4000.
- * DUPLICATE_POLICY - configure what to do on duplicate sample, possible values: BLOCK, FIRST, LAST, MIN, MAX.
+ * DUPLICATE_POLICY - configure what to do on duplicate sample.
    When this is not set, the server-wide default will be used. 
+   For further details: [Duplicate sample policy](configuration.md#DUPLICATE_POLICY).
  * labels - Set of label-value pairs that represent metadata labels of the key
 
 #### Complexity
@@ -83,7 +84,7 @@ These arguments are optional because they can be set by TS.CREATE:
     * When set to 0, the series is not trimmed at all
  * UNCOMPRESSED - Changes data storage from compressed (by default) to uncompressed
  * CHUNK_SIZE - amount of memory, in bytes, allocated for data. Default: 4000.
- * ON_DUPLICATE - overwrite key and database configuration for `DUPLICATE_POLICY`.
+ * ON_DUPLICATE - overwrite key and database configuration for `DUPLICATE_POLICY`. [See Duplicate sample policy](configuration.md#DUPLICATE_POLICY)
  * labels - Set of label-value pairs that represent metadata labels of the key
 
 If this command is used to add data to an existing timeseries, `retentionTime` and `labels` are ignored.
@@ -519,7 +520,7 @@ Array-reply, specifically:
 * retentionTime - Retention time, in milliseconds, for the time series.
 * chunkCount - Number of Memory Chunks used for the time series.
 * chunkSize - amount of memory, in bytes, allocated for data.
-* duplicatePolicy - Duplicate sample handling policy.
+* duplicatePolicy - [Duplicate sample policy](configuration.md#DUPLICATE_POLICY).
 * labels - A nested array of label-value pairs that represent the metadata labels of the time series.
 * sourceKey - Key name for source time series in case the current series is a target of a [rule](#tscreaterule).
 * rules - A nested array of compaction [rules](#tscreaterule) of the time series.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -32,7 +32,7 @@ TS.CREATE complexity is O(1).
 #### Create Example
 
 ```sql
-TS.CREATE temperature:2:32 RETENTION 60000 LABELS sensor_id 2 area_id 32
+TS.CREATE temperature:2:32 RETENTION 60000 DUPLICATE_POLICY MAX LABELS sensor_id 2 area_id 32
 ```
 
 ## Delete

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -518,7 +518,7 @@ Array-reply, specifically:
 * lastTimestamp - Last timestamp present in the time series.
 * retentionTime - Retention time, in milliseconds, for the time series.
 * chunkCount - Number of Memory Chunks used for the time series.
-* chunkSize - Maximum Number of samples per Memory Chunk.
+* chunkSize - amount of memory, in bytes, allocated for data.
 * duplicatePolicy - Duplicate sample handling policy.
 * labels - A nested array of label-value pairs that represent the metadata labels of the time series.
 * sourceKey - Key name for source time series in case the current series is a target of a [rule](#tscreaterule).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -21,7 +21,7 @@ Optional args:
    Adding this flag will keep data in an uncompressed form. Compression not only saves
    memory but usually improve performance due to lower number of memory accesses. 
  * CHUNK_SIZE - amount of memory, in bytes, allocated for data. Default: 4000.
- * DUPLICATE_POLICY - configure what to do on duplicate sample, possible values: BLOCK, FIRST, LAST.
+ * DUPLICATE_POLICY - configure what to do on duplicate sample, possible values: BLOCK, FIRST, LAST, MIN, MAX.
    When this is not set, the server-wide default will be used. 
  * labels - Set of label-value pairs that represent metadata labels of the key
 
@@ -70,7 +70,7 @@ TS.ALTER temperature:2:32 LABELS sensor_id 2 area_id 32 sub_area_id 15
 Append (or create and append) a new sample to the series.
 
 ```sql
-TS.ADD key timestamp value [RETENTION retentionTime] [UNCOMPRESSED] [CHUNK_SIZE size] [LABELS label value..]
+TS.ADD key timestamp value [RETENTION retentionTime] [UNCOMPRESSED] [CHUNK_SIZE size] [ON_DUPLICATE policy] [LABELS label value..]
 ```
 
 * timestamp - UNIX timestamp of the sample. `*` can be used for automatic timestamp (using the system clock)
@@ -83,6 +83,7 @@ These arguments are optional because they can be set by TS.CREATE:
     * When set to 0, the series is not trimmed at all
  * UNCOMPRESSED - Changes data storage from compressed (by default) to uncompressed
  * CHUNK_SIZE - amount of memory, in bytes, allocated for data. Default: 4000.
+ * ON_DUPLICATE - overwrite key and database configuration for `DUPLICATE_POLICY`.
  * labels - Set of label-value pairs that represent metadata labels of the key
 
 If this command is used to add data to an existing timeseries, `retentionTime` and `labels` are ignored.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -21,6 +21,8 @@ Optional args:
    Adding this flag will keep data in an uncompressed form. Compression not only saves
    memory but usually improve performance due to lower number of memory accesses. 
  * CHUNK_SIZE - amount of memory, in bytes, allocated for data. Default: 4000.
+ * DUPLICATE_POLICY - configure what to do on duplicate sample, possible values: BLOCK, FIRST, LAST.
+   When this is not set, the server-wide default will be used. 
  * labels - Set of label-value pairs that represent metadata labels of the key
 
 #### Complexity
@@ -515,7 +517,8 @@ Array-reply, specifically:
 * lastTimestamp - Last timestamp present in the time series.
 * retentionTime - Retention time, in milliseconds, for the time series.
 * chunkCount - Number of Memory Chunks used for the time series.
-* maxSamplesPerChunk - Maximum Number of samples per Memory Chunk.
+* chunkSize - Maximum Number of samples per Memory Chunk.
+* duplicatePolicy - Duplicate sample handling policy.
 * labels - A nested array of label-value pairs that represent the metadata labels of the time series.
 * sourceKey - Key name for source time series in case the current series is a target of a [rule](#tscreaterule).
 * rules - A nested array of compaction [rules](#tscreaterule) of the time series.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,5 +64,26 @@ the default retention for newly created keys that do not have a an override.
 #### Example
 
 ```
-$ redis-server --loadmodule ./redistimeseries.so 20
+$ redis-server --loadmodule ./redistimeseries.so RETENTION_POLICY 20
+```
+
+### DUPLICATE_POLICY
+
+Policy that will define handling of duplicate samples.
+The following are the possible policies:
+* BlOCK
+* FIRST
+* LAST
+
+#### Precedence order
+Since the duplication policy can be provided at different levels, the actual precedence of the used policy will be:
+
+1. TS.ADD input
+2. Key level policy
+3. Module configuration (AKA server-wide)
+
+#### Example
+
+```
+$ redis-server --loadmodule ./redistimeseries.so DUPLICATE_POLICY LAST
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,9 @@ Since the duplication policy can be provided at different levels, the actual pre
 2. Key level policy
 3. Module configuration (AKA database-wide)
 
+#### Default configuration
+The default policy for database-wide is `BLOCK`, new and pre-existing keys will have no default policy.
+
 #### Example
 
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,16 +71,18 @@ $ redis-server --loadmodule ./redistimeseries.so RETENTION_POLICY 20
 
 Policy that will define handling of duplicate samples.
 The following are the possible policies:
-* BlOCK
+* BLOCK
 * FIRST
 * LAST
+* MIN
+* MAX
 
 #### Precedence order
 Since the duplication policy can be provided at different levels, the actual precedence of the used policy will be:
 
 1. TS.ADD input
 2. Key level policy
-3. Module configuration (AKA server-wide)
+3. Module configuration (AKA database-wide)
 
 #### Example
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,11 +71,11 @@ $ redis-server --loadmodule ./redistimeseries.so RETENTION_POLICY 20
 
 Policy that will define handling of duplicate samples.
 The following are the possible policies:
-* BLOCK
-* FIRST
-* LAST
-* MIN
-* MAX
+* `BLOCK` - an error will occur for any out of order sample
+* `FIRST` - ignore the new value
+* `LAST` - override with latest value
+* `MIN` - only override if the value is lower than the existing value
+* `MAX` - only override if the value is higher than the existing value
 
 #### Precedence order
 Since the duplication policy can be provided at different levels, the actual precedence of the used policy will be:

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -115,7 +115,7 @@ static void upsertChunk(Chunk *chunk, size_t idx, Sample *sample) {
  * @param size
  * @return
  */
-ChunkResult Uncompressed_UpsertSample(UpsertCtx *uCtx, int *size) {
+ChunkResult Uncompressed_UpsertSample(UpsertCtx *uCtx, int *size, DuplicatePolicy duplicatePolicy) {
     *size = 0;
     Chunk *regChunk = (Chunk *)uCtx->inChunk;
     timestamp_t ts = uCtx->sample.timestamp;

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -51,7 +51,7 @@ ChunkResult Uncompressed_AddSample(Chunk_t *chunk, Sample *sample);
  * @param size
  * @return
  */
-ChunkResult Uncompressed_UpsertSample(UpsertCtx *uCtx, int *size);
+ChunkResult Uncompressed_UpsertSample(UpsertCtx *uCtx, int *size, DuplicatePolicy duplicatePolicy);
 
 u_int64_t Uncompressed_NumOfSample(Chunk_t *chunk);
 timestamp_t Uncompressed_GetLastTimestamp(Chunk_t *chunk);

--- a/src/compressed_chunk.c
+++ b/src/compressed_chunk.c
@@ -101,7 +101,7 @@ Chunk_t *Compressed_SplitChunk(Chunk_t *chunk) {
     return newChunk2;
 }
 
-ChunkResult Compressed_UpsertSample(UpsertCtx *uCtx, int *size) {
+ChunkResult Compressed_UpsertSample(UpsertCtx *uCtx, int *size, DuplicatePolicy duplicatePolicy) {
     *size = 0;
     ChunkResult rv = CR_OK;
     ChunkResult nextRes = CR_OK;
@@ -125,6 +125,12 @@ ChunkResult Compressed_UpsertSample(UpsertCtx *uCtx, int *size) {
     }
 
     if (ts == iterSample.timestamp) {
+        ChunkResult cr = handleDuplicateSample(duplicatePolicy, iterSample, &uCtx->sample);
+        if (cr != CR_OK) {
+            Compressed_FreeChunkIterator(iter);
+            Compressed_FreeChunk(newChunk);
+            return CR_ERR;
+        }
         nextRes = Compressed_ChunkIteratorGetNext(iter, &iterSample);
         *size = -1; // we skipped a sample
     }

--- a/src/compressed_chunk.h
+++ b/src/compressed_chunk.h
@@ -19,7 +19,7 @@ Chunk_t *Compressed_SplitChunk(Chunk_t *chunk);
 
 // Append a sample to a compressed chunk
 ChunkResult Compressed_AddSample(Chunk_t *chunk, Sample *sample);
-ChunkResult Compressed_UpsertSample(UpsertCtx *uCtx, int *size);
+ChunkResult Compressed_UpsertSample(UpsertCtx *uCtx, int *size, DuplicatePolicy duplicatePolicy);
 
 // Read from compressed chunk using an iterator
 ChunkIter_t *Compressed_NewChunkIterator(Chunk_t *chunk, int options, ChunkIterFuncs* retChunkIterClass);

--- a/src/config.c
+++ b/src/config.c
@@ -22,7 +22,7 @@ int ParseDuplicatePolicy(RedisModuleCtx *ctx,
                          const char *arg_prefix,
                          DuplicatePolicy *policy);
 
-        int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     TSGlobalConfig.hasGlobalConfig = FALSE;
     TSGlobalConfig.options = SERIES_OPT_UNCOMPRESSED;
 
@@ -77,7 +77,8 @@ int ParseDuplicatePolicy(RedisModuleCtx *ctx,
                     TSGlobalConfig.chunkSizeBytes);
 
     TSGlobalConfig.duplicatePolicy = DEFAULT_DUPLICATE_POLICY;
-    if (ParseDuplicatePolicy(ctx, argv, argc, DUPLICATE_POLICY_ARG, &TSGlobalConfig.duplicatePolicy) != TSDB_OK) {
+    if (ParseDuplicatePolicy(
+            ctx, argv, argc, DUPLICATE_POLICY_ARG, &TSGlobalConfig.duplicatePolicy) != TSDB_OK) {
         return TSDB_ERROR;
     }
     RedisModule_Log(ctx,

--- a/src/config.c
+++ b/src/config.c
@@ -16,6 +16,11 @@
 
 TSConfig TSGlobalConfig;
 
+int ParseDuplicatePolicy(RedisModuleCtx *ctx,
+                         RedisModuleString **argv,
+                         int argc,
+                         DuplicatePolicy *policy);
+
 int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     TSGlobalConfig.hasGlobalConfig = FALSE;
     TSGlobalConfig.options = SERIES_OPT_UNCOMPRESSED;
@@ -69,6 +74,16 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                     "verbose",
                     "loaded default CHUNK_SIZE_BYTES policy: %lld \n",
                     TSGlobalConfig.chunkSizeBytes);
+
+    TSGlobalConfig.duplicatePolicy = DEFAULT_DUPLICATE_POLICY;
+    if (ParseDuplicatePolicy(ctx, argv, argc, &TSGlobalConfig.duplicatePolicy) != TSDB_OK) {
+        return TSDB_ERROR;
+    }
+    RedisModule_Log(ctx,
+                    "verbose",
+                    "loaded server DUPLICATE_POLICY: %s \n",
+                    DuplicatePolicyToString(TSGlobalConfig.duplicatePolicy));
+
     return TSDB_OK;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -19,9 +19,10 @@ TSConfig TSGlobalConfig;
 int ParseDuplicatePolicy(RedisModuleCtx *ctx,
                          RedisModuleString **argv,
                          int argc,
+                         const char *arg_prefix,
                          DuplicatePolicy *policy);
 
-int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+        int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     TSGlobalConfig.hasGlobalConfig = FALSE;
     TSGlobalConfig.options = SERIES_OPT_UNCOMPRESSED;
 
@@ -76,7 +77,7 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                     TSGlobalConfig.chunkSizeBytes);
 
     TSGlobalConfig.duplicatePolicy = DEFAULT_DUPLICATE_POLICY;
-    if (ParseDuplicatePolicy(ctx, argv, argc, &TSGlobalConfig.duplicatePolicy) != TSDB_OK) {
+    if (ParseDuplicatePolicy(ctx, argv, argc, DUPLICATE_POLICY_ARG, &TSGlobalConfig.duplicatePolicy) != TSDB_OK) {
         return TSDB_ERROR;
     }
     RedisModule_Log(ctx,

--- a/src/config.h
+++ b/src/config.h
@@ -17,6 +17,7 @@ typedef struct {
     long long chunkSizeBytes;
     short options;
     int hasGlobalConfig;
+    DuplicatePolicy duplicatePolicy;
 } TSConfig;
 
 extern TSConfig TSGlobalConfig;

--- a/src/consts.h
+++ b/src/consts.h
@@ -57,6 +57,11 @@ typedef enum {
   CR_END = 2,   // END_OF_CHUNK
 } ChunkResult;
 
+/* parsing */
+
+#define DUPLICATE_POLICY_ARG "DUPLICATE_POLICY"
+#define TS_ADD_DUPLICATE_POLICY_ARG "ON_DUPLICATE"
+
 #define SAMPLES_TO_BYTES(size) (size * sizeof(Sample))
 
 static inline u_int64_t max(u_int64_t a, u_int64_t b) {

--- a/src/consts.h
+++ b/src/consts.h
@@ -26,7 +26,7 @@
 #define RETENTION_TIME_DEFAULT          0LL
 #define Chunk_SIZE_BYTES_SECS           4096LL   // fills one page 4096
 #define SPLIT_FACTOR                    1.2
-#define DEFAULT_DUPLICATE_POLICY        1       // DP_BLOCK
+#define DEFAULT_DUPLICATE_POLICY        DP_BLOCK
 
 /* TS.Range Aggregation types */
 typedef enum {
@@ -46,6 +46,17 @@ typedef enum {
     TS_AGG_VAR_S,
     TS_AGG_TYPES_MAX // 13
 } TS_AGG_TYPES_T;
+
+
+typedef enum DuplicatePolicy {
+    DP_INVALID = -1,
+    DP_NONE = 0,
+    DP_BLOCK,
+    DP_LAST,
+    DP_FIRST,
+    DP_MIN,
+    DP_MAX,
+} DuplicatePolicy;
 
 /* Series struct options */
 #define SERIES_OPT_UNCOMPRESSED 0x1

--- a/src/consts.h
+++ b/src/consts.h
@@ -51,11 +51,11 @@ typedef enum {
 typedef enum DuplicatePolicy {
     DP_INVALID = -1,
     DP_NONE = 0,
-    DP_BLOCK,
-    DP_LAST,
-    DP_FIRST,
-    DP_MIN,
-    DP_MAX,
+    DP_BLOCK = 1,
+    DP_LAST = 2,
+    DP_FIRST = 3,
+    DP_MIN = 4,
+    DP_MAX = 5,
 } DuplicatePolicy;
 
 /* Series struct options */

--- a/src/consts.h
+++ b/src/consts.h
@@ -26,6 +26,7 @@
 #define RETENTION_TIME_DEFAULT          0LL
 #define Chunk_SIZE_BYTES_SECS           4096LL   // fills one page 4096
 #define SPLIT_FACTOR                    1.2
+#define DEFAULT_DUPLICATE_POLICY        1       // DP_BLOCK
 
 /* TS.Range Aggregation types */
 typedef enum {

--- a/src/consts.h
+++ b/src/consts.h
@@ -63,4 +63,8 @@ static inline u_int64_t max(u_int64_t a, u_int64_t b) {
     return a > b ? a : b;
 }
 
+static inline u_int64_t min(u_int64_t a, u_int64_t b) {
+    return a < b ? a : b;
+}
+
 #endif

--- a/src/generic_chunk.c
+++ b/src/generic_chunk.c
@@ -57,8 +57,8 @@ static ChunkIterFuncs compressedChunkIteratorClass = {
     .GetPrev = NULL,
 };
 
-// This function will decide according to the policy how to handle duplicate sample, the `newSample` will contain the
-// data that will be kept in the database.
+// This function will decide according to the policy how to handle duplicate sample, the `newSample`
+// will contain the data that will be kept in the database.
 ChunkResult handleDuplicateSample(DuplicatePolicy policy, Sample oldSample, Sample *newSample) {
     switch (policy) {
         case DP_BLOCK:

--- a/src/generic_chunk.c
+++ b/src/generic_chunk.c
@@ -63,11 +63,9 @@ ChunkResult handleDuplicateSample(DuplicatePolicy policy, Sample oldSample, Samp
     switch (policy) {
         case DP_BLOCK:
             return CR_ERR;
-            break;
         case DP_FIRST:
             *newSample = oldSample;
             return CR_OK;
-            break;
         case DP_LAST:
             return CR_OK;
         case DP_MIN:

--- a/src/generic_chunk.h
+++ b/src/generic_chunk.h
@@ -35,16 +35,6 @@ typedef enum {
     CHUNK_COMPRESSED 
 } CHUNK_TYPES_T;
 
-typedef enum DuplicatePolicy {
-    DP_NONE,
-    DP_BLOCK,
-    DP_LAST,
-    DP_FIRST,
-    DP_MIN,
-    DP_MAX,
-    DP_INVALID,
-} DuplicatePolicy;
-
 typedef struct UpsertCtx {
     Sample sample;
     Chunk_t *inChunk;       // original chunk  

--- a/src/generic_chunk.h
+++ b/src/generic_chunk.h
@@ -40,6 +40,8 @@ typedef enum DuplicatePolicy {
     DP_BLOCK,
     DP_LAST,
     DP_FIRST,
+    DP_MIN,
+    DP_MAX,
     DP_INVALID,
 } DuplicatePolicy;
 

--- a/src/generic_chunk.h
+++ b/src/generic_chunk.h
@@ -8,6 +8,7 @@
 #define GENERIC__CHUNK_H
 
 #include <sys/types.h>
+#include <rmutil/strings.h>
 #include <stdlib.h>         // malloc
 #include <stdio.h>          // printf
 #include <string.h>         // memcpy, memmove
@@ -34,6 +35,14 @@ typedef enum {
     CHUNK_COMPRESSED 
 } CHUNK_TYPES_T;
 
+typedef enum DuplicatePolicy {
+    DP_NONE,
+    DP_BLOCK,
+    DP_LAST,
+    DP_FIRST,
+    DP_INVALID,
+} DuplicatePolicy;
+
 typedef struct UpsertCtx {
     Sample sample;
     Chunk_t *inChunk;       // original chunk  
@@ -52,7 +61,7 @@ typedef struct ChunkFuncs {
     Chunk_t *(*SplitChunk)(Chunk_t *chunk);
 
     ChunkResult(*AddSample)(Chunk_t *chunk, Sample *sample);
-    ChunkResult(*UpsertSample)(UpsertCtx *uCtx, int *size);
+    ChunkResult(*UpsertSample)(UpsertCtx *uCtx, int *size, DuplicatePolicy duplicatePolicy);
 
     ChunkIter_t *(*NewChunkIterator)(Chunk_t *chunk, int options, ChunkIterFuncs* retChunkIterClass);
 
@@ -64,6 +73,11 @@ typedef struct ChunkFuncs {
     void (*SaveToRDB)(Chunk_t *chunk, struct RedisModuleIO *io);
     void (*LoadFromRDB)(Chunk_t **chunk, struct RedisModuleIO *io);
 } ChunkFuncs;
+
+ChunkResult handleDuplicateSample(DuplicatePolicy policy, Sample oldSample, Sample *newSample);
+const char * DuplicatePolicyToString(DuplicatePolicy policy);
+int RMStringLenDuplicationPolicyToEnum(RedisModuleString *aggTypeStr);
+DuplicatePolicy DuplicatePolicyFromString(const char *input, size_t len);
 
 ChunkFuncs *GetChunkClass(CHUNK_TYPES_T chunkClass);
 ChunkIterFuncs *GetChunkIteratorClass(CHUNK_TYPES_T chunkType);

--- a/src/module.c
+++ b/src/module.c
@@ -101,10 +101,11 @@ int GetSeries(RedisModuleCtx *ctx,
 int ParseDuplicatePolicy(RedisModuleCtx *ctx,
                          RedisModuleString **argv,
                          int argc,
+                         const char *arg_prefix,
                          DuplicatePolicy *policy) {
     RedisModuleString *duplicationPolicyInput = NULL;
-    if (RMUtil_ArgIndex("DUPLICATE_POLICY", argv, argc) > 0) {
-        if (RMUtil_ParseArgsAfter("DUPLICATE_POLICY", argv, argc, "s", &duplicationPolicyInput) !=
+    if (RMUtil_ArgIndex(arg_prefix, argv, argc) != -1) {
+        if (RMUtil_ParseArgsAfter(arg_prefix, argv, argc, "s", &duplicationPolicyInput) !=
             REDISMODULE_OK) {
             RTS_ReplyGeneralError(ctx, "TSDB: Couldn't parse DUPLICATE_POLICY");
             return TSDB_ERROR;
@@ -162,7 +163,7 @@ static int parseCreateArgs(RedisModuleCtx *ctx,
     }
 
     cCtx->duplicatePolicy = DP_NONE;
-    if (ParseDuplicatePolicy(ctx, argv, argc, &cCtx->duplicatePolicy) != TSDB_OK) {
+    if (ParseDuplicatePolicy(ctx, argv, argc, DUPLICATE_POLICY_ARG, &cCtx->duplicatePolicy) != TSDB_OK) {
         return TSDB_ERROR;
     }
 
@@ -788,7 +789,7 @@ static inline int add(RedisModuleCtx *ctx,
         return RTS_ReplyGeneralError(ctx, "TSDB: the key is not a TSDB key");
     } else {
         series = RedisModule_ModuleTypeGetValue(key);
-        if (ParseDuplicatePolicy(ctx, argv, argc, &dp) != TSDB_OK) {
+        if (ParseDuplicatePolicy(ctx, argv, argc, TS_ADD_DUPLICATE_POLICY_ARG, &dp) != TSDB_OK) {
             return REDISMODULE_ERR;
         }
     }

--- a/src/module.c
+++ b/src/module.c
@@ -163,7 +163,8 @@ static int parseCreateArgs(RedisModuleCtx *ctx,
     }
 
     cCtx->duplicatePolicy = DP_NONE;
-    if (ParseDuplicatePolicy(ctx, argv, argc, DUPLICATE_POLICY_ARG, &cCtx->duplicatePolicy) != TSDB_OK) {
+    if (ParseDuplicatePolicy(ctx, argv, argc, DUPLICATE_POLICY_ARG, &cCtx->duplicatePolicy) !=
+        TSDB_OK) {
         return TSDB_ERROR;
     }
 

--- a/src/module.c
+++ b/src/module.c
@@ -98,6 +98,29 @@ int GetSeries(RedisModuleCtx *ctx,
     return TRUE;
 }
 
+int ParseDuplicatePolicy(RedisModuleCtx *ctx,
+                         RedisModuleString **argv,
+                         int argc,
+                         DuplicatePolicy *policy) {
+    RedisModuleString *duplicationPolicyInput = NULL;
+    if (RMUtil_ArgIndex("DUPLICATE_POLICY", argv, argc) > 0) {
+        if (RMUtil_ParseArgsAfter("DUPLICATE_POLICY", argv, argc, "s", &duplicationPolicyInput) !=
+            REDISMODULE_OK) {
+            RTS_ReplyGeneralError(ctx, "TSDB: Couldn't parse DUPLICATE_POLICY");
+            return TSDB_ERROR;
+        }
+
+        DuplicatePolicy parsePolicy = RMStringLenDuplicationPolicyToEnum(duplicationPolicyInput);
+        if (parsePolicy == DP_INVALID) {
+            RTS_ReplyGeneralError(ctx, "TSDB: Unknown DUPLICATE_POLICY");
+            return TSDB_ERROR;
+        }
+        *policy = parsePolicy;
+        return TSDB_OK;
+    }
+    return TSDB_OK;
+}
+
 static int parseCreateArgs(RedisModuleCtx *ctx,
                            RedisModuleString **argv,
                            int argc,
@@ -136,6 +159,11 @@ static int parseCreateArgs(RedisModuleCtx *ctx,
 
     if (RMUtil_ArgIndex("UNCOMPRESSED", argv, argc) > 0) {
         cCtx->options |= SERIES_OPT_UNCOMPRESSED;
+    }
+
+    cCtx->duplicatePolicy = DP_NONE;
+    if (ParseDuplicatePolicy(ctx, argv, argc, &cCtx->duplicatePolicy) != TSDB_OK) {
+        return TSDB_ERROR;
     }
 
     return REDISMODULE_OK;
@@ -273,7 +301,7 @@ int TSDB_info(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return REDISMODULE_ERR;
     }
 
-    RedisModule_ReplyWithArray(ctx, 10 * 2);
+    RedisModule_ReplyWithArray(ctx, 11 * 2);
 
     long long skippedSamples;
     long long firstTimestamp = getFirstValidTimestamp(series, &skippedSamples);
@@ -292,6 +320,12 @@ int TSDB_info(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_ReplyWithLongLong(ctx, RedisModule_DictSize(series->chunks));
     RedisModule_ReplyWithSimpleString(ctx, "chunkSize");
     RedisModule_ReplyWithLongLong(ctx, series->chunkSizeBytes);
+    RedisModule_ReplyWithSimpleString(ctx, "duplicatePolicy");
+    if (series->duplicatePolicy != DP_NONE) {
+        RedisModule_ReplyWithSimpleString(ctx, DuplicatePolicyToString(series->duplicatePolicy));
+    } else {
+        RedisModule_ReplyWithNull(ctx);
+    }
 
     RedisModule_ReplyWithSimpleString(ctx, "labels");
     ReplyWithSeriesLabels(ctx, series);
@@ -686,7 +720,8 @@ static void handleCompaction(RedisModuleCtx *ctx,
 static int internalAdd(RedisModuleCtx *ctx,
                        Series *series,
                        api_timestamp_t timestamp,
-                       double value) {
+                       double value,
+                       DuplicatePolicy dp_override) {
     timestamp_t lastTS = series->lastTimestamp;
     uint64_t retention = series->retentionTime;
     // ensure inside retention period.
@@ -696,7 +731,7 @@ static int internalAdd(RedisModuleCtx *ctx,
     }
 
     if (timestamp <= series->lastTimestamp && series->totalSamples != 0) {
-        if (SeriesUpsertSample(series, timestamp, value) != REDISMODULE_OK) {
+        if (SeriesUpsertSample(series, timestamp, value, dp_override) != REDISMODULE_OK) {
             RTS_ReplyGeneralError(ctx, "TSDB: Error at upsert");
             return REDISMODULE_ERR;
         }
@@ -738,6 +773,7 @@ static inline int add(RedisModuleCtx *ctx,
     }
 
     Series *series = NULL;
+    DuplicatePolicy dp = DP_NONE;
 
     if (argv != NULL && RedisModule_KeyType(key) == REDISMODULE_KEYTYPE_EMPTY) {
         // the key doesn't exist, lets check we have enough information to create one
@@ -752,8 +788,11 @@ static inline int add(RedisModuleCtx *ctx,
         return RTS_ReplyGeneralError(ctx, "TSDB: the key is not a TSDB key");
     } else {
         series = RedisModule_ModuleTypeGetValue(key);
+        if (ParseDuplicatePolicy(ctx, argv, argc, &dp) != TSDB_OK) {
+            return REDISMODULE_ERR;
+        }
     }
-    int rv = internalAdd(ctx, series, timestamp, value);
+    int rv = internalAdd(ctx, series, timestamp, value, dp);
     RedisModule_CloseKey(key);
     return rv;
 }
@@ -867,6 +906,10 @@ int TSDB_alter(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     if (RMUtil_ArgIndex("CHUNK_SIZE", argv, argc) > 0) {
         series->chunkSizeBytes = cCtx.chunkSizeBytes;
+    }
+
+    if (RMUtil_ArgIndex("DUPLICATE_POLICY", argv, argc) > 0) {
+        series->duplicatePolicy = cCtx.duplicatePolicy;
     }
 
     if (RMUtil_ArgIndex("LABELS", argv, argc) > 0) {
@@ -1050,7 +1093,7 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         result -= incrby;
     }
 
-    int rv = internalAdd(ctx, series, currentUpdatedTime, result);
+    int rv = internalAdd(ctx, series, currentUpdatedTime, result, DP_LAST);
     RedisModule_ReplicateVerbatim(ctx);
     RedisModule_CloseKey(key);
     return rv;

--- a/src/parse_policies.h
+++ b/src/parse_policies.h
@@ -9,6 +9,8 @@
 #include <sys/types.h>
 #include <stdint.h>
 
+#include "generic_chunk.h"
+
 typedef struct SimpleCompactionRule {
     uint64_t timeBucket;
     uint64_t retentionSizeMillisec;

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -45,6 +45,8 @@ Series *NewSeries(RedisModuleString *keyName, CreateCtx *cCtx) {
     newSeries->labels = cCtx->labels;
     newSeries->labelsCount = cCtx->labelsCount;
     newSeries->options = cCtx->options;
+    newSeries->duplicatePolicy = cCtx->duplicatePolicy;
+
     if (newSeries->options & SERIES_OPT_UNCOMPRESSED) {
         newSeries->options |= SERIES_OPT_UNCOMPRESSED;
         newSeries->funcs = GetChunkClass(CHUNK_REGULAR);
@@ -245,7 +247,7 @@ static void upsertCompaction(Series *series, UpsertCtx *uCtx) {
                 RedisModule_Log(ctx, "verbose", "%s", "Failed to retrieve downsample series");
                 continue;
             }
-            SeriesUpsertSample(destSeries, start, val);
+            SeriesUpsertSample(destSeries, start, val, DP_LAST);
             RedisModule_CloseKey(key);
         }
         rule = rule->nextRule;
@@ -253,7 +255,10 @@ static void upsertCompaction(Series *series, UpsertCtx *uCtx) {
     RedisModule_FreeThreadSafeContext(ctx);
 }
 
-int SeriesUpsertSample(Series *series, api_timestamp_t timestamp, double value) {
+int SeriesUpsertSample(Series *series,
+                       api_timestamp_t timestamp,
+                       double value,
+                       DuplicatePolicy dp_override) {
     bool latestChunk = true;
     void *chunkKey = NULL;
     ChunkFuncs *funcs = series->funcs;
@@ -296,18 +301,28 @@ int SeriesUpsertSample(Series *series, api_timestamp_t timestamp, double value) 
         }
     }
 
-    Sample sample = { .timestamp = timestamp, .value = value };
     UpsertCtx uCtx = {
         .inChunk = chunk,
-        .sample = sample,
+        .sample = { .timestamp = timestamp, .value = value },
     };
 
     int size = 0;
-    ChunkResult rv = funcs->UpsertSample(&uCtx, &size);
+
+    // Use module level configuration if key level configuration doesn't exists
+    DuplicatePolicy dp_policy;
+    if (dp_override != DP_NONE) {
+        dp_policy = dp_override;
+    } else if (series->duplicatePolicy != DP_NONE) {
+        dp_policy = series->duplicatePolicy;
+    } else {
+        dp_policy = TSGlobalConfig.duplicatePolicy;
+    }
+
+    ChunkResult rv = funcs->UpsertSample(&uCtx, &size, dp_policy);
     if (rv == CR_OK) {
         series->totalSamples += size;
         if (timestamp == series->lastTimestamp) {
-            series->lastValue = value;
+            series->lastValue = uCtx.sample.value;
         }
         timestamp_t chunkFirstTSAfterOp = funcs->GetFirstTimestamp(uCtx.inChunk);
         if (chunkFirstTSAfterOp != chunkFirstTS) {

--- a/src/tsdb.h
+++ b/src/tsdb.h
@@ -28,6 +28,7 @@ typedef struct CreateCtx {
     size_t labelsCount;
     Label *labels;
     int options;
+    DuplicatePolicy duplicatePolicy;
 } CreateCtx;
 
 typedef struct Series {
@@ -45,6 +46,7 @@ typedef struct Series {
     RedisModuleString *srcKey;
     ChunkFuncs *funcs;
     size_t totalSamples;
+    DuplicatePolicy duplicatePolicy;
 } Series;
 
 typedef struct SeriesIterator {
@@ -65,7 +67,7 @@ void CleanLastDeletedSeries(RedisModuleCtx *ctx, RedisModuleString *key);
 void FreeCompactionRule(void *value);
 size_t SeriesMemUsage(const void *value);
 int SeriesAddSample(Series *series, api_timestamp_t timestamp, double value);
-int SeriesUpsertSample(Series *series, api_timestamp_t timestamp, double value);
+int SeriesUpsertSample(Series *series, api_timestamp_t timestamp, double value, DuplicatePolicy dp_override);
 int SeriesUpdateLastSample(Series *series);
 int SeriesDeleteRule(Series *series, RedisModuleString *destKey);
 int SeriesSetSrcRule(Series *series, RedisModuleString *srctKey);

--- a/src/unittests_parse_policies.c
+++ b/src/unittests_parse_policies.c
@@ -41,7 +41,7 @@ MU_TEST(test_valid_policy) {
 
 MU_TEST(test_invalid_policy) {
     SimpleCompactionRule* parsedRules;
-    size_t rulesCount;
+    uint64_t rulesCount;
     int result;
     result = ParseCompactionPolicy("max:1M;mins:10s;avg:2h;avg:1d", &parsedRules, &rulesCount);
 	mu_check(result == FALSE);

--- a/src/unittests_uncompressed_chunk.c
+++ b/src/unittests_uncompressed_chunk.c
@@ -84,7 +84,7 @@ MU_TEST(test_Uncompressed_Uncompressed_UpsertSample) {
 
     int size = 0;
     // We're forcing the chunk to grow 
-    rv = Uncompressed_UpsertSample(&uCtxS3, &size);
+    rv = Uncompressed_UpsertSample(&uCtxS3, &size, DP_LAST);
     total_added_samples++;
     mu_assert(rv == CR_OK, "upsert");
     mu_assert_int_eq(total_added_samples,chunk->num_samples);


### PR DESCRIPTION
#521 Added support for multiple policies to handle duplicate samples.
Supported policies are: Block, first, last, min, max.
The policy can be configured at 3 levels:
1. database-wide during module loading, if not set the default will be `Block`.
2. key level configuration - if not set we will use configuration from 1.
3. `TS.ADD ... [ON_DUPLICATE policy]` - this will override both 1 & 2.  