### PR TITLE
Add redis-time-series gem to list of clients

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -19,3 +19,4 @@ Some languages have client libraries that provide support for RedisTimeSeries co
 | redistimeseries-js | JavaScript | MIT | [Milos Nikolovski](https://github.com/nikolovskimilos) | [Github](https://github.com/nikolovskimilos/redistimeseries-js) |
 | redis_ts | Rust | BSD-3 | [Thomas Profelt](https://github.com/tompro) | [Github](https://github.com/tompro/redis_ts) |
 | redistimeseries | Ruby | MIT | [Eaden McKee](https://github.com/eadz) | [Github](https://github.com/eadz/redistimeseries) |
+| redis-time-series | Ruby | MIT | [Matt Duszynski](https://github.com/dzunk) | [Github](https://github.com/dzunk/redis-time-series) |


### PR DESCRIPTION
Here I was wondering why my gem never showed up on the official website... turns out it's based on a different set of docs 😬 

Updating list of clients I missed in https://github.com/RedisTimeSeries/RedisTimeSeries/pull/476