### PR TITLE
Optimized upsertCompaction from passing common pointers multiple times to constants

### DIFF
--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -222,20 +222,23 @@ size_t SeriesGetNumSamples(const Series *series) {
 static void upsertCompaction(Series *series, UpsertCtx *uCtx) {
     CompactionRule *rule = series->rules;
     RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
+    const timestamp_t upsertTimestamp = uCtx->sample.timestamp;
+    const timestamp_t seriesLastTimestamp = series->lastTimestamp;
     while (rule != NULL) {
-        timestamp_t curAggWindowStart = CalcWindowStart(series->lastTimestamp, rule->timeBucket);
-        if (uCtx->sample.timestamp >= curAggWindowStart) {
+        const timestamp_t ruleTimebucket = rule->timeBucket;
+        const timestamp_t curAggWindowStart = CalcWindowStart(seriesLastTimestamp, ruleTimebucket);
+        if (upsertTimestamp >= curAggWindowStart) {
             // upsert in latest timebucket
-            int rv = SeriesCalcRange(series, curAggWindowStart, UINT64_MAX, rule, NULL);
+            const int rv = SeriesCalcRange(series, curAggWindowStart, UINT64_MAX, rule, NULL);
             if (rv == TSDB_ERROR) {
                 RedisModule_Log(ctx, "verbose", "%s", "Failed to calculate range for downsample");
                 continue;
             }
         } else {
-            timestamp_t start = CalcWindowStart(uCtx->sample.timestamp, rule->timeBucket);
+            const timestamp_t start = CalcWindowStart(upsertTimestamp, ruleTimebucket);
             // ensure last include/exclude
             double val = 0;
-            int rv = SeriesCalcRange(series, start, start + rule->timeBucket - 1, rule, &val);
+            const int rv = SeriesCalcRange(series, start, start + ruleTimebucket - 1, rule, &val);
             if (rv == TSDB_ERROR) {
                 RedisModule_Log(ctx, "verbose", "%s", "Failed to calculate range for downsample");
                 continue;


### PR DESCRIPTION
This is a simple PR doing some very simple optimizations:
- set every return variable to const whenever possible
- move from passing common pointers multiple times to constants, specifically `uCtx->sample.timestamp`, `series->lastTimestamp`, and `rule->timeBucket`