### PR TITLE
fix #561: call SeriesAddSample when updating an empty downsampled rul…

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -130,7 +130,11 @@ ChunkResult Uncompressed_UpsertSample(UpsertCtx *uCtx, int *size, DuplicatePolic
         }
     }
     // update value in case timestamp exists
-    if (ts == sample->timestamp) {
+    if (sample != NULL && ts == sample->timestamp) {
+        ChunkResult cr = handleDuplicateSample(duplicatePolicy, *sample, &uCtx->sample);
+        if (cr != CR_OK) {
+            return CR_ERR;
+        }
         regChunk->samples[i].value = uCtx->sample.value;
         return CR_OK;
     }

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -247,7 +247,11 @@ static void upsertCompaction(Series *series, UpsertCtx *uCtx) {
                 RedisModule_Log(ctx, "verbose", "%s", "Failed to retrieve downsample series");
                 continue;
             }
-            SeriesUpsertSample(destSeries, start, val, DP_LAST);
+            if (destSeries->totalSamples == 0) {
+                SeriesAddSample(destSeries, start, val);
+            } else {
+                SeriesUpsertSample(destSeries, start, val, DP_LAST);
+            }
             RedisModule_CloseKey(key);
         }
         rule = rule->nextRule;


### PR DESCRIPTION
…e, also handle duplication policy in uncompressed chunks.