### PR TITLE
Ensuring proper string length limit on RMLog calls within ts.mget and ts.mrange errors

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -587,8 +587,11 @@ int TSDB_generic_mrange(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                                            &series,
                                            REDISMODULE_READ);
         if (!status) {
-            RedisModule_Log(
-                ctx, "warning", "couldn't open key or key is not a Timeseries. key=%s", currentKey);
+            RedisModule_Log(ctx,
+                            "warning",
+                            "couldn't open key or key is not a Timeseries. key=%*s",
+                            currentKeyLen,
+                            currentKey);
             // The iterator may have been invalidated, stop and restart from after the current key.
             RedisModule_DictIteratorStop(iter);
             iter = RedisModule_DictIteratorStartC(result, ">", currentKey, currentKeyLen);
@@ -1223,8 +1226,11 @@ int TSDB_mget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                                            &series,
                                            REDISMODULE_READ);
         if (!status) {
-            RedisModule_Log(
-                ctx, "warning", "couldn't open key or key is not a Timeseries. key=%s", currentKey);
+            RedisModule_Log(ctx,
+                            "warning",
+                            "couldn't open key or key is not a Timeseries. key=%*s",
+                            currentKeyLen,
+                            currentKey);
             continue;
         }
         RedisModule_ReplyWithArray(ctx, 3);


### PR DESCRIPTION
Fix for this type of issues https://app.circleci.com/pipelines/github/RedisTimeSeries/RedisTimeSeries/2264/workflows/6e3d5fa4-c359-4cca-bf40-4cbc816c0262/jobs/5915 . This goes around the issue of non null terminated strings due to our implicit conversion from RMString to String but should prevent further failed valgrind builds due to this...