### PR TITLE
Fixed duplicate policy min/max rules not working for negative values

### DIFF
--- a/src/generic_chunk.c
+++ b/src/generic_chunk.c
@@ -69,13 +69,15 @@ ChunkResult handleDuplicateSample(DuplicatePolicy policy, Sample oldSample, Samp
         case DP_LAST:
             return CR_OK;
         case DP_MIN:
-            newSample->value = min(oldSample.value, newSample->value);
+            if (oldSample.value < newSample->value)
+                newSample->value = oldSample.value;
             return CR_OK;
         case DP_MAX:
-            newSample->value = max(oldSample.value, newSample->value);
+            if (oldSample.value > newSample->value)
+                newSample->value = oldSample.value;
             return CR_OK;
         case DP_SUM:
-            newSample->value = oldSample.value + newSample->value;
+            newSample->value += (oldSample.value);
             return CR_OK;
         default:
             return CR_ERR;

--- a/src/generic_chunk.c
+++ b/src/generic_chunk.c
@@ -77,7 +77,7 @@ ChunkResult handleDuplicateSample(DuplicatePolicy policy, Sample oldSample, Samp
                 newSample->value = oldSample.value;
             return CR_OK;
         case DP_SUM:
-            newSample->value += (oldSample.value);
+            newSample->value += oldSample.value;
             return CR_OK;
         default:
             return CR_ERR;

--- a/src/unittests.c
+++ b/src/unittests.c
@@ -22,5 +22,5 @@ int main(int argc, char *argv[]) {
     MU_RUN_SUITE(compressed_chunk_test_suite);
     MU_RUN_SUITE(parse_duplicate_policy_test_suite);
 	MU_REPORT();
-	return 0;
+	return minunit_fail;
 }

--- a/src/unittests_uncompressed_chunk.c
+++ b/src/unittests_uncompressed_chunk.c
@@ -116,18 +116,27 @@ MU_TEST(test_Uncompressed_Uncompressed_UpsertSample_DuplicatePolicy) {
     const u_int64_t firstTs = Uncompressed_GetFirstTimestamp(chunk);
     mu_assert_int_eq(1,firstTs);
     mu_assert_double_eq(-0.5,chunk->samples[0].value);
-    // DP_MIN should replace -0.5 by -0.6 
+    // DP_MAX should keep -0.5 given that -0.4 is smaller
+    uCtx.sample.value = -0.4;
     rv = Uncompressed_UpsertSample(&uCtx, &size, DP_MIN);
-    mu_assert(rv == CR_OK, "duplicate min");
+    mu_assert(rv == CR_OK, "duplicate min not changing old value");
+    mu_assert_int_eq(1,chunk->num_samples);
+    mu_assert_double_eq(-0.5,chunk->samples[0].value);
+    // DP_MIN should replace -0.5 by -0.6 
+    uCtx.sample.value = -0.6;
+    rv = Uncompressed_UpsertSample(&uCtx, &size, DP_MIN);
+    mu_assert(rv == CR_OK, "duplicate min changing old value");
     mu_assert_int_eq(1,chunk->num_samples);
     mu_assert_double_eq(-0.6,chunk->samples[0].value);
     // DP_MAX should keep -0.6 given that -1 is smaller
     uCtx.sample.value = -1.0;
     rv = Uncompressed_UpsertSample(&uCtx, &size, DP_MAX);
+    mu_assert(rv == CR_OK, "duplicate max not changing old value");
     mu_assert_double_eq(-0.6,chunk->samples[0].value);
     // DP_MAX should replace -0.6 by -0.2
     uCtx.sample.value = -0.2;
     rv = Uncompressed_UpsertSample(&uCtx, &size, DP_MAX);
+    mu_assert(rv == CR_OK, "duplicate max changing old value");
     mu_assert_double_eq(-0.2,chunk->samples[0].value);
     Uncompressed_FreeChunk(chunk);
 }

--- a/src/unittests_uncompressed_chunk.c
+++ b/src/unittests_uncompressed_chunk.c
@@ -91,8 +91,41 @@ MU_TEST(test_Uncompressed_Uncompressed_UpsertSample) {
     Uncompressed_FreeChunk(chunk);
 }
 
+MU_TEST(test_Uncompressed_Uncompressed_UpsertSample_DuplicatePolicy) {
+    srand((unsigned int)time(NULL));
+    const size_t chunk_size = 4096; // 4096 bytes (data) chunck
+     Chunk *chunk = Uncompressed_NewChunk(chunk_size);
+    mu_assert(chunk != NULL, "create uncompressed chunk");
+    mu_assert_short_eq(0,chunk->num_samples);
+    ChunkResult rv = CR_OK;
+    Sample s1 = { .timestamp = 1, .value = -0.5 };
+    Sample s2 = { .timestamp = 1, .value = -0.6 };
+    rv = Uncompressed_AddSample(chunk,&s1);
+    mu_assert(rv == CR_OK, "add sample");
+    UpsertCtx uCtx = {
+        .inChunk = chunk,
+        .sample = s2,
+    };
+
+    int size = 0;
+    // We're forcing the chunk to grow 
+    rv = Uncompressed_UpsertSample(&uCtx, &size, DP_BLOCK);
+    mu_assert(rv == CR_ERR, "duplicate block");
+    mu_assert_int_eq(1,chunk->num_samples);
+    const u_int64_t firstTs = Uncompressed_GetFirstTimestamp(chunk);
+    mu_assert_int_eq(1,firstTs);
+    mu_assert_double_eq(-0.5,chunk->samples[0].value);
+    rv = Uncompressed_UpsertSample(&uCtx, &size, DP_MIN);
+    mu_assert(rv == CR_OK, "duplicate min");
+    mu_assert_int_eq(1,chunk->num_samples);
+    mu_assert_double_eq(-0.6,chunk->samples[0].value);
+    Uncompressed_FreeChunk(chunk);
+}
+
 MU_TEST_SUITE(uncompressed_chunk_test_suite) {
     MU_RUN_TEST(test_Uncompressed_NewChunk);
     MU_RUN_TEST(test_Uncompressed_Uncompressed_AddSample);
     MU_RUN_TEST(test_Uncompressed_Uncompressed_UpsertSample);
+    MU_RUN_TEST(test_Uncompressed_Uncompressed_UpsertSample_DuplicatePolicy);
+    
 }


### PR DESCRIPTION
- [add] Added test_Uncompressed_Uncompressed_UpsertSample_DuplicatePolicy to mimic issue #588
- Fixes #588 by doing the proper double comparison ( PS: simplified further the comparison @danni-m )
- Fixes #591 by using the number of failed unit tests as the unit wrapper return code