### PR TITLE
Applied clang-format to header files; Fixed test compiler warnings;

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -117,16 +117,21 @@ _SOURCES=\
 
 _TEST_SOURCES=\
 	unittests.c \
+	endianconv.c
+
+_TEST_FILES=\
+	unittests.c \
 	unittests_parse_policies.c \
 	unittests_uncompressed_chunk.c \
 	unittests_compressed_chunk.c \
-	unittests_parse_duplicate_policy.c \
-	endianconv.c
+	unittests_parse_duplicate_policy.c
 
 SOURCES=$(addprefix $(SRCDIR)/,$(_SOURCES))
+HEADERS=$(patsubst $(SRCDIR)/%.c,$(SRCDIR)/%.h,$(SOURCES))
 OBJECTS=$(patsubst $(SRCDIR)/%.c,$(BINDIR)/%.o,$(SOURCES))
 
 TEST_SOURCES=$(addprefix $(SRCDIR)/,$(_TEST_SOURCES))
+TEST_FILES=$(addprefix $(SRCDIR)/,$(_TEST_FILES))
 TEST_OBJECTS=$(patsubst $(SRCDIR)/%.c,$(BINDIR)/%.o,$(TEST_SOURCES))
 
 CC_DEPS = $(patsubst $(SRCDIR)/%.c, $(BINDIR)/%.d, $(SOURCES) $(TEST_SOURCES))
@@ -153,11 +158,13 @@ docker_lint:
 
 lint:
 	clang-format -Werror -n $(SOURCES)
-	clang-format -Werror -n $(TEST_SOURCES)
+	clang-format -Werror -n $(HEADERS)
+	clang-format -Werror -n $(TEST_FILES)
 
 format:
 	clang-format -i $(SOURCES)
-	clang-format -i $(TEST_SOURCES)
+	clang-format -i $(HEADERS)
+	clang-format -i $(TEST_FILES)
 
 clean:
 	-$(SHOW)[ -e $(BINDIR) ] && find $(BINDIR) -name '*.[oadh]' -type f -delete

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -1,23 +1,26 @@
 /*
-* Copyright 2018-2019 Redis Labs Ltd. and Contributors
-*
-* This file is available under the Redis Labs Source Available License Agreement
-*/
+ * Copyright 2018-2019 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
 #ifndef CHUNK_H
 #define CHUNK_H
 
 #include "consts.h"
 #include "generic_chunk.h"
+
 #include <sys/types.h>
 
-typedef struct Chunk {
+typedef struct Chunk
+{
     timestamp_t base_timestamp;
     Sample *samples;
     unsigned int num_samples;
     size_t size;
 } Chunk;
 
-typedef struct ChunkIterator {
+typedef struct ChunkIterator
+{
     Chunk *chunk;
     int currentIndex;
     timestamp_t lastTimestamp;
@@ -57,7 +60,9 @@ u_int64_t Uncompressed_NumOfSample(Chunk_t *chunk);
 timestamp_t Uncompressed_GetLastTimestamp(Chunk_t *chunk);
 timestamp_t Uncompressed_GetFirstTimestamp(Chunk_t *chunk);
 
-ChunkIter_t *Uncompressed_NewChunkIterator(Chunk_t *chunk, int options, ChunkIterFuncs* retChunkIterClass);
+ChunkIter_t *Uncompressed_NewChunkIterator(Chunk_t *chunk,
+                                           int options,
+                                           ChunkIterFuncs *retChunkIterClass);
 ChunkResult Uncompressed_ChunkIteratorGetNext(ChunkIter_t *iterator, Sample *sample);
 ChunkResult Uncompressed_ChunkIteratorGetPrev(ChunkIter_t *iterator, Sample *sample);
 void Uncompressed_FreeChunkIterator(ChunkIter_t *iter);

--- a/src/compaction.h
+++ b/src/compaction.h
@@ -1,24 +1,25 @@
 /*
-* Copyright 2018-2019 Redis Labs Ltd. and Contributors
-*
-* This file is available under the Redis Labs Source Available License Agreement
-*/
+ * Copyright 2018-2019 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
 #ifndef COMPACTION_H
 #define COMPACTION_H
-#include <sys/types.h>
-#include "redismodule.h"
 #include "consts.h"
+#include "redismodule.h"
+
+#include <sys/types.h>
 #include <rmutil/util.h>
 
 typedef struct AggregationClass
 {
     void *(*createContext)();
-    void(*freeContext)(void *context);
-    void(*appendValue)(void *context, double value);
-    void(*resetContext)(void *context);
-    void(*writeContext)(void *context, RedisModuleIO *io);
-    void(*readContext)(void *context, RedisModuleIO *io);
-    int(*finalize)(void *context, double *value);
+    void (*freeContext)(void *context);
+    void (*appendValue)(void *context, double value);
+    void (*resetContext)(void *context);
+    void (*writeContext)(void *context, RedisModuleIO *io);
+    void (*readContext)(void *context, RedisModuleIO *io);
+    int (*finalize)(void *context, double *value);
 } AggregationClass;
 
 AggregationClass *GetAggClass(TS_AGG_TYPES_T aggType);

--- a/src/compressed_chunk.h
+++ b/src/compressed_chunk.h
@@ -1,16 +1,17 @@
 /*
-* Copyright 2018-2019 Redis Labs Ltd. and Contributors
-*
-* This file is available under the Redis Labs Source Available License Agreement
-*/
+ * Copyright 2018-2019 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
 
 #ifndef COMPRESSED_CHUNK_H
 #define COMPRESSED_CHUNK_H
 
-#include <sys/types.h>      // u_int_t
-#include <stdbool.h>        // bool
-#include "gorilla.h"
 #include "generic_chunk.h"
+#include "gorilla.h"
+
+#include <stdbool.h>   // bool
+#include <sys/types.h> // u_int_t
 
 // Initialize compressed chunk
 Chunk_t *Compressed_NewChunk(size_t size);
@@ -22,15 +23,17 @@ ChunkResult Compressed_AddSample(Chunk_t *chunk, Sample *sample);
 ChunkResult Compressed_UpsertSample(UpsertCtx *uCtx, int *size, DuplicatePolicy duplicatePolicy);
 
 // Read from compressed chunk using an iterator
-ChunkIter_t *Compressed_NewChunkIterator(Chunk_t *chunk, int options, ChunkIterFuncs* retChunkIterClass);
-ChunkResult Compressed_ChunkIteratorGetNext(ChunkIter_t *iter, Sample* sample);
+ChunkIter_t *Compressed_NewChunkIterator(Chunk_t *chunk,
+                                         int options,
+                                         ChunkIterFuncs *retChunkIterClass);
+ChunkResult Compressed_ChunkIteratorGetNext(ChunkIter_t *iter, Sample *sample);
 void Compressed_FreeChunkIterator(ChunkIter_t *iter);
 
 // Miscellaneous
 size_t Compressed_GetChunkSize(Chunk_t *chunk, bool includeStruct);
-u_int64_t Compressed_ChunkNumOfSample (Chunk_t *chunk);
+u_int64_t Compressed_ChunkNumOfSample(Chunk_t *chunk);
 timestamp_t Compressed_GetFirstTimestamp(Chunk_t *chunk);
-timestamp_t Compressed_GetLastTimestamp (Chunk_t *chunk);
+timestamp_t Compressed_GetLastTimestamp(Chunk_t *chunk);
 
 // RDB
 void Compressed_SaveToRDB(Chunk_t *chunk, struct RedisModuleIO *io);

--- a/src/config.h
+++ b/src/config.h
@@ -1,16 +1,18 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
-*
-* This file is available under the Redis Labs Source Available License Agreement
-*/
+ * Copyright 2018-2020 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#include "redismodule.h"
 #include "parse_policies.h"
+#include "redismodule.h"
+
 #include <stdbool.h>
 
-typedef struct {
+typedef struct
+{
     SimpleCompactionRule *compactionRules;
     uint64_t compactionRulesCount;
     long long retentionPolicy;
@@ -24,10 +26,11 @@ extern TSConfig TSGlobalConfig;
 
 int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
-typedef struct RTS_RedisVersion {
-  int redisMajorVersion;
-  int redisMinorVersion;
-  int redisPatchVersion;
+typedef struct RTS_RedisVersion
+{
+    int redisMajorVersion;
+    int redisMinorVersion;
+    int redisPatchVersion;
 } RTS_RedisVersion;
 
 extern RTS_RedisVersion RTS_currVersion;
@@ -38,7 +41,9 @@ extern int RTS_RlecMinorVersion;
 extern int RTS_RlecPatchVersion;
 extern int RTS_RlecBuild;
 
-static inline int RTS_IsEnterprise() { return RTS_RlecMajorVersion != -1; }
+static inline int RTS_IsEnterprise() {
+    return RTS_RlecMajorVersion != -1;
+}
 
 int RTS_CheckSupportedVestion();
 void RTS_GetRedisVersion();

--- a/src/generic_chunk.h
+++ b/src/generic_chunk.h
@@ -1,22 +1,24 @@
 /*
-* Copyright 2018-2019 Redis Labs Ltd. and Contributors
-*
-* This file is available under the Redis Labs Source Available License Agreement
-*/
+ * Copyright 2018-2019 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
 
 #ifndef GENERIC__CHUNK_H
 #define GENERIC__CHUNK_H
 
+#include "consts.h"
+
+#include <stdio.h>  // printf
+#include <stdlib.h> // malloc
+#include <string.h> // memcpy, memmove
 #include <sys/types.h>
 #include <rmutil/strings.h>
-#include <stdlib.h>         // malloc
-#include <stdio.h>          // printf
-#include <string.h>         // memcpy, memmove
-#include "consts.h"
 
 struct RedisModuleIO;
 
-typedef struct Sample {
+typedef struct Sample
+{
     timestamp_t timestamp;
     double value;
 } Sample;
@@ -26,52 +28,58 @@ typedef void ChunkIter_t;
 
 #define CHUNK_ITER_OP_NONE 0
 #define CHUNK_ITER_OP_REVERSE 1
-// This is supported *only* by uncompressed chunk, this is used when we reverse read a compressed chunk by
-// uncompressing it into a *un*compressed chunk and returning a reverse iterator on that "temporary" uncompressed chunk.
+// This is supported *only* by uncompressed chunk, this is used when we reverse read a compressed
+// chunk by uncompressing it into a *un*compressed chunk and returning a reverse iterator on that
+// "temporary" uncompressed chunk.
 #define CHUNK_ITER_OP_FREE_CHUNK 1 << 2
 
-typedef enum {
+typedef enum
+{
     CHUNK_REGULAR,
-    CHUNK_COMPRESSED 
+    CHUNK_COMPRESSED
 } CHUNK_TYPES_T;
 
-typedef struct UpsertCtx {
+typedef struct UpsertCtx
+{
     Sample sample;
-    Chunk_t *inChunk;       // original chunk  
+    Chunk_t *inChunk; // original chunk
 } UpsertCtx;
 
-typedef struct ChunkIterFuncs {
-    void(*Free)(ChunkIter_t *iter);
-    ChunkResult(*GetNext)(ChunkIter_t *iter, Sample *sample);
-    ChunkResult(*GetPrev)(ChunkIter_t *iter, Sample *sample);
+typedef struct ChunkIterFuncs
+{
+    void (*Free)(ChunkIter_t *iter);
+    ChunkResult (*GetNext)(ChunkIter_t *iter, Sample *sample);
+    ChunkResult (*GetPrev)(ChunkIter_t *iter, Sample *sample);
 } ChunkIterFuncs;
 
-
-typedef struct ChunkFuncs {
+typedef struct ChunkFuncs
+{
     Chunk_t *(*NewChunk)(size_t sampleCount);
-    void(*FreeChunk)(Chunk_t *chunk);
+    void (*FreeChunk)(Chunk_t *chunk);
     Chunk_t *(*SplitChunk)(Chunk_t *chunk);
 
-    ChunkResult(*AddSample)(Chunk_t *chunk, Sample *sample);
-    ChunkResult(*UpsertSample)(UpsertCtx *uCtx, int *size, DuplicatePolicy duplicatePolicy);
+    ChunkResult (*AddSample)(Chunk_t *chunk, Sample *sample);
+    ChunkResult (*UpsertSample)(UpsertCtx *uCtx, int *size, DuplicatePolicy duplicatePolicy);
 
-    ChunkIter_t *(*NewChunkIterator)(Chunk_t *chunk, int options, ChunkIterFuncs* retChunkIterClass);
+    ChunkIter_t *(*NewChunkIterator)(Chunk_t *chunk,
+                                     int options,
+                                     ChunkIterFuncs *retChunkIterClass);
 
-    size_t(*GetChunkSize)(Chunk_t *chunk, bool includeStruct);
-    u_int64_t(*GetNumOfSample)(Chunk_t *chunk);
-    u_int64_t(*GetLastTimestamp)(Chunk_t *chunk);
-    u_int64_t(*GetFirstTimestamp)(Chunk_t *chunk);
+    size_t (*GetChunkSize)(Chunk_t *chunk, bool includeStruct);
+    u_int64_t (*GetNumOfSample)(Chunk_t *chunk);
+    u_int64_t (*GetLastTimestamp)(Chunk_t *chunk);
+    u_int64_t (*GetFirstTimestamp)(Chunk_t *chunk);
 
     void (*SaveToRDB)(Chunk_t *chunk, struct RedisModuleIO *io);
     void (*LoadFromRDB)(Chunk_t **chunk, struct RedisModuleIO *io);
 } ChunkFuncs;
 
 ChunkResult handleDuplicateSample(DuplicatePolicy policy, Sample oldSample, Sample *newSample);
-const char * DuplicatePolicyToString(DuplicatePolicy policy);
+const char *DuplicatePolicyToString(DuplicatePolicy policy);
 int RMStringLenDuplicationPolicyToEnum(RedisModuleString *aggTypeStr);
 DuplicatePolicy DuplicatePolicyFromString(const char *input, size_t len);
 
 ChunkFuncs *GetChunkClass(CHUNK_TYPES_T chunkClass);
 ChunkIterFuncs *GetChunkIteratorClass(CHUNK_TYPES_T chunkType);
 
-#endif //GENERIC__CHUNK_H
+#endif // GENERIC__CHUNK_H

--- a/src/gorilla.h
+++ b/src/gorilla.h
@@ -1,29 +1,32 @@
 /*
-* Copyright 2018-2019 Redis Labs Ltd. and Contributors
-*
-* This file is available under the Redis Labs Source Available License Agreement
-*/
+ * Copyright 2018-2019 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
 
 #ifndef GORILLA_H
 #define GORILLA_H
 
-#include <sys/types.h>      // u_int_t
-#include <stdbool.h>        // bool
 #include "consts.h"
 #include "generic_chunk.h"
+
+#include <stdbool.h>   // bool
+#include <sys/types.h> // u_int_t
 
 typedef u_int64_t timestamp_t;
 typedef u_int64_t binary_t;
 typedef u_int64_t globalbit_t;
 typedef u_int8_t localbit_t;
 
-typedef union {
+typedef union
+{
     double d;
     int64_t i;
     u_int64_t u;
 } union64bits;
 
-typedef struct CompressedChunk {
+typedef struct CompressedChunk
+{
     u_int64_t size;
     u_int64_t count;
     u_int64_t idx;
@@ -32,7 +35,7 @@ typedef struct CompressedChunk {
     u_int64_t baseTimestamp;
 
     u_int64_t *data;
-    
+
     u_int64_t prevTimestamp;
     int64_t prevTimestampDelta;
 
@@ -41,19 +44,20 @@ typedef struct CompressedChunk {
     u_int8_t prevTrailing;
 } CompressedChunk;
 
-typedef struct Compressed_Iterator {
-  CompressedChunk *chunk;
-  u_int64_t idx;
-  u_int64_t count;
+typedef struct Compressed_Iterator
+{
+    CompressedChunk *chunk;
+    u_int64_t idx;
+    u_int64_t count;
 
-  // timestamp vars
-  u_int64_t prevTS;
-  int64_t prevDelta;
+    // timestamp vars
+    u_int64_t prevTS;
+    int64_t prevDelta;
 
-  // value vars
-  union64bits prevValue;  
-  u_int8_t prevLeading;
-  u_int8_t prevTrailing;
+    // value vars
+    union64bits prevValue;
+    u_int8_t prevLeading;
+    u_int8_t prevTrailing;
 } Compressed_Iterator;
 
 ChunkResult Compressed_Append(CompressedChunk *chunk, u_int64_t timestamp, double value);

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -1,33 +1,37 @@
 /*
-* Copyright 2018-2019 Redis Labs Ltd. and Contributors
-*
-* This file is available under the Redis Labs Source Available License Agreement
-*/
+ * Copyright 2018-2019 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
 #ifndef INDEXER_H
 #define INDEXER_H
 
-#include <sys/types.h>
 #include "redismodule.h"
 
-typedef struct {
+#include <sys/types.h>
+
+typedef struct
+{
     RedisModuleString *key;
     RedisModuleString *value;
 } Label;
 
-typedef enum  {
+typedef enum
+{
     EQ,
     NEQ,
     // Contains a label
     CONTAINS,
     // Not Contains a label
     NCONTAINS,
-    LIST_MATCH,  // List of matching predicates
-    LIST_NOTMATCH,  // List of non-matching predicates
+    LIST_MATCH,    // List of matching predicates
+    LIST_NOTMATCH, // List of non-matching predicates
     // REQ,
     // NREQ
 } PredicateType;
 
-typedef struct QueryPredicate {
+typedef struct QueryPredicate
+{
     PredicateType type;
     RedisModuleString *key;
     RedisModuleString **valuesList;
@@ -36,9 +40,20 @@ typedef struct QueryPredicate {
 
 void IndexInit();
 void FreeLabels(void *value, size_t labelsCount);
-void IndexMetric(RedisModuleCtx *ctx, RedisModuleString *ts_key, Label *labels, size_t labels_count);
-void RemoveIndexedMetric(RedisModuleCtx *ctx, RedisModuleString *ts_key, Label *labels, size_t labels_count);
-RedisModuleDict *QueryIndex(RedisModuleCtx *ctx, QueryPredicate *index_predicate, size_t predicate_count);
-int parsePredicate(RedisModuleCtx *ctx, RedisModuleString *label, QueryPredicate *retQuery, const char *separator);
+void IndexMetric(RedisModuleCtx *ctx,
+                 RedisModuleString *ts_key,
+                 Label *labels,
+                 size_t labels_count);
+void RemoveIndexedMetric(RedisModuleCtx *ctx,
+                         RedisModuleString *ts_key,
+                         Label *labels,
+                         size_t labels_count);
+RedisModuleDict *QueryIndex(RedisModuleCtx *ctx,
+                            QueryPredicate *index_predicate,
+                            size_t predicate_count);
+int parsePredicate(RedisModuleCtx *ctx,
+                   RedisModuleString *label,
+                   QueryPredicate *retQuery,
+                   const char *separator);
 int CountPredicateType(QueryPredicate *queries, size_t query_count, PredicateType type);
 #endif

--- a/src/module.h
+++ b/src/module.h
@@ -1,8 +1,8 @@
 /*
-* Copyright 2018-2019 Redis Labs Ltd. and Contributors
-*
-* This file is available under the Redis Labs Source Available License Agreement
-*/
+ * Copyright 2018-2019 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
 #ifndef MODULE_H
 #define MODULE_H
 
@@ -11,16 +11,27 @@
 
 extern RedisModuleType *SeriesType;
 
-// Create a new TS key, if key is NULL the function will open the key, the user must call to RedisModule_CloseKey
-// The function assumes the key doesn't exists
-int CreateTsKey(RedisModuleCtx *ctx, RedisModuleString *keyName,
-                CreateCtx *cCtx, Series **series, RedisModuleKey **key);
+// Create a new TS key, if key is NULL the function will open the key, the user must call to
+// RedisModule_CloseKey The function assumes the key doesn't exists
+int CreateTsKey(RedisModuleCtx *ctx,
+                RedisModuleString *keyName,
+                CreateCtx *cCtx,
+                Series **series,
+                RedisModuleKey **key);
 
-
-int GetSeries(RedisModuleCtx *ctx, RedisModuleString *keyName, RedisModuleKey **key, Series **series, int mode);
+int GetSeries(RedisModuleCtx *ctx,
+              RedisModuleString *keyName,
+              RedisModuleKey **key,
+              Series **series,
+              int mode);
 
 // This method provides the same logic as GetSeries, without replying to the client in case of error
-// The caller method should check the result for TRUE/FALSE and update the client accordingly if required
-int SilentGetSeries(RedisModuleCtx *ctx, RedisModuleString *keyName, RedisModuleKey **key, Series **series, int mode);
+// The caller method should check the result for TRUE/FALSE and update the client accordingly if
+// required
+int SilentGetSeries(RedisModuleCtx *ctx,
+                    RedisModuleString *keyName,
+                    RedisModuleKey **key,
+                    Series **series,
+                    int mode);
 
 #endif

--- a/src/parse_policies.h
+++ b/src/parse_policies.h
@@ -1,21 +1,24 @@
 /*
-* Copyright 2018-2019 Redis Labs Ltd. and Contributors
-*
-* This file is available under the Redis Labs Source Available License Agreement
-*/
+ * Copyright 2018-2019 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
 #ifndef PARSE_POLICIES_H
 #define PARSE_POLICIES_H
 
-#include <sys/types.h>
-#include <stdint.h>
-
 #include "generic_chunk.h"
 
-typedef struct SimpleCompactionRule {
+#include <stdint.h>
+#include <sys/types.h>
+
+typedef struct SimpleCompactionRule
+{
     uint64_t timeBucket;
     uint64_t retentionSizeMillisec;
     int aggType;
 } SimpleCompactionRule;
 
-int ParseCompactionPolicy(const char * policy_string, SimpleCompactionRule **parsed_rules, uint64_t *count_rules);
+int ParseCompactionPolicy(const char *policy_string,
+                          SimpleCompactionRule **parsed_rules,
+                          uint64_t *count_rules);
 #endif

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -1,8 +1,8 @@
 /*
-* Copyright 2018-2019 Redis Labs Ltd. and Contributors
-*
-* This file is available under the Redis Labs Source Available License Agreement
-*/
+ * Copyright 2018-2019 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
 #include "redismodule.h"
 #include "tsdb.h"
 

--- a/src/tsdb.h
+++ b/src/tsdb.h
@@ -1,18 +1,19 @@
 /*
-* Copyright 2018-2019 Redis Labs Ltd. and Contributors
-*
-* This file is available under the Redis Labs Source Available License Agreement
-*/
+ * Copyright 2018-2019 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
 #ifndef TSDB_H
 #define TSDB_H
 
-#include "redismodule.h"
 #include "compaction.h"
 #include "consts.h"
-#include "indexer.h"
 #include "generic_chunk.h"
+#include "indexer.h"
+#include "redismodule.h"
 
-typedef struct CompactionRule {
+typedef struct CompactionRule
+{
     RedisModuleString *destKey;
     timestamp_t timeBucket;
     AggregationClass *aggClass;
@@ -22,7 +23,8 @@ typedef struct CompactionRule {
     timestamp_t startCurrentTimeBucket;
 } CompactionRule;
 
-typedef struct CreateCtx {
+typedef struct CreateCtx
+{
     long long retentionTime;
     long long chunkSizeBytes;
     size_t labelsCount;
@@ -31,8 +33,9 @@ typedef struct CreateCtx {
     DuplicatePolicy duplicatePolicy;
 } CreateCtx;
 
-typedef struct Series {
-    RedisModuleDict* chunks;
+typedef struct Series
+{
+    RedisModuleDict *chunks;
     Chunk_t *lastChunk;
     uint64_t retentionTime;
     short chunkSizeBytes;
@@ -49,7 +52,8 @@ typedef struct Series {
     DuplicatePolicy duplicatePolicy;
 } Series;
 
-typedef struct SeriesIterator {
+typedef struct SeriesIterator
+{
     Series *series;
     RedisModuleDictIter *dictIter;
     Chunk_t *currentChunk;
@@ -67,14 +71,24 @@ void CleanLastDeletedSeries(RedisModuleCtx *ctx, RedisModuleString *key);
 void FreeCompactionRule(void *value);
 size_t SeriesMemUsage(const void *value);
 int SeriesAddSample(Series *series, api_timestamp_t timestamp, double value);
-int SeriesUpsertSample(Series *series, api_timestamp_t timestamp, double value, DuplicatePolicy dp_override);
+int SeriesUpsertSample(Series *series,
+                       api_timestamp_t timestamp,
+                       double value,
+                       DuplicatePolicy dp_override);
 int SeriesUpdateLastSample(Series *series);
 int SeriesDeleteRule(Series *series, RedisModuleString *destKey);
 int SeriesSetSrcRule(Series *series, RedisModuleString *srctKey);
 int SeriesDeleteSrcRule(Series *series, RedisModuleString *srctKey);
 
-CompactionRule *SeriesAddRule(Series *series, RedisModuleString *destKeyStr, int aggType, uint64_t timeBucket);
-int SeriesCreateRulesFromGlobalConfig(RedisModuleCtx *ctx, RedisModuleString *keyName, Series *series, Label *labels, size_t labelsCount);
+CompactionRule *SeriesAddRule(Series *series,
+                              RedisModuleString *destKeyStr,
+                              int aggType,
+                              uint64_t timeBucket);
+int SeriesCreateRulesFromGlobalConfig(RedisModuleCtx *ctx,
+                                      RedisModuleString *keyName,
+                                      Series *series,
+                                      Label *labels,
+                                      size_t labelsCount);
 size_t SeriesGetNumSamples(const Series *series);
 
 // Iterator over the series
@@ -85,19 +99,21 @@ void SeriesIteratorClose(SeriesIterator *iterator);
 int SeriesCalcRange(Series *series,
                     timestamp_t start_ts,
                     timestamp_t end_ts,
-                    CompactionRule * rule,
+                    CompactionRule *rule,
                     double *val);
-                    
+
 // Calculate the begining of  aggregation window
 timestamp_t CalcWindowStart(timestamp_t timestamp, size_t window);
 
-// return first timestamp in retention window, and set `skipped` to number of samples outside of retention
+// return first timestamp in retention window, and set `skipped` to number of samples outside of
+// retention
 timestamp_t getFirstValidTimestamp(Series *series, long long *skipped);
 
 CompactionRule *NewRule(RedisModuleString *destKey, int aggType, uint64_t timeBucket);
 
 // set/delete/replace a chunk in a dictionary
-typedef enum {
+typedef enum
+{
     DICT_OP_SET = 0,
     DICT_OP_REPLACE = 1,
     DICT_OP_DEL = 2

--- a/src/unittests_compressed_chunk.c
+++ b/src/unittests_compressed_chunk.c
@@ -26,7 +26,7 @@ MU_TEST(test_compressed_upsert) {
         CompressedChunk *chunk = Compressed_NewChunk(chunk_size);
         mu_assert(chunk != NULL, "create compressed chunk");
         for (size_t i = 1; i <= total_data_points; i++) {
-            float value = minV + (float)rand() / (float)(RAND_MAX / maxV);
+            float value = minV + (float)rand() / ((float)RAND_MAX / maxV);
             Sample sample = { .timestamp = i, .value = value };
             total_upserts++;
             UpsertCtx uCtx = {
@@ -68,7 +68,7 @@ MU_TEST(test_compressed_fail_appendInteger) {
     mu_assert_int_eq(6, Compressed_GetFirstTimestamp(chunk));
     mu_assert_int_eq(10, Compressed_GetLastTimestamp(chunk));
     for (size_t i = 0; i < 10; i++) {
-        s2.value = minV + (float)rand() / (float)(RAND_MAX / maxV);
+        s2.value = minV + (float)rand() / ((float)RAND_MAX / maxV);
         Compressed_UpsertSample(&uCtx, &size, DP_LAST);
         // ensure we're not adding more datapoints and only overwritting previous ones
         mu_assert_int_eq(2, Compressed_ChunkNumOfSample(chunk));
@@ -86,7 +86,7 @@ MU_TEST(test_compressed_fail_appendInteger) {
     mu_assert_int_eq(10, Compressed_GetLastTimestamp(chunk2));
 
     for (size_t i = 1; i < 6; i++) {
-        Sample s3 = { .timestamp = i, .value = minV + (float)rand() / (float)(RAND_MAX / maxV) };
+        Sample s3 = { .timestamp = i, .value = minV + (float)rand() / ((float)RAND_MAX / maxV) };
         UpsertCtx uCtxS3 = {
             .inChunk = chunk,
             .sample = s3,


### PR DESCRIPTION
The following PR:
- fixes compile warnings on unit tests
- applies clang-format to headers ( for some reason we missed this in the past )
- fixes implicit int conversion issues on unit tests #614 