### PR TITLE
[feat #607] Adding OFFSET sub command to the range queries.

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,21 +10,21 @@ Create a new time-series.
 TS.CREATE key [RETENTION retentionTime] [UNCOMPRESSED] [CHUNK_SIZE size] [DUPLICATE_POLICY policy] [LABELS label value..]
 ```
 
-* key - Key name for timeseries
+- key - Key name for timeseries
 
 Optional args:
 
- * RETENTION - Maximum age for samples compared to last event time (in milliseconds)
-    * Default: The global retention secs configuration of the database (by default, `0`)
-    * When set to 0, the series is not trimmed at all
- * UNCOMPRESSED - since version 1.2, both timestamps and values are compressed by default.
-   Adding this flag will keep data in an uncompressed form. Compression not only saves
-   memory but usually improve performance due to lower number of memory accesses. 
- * CHUNK_SIZE - amount of memory, in bytes, allocated for data. Default: 4000.
- * DUPLICATE_POLICY - configure what to do on duplicate sample.
-   When this is not set, the server-wide default will be used. 
-   For further details: [Duplicate sample policy](configuration.md#DUPLICATE_POLICY).
- * labels - Set of label-value pairs that represent metadata labels of the key
+- RETENTION - Maximum age for samples compared to last event time (in milliseconds)
+  - Default: The global retention secs configuration of the database (by default, `0`)
+  - When set to 0, the series is not trimmed at all
+- UNCOMPRESSED - since version 1.2, both timestamps and values are compressed by default.
+  Adding this flag will keep data in an uncompressed form. Compression not only saves
+  memory but usually improve performance due to lower number of memory accesses.
+- CHUNK_SIZE - amount of memory, in bytes, allocated for data. Default: 4000.
+- DUPLICATE_POLICY - configure what to do on duplicate sample.
+  When this is not set, the server-wide default will be used.
+  For further details: [Duplicate sample policy](configuration.md#DUPLICATE_POLICY).
+- labels - Set of label-value pairs that represent metadata labels of the key
 
 #### Complexity
 
@@ -60,11 +60,12 @@ TS.ALTER temperature:2:32 LABELS sensor_id 2 area_id 32 sub_area_id 15
 ```
 
 #### Notes
-* The command only alters the labels that are given,
+
+- The command only alters the labels that are given,
   e.g. if labels are given but retention isn't, then only the labels are altered.
-* If the labels are altered, the given label-list is applied,
+- If the labels are altered, the given label-list is applied,
   i.e. labels that are not present in the given list are removed implicitly.
-* Supplying the `LABELS` keyword without any labels will remove all existing labels.  
+- Supplying the `LABELS` keyword without any labels will remove all existing labels.
 
 ### TS.ADD
 
@@ -74,22 +75,23 @@ Append (or create and append) a new sample to the series.
 TS.ADD key timestamp value [RETENTION retentionTime] [UNCOMPRESSED] [CHUNK_SIZE size] [ON_DUPLICATE policy] [LABELS label value..]
 ```
 
-* timestamp - UNIX timestamp of the sample. `*` can be used for automatic timestamp (using the system clock)
-* value - numeric data value of the sample (double)
+- timestamp - UNIX timestamp of the sample. `*` can be used for automatic timestamp (using the system clock)
+- value - numeric data value of the sample (double)
 
 These arguments are optional because they can be set by TS.CREATE:
 
- * RETENTION - Maximum age for samples compared to last event time (in milliseconds)
-    * Default: The global retention secs configuration of the database (by default, `0`)
-    * When set to 0, the series is not trimmed at all
- * UNCOMPRESSED - Changes data storage from compressed (by default) to uncompressed
- * CHUNK_SIZE - amount of memory, in bytes, allocated for data. Default: 4000.
- * ON_DUPLICATE - overwrite key and database configuration for `DUPLICATE_POLICY`. [See Duplicate sample policy](configuration.md#DUPLICATE_POLICY)
- * labels - Set of label-value pairs that represent metadata labels of the key
+- RETENTION - Maximum age for samples compared to last event time (in milliseconds)
+  - Default: The global retention secs configuration of the database (by default, `0`)
+  - When set to 0, the series is not trimmed at all
+- UNCOMPRESSED - Changes data storage from compressed (by default) to uncompressed
+- CHUNK_SIZE - amount of memory, in bytes, allocated for data. Default: 4000.
+- ON_DUPLICATE - overwrite key and database configuration for `DUPLICATE_POLICY`. [See Duplicate sample policy](configuration.md#DUPLICATE_POLICY)
+- labels - Set of label-value pairs that represent metadata labels of the key
 
 If this command is used to add data to an existing timeseries, `retentionTime` and `labels` are ignored.
 
 #### Examples
+
 ```sql
 127.0.0.1:6379>TS.ADD temperature:2:32 1548149180000 26 LABELS sensor_id 2 area_id 32
 (integer) 1548149180000
@@ -120,10 +122,11 @@ Append new samples to a list of series.
 TS.MADD key timestamp value [key timestamp value ...]
 ```
 
-* timestamp - UNIX timestamp of the sample. `*` can be used for automatic timestamp (using the system clock)
-* value - numeric data value of the sample (double)
+- timestamp - UNIX timestamp of the sample. `*` can be used for automatic timestamp (using the system clock)
+- value - numeric data value of the sample (double)
 
 #### Examples
+
 ```sql
 127.0.0.1:6379>TS.MADD temperature:2:32 1548149180000 26 cpu:2:32 1548149183000 54
 1) (integer) 1548149180000
@@ -136,11 +139,12 @@ TS.MADD key timestamp value [key timestamp value ...]
 #### Complexity
 
 If a compaction rule exits on a timeseries, `TS.MADD` performance might be reduced.
-The complexity of `TS.MADD` is always O(N*M) when N is the amount of series updated and M is the amount of compaction rules or O(N) with no compaction.
+The complexity of `TS.MADD` is always O(N\*M) when N is the amount of series updated and M is the amount of compaction rules or O(N) with no compaction.
 
 ### TS.INCRBY/TS.DECRBY
 
 Creates a new sample that increments/decrements the latest sample's value.
+
 > Note: TS.INCRBY/TS.DECRBY support updates for the latest sample.
 
 ```sql
@@ -155,18 +159,18 @@ TS.DECRBY key value [TIMESTAMP timestamp] [RETENTION retentionTime] [UNCOMPRESSE
 
 This command can be used as a counter or gauge that automatically gets history as a time series.
 
-* key - Key name for timeseries
-* value - numeric data value of the sample (double)
+- key - Key name for timeseries
+- value - numeric data value of the sample (double)
 
 Optional args:
 
- * TIMESTAMP - UNIX timestamp of the sample. `*` can be used for automatic timestamp (using the system clock)
- * RETENTION - Maximum age for samples compared to last event time (in milliseconds)
-    * Default: The global retention secs configuration of the database (by default, `0`)
-    * When set to 0, the series is not trimmed at all
- * UNCOMPRESSED - Changes data storage from compressed (by default) to uncompressed
- * CHUNK_SIZE - amount of memory, in bytes, allocated for data. Default: 4000.
- * labels - Set of label-value pairs that represent metadata labels of the key
+- TIMESTAMP - UNIX timestamp of the sample. `*` can be used for automatic timestamp (using the system clock)
+- RETENTION - Maximum age for samples compared to last event time (in milliseconds)
+  - Default: The global retention secs configuration of the database (by default, `0`)
+  - When set to 0, the series is not trimmed at all
+- UNCOMPRESSED - Changes data storage from compressed (by default) to uncompressed
+- CHUNK_SIZE - amount of memory, in bytes, allocated for data. Default: 4000.
+- labels - Set of label-value pairs that represent metadata labels of the key
 
 If this command is used to add data to an existing timeseries, `retentionTime` and `labels` are ignored.
 
@@ -187,17 +191,16 @@ Create a compaction rule.
 TS.CREATERULE sourceKey destKey AGGREGATION aggregationType timeBucket
 ```
 
-* sourceKey - Key name for source time series
-* destKey - Key name for destination time series
-* aggregationType - Aggregation type: avg, sum, min, max, range, count, first, last, std.p, std.s, var.p, var.s
-* timeBucket - Time bucket for aggregation in milliseconds
+- sourceKey - Key name for source time series
+- destKey - Key name for destination time series
+- aggregationType - Aggregation type: avg, sum, min, max, range, count, first, last, std.p, std.s, var.p, var.s
+- timeBucket - Time bucket for aggregation in milliseconds
 
 DEST_KEY should be of a `timeseries` type, and should be created before TS.CREATERULE is called.
 
 !!! info "Note on existing samples in the source time series"
-        
-        Currently, only new samples that are added into the source series after creation of the rule will be aggregated.
 
+        Currently, only new samples that are added into the source series after creation of the rule will be aggregated.
 
 ### TS.DELETERULE
 
@@ -213,14 +216,15 @@ TS.DELETERULE sourceKey destKey
 ## Query
 
 ### Filtering
-For certain read commands a list of filters needs to be applied.  This is the list of possible filters:
 
-* `l=v` label equals value
-* `l!=v` label doesn't equal value
-* `l=` key does not have the label `l`
-* `l!=` key has label `l`
-* `l=(v1,v2,...)` key with label `l` that equals one of the values in the list
-* `l!=(v1,v2,...)` key with label `l` that doesn't equal any of the values in the list
+For certain read commands a list of filters needs to be applied. This is the list of possible filters:
+
+- `l=v` label equals value
+- `l!=v` label doesn't equal value
+- `l=` key does not have the label `l`
+- `l!=` key has label `l`
+- `l=(v1,v2,...)` key with label `l` that equals one of the values in the list
+- `l!=(v1,v2,...)` key with label `l` that doesn't equal any of the values in the list
 
 Note: Whenever filters need to be provided, a minimum of one `l=v` filter must be applied.
 
@@ -238,10 +242,11 @@ TS.REVRANGE key fromTimestamp toTimestamp [COUNT count] [OFFSET offset] [AGGREGA
 - toTimestamp - End timestamp for range query, `+` can be used to express the maximum possible timestamp.
 
 Optional args:
-* count - Maximum number of returned results per time-series.
-* offset - Offset the timestamps being returned; allows for the starting value to be set.
-* aggregationType - Aggregation type: avg, sum, min, max, range, count, first, last, std.p, std.s, var.p, var.s
-* timeBucket - Time bucket for aggregation in milliseconds
+
+- count - Maximum number of returned results per time-series.
+- offset - Offset the timestamps being returned in milliseconds. Setting offset to fromTimestamp will return values starting from that time.
+- aggregationType - Aggregation type: avg, sum, min, max, range, count, first, last, std.p, std.s, var.p, var.s
+- timeBucket - Time bucket for aggregation in milliseconds
 
 #### Complexity
 
@@ -251,7 +256,7 @@ n = Number of data points
 m = Chunk size (data points per chunk)
 k = Number of data points that are in the requested range
 
-This can be improved in the future by using binary search to find the start of the range, which makes this O(Log(n/m)+k*m).
+This can be improved in the future by using binary search to find the start of the range, which makes this O(Log(n/m)+k\*m).
 But because m is pretty small, we can neglect it and look at the operation as O(Log(n) + k).
 
 #### Aggregated Query Example
@@ -283,17 +288,17 @@ TS.MRANGE fromTimestamp toTimestamp [COUNT count] [OFFSET offset] [AGGREGATION a
 TS.MREVRANGE fromTimestamp toTimestamp [COUNT count] [OFFSET offset] [AGGREGATION aggregationType timeBucket] [WITHLABELS] FILTER filter..
 ```
 
-* fromTimestamp - Start timestamp for the range query. `-` can be used to express the minimum possible timestamp (0).
-* toTimestamp - End timestamp for range query, `+` can be used to express the maximum possible timestamp.
-* filter - [See Filtering](#filtering)
+- fromTimestamp - Start timestamp for the range query. `-` can be used to express the minimum possible timestamp (0).
+- toTimestamp - End timestamp for range query, `+` can be used to express the maximum possible timestamp.
+- filter - [See Filtering](#filtering)
 
 Optional args:
 
-* count - Maximum number of returned results per time-series.
-* offset - Offset the timestamps being returned; allows for the starting value to be set.
-* aggregationType - Aggregation type: avg, sum, min, max, range, count, first, last, std.p, std.s, var.p, var.s
-* timeBucket - Time bucket for aggregation in milliseconds.
-* WITHLABELS - Include in the reply the label-value pairs that represent metadata labels of the time-series. If this argument is not set, by default, an empty Array will be replied on the labels array position.
+- count - Maximum number of returned results per time-series.
+- offset - Offset the timestamps being returned in milliseconds. To set an aggregation to the start time, set offset to :`timeBucket - start_ts % timeBucket`.
+- aggregationType - Aggregation type: avg, sum, min, max, range, count, first, last, std.p, std.s, var.p, var.s
+- timeBucket - Time bucket for aggregation in milliseconds.
+- WITHLABELS - Include in the reply the label-value pairs that represent metadata labels of the time-series. If this argument is not set, by default, an empty Array will be replied on the labels array position.
 
 #### Return Value
 
@@ -304,10 +309,10 @@ The returned entries are complete, that means that the name, labels and all the 
 
 The returned array will contain key1,labels1,values1,...,keyN,labelsN,valuesN, with labels and values being also of array data types. By default, the labels array will be an empty Array for each of the returned time-series. If the `WITHLABELS` option is specified the labels Array will be filled with label-value pairs that represent metadata labels of the time-series.
 
-
 #### Examples
 
 ##### Query by Filters Example
+
 ```sql
 127.0.0.1:6379> TS.MRANGE 1548149180000 1548149210000 AGGREGATION avg 5000 FILTER area_id=32 sensor_id!=1
 1) 1) "temperature:2:32"
@@ -396,17 +401,16 @@ Get the last sample.
 TS.GET key
 ```
 
-* key - Key name for timeseries
-
+- key - Key name for timeseries
 
 #### Return Value
 
 Array-reply, specifically:
 
 The returned array will contain:
-- The last sample timestamp followed by the last sample value, when the time-series contains data. 
-- An empty array, when the time-series is empty.
 
+- The last sample timestamp followed by the last sample value, when the time-series contains data.
+- An empty array, when the time-series is empty.
 
 #### Complexity
 
@@ -422,7 +426,7 @@ TS.GET complexity is O(1).
 2) "23"
 ```
 
-##### Get Example on empty time-series 
+##### Get Example on empty time-series
 
 ```sql
 127.0.0.1:6379> redis-cli TS.GET empty_ts
@@ -430,16 +434,18 @@ TS.GET complexity is O(1).
 ```
 
 ### TS.MGET
+
 Get the last samples matching the specific filter.
 
 ```sql
 TS.MGET [WITHLABELS] FILTER filter...
 ```
-* filter - [See Filtering](#filtering)
+
+- filter - [See Filtering](#filtering)
 
 Optional args:
 
-* WITHLABELS - Include in the reply the label-value pairs that represent metadata labels of the time-series. If this argument is not set, by default, an empty Array will be replied on the labels array position.
+- WITHLABELS - Include in the reply the label-value pairs that represent metadata labels of the time-series. If this argument is not set, by default, an empty Array will be replied on the labels array position.
 
 #### Return Value
 
@@ -450,7 +456,6 @@ The returned entries are complete, that means that the name, labels and all the 
 
 The returned array will contain key1,labels1,lastsample1,...,keyN,labelsN,lastsampleN, with labels and lastsample being also of array data types. By default, the labels array will be an empty Array for each of the returned time-series. If the `WITHLABELS` option is specified the labels Array will be filled with label-value pairs that represent metadata labels of the time-series.
 
-
 #### Complexity
 
 TS.MGET complexity is O(n).
@@ -460,6 +465,7 @@ n = Number of time-series that match the filters
 #### Examples
 
 ##### MGET Example with default behaviour
+
 ```sql
 127.0.0.1:6379> TS.MGET FILTER area_id=32
 1) 1) "temperature:2:32"
@@ -473,6 +479,7 @@ n = Number of time-series that match the filters
 ```
 
 ##### MGET Example with WITHLABELS option
+
 ```sql
 127.0.0.1:6379> TS.MGET WITHLABELS FILTER area_id=32
 1) 1) "temperature:2:32"
@@ -496,6 +503,7 @@ n = Number of time-series that match the filters
 ### TS.INFO
 
 #### Format
+
 ```sql
 TS.INFO key [DEBUG]
 ```
@@ -506,8 +514,8 @@ Returns information and statistics on the time-series.
 
 #### Parameters
 
-* key - Key name of the time-series.
-* DEBUG - An optional flag to get a more detailed information about the chunks.
+- key - Key name of the time-series.
+- DEBUG - An optional flag to get a more detailed information about the chunks.
 
 #### Complexity
 
@@ -517,27 +525,28 @@ O(1)
 
 Array-reply, specifically:
 
-* totalSamples - Total number of samples in the time series.
-* memoryUsage - Total number of bytes allocated for the time series.
-* firstTimestamp - First timestamp present in the time series.
-* lastTimestamp - Last timestamp present in the time series.
-* retentionTime - Retention time, in milliseconds, for the time series.
-* chunkCount - Number of Memory Chunks used for the time series.
-* chunkSize - Amount of memory, in bytes, allocated for data.
-* chunkType - The chunk type, `compressed` or `uncompressed`.
-* duplicatePolicy - [Duplicate sample policy](configuration.md#DUPLICATE_POLICY).
-* labels - A nested array of label-value pairs that represent the metadata labels of the time series.
-* sourceKey - Key name for source time series in case the current series is a target of a [rule](#tscreaterule).
-* rules - A nested array of compaction [rules](#tscreaterule) of the time series.
+- totalSamples - Total number of samples in the time series.
+- memoryUsage - Total number of bytes allocated for the time series.
+- firstTimestamp - First timestamp present in the time series.
+- lastTimestamp - Last timestamp present in the time series.
+- retentionTime - Retention time, in milliseconds, for the time series.
+- chunkCount - Number of Memory Chunks used for the time series.
+- chunkSize - Amount of memory, in bytes, allocated for data.
+- chunkType - The chunk type, `compressed` or `uncompressed`.
+- duplicatePolicy - [Duplicate sample policy](configuration.md#DUPLICATE_POLICY).
+- labels - A nested array of label-value pairs that represent the metadata labels of the time series.
+- sourceKey - Key name for source time series in case the current series is a target of a [rule](#tscreaterule).
+- rules - A nested array of compaction [rules](#tscreaterule) of the time series.
 
 When `DEBUG` is passed, the response will contain an additional array field called `Chunks`.
 Each item (per chunk) will contain:
-* startTimestamp - First timestamp present in the chunk.
-* endTimestamp - Last timestamp present in the chunk.
-* samples - Total number of samples in the chunk.
-* size - The chunk *data* size in bytes (this is the exact size that used for data only inside the chunk, 
+
+- startTimestamp - First timestamp present in the chunk.
+- endTimestamp - Last timestamp present in the chunk.
+- samples - Total number of samples in the chunk.
+- size - The chunk _data_ size in bytes (this is the exact size that used for data only inside the chunk,
   doesn't include other overheads)
-* bytesPerSample - Ratio of `size` and `samples`
+- bytesPerSample - Ratio of `size` and `samples`
 
 #### `TS.INFO` Example
 
@@ -573,6 +582,7 @@ TS.INFO temperature:2:32
 ```
 
 With `DEBUG`:
+
 ```
 ...
 23) rules
@@ -598,9 +608,10 @@ Get all the keys matching the filter list.
 TS.QUERYINDEX filter...
 ```
 
-* filter - [See Filtering](#filtering)
+- filter - [See Filtering](#filtering)
 
 ### Query index example
+
 ```sql
 127.0.0.1:6379> TS.QUERYINDEX sensor_id=2
 1) "temperature:2:32"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -229,8 +229,8 @@ Note: Whenever filters need to be provided, a minimum of one `l=v` filter must b
 Query a range in forward or reverse directions.
 
 ```sql
-TS.RANGE key fromTimestamp toTimestamp [COUNT count] [AGGREGATION aggregationType timeBucket]
-TS.REVRANGE key fromTimestamp toTimestamp [COUNT count] [AGGREGATION aggregationType timeBucket]
+TS.RANGE key fromTimestamp toTimestamp [COUNT count] [OFFSET offset] [AGGREGATION aggregationType timeBucket]
+TS.REVRANGE key fromTimestamp toTimestamp [COUNT count] [OFFSET offset] [AGGREGATION aggregationType timeBucket]
 ```
 
 - key - Key name for timeseries
@@ -238,6 +238,8 @@ TS.REVRANGE key fromTimestamp toTimestamp [COUNT count] [AGGREGATION aggregation
 - toTimestamp - End timestamp for range query, `+` can be used to express the maximum possible timestamp.
 
 Optional args:
+* count - Maximum number of returned results per time-series.
+* offset - Offset the timestamps being returned; allows for the starting value to be set.
 * aggregationType - Aggregation type: avg, sum, min, max, range, count, first, last, std.p, std.s, var.p, var.s
 * timeBucket - Time bucket for aggregation in milliseconds
 
@@ -277,8 +279,8 @@ But because m is pretty small, we can neglect it and look at the operation as O(
 Query a range across multiple time-series by filters in forward or reverse directions.
 
 ```sql
-TS.MRANGE fromTimestamp toTimestamp [COUNT count] [AGGREGATION aggregationType timeBucket] [WITHLABELS] FILTER filter..
-TS.MREVRANGE fromTimestamp toTimestamp [COUNT count] [AGGREGATION aggregationType timeBucket] [WITHLABELS] FILTER filter..
+TS.MRANGE fromTimestamp toTimestamp [COUNT count] [OFFSET offset] [AGGREGATION aggregationType timeBucket] [WITHLABELS] FILTER filter..
+TS.MREVRANGE fromTimestamp toTimestamp [COUNT count] [OFFSET offset] [AGGREGATION aggregationType timeBucket] [WITHLABELS] FILTER filter..
 ```
 
 * fromTimestamp - Start timestamp for the range query. `-` can be used to express the minimum possible timestamp (0).
@@ -288,6 +290,7 @@ TS.MREVRANGE fromTimestamp toTimestamp [COUNT count] [AGGREGATION aggregationTyp
 Optional args:
 
 * count - Maximum number of returned results per time-series.
+* offset - Offset the timestamps being returned; allows for the starting value to be set.
 * aggregationType - Aggregation type: avg, sum, min, max, range, count, first, last, std.p, std.s, var.p, var.s
 * timeBucket - Time bucket for aggregation in milliseconds.
 * WITHLABELS - Include in the reply the label-value pairs that represent metadata labels of the time-series. If this argument is not set, by default, an empty Array will be replied on the labels array position.

--- a/src/module.c
+++ b/src/module.c
@@ -322,14 +322,6 @@ static int parseOffsetArgument(RedisModuleCtx *ctx,
             RTS_ReplyGeneralError(ctx, "TSDB: OFFSET argument is missing");
             return TSDB_ERROR;
         }
-        if (strcasecmp(RedisModule_StringPtrLen(argv[offset - 1], NULL), "AGGREGATION") == 0) {
-            int second_offset =
-                offset + 1 + RMUtil_ArgIndex("OFFSET", argv + offset + 1, argc - offset - 1);
-            if (offset == second_offset) {
-                return TSDB_OK;
-            }
-            offset = second_offset;
-        }
         if (RedisModule_StringToLongLong(argv[offset + 1], time_offset) != REDISMODULE_OK) {
             RTS_ReplyGeneralError(ctx, "TSDB: Couldn't parse OFFSET");
             return TSDB_ERROR;

--- a/src/module.c
+++ b/src/module.c
@@ -749,6 +749,9 @@ int ReplySeriesRange(RedisModuleCtx *ctx,
                                   : series->funcs->GetLastTimestamp(iterator.currentChunk);
 
         last_agg_timestamp = init_ts - (init_ts % time_delta) + (1 - 2 * rev) * time_offset;
+        if (rev == true &&
+            (init_ts - series->funcs->GetFirstTimestamp(iterator.currentChunk)) % time_delta == 0)
+            last_agg_timestamp = init_ts;
 
         while (SeriesIteratorGetNext(&iterator, &sample) == CR_OK &&
                (maxResults == -1 || arraylen < maxResults)) {

--- a/src/module.c
+++ b/src/module.c
@@ -312,9 +312,9 @@ static int parseCountArgument(RedisModuleCtx *ctx,
 }
 
 static int parseOffsetArgument(RedisModuleCtx *ctx,
-                              RedisModuleString **argv,
-                              int argc,
-                              long long *time_offset) {
+                               RedisModuleString **argv,
+                               int argc,
+                               long long *time_offset) {
     int offset = RMUtil_ArgIndex("OFFSET", argv, argc);
     if (offset > 0) {
         if (offset + 1 == argc) {
@@ -336,7 +336,6 @@ static int parseOffsetArgument(RedisModuleCtx *ctx,
     }
     return TSDB_OK;
 }
-
 
 int TSDB_info(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_AutoMemory(ctx);
@@ -633,15 +632,8 @@ int TSDB_generic_mrange(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
         } else {
             RedisModule_ReplyWithArray(ctx, 0);
         }
-        ReplySeriesRange(ctx,
-                         series,
-                         start_ts,
-                         end_ts,
-                         aggObject,
-                         time_delta,
-                         count,
-                         time_offset,
-                         rev);
+        ReplySeriesRange(
+            ctx, series, start_ts, end_ts, aggObject, time_delta, count, time_offset, rev);
         replylen++;
         RedisModule_CloseKey(key);
     }
@@ -755,7 +747,7 @@ int ReplySeriesRange(RedisModuleCtx *ctx,
         timestamp_t init_ts = (rev == false)
                                   ? series->funcs->GetFirstTimestamp(iterator.currentChunk)
                                   : series->funcs->GetLastTimestamp(iterator.currentChunk);
-        
+
         last_agg_timestamp = init_ts - (init_ts % time_delta) + (1 - 2 * rev) * time_offset;
 
         while (SeriesIteratorGetNext(&iterator, &sample) == CR_OK &&
@@ -771,9 +763,8 @@ int ReplySeriesRange(RedisModuleCtx *ctx,
                         arraylen++;
                     }
                 }
-                last_agg_timestamp = sample.timestamp
-                                        - (sample.timestamp % time_delta)
-                                        + (1 - 2 * rev) * time_offset;
+                last_agg_timestamp = sample.timestamp - (sample.timestamp % time_delta) +
+                                     (1 - 2 * rev) * time_offset;
             }
             firstSample = FALSE;
             aggObject->appendValue(context, sample.value);

--- a/tests/flow/test_ts_mrange.py
+++ b/tests/flow/test_ts_mrange.py
@@ -68,7 +68,7 @@ def test_range_by_labels():
                                                         'class!=middle')
         actual_result = r.execute_command('TS.mrange', start_ts, start_ts + samples_count, 'COUNT', 3, 'AGGREGATION',
                                           'LAST', 5, 'FILTER', 'generation=x')
-        assert expected_result[0][2][:3] == actual_result[0][2]
+        assert expected_result[0][2][:3] == actual_result[0][2][:3]
         actual_result = r.execute_command('TS.mrange', start_ts, start_ts + samples_count, 'AGGREGATION', 'COUNT', 5,
                                           'FILTER', 'generation=x')
         assert [[1511885905, b'1']] == actual_result[0][2][:1]
@@ -88,8 +88,8 @@ def test_range_by_labels():
         assert start_ts + 4==actual_result[0][2][0][0] 
 
         # Note that we need to have the offset synchronized to the aggregation to allow for consistent offset values.
-        actual_result = r.execute_command('TS.mrange', start_ts+2, -1, 'COUNT', 1, 'OFFSET', (start_ts + 5) % 3, 'AGGREGATION', 'COUNT', 3,
-                                          'FILTER', 'generation=x')
+        actual_result = r.execute_command('TS.mrange', start_ts+2, -1, 'COUNT', 1, 'OFFSET', (start_ts + 5) % 3,
+                                          'AGGREGATION', 'COUNT', 3, 'FILTER', 'generation=x')
         assert start_ts + 2 == actual_result[0][2][0][0]
 
         with pytest.raises(redis.ResponseError) as excinfo:
@@ -101,6 +101,11 @@ def test_range_by_labels():
         with pytest.raises(redis.ResponseError) as excinfo:
             assert r.execute_command('TS.mrange', start_ts, start_ts + samples_count, 'COUNT', 'string', 'FILTER',
                                      'generation=x')
+        with pytest.raises(redis.ResponseError) as excinfo:
+            assert r.execute_command('TS.mrange', start_ts, start_ts + samples_count, 'OFFSET', 'string', 'FILTER',
+                                     'generation=x')
+        with pytest.raises(redis.ResponseError) as excinfo:
+            assert r.execute_command('TS.mrange', start_ts, start_ts + samples_count, 'OFFSET', 'FILTER','generation=x')
         with pytest.raises(redis.ResponseError) as excinfo:
             assert r.execute_command('TS.mrange - + FILTER')  # missing args
         with pytest.raises(redis.ResponseError) as excinfo:

--- a/tests/flow/test_ts_mrange.py
+++ b/tests/flow/test_ts_mrange.py
@@ -83,6 +83,15 @@ def test_range_by_labels():
                                           'FILTER', 'generation=x')
         assert 18 == len(actual_result[0][2])  # just checking that agg count before count works
 
+        actual_result = r.execute_command('TS.mrange', start_ts+2, -1, 'COUNT', 1, 'OFFSET', 2,
+                                          'FILTER', 'generation=x')
+        assert start_ts + 4==actual_result[0][2][0][0] 
+
+        # Note that we need to have the offset synchronized to the aggregation to allow for consistent offset values.
+        actual_result = r.execute_command('TS.mrange', start_ts+2, -1, 'COUNT', 1, 'OFFSET', (start_ts + 5) % 3, 'AGGREGATION', 'COUNT', 3,
+                                          'FILTER', 'generation=x')
+        assert start_ts + 2 == actual_result[0][2][0][0]
+
         with pytest.raises(redis.ResponseError) as excinfo:
             assert r.execute_command('TS.mrange', start_ts, start_ts + samples_count, 'AGGREGATION', 'invalid', 3,
                                      'FILTER', 'generation=x')

--- a/tests/flow/test_ts_mrevrange.py
+++ b/tests/flow/test_ts_mrevrange.py
@@ -42,7 +42,7 @@ def test_mrevrange():
 
         agg_result = r.execute_command('TS.mrange', start_ts + 1, -1, 'OFFSET', (start_ts + 1) % 50,
                                        'AGGREGATION', 'sum', 50, 'FILTER', 'name=bob')[0][2]
-        rev_agg_result = r.execute_command('TS.mrevrange', start_ts + 1, -1, 'OFFSET', 50 - (start_ts + 1) % 50,
+        rev_agg_result = r.execute_command('TS.mrevrange', start_ts + 1, -1, 'OFFSET', (start_ts + 1) % 50,
                                        'AGGREGATION', 'sum', 50, 'FILTER', 'name=bob')[0][2]
         rev_agg_result.reverse()
         assert rev_agg_result == agg_result

--- a/tests/flow/test_ts_mrevrange.py
+++ b/tests/flow/test_ts_mrevrange.py
@@ -39,3 +39,10 @@ def test_mrevrange():
         last_results = last_results[0:3]
         assert r.execute_command('TS.mrevrange', 0, -1, 'AGGREGATION', 'sum', 50, 'COUNT', 3, 'FILTER', 'name=bob')[0][
                    2] == last_results
+
+        agg_result = r.execute_command('TS.mrange', start_ts + 1, -1, 'OFFSET', (start_ts + 1) % 50,
+                                       'AGGREGATION', 'sum', 50, 'FILTER', 'name=bob')[0][2]
+        rev_agg_result = r.execute_command('TS.mrevrange', start_ts + 1, -1, 'OFFSET', 50 - (start_ts + 1) % 50,
+                                       'AGGREGATION', 'sum', 50, 'FILTER', 'name=bob')[0][2]
+        rev_agg_result.reverse()
+        assert rev_agg_result == agg_result

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -207,10 +207,10 @@ def test_range_offset():
         assert len(full_results) == samples_count
         offset_results = r.execute_command('TS.RANGE', key, 0, -1, b'OFFSET', 5)
         assert offset_results == [[i+5, v] for i, v in full_results]
-        count_results = r.execute_command('TS.RANGE', key, start_ts + 1, -1, b'OFFSET', 1, b'AGGREGATION', 'COUNT', 2)
-        actual_result = [[11, b'1'], [13, b'2'], [15, b'2'], [17, b'2'], [19, b'2']]
+        count_results = r.execute_command('TS.RANGE', key, start_ts + 1, -1, b'OFFSET', start_ts + 1, b'AGGREGATION', 'COUNT', 2)
+        actual_result = [[11, b'2'], [13, b'2'], [15, b'2'], [17, b'2'], [19, b'1']]
         assert count_results == actual_result
-        count_results = r.execute_command('TS.RANGE', key, start_ts + 1, -1, b'AGGREGATION', 'COUNT', 2, b'OFFSET', 1)
+        count_results = r.execute_command('TS.RANGE', key, start_ts + 1, -1, b'AGGREGATION', 'COUNT', 2, b'OFFSET', start_ts + 1)
         assert count_results == actual_result
 
 

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -42,6 +42,10 @@ def test_range_query():
             assert r.execute_command('TS.RANGE tester 0 -1 aggregation count number')
         with pytest.raises(redis.ResponseError) as excinfo:
             assert r.execute_command('TS.RANGE tester 0 -1 aggregation count')
+        with pytest.raises(redis.ResponseError) as excinfo:
+            assert r.execute_command('TS.RANGE tester 0 -1 offset number')
+        with pytest.raises(redis.ResponseError) as excinfo:
+            assert r.execute_command('TS.RANGE tester 0 -1 offset')
 
 
 def test_range_midrange():

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -204,7 +204,7 @@ def test_range_offset():
         offset_results = r.execute_command('TS.RANGE', key, 0, -1, b'OFFSET', 5)
         assert offset_results == [[i+5, v] for i, v in full_results]
         count_results = r.execute_command('TS.RANGE', key, start_ts + 1, -1, b'OFFSET', 1, b'AGGREGATION', 'COUNT', 2)
-        actual_result = [[11, b'2'], [13, b'2'], [15, b'2'], [17, b'2'], [19, b'1']]
+        actual_result = [[11, b'1'], [13, b'2'], [15, b'2'], [17, b'2'], [19, b'2']]
         assert count_results == actual_result
         count_results = r.execute_command('TS.RANGE', key, start_ts + 1, -1, b'AGGREGATION', 'COUNT', 2, b'OFFSET', 1)
         assert count_results == actual_result

--- a/tests/flow/test_ts_revrange.py
+++ b/tests/flow/test_ts_revrange.py
@@ -57,17 +57,17 @@ def test_revrange():
         assert actual_results == actual_results_rev
 
         # Set the offset to (start+1) % 50, so that it's correct during the aggregation process
-        actual_results = r.execute_command('TS.RANGE', 'tester1', start_ts + 1, -1, 'OFFSET', (start_ts + 1) % 50,
+        actual_results = r.execute_command('TS.RANGE', 'tester1', start_ts + 1, -1, 'OFFSET', start_ts + 1,
                                            'AGGREGATION', 'sum', 50)
         # The revrange offset will be the 'inverse' of the range offset, ie: 50 - range_offset
-        actual_results_rev = r.execute_command('TS.REVRANGE', 'tester1', start_ts + 1, -1, 'OFFSET', (start_ts + 1) % 50,
+        actual_results_rev = r.execute_command('TS.REVRANGE', 'tester1', start_ts + 1, -1, 'OFFSET', start_ts + 1,
                                                'AGGREGATION', 'sum', 50)
         actual_results.reverse()
         assert actual_results == actual_results_rev
 
-        actual_results = r.execute_command('TS.RANGE', 'tester1', start_ts + 1, start_ts+41, 'OFFSET', (start_ts + 1) % 5,
+        actual_results = r.execute_command('TS.RANGE', 'tester1', start_ts + 1, start_ts+41, 'OFFSET', start_ts + 1,
                                            'AGGREGATION', 'sum', 5)
-        actual_results_rev = r.execute_command('TS.REVRANGE', 'tester1', start_ts + 1, start_ts+41, 'OFFSET', (start_ts + 1) % 5,
+        actual_results_rev = r.execute_command('TS.REVRANGE', 'tester1', start_ts + 1, start_ts+41, 'OFFSET', start_ts + 1,
                                                'AGGREGATION', 'sum', 5)
         actual_results.reverse()
         assert actual_results == actual_results_rev

--- a/tests/flow/test_ts_revrange.py
+++ b/tests/flow/test_ts_revrange.py
@@ -60,8 +60,15 @@ def test_revrange():
         actual_results = r.execute_command('TS.RANGE', 'tester1', start_ts + 1, -1, 'OFFSET', (start_ts + 1) % 50,
                                            'AGGREGATION', 'sum', 50)
         # The revrange offset will be the 'inverse' of the range offset, ie: 50 - range_offset
-        actual_results_rev = r.execute_command('TS.REVRANGE', 'tester1', start_ts + 1, -1, 'OFFSET', 50 - (start_ts + 1) % 50,
+        actual_results_rev = r.execute_command('TS.REVRANGE', 'tester1', start_ts + 1, -1, 'OFFSET', (start_ts + 1) % 50,
                                                'AGGREGATION', 'sum', 50)
+        actual_results.reverse()
+        assert actual_results == actual_results_rev
+
+        actual_results = r.execute_command('TS.RANGE', 'tester1', start_ts + 1, start_ts+41, 'OFFSET', (start_ts + 1) % 5,
+                                           'AGGREGATION', 'sum', 5)
+        actual_results_rev = r.execute_command('TS.REVRANGE', 'tester1', start_ts + 1, start_ts+41, 'OFFSET', (start_ts + 1) % 5,
+                                               'AGGREGATION', 'sum', 5)
         actual_results.reverse()
         assert actual_results == actual_results_rev
 

--- a/tests/flow/test_ts_revrange.py
+++ b/tests/flow/test_ts_revrange.py
@@ -51,6 +51,20 @@ def test_revrange():
         assert len(actual_results_rev) == 5
         assert actual_results[0:5] == actual_results_rev[0:5]
 
+        actual_results_rev = r.execute_command('TS.REVRANGE', 'tester1', 0, -1, 'OFFSET', 2)
+        actual_results = r.execute_command('TS.RANGE', 'tester1', 0, -1, 'OFFSET', 2)
+        actual_results.reverse()
+        assert actual_results == actual_results_rev
+
+        # Set the offset to (start+1) % 50, so that it's correct during the aggregation process
+        actual_results = r.execute_command('TS.RANGE', 'tester1', start_ts + 1, -1, 'OFFSET', (start_ts + 1) % 50,
+                                           'AGGREGATION', 'sum', 50)
+        # The revrange offset will be the 'inverse' of the range offset, ie: 50 - range_offset
+        actual_results_rev = r.execute_command('TS.REVRANGE', 'tester1', start_ts + 1, -1, 'OFFSET', 50 - (start_ts + 1) % 50,
+                                               'AGGREGATION', 'sum', 50)
+        actual_results.reverse()
+        assert actual_results == actual_results_rev
+
 
 def test_issue400():
     with Env().getConnection() as r:


### PR DESCRIPTION
PR closes #607 

This PR adds an `OFFSET` subcommand (similar to the `COUNT` subcommand) to allow for a time series offset to be set. 

I decided against adding an extra option to the `AGGREGATE` command, because that would require downstream clients to change. By adding the `OFFSET` as it's own subcommand, nothing else changes (no tests fail), and setting the offset makes sense to be uncoupled from aggregation.

