### PR TITLE
`SUM` duplicate sample policy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,14 @@
-bin/
-/VARIANT
-/BINDIR
+# ignore everything
+**
 
+# except
+!/system-setup.py
+!/deps/**
+!/docs/**
+!/src/**
+!/tests/**
+!/tools/**
+!/build/**
+!/.git/**
+!/.gitmodules
+!/Makefile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,14 +1,4 @@
-# ignore everything
-**
+bin/
+/VARIANT
+/BINDIR
 
-# except
-!/system-setup.py
-!/deps/**
-!/docs/**
-!/src/**
-!/tests/**
-!/tools/**
-!/build/**
-!/.git/**
-!/.gitmodules
-!/Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,21 @@ FROM redisfab/redis:${REDIS_VER}-${ARCH}-${OSNICK} AS builder
 
 ARG REDIS_VER
 
-ADD ./ /build
+# Add in deps. Only add this in s.t. this step is
+#   cached and doesn't need to be re-done on subsequent
+#   rebuilds
+ADD ./deps /build/deps
 WORKDIR /build
-
 RUN ./deps/readies/bin/getpy2
+
+# Set up the system. Need just system-setup.py and the
+#   test requirement file.
+ADD ./system-setup.py .
+ADD ./tests/requirements.txt ./tests/requirements.txt
 RUN ./system-setup.py
+
+# Now, add in the source for the build.
+ADD . /build
 RUN make fetch
 RUN make build
 

--- a/README.md
+++ b/README.md
@@ -95,11 +95,35 @@ In your redis-server run: `loadmodule bin/redistimeseries.so`
 
 For more information about modules, go to the [redis official documentation](https://redis.io/topics/modules-intro).
 
+### Development with Docker
+
+This repository contains a `Dockerfile` that can be used for local development in case you prefer to or have trouble getting your machine configured. You can run:
+
+```
+$ docker-compose build
+$ docker-compose up -d
+```
+
+To build and launch a container that contains all of the necessary requirements. The source code from your host machine will also be linked into the Docker container, meaning you can edit your code using your favorite editor on your host machine and build/debug in the standardized docker environment:
+
+```
+$ docker exec -it redis-timeseries bash
+# make clean
+# make build
+# cd src && make tests
+```
+
+When finished, spin down the container with:
+
+```
+$ docker-compose down -t0
+```
+
 ## Give it a try
 
 After you setup RedisTimeSeries, you can interact with it using redis-cli.
 
-Here we'll create a time series representing sensor temperature measurements. 
+Here we'll create a time series representing sensor temperature measurements.
 After you create the time series, you can send temperature measurements.
 Then you can query the data for a time range on some aggregation rule.
 
@@ -140,10 +164,12 @@ Some languages have client libraries that provide support for RedisTimeSeries co
 ## Tests
 Tests are written in python using the [rmtest](https://github.com/RedisLabs/rmtest) library.
 ```
-$ cd src
 $ pip install -r tests/requirements.txt # optional, use virtualenv
+$ cd src
 $ make tests
 ```
+
+To run a single or subset of tests, replace `make tests` in the above with `TEST="" make tests` where the `TEST` string will by passed to `pytest` using the `-k` flag and therefore follow's `pytest`'s standard filtering rules.
 
 ## Documentation
 Read the docs at http://redistimeseries.io

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "2.3"
+
+services:
+
+  redis-timeseries:
+    container_name: redis-timeseries
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: builder
+      args:
+        REDIS_VER: 6.0.5
+        OSNICK: buster
+        ARCH: x64
+    volumes:
+      - ".:/build"
+    network_mode: host
+    command: tail -f /dev/null

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Run-time configuration
 
-RedisTimeSeries supports a few run-time configuration options that should be determined when loading the module. In time more options will be added. 
+RedisTimeSeries supports a few run-time configuration options that should be determined when loading the module. In time more options will be added.
 
 ## Passing Configuration Options During Loading
 
@@ -79,6 +79,7 @@ The following are the possible policies:
 * `LAST` - override with latest value
 * `MIN` - only override if the value is lower than the existing value
 * `MAX` - only override if the value is higher than the existing value
+* `SUM` - If a previous sample exists, add the new sample to it so that the updated value is equal to (previous + new). If no previous sample exists, set the updated value equal to the new value.
 
 #### Precedence order
 Since the duplication policy can be provided at different levels, the actual precedence of the used policy will be:

--- a/src/consts.h
+++ b/src/consts.h
@@ -56,6 +56,7 @@ typedef enum DuplicatePolicy {
     DP_FIRST = 3,
     DP_MIN = 4,
     DP_MAX = 5,
+    DP_SUM = 6,
 } DuplicatePolicy;
 
 /* Series struct options */

--- a/src/generic_chunk.c
+++ b/src/generic_chunk.c
@@ -74,6 +74,9 @@ ChunkResult handleDuplicateSample(DuplicatePolicy policy, Sample oldSample, Samp
         case DP_MAX:
             newSample->value = max(oldSample.value, newSample->value);
             return CR_OK;
+        case DP_SUM:
+            newSample->value = oldSample.value + newSample->value;
+            return CR_OK;
         default:
             return CR_ERR;
     }
@@ -113,6 +116,8 @@ const char *DuplicatePolicyToString(DuplicatePolicy policy) {
             return "max";
         case DP_MIN:
             return "min";
+        case DP_SUM:
+            return "sum";
         default:
             return "invalid";
     }
@@ -134,6 +139,8 @@ DuplicatePolicy DuplicatePolicyFromString(const char *input, size_t len) {
             return DP_MIN;
         } else if (strncmp(input_lower, "max", len) == 0) {
             return DP_MAX;
+        } else if (strncmp(input_lower, "sum", len) == 0) {
+            return DP_SUM;
         }
     } else if (len == 4) {
         if (strncmp(input_lower, "last", len) == 0) {

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -5,7 +5,7 @@ import time
 import __builtin__
 import math
 import random
-import statistics 
+import statistics
 from rmtest import ModuleTestCase
 from includes import *
 
@@ -45,7 +45,7 @@ class TSInfo(object):
         if 'firstTimestamp' in response: self.first_time_stamp = response['firstTimestamp']
         if 'chunkSize' in response: self.chunk_size_bytes = response['chunkSize']
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         if not isinstance(other, TSInfo):
             return NotImplemented
         return self.rules == other.rules and \
@@ -57,7 +57,7 @@ class TSInfo(object):
         self.last_time_stamp == other.last_time_stamp and \
         self.first_time_stamp == other.first_time_stamp and \
         self.chunk_size_bytes == other.chunk_size_bytes
-        
+
 class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
     def _get_ts_info(self, redis, key):
         return TSInfo(redis.execute_command('TS.INFO', key))
@@ -291,26 +291,26 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             assert r.execute_command('TS.CREATERULE', 'tester', 'tester_agg_sum_10', 'AGGREGATION', 'SUM', 10)
             assert r.execute_command('TS.CREATERULE', 'tester', 'tester_agg_stds_10', 'AGGREGATION', 'STD.S', 10)
             self._insert_data(r, 'tester', start_ts, samples_count, 5)
-            
+
             data = r.execute_command('DUMP', 'tester')
             avg_data = r.execute_command('DUMP', 'tester_agg_avg_10')
-            
+
             r.execute_command('DEL', 'tester', 'tester_agg_avg_10')
-            
+
             r.execute_command('RESTORE', 'tester', 0, data)
             r.execute_command('RESTORE', 'tester_agg_avg_10', 0, avg_data)
-            
+
             expected_result = [[start_ts+i, str(5)] for i in range(samples_count)]
             actual_result = r.execute_command('TS.range', 'tester', start_ts, start_ts + samples_count)
             assert expected_result == actual_result
             actual_result = r.execute_command('TS.range', 'tester', start_ts, start_ts + samples_count, 'count', 3)
             assert expected_result[:3] == actual_result
 
-            assert self._get_ts_info(r, 'tester').rules == [['tester_agg_avg_10', 10L, 'AVG'], 
+            assert self._get_ts_info(r, 'tester').rules == [['tester_agg_avg_10', 10L, 'AVG'],
                                                             ['tester_agg_max_10', 10L, 'MAX'],
                                                             ['tester_agg_sum_10', 10L, 'SUM'],
                                                             ['tester_agg_stds_10',10L, 'STD.S']]
-                                   
+
             assert self._get_ts_info(r, 'tester_agg_avg_10').sourceKey == 'tester'
 
     def test_rdb_aggregation_context(self):
@@ -400,7 +400,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             self._ts_alter_cmd(r, key, set_retention=expected_retention)
             self._assert_alter_cmd(r, key, end_ts-201, end_ts, expected_data[-201:], expected_retention,
                                    expected_chunk_size, expected_labels)
-            
+
             # test alter chunk size
             expected_chunk_size = 100
             expected_labels = [['A', '1'], ['B', '2'], ['C', '3']]
@@ -460,7 +460,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             expected_result_withlabels = [
                 [keys[2], [kvlabels[2]], [time_stamp, str(values[2])]]
             ]
-            
+
             actual_result = r.execute_command('TS.MGET', 'WITHLABELS', 'FILTER', 'a!=1', 'b=1')
             assert expected_result_withlabels == actual_result
 
@@ -469,7 +469,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
                 [keys[0], [kvlabels[0]], [time_stamp, str(values[0])]],
                 [keys[1], [kvlabels[1]], [time_stamp, str(values[1])]]
             ]
-            
+
             actual_result = r.execute_command('TS.MGET', 'WITHLABELS', 'FILTER', 'a=1')
             assert expected_result_withlabels == actual_result
 
@@ -503,7 +503,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
 
             assert [] == r.execute_command('TS.revrange', 'tester', start_ts * 2, -1)
             assert [] == r.execute_command('TS.revrange', 'tester', start_ts / 3, start_ts / 2)
-            
+
             with pytest.raises(redis.ResponseError) as excinfo:
                 assert r.execute_command('TS.RANGE tester string -1')
             with pytest.raises(redis.ResponseError) as excinfo:
@@ -542,7 +542,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
         with self.redis() as r:
             assert r.execute_command('TS.CREATE', 'tester')
             self._insert_data(r, 'tester', start_ts, samples_count, 5)
-            
+
             expected_result = [[1488823000L, '116'], [1488823500L, '500'], [1488824000L, '500'], [1488824500L, '384']]
             actual_result = r.execute_command('TS.range', 'tester', start_ts, start_ts + samples_count, 'AGGREGATION',
                                               'count', 500)
@@ -588,12 +588,12 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             assert r.execute_command('TS.CREATERULE', 'tester', 'tester_agg_max_10', 'AGGREGATION', 'avg', 10)
             assert r.delete('tester_agg_max_10')
             assert self._get_ts_info(r, 'tester').rules == []
-            
+
             assert r.execute_command('TS.CREATE', 'tester_agg_max_10')
             assert r.execute_command('TS.CREATERULE', 'tester', 'tester_agg_max_10', 'AGGREGATION', 'avg', 11)
             assert r.delete('tester')
             assert self._get_ts_info(r, 'tester_agg_max_10').sourceKey == None
-            
+
             assert r.execute_command('TS.CREATE', 'tester')
             assert r.execute_command('TS.CREATERULE', 'tester', 'tester_agg_max_10', 'AGGREGATION', 'avg', 12)
             assert self._get_ts_info(r, 'tester').rules == [['tester_agg_max_10', 12L, 'AVG']]
@@ -601,7 +601,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
     def test_create_retention(self):
         with self.redis() as r:
             assert r.execute_command('TS.CREATE', 'tester', 'RETENTION', 1000)
-            
+
             assert r.execute_command('TS.ADD', 'tester', 500, 10)
             expected_result = [[500L, '10']]
             actual_result = r.execute_command('TS.range', 'tester', '-', '+')
@@ -614,7 +614,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             actual_result = r.execute_command('TS.range', 'tester', '-', '+')
             assert expected_result == actual_result
             assert self._get_ts_info(r, 'tester').total_samples == 2
-            
+
             assert r.execute_command('TS.ADD', 'tester', 2000, 30)
             expected_result = [[1001L, '20'], [2000L, '30']]
             actual_result = r.execute_command('TS.range', 'tester', '-', '+')
@@ -664,7 +664,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             assert r.execute_command('TS.CREATERULE', 'tester', 'tester_agg_max_10', 'AGGREGATION', 'MAX', 10)
             with pytest.raises(redis.ResponseError) as excinfo:
                 assert r.execute_command('TS.CREATERULE', 'tester', 'tester_agg_max_10', 'AGGREGATION', 'MAX', 10)
-                
+
     def test_create_compaction_rule_override_dest(self):
         with self.redis() as r:
             assert r.execute_command('TS.CREATE', 'tester')
@@ -777,7 +777,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             assert len(result) == 20
             assert result[19][1] == '100'
 
-            query_res = r.execute_command('ts.incrby', 'tester', '5', 'TIMESTAMP', '*')/1000 
+            query_res = r.execute_command('ts.incrby', 'tester', '5', 'TIMESTAMP', '*')/1000
             cur_time = int(time.time())
             assert query_res >= cur_time
             assert query_res <= cur_time + 1
@@ -838,7 +838,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             random_numbers = 100
             random.seed(0)
             items = random.sample(range(random_numbers), random_numbers)
-        
+
             stdev = statistics.stdev(items)
             var = statistics.variance(items)
             assert r.execute_command('TS.CREATE', raw_key)
@@ -846,11 +846,11 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             assert r.execute_command('TS.CREATE', var_key)
             assert r.execute_command('TS.CREATERULE', raw_key, std_key, "AGGREGATION", 'std.s', random_numbers)
             assert r.execute_command('TS.CREATERULE', raw_key, var_key, "AGGREGATION", 'var.s', random_numbers)
-    
+
             for i in range(random_numbers):
                 r.execute_command('TS.ADD', raw_key, i, items[i])
             r.execute_command('TS.ADD', raw_key, random_numbers, 0) #close time bucket
-    
+
             assert abs(stdev - float(r.execute_command('TS.GET', std_key)[1])) < ALLOWED_ERROR
             assert abs(var - float(r.execute_command('TS.GET', var_key)[1])) < ALLOWED_ERROR
 
@@ -956,7 +956,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             values = range(samples_count)
             self._insert_data(r, 'tester', start_ts, samples_count, values)
             r.execute_command('TS.ADD', 'tester', 3000, 7.77)
-            
+
             for rule in rules:
                 for resolution in resolutions:
                     actual_result = r.execute_command('TS.RANGE', 'tester_{}_{}'.format(rule, resolution),
@@ -993,13 +993,13 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             ts = time.time()
             assert r.execute_command('TS.ADD', 'tester1', str(int(ts)), str(ts), 'RETENTION', '666', 'LABELS', 'name', 'blabla') == int(ts)
             info = self._get_ts_info(r, 'tester1')
-            assert info.total_samples == 1L 
+            assert info.total_samples == 1L
             assert info.retention_msecs == 666L
             assert info.labels == {'name': 'blabla'}
 
             assert r.execute_command('TS.ADD', 'tester2', str(int(ts)), str(ts), 'LABELS', 'name', 'blabla2', 'location', 'earth')
             info = self._get_ts_info(r, 'tester2')
-            assert info.total_samples == 1L 
+            assert info.total_samples == 1L
             assert info.labels == {'location': 'earth', 'name': 'blabla2'}
 
     def test_range_by_labels(self):
@@ -1059,7 +1059,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
                 assert r.execute_command('TS.mrange', start_ts, 'string', 'FILTER', 'generation=x')
             with pytest.raises(redis.ResponseError) as excinfo:
                 assert r.execute_command('TS.mrange', start_ts, start_ts + samples_count, 'FILTER', 'generation+x')
-    
+
             #issue 414
             with pytest.raises(redis.ResponseError) as excinfo:
                 assert r.execute_command('TS.mrange', start_ts, start_ts + samples_count, 'FILTER', 'name=(bob,rudy,)')
@@ -1105,7 +1105,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             assert len(count_results) == 10
             count_results = r.execute_command('TS.RANGE', 'tester1', 0, -1, 'AGGREGATION', 'COUNT', 3)
             assert len(count_results) == math.ceil(samples_count / 3.0)
-            
+
     def test_revrange(self):
         start_ts = 1511885908L
         samples_count = 200
@@ -1119,7 +1119,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             actual_results_rev = r.execute_command('TS.REVRANGE', 'tester1', 0, -1)
             actual_results_rev.reverse()
             assert actual_results == actual_results_rev
-            
+
             actual_results = r.execute_command('TS.RANGE', 'tester1', 1511885910L, 1511886000L)
             actual_results_rev = r.execute_command('TS.REVRANGE', 'tester1', 1511885910L, 1511886000L)
             actual_results_rev.reverse()
@@ -1139,7 +1139,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             actual_results_rev = r.execute_command('TS.REVRANGE', 'tester1', 0, -1)
             actual_results_rev.reverse()
             assert actual_results == actual_results_rev
-            
+
             actual_results = r.execute_command('TS.RANGE', 'tester1', 1511885910L, 1511886000L)
             actual_results_rev = r.execute_command('TS.REVRANGE', 'tester1', 1511885910L, 1511886000L)
             actual_results_rev.reverse()
@@ -1185,7 +1185,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             assert r.execute_command('TS.CREATE', 'tester1', 'LABELS', 'name', 'bob', 'class', 'middle', 'generation', 'x')
             assert r.execute_command('TS.CREATE', 'tester2', 'LABELS', 'name', 'rudy', 'class', 'junior', 'generation', 'x')
             assert r.execute_command('TS.CREATE', 'tester3', 'LABELS', 'name', 'fabi', 'class', 'top', 'generation', 'x')
-            
+
             assert r.execute_command('TS.ADD', 'tester1', 0, 1) == 0
             assert r.execute_command('TS.ADD', 'tester2', 0, 2) == 0
             assert r.execute_command('TS.ADD', 'tester3', 0, 3) == 0
@@ -1279,7 +1279,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             for sample in res:
                 assert sample == [6000+i, str(i)]
                 i += 1
-    
+
     def test_partial_madd(self):
         with self.redis() as r:
             r.execute_command("ts.create", 'test_key1')
@@ -1297,7 +1297,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             assert len(r.execute_command('ts.range', 'test_key1', "-", "+")) == 2
             assert len(r.execute_command('ts.range', 'test_key2', "-", "+")) == 2
             assert len(r.execute_command('ts.range', 'test_key3', "-", "+")) == 2
-    
+
     def test_rule_timebucket_64bit(self):
         with self.redis() as r:
             BELOW_32BIT_LIMIT = 2147483647
@@ -1307,7 +1307,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             r.execute_command("ts.create", 'above_32bit_limit')
             r.execute_command("ts.createrule", 'test_key', 'below_32bit_limit', 'AGGREGATION', 'max', BELOW_32BIT_LIMIT)
             r.execute_command("ts.createrule", 'test_key', 'above_32bit_limit', 'AGGREGATION', 'max', ABOVE_32BIT_LIMIT)
-            info = self._get_ts_info(r, 'test_key') 
+            info = self._get_ts_info(r, 'test_key')
             assert info.rules[0][1] == BELOW_32BIT_LIMIT
             assert info.rules[1][1] == ABOVE_32BIT_LIMIT
 
@@ -1338,7 +1338,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             # test deletion
             assert r.delete('not_compressed')
 
-    
+
     def test_trim(self):
         with self.redis() as r:
             for mode in ["UNCOMPRESSED","COMPRESSED"]:
@@ -1350,7 +1350,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
                 for i in range(samples):
                     r.execute_command('ts.add trim_me', i, i * 1.1)
                     r.execute_command('ts.add dont_trim_me', i, i * 1.1)
-                
+
                 trimmed_info = self._get_ts_info(r, 'trim_me')
                 untrimmed_info = self._get_ts_info(r, 'dont_trim_me')
                 assert 2 == trimmed_info.chunk_count
@@ -1376,7 +1376,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             assert info.total_samples == 0
             assert [] == r.execute_command('TS.range empty_uncompressed 0 -1')
             assert [] == r.execute_command('TS.get empty')
-    
+
     def test_expire(self):
         with self.redis() as r:
             assert r.execute_command('ts.create test') == 'OK'
@@ -1408,7 +1408,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             r.execute_command('ts.add monkey 10000011000001 1')
             r.execute_command('ts.add monkey 10000011000002 1')
             expected_result = [[0L, '1'], [1L, '1'], [2L, '1'], [50L, '1'], [51L, '1'],
-                               [500L, '1'], [501L, '1'], [3000L, '1'], [3001L, '1'], 
+                               [500L, '1'], [501L, '1'], [3000L, '1'], [3001L, '1'],
                                [10000L, '1'], [10001L, '1'], [100000L, '1'], [100001L, '1'],
                                [100002L, '1'], [100004L, '1'], [1000000L, '1'], [1000001L, '1'],
                                [10000011000001L, '1'], [10000011000002L, '1']]
@@ -1595,7 +1595,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
                     assert r.execute_command('TS.ADD', key, 15, 15) == 15
                     assert r.execute_command('TS.ADD', key, 14, 14) == 14
                     assert r.execute_command('TS.ADD', key, 20, 20) == 20
-                    
+
                     expected_result = r.execute_command('TS.RANGE', key, 0, -1, 'aggregation', agg_type, 10)
                     actual_result = r.execute_command('TS.RANGE', agg_key, 0, -1)
                     assert expected_result[0:1] == actual_result[0:1]
@@ -1606,7 +1606,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
                     assert r.execute_command('TS.ADD', key, 27, 27) == 27
                     assert r.execute_command('TS.ADD', key, 23, 25) == 23
                     assert r.execute_command('TS.ADD', key, 30, 30) == 30
-                    
+
                     expected_result = r.execute_command('TS.RANGE', key, 0, -1, 'aggregation', agg_type, 10)
                     actual_result = r.execute_command('TS.RANGE', agg_key, 0, -1)
                     assert expected_result[0:3] == actual_result[0:3]
@@ -1653,7 +1653,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
     def test_ooo_split(self):
         with self.redis() as r:
             quantity = 5000
-            
+
             type_list = ['', 'UNCOMPRESSED']
             for chunk_type in type_list:
                 r.execute_command('ts.create', 'split', chunk_type)
@@ -1665,7 +1665,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
                 for i in range(quantity - 1):
                     assert res[i][0] + 1 == res[i + 1][0]
                     assert round(float(res[i][1]) + 1.01, 2) == round(float(res[i + 1][1]), 2)
-                    
+
                 r.execute_command('DEL split')
 
     def test_rand_oom(self):
@@ -1705,7 +1705,7 @@ class RedisTimeseriesTests(ModuleTestCase(REDISTIMESERIES)):
             assert r.execute_command('ts.add', 'tester', 99, 1) == 99
             assert r.execute_command('ts.add', 'tester', 98, 1) == 98
 
-class GlobalConfigTests(ModuleTestCase(REDISTIMESERIES, 
+class GlobalConfigTests(ModuleTestCase(REDISTIMESERIES,
         module_args=['COMPACTION_POLICY', 'max:1m:1d;min:10s:1h;avg:2h:10d;avg:3d:100d'])):
     def test_autocreate(self):
         with self.redis() as r:
@@ -1799,7 +1799,8 @@ class DuplicationPolicyTests(ModuleTestCase(REDISTIMESERIES,
             'LAST': lambda x, y: y,
             'FIRST': lambda x, y: x,
             'MIN': min,
-            'MAX': max
+            'MAX': max,
+            'SUM': lambda x, y: x + y
         }
 
         with self.redis() as r:
@@ -1812,11 +1813,11 @@ class DuplicationPolicyTests(ModuleTestCase(REDISTIMESERIES,
                 r.execute_command('TS.ADD', key, overrided_ts, 1)
 
             for policy in policies:
-                old_value = r.execute_command('TS.RANGE', key, overrided_ts, overrided_ts)[0][1]
+                old_value = int(r.execute_command('TS.RANGE', key, overrided_ts, overrided_ts)[0][1])
                 new_value = random.randint(5000, 1000000)
                 assert r.execute_command('TS.ADD', key, overrided_ts, new_value, 'ON_DUPLICATE', policy) == overrided_ts
-                proccessed_value = r.execute_command('TS.RANGE', key, overrided_ts, overrided_ts)[0][1]
-                assert str(policies[policy](old_value, new_value)) == proccessed_value, "check that {} is correct".format(policy)
+                proccessed_value = int(r.execute_command('TS.RANGE', key, overrided_ts, overrided_ts)[0][1])
+                assert policies[policy](old_value, new_value) == proccessed_value, "check that {} is correct".format(policy)
 
 ########## Test init args ##########
 def ModuleArgsTestCase(good, args):


### PR DESCRIPTION
Hello! This PR has two independent pieces of functionality:
- `SUM` Duplicate sample policy option
- Docker build + development improvements

I started developing the code for the `SUM` duplicate policy option and found that the Docker build improvements helped for my typical dev flow. I'm happy to remove that commit from this PR if you'd like as I realize this is definitely subject to individual dev flows and opinions.

--------------------------------

**SUM Duplicate Policy**

Setting SUM as a duplicate policy will result in the value for a single time window being the sum of all data written in the time window. This is useful for high-frequency event counting that can't guarantee two samples won't be written in the same time window.

I discussed mine and my company's motivation for this feature in #492. This would be a huge win for us as a company as we're using RTS very successfully in multiple places but seeing this occasionally. Thank you for considering!

--------------------------------

**Docker build + development improvements**

- Updates .dockerignore to ignore everything by default and adds
back in files needed for build. This is configured to be decently
permissive at the moment, but will stop the .circleCI and .github
files from being added into the container along with things like
the Dockerfile, .yml files, etc.
- Updates Dockerfile to improve build-to-build caching. Previously,
dependencies were being re-installed on source code changes, this
should speed up local builds and also CI/CD builds if build caching
is being used.
- Adds docker-compose file and documentation for local development
using Docker. This is convenient as it can allow users to edit
code as they normally would, but build/test inside roughly the
production docker container. It can reduce "works on my machine" type
issues and is generally nice for people with broken installs of
python on their machine or people who don't want to change their
python configuration.
- Adds a bit of detail to testing docs

Adding the option to easily develop in a Docker container is quite useful for me as a dev as it helps me isolate the configurations needed for the various projects I work on. The goal of these changes was to make them non-invasive and parallel to the typical dev flow. One thing that did need to be updated was the improvements to the Dockerfile to improve caching, as otherwise Docker rebuilds were taking quite a while locally. The `.dockerignore` changes also aren't strictly necessary since this project is already doing a nice job using a `builder` stage and copying the contents -- this is more of a policy I've found useful for helping to keep our container sizes down that I figured I would propose. I appreciate your considering these changes and again would be happy to remove this commit from the PR as it is completely non-essential.
