### PR TITLE
TS.MGET/TS.MRANGE: Fixed crash/spurious errors due to inconsistencies between referenced keys on QueryIndexPredicate result dict and the updated labelsIndex

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -257,8 +257,7 @@ RedisModuleDict *GetPredicateKeysDict(RedisModuleCtx *ctx, QueryPredicate *predi
 
 RedisModuleDict *QueryIndexPredicate(RedisModuleCtx *ctx,
                                      QueryPredicate *predicate,
-                                     RedisModuleDict *prevResults,
-                                     int createResultDict) {
+                                     RedisModuleDict *prevResults) {
     RedisModuleDict *localResult = RedisModule_CreateDict(ctx);
     RedisModuleDict *currentLeaf;
 
@@ -269,7 +268,7 @@ RedisModuleDict *QueryIndexPredicate(RedisModuleCtx *ctx,
         // In the next iteration, when prevResults is no longer NULL, there is
         // no need to copy again. We can work on currentLeaf, since only the left dict is being
         // changed during intersection / difference.
-        if (createResultDict && prevResults == NULL) {
+        if (prevResults == NULL) {
             RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(currentLeaf, "^", NULL, 0);
             RedisModuleString *currentKey;
             while ((currentKey = RedisModule_DictNext(ctx, iter, NULL)) != NULL) {
@@ -342,7 +341,7 @@ RedisModuleDict *QueryIndex(RedisModuleCtx *ctx,
     for (int i = 0; i < predicate_count; i++) {
         if (index_predicate[i].type == EQ || index_predicate[i].type == CONTAINS ||
             index_predicate[i].type == LIST_MATCH) {
-            result = QueryIndexPredicate(ctx, &index_predicate[i], result, 1);
+            result = QueryIndexPredicate(ctx, &index_predicate[i], result);
             if (result == NULL) {
                 return RedisModule_CreateDict(ctx);
             }
@@ -354,7 +353,7 @@ RedisModuleDict *QueryIndex(RedisModuleCtx *ctx,
     for (int i = 0; i < predicate_count; i++) {
         if (index_predicate[i].type == NCONTAINS || index_predicate[i].type == NEQ ||
             index_predicate[i].type == LIST_NOTMATCH) {
-            result = QueryIndexPredicate(ctx, &index_predicate[i], result, 1);
+            result = QueryIndexPredicate(ctx, &index_predicate[i], result);
             if (result == NULL) {
                 return RedisModule_CreateDict(ctx);
             }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -265,8 +265,8 @@ RedisModuleDict *QueryIndexPredicate(RedisModuleCtx *ctx,
     currentLeaf = GetPredicateKeysDict(ctx, predicate);
 
     if (currentLeaf != NULL) {
-        // Copy everything to new dict only in case this is the first predicate (and there is more
-        // than one predicate). In the next iteration, when prevResults is no longer NULL, there is
+        // Copy everything to new dict only in case this is the first predicate.
+        // In the next iteration, when prevResults is no longer NULL, there is
         // no need to copy again. We can work on currentLeaf, since only the left dict is being
         // changed during intersection / difference.
         if (createResultDict && prevResults == NULL) {
@@ -335,7 +335,6 @@ RedisModuleDict *QueryIndex(RedisModuleCtx *ctx,
                             QueryPredicate *index_predicate,
                             size_t predicate_count) {
     RedisModuleDict *result = NULL;
-    int shouldCreateNewDict = (predicate_count > 1);
 
     PromoteSmallestPredicateToFront(ctx, index_predicate, predicate_count);
 
@@ -343,7 +342,7 @@ RedisModuleDict *QueryIndex(RedisModuleCtx *ctx,
     for (int i = 0; i < predicate_count; i++) {
         if (index_predicate[i].type == EQ || index_predicate[i].type == CONTAINS ||
             index_predicate[i].type == LIST_MATCH) {
-            result = QueryIndexPredicate(ctx, &index_predicate[i], result, shouldCreateNewDict);
+            result = QueryIndexPredicate(ctx, &index_predicate[i], result, 1);
             if (result == NULL) {
                 return RedisModule_CreateDict(ctx);
             }
@@ -355,7 +354,7 @@ RedisModuleDict *QueryIndex(RedisModuleCtx *ctx,
     for (int i = 0; i < predicate_count; i++) {
         if (index_predicate[i].type == NCONTAINS || index_predicate[i].type == NEQ ||
             index_predicate[i].type == LIST_NOTMATCH) {
-            result = QueryIndexPredicate(ctx, &index_predicate[i], result, shouldCreateNewDict);
+            result = QueryIndexPredicate(ctx, &index_predicate[i], result, 1);
             if (result == NULL) {
                 return RedisModule_CreateDict(ctx);
             }

--- a/src/module.c
+++ b/src/module.c
@@ -81,24 +81,6 @@ static int parseLabelsFromArgs(RedisModuleString **argv,
     return REDISMODULE_OK;
 }
 
-int SilentGetSeries(RedisModuleCtx *ctx,
-                    RedisModuleString *keyName,
-                    RedisModuleKey **key,
-                    Series **series,
-                    int mode) {
-    *key = RedisModule_OpenKey(ctx, keyName, mode);
-    if (RedisModule_KeyType(*key) == REDISMODULE_KEYTYPE_EMPTY) {
-        RedisModule_CloseKey(*key);
-        return FALSE;
-    }
-    if (RedisModule_ModuleTypeGetType(*key) != SeriesType) {
-        RedisModule_CloseKey(*key);
-        return FALSE;
-    }
-    *series = RedisModule_ModuleTypeGetValue(*key);
-    return TRUE;
-}
-
 int GetSeries(RedisModuleCtx *ctx,
               RedisModuleString *keyName,
               RedisModuleKey **key,
@@ -113,6 +95,24 @@ int GetSeries(RedisModuleCtx *ctx,
     if (RedisModule_ModuleTypeGetType(*key) != SeriesType) {
         RedisModule_CloseKey(*key);
         RTS_ReplyGeneralError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+        return FALSE;
+    }
+    *series = RedisModule_ModuleTypeGetValue(*key);
+    return TRUE;
+}
+
+int SilentGetSeries(RedisModuleCtx *ctx,
+                    RedisModuleString *keyName,
+                    RedisModuleKey **key,
+                    Series **series,
+                    int mode) {
+    *key = RedisModule_OpenKey(ctx, keyName, mode);
+    if (RedisModule_KeyType(*key) == REDISMODULE_KEYTYPE_EMPTY) {
+        RedisModule_CloseKey(*key);
+        return FALSE;
+    }
+    if (RedisModule_ModuleTypeGetType(*key) != SeriesType) {
+        RedisModule_CloseKey(*key);
         return FALSE;
     }
     *series = RedisModule_ModuleTypeGetValue(*key);

--- a/src/module.h
+++ b/src/module.h
@@ -16,6 +16,10 @@ extern RedisModuleType *SeriesType;
 int CreateTsKey(RedisModuleCtx *ctx, RedisModuleString *keyName,
                 CreateCtx *cCtx, Series **series, RedisModuleKey **key);
 
+// This method provides the same logic as GetSeries, without replying to the client in case of error
+// The caller method should check the result for TRUE/FALSE and update the client accordingly if required
+int SilentGetSeries(RedisModuleCtx *ctx, RedisModuleString *keyName, RedisModuleKey **key, Series **series, int mode);
+
 int GetSeries(RedisModuleCtx *ctx, RedisModuleString *keyName, RedisModuleKey **key, Series **series, int mode);
 
 #endif

--- a/src/module.h
+++ b/src/module.h
@@ -16,10 +16,11 @@ extern RedisModuleType *SeriesType;
 int CreateTsKey(RedisModuleCtx *ctx, RedisModuleString *keyName,
                 CreateCtx *cCtx, Series **series, RedisModuleKey **key);
 
+
+int GetSeries(RedisModuleCtx *ctx, RedisModuleString *keyName, RedisModuleKey **key, Series **series, int mode);
+
 // This method provides the same logic as GetSeries, without replying to the client in case of error
 // The caller method should check the result for TRUE/FALSE and update the client accordingly if required
 int SilentGetSeries(RedisModuleCtx *ctx, RedisModuleString *keyName, RedisModuleKey **key, Series **series, int mode);
-
-int GetSeries(RedisModuleCtx *ctx, RedisModuleString *keyName, RedisModuleKey **key, Series **series, int mode);
 
 #endif

--- a/tests/flow/test_ts_mget.py
+++ b/tests/flow/test_ts_mget.py
@@ -1,7 +1,24 @@
 import pytest
 import redis
+import time 
 from RLTest import Env
 
+def test_mget_with_expire_cmd():
+    with Env().getConnection() as r:
+        # Lower hz value to make it more likely that mget triggers key expiration
+        assert r.execute_command('config set hz 1') == b'OK'
+        assert r.execute_command("TS.ADD", "X" ,"*" ,"1" ,"LABELS", "type", "DELAYED")
+        assert r.execute_command("TS.ADD", "Y" ,"*" ,"1" ,"LABELS", "type", "DELAYED")
+        assert r.execute_command("TS.ADD", "Z" ,"*" ,"1" ,"LABELS", "type", "DELAYED")
+        current_ts = time.time()
+        assert r.execute_command("EXPIRE","X", 5)
+        assert r.execute_command("EXPIRE","Y", 6)
+        assert r.execute_command("EXPIRE","Z", 7)
+        while time.time() < (current_ts+10):
+            reply = r.execute_command('TS.MGET', 'FILTER', 'type=DELAYED')
+            assert(len(reply)>=0 and len(reply)<=3)
+        assert r.execute_command("PING")
+        
 
 def test_mget_cmd():
     num_of_keys = 3


### PR DESCRIPTION
This PR provides an easy fix for #612 . Bottom line this happens when on a single predicate query and between the moment we call QueryIndexPredicate() and iterate over the resulting dict we've removed/expired keys. 
- This only happens on single predicate queries because on multiple conditions we copy the dictionary. Therefore, forcing the copy also on single predicates we fix the issue without substancial code changes.
- On queries with more than one predicate the crash does not occur but we still reply with errors that are not supposed to be passed to the client ( key does not exist ). Therefore we have two options: 1) use locking to remove this inconsistencies on the global labels dict meaning we will have performance penalties. 2) use the relaxed version ( this one ) that ignores the missing keys between queryIndexPredicate and the reply. 
To verify that this crash dos not occur follow the suggestion of #612 :
```
TS.ADD X * 1 LABELS type DELAYED
TS.ADD Y * 2 LABELS type DELAYED
TS.ADD Z * 3 LABELS type DELAYED
EXPIRE X 3
EXPIRE Y 4
EXPIRE Z 5
```
and run an exhaustive check that will now neither crash or reply with spurious errors
```
redis-cli -p 6379 <./cmds && redis-benchmark -p 6379 -n 40000000000000 -e TS.MGET FILTER type=DELAYED
```