### PR TITLE
Fixed configuration docs page

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,8 +31,10 @@ $ redis-server --loadmodule ./redistimeseries.so OPT1 OPT2
 Default compaction/downsampling rules for newly created key with `TS.ADD`.
 
 Each rule is separated by a semicolon (`;`), the rule consists of several fields that are separated by a colon (`:`):
+
 * aggregation function - avg, sum, min, max, count, first, last
 * time bucket - number and the time representation (Example for 1 minute: 1M)
+
     * m - millisecond
     * M - minute
     * s - seconds
@@ -71,6 +73,7 @@ $ redis-server --loadmodule ./redistimeseries.so RETENTION_POLICY 20
 
 Policy that will define handling of duplicate samples.
 The following are the possible policies:
+
 * `BLOCK` - an error will occur for any out of order sample
 * `FIRST` - ignore the new value
 * `LAST` - override with latest value


### PR DESCRIPTION
This PR fixed fixed configuration docs page with regards to the bullet points being mangled.
## Current output: 
![image](https://user-images.githubusercontent.com/5832149/93190550-694ce680-f73b-11ea-9c6a-958a38c6fe77.png)


## Expected output: 
![image](https://user-images.githubusercontent.com/5832149/93190434-47ebfa80-f73b-11ea-8985-1b94c7971717.png)
