### PR TITLE
Build checks for macos, centos7 and ubuntu-16.04 on GH actions

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -32,14 +32,16 @@ jobs:
       run: |
         make unittests
 
-  build-centos7:
+  build-centos:
     runs-on: ubuntu-latest
-    container: centos:7
+      matrix:
+        centos: ["7", "8"]
+    container:
+      image: centos:${{ matrix.centos }}
     steps:
     - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: |
-        yum -y install git gcc make
+    - name: Install packages
+      run: yum install -y install git gcc make
     - name: Submodule checkout
       run: |
         git submodule update --init --recursive

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -44,7 +44,7 @@ jobs:
       run: yum install -y install git gcc make
     - name: Submodule checkout
       run: |
-        git submodule update --init --recursive
+        export GIT_DISCOVERY_ACROSS_FILESYSTEM=1 && git submodule update --init --recursive
     - name: make
       run: |
         make

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -35,12 +35,12 @@ jobs:
   build-centos:
     runs-on: ubuntu-latest
     container:
-      image: centos7
+      image: centos:7
     steps:
-    - uses: actions/checkout@v2
     - name: Install packages
       run: yum install -y install git gcc make
     - name: Submodule checkout
+    - uses: actions/checkout@v2
       run: |
         export GIT_DISCOVERY_ACROSS_FILESYSTEM=1 && git submodule update --init --recursive
     - name: make

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -33,9 +33,10 @@ jobs:
         make unittests
 
   build-centos:
-    runs-on: ubuntu-latest
+    strategy:
       matrix:
-        centos: ["7", "8"]
+        centos: [7,8]
+    runs-on: ubuntu-latest
     container:
       image: centos:${{ matrix.centos }}
     steps:

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,0 +1,51 @@
+name: CI Build Checks
+
+on: [push, pull_request]
+
+jobs:
+
+  build-ubuntu-old:
+    runs-on: ubuntu-16.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Submodule checkout
+      run: |
+        git submodule update --init --recursive
+    - name: make
+      run: |
+        make
+    - name: Run unit tests
+      run: |
+        make unittests
+
+  build-macos-latest:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Submodule checkout
+      run: |
+        git submodule update --init --recursive
+    - name: make
+      run: |
+        make
+    - name: Run unit tests
+      run: |
+        make unittests
+
+  build-centos7:
+    runs-on: ubuntu-latest
+    container: centos:7
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        yum -y install git gcc make
+    - name: Submodule checkout
+      run: |
+        git submodule update --init --recursive
+    - name: make
+      run: |
+        make
+    - name: Run unit tests
+      run: |
+        make unittests

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -33,12 +33,9 @@ jobs:
         make unittests
 
   build-centos:
-    strategy:
-      matrix:
-        centos: [7,8]
     runs-on: ubuntu-latest
     container:
-      image: centos:${{ matrix.centos }}
+      image: centos7
     steps:
     - uses: actions/checkout@v2
     - name: Install packages


### PR DESCRIPTION
The following PR checks that the build process is not broken for both macos, ubuntu, and centos7 OS flavours. It does not run a full test suite, for that we have circleCI. 