### PR TITLE
Ensure proper null-terminated string prior logging on ts.mget and ts.mrange

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -587,6 +587,7 @@ int TSDB_generic_mrange(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                                            &series,
                                            REDISMODULE_READ);
         if (!status) {
+            currentKey[currentKeyLen] = '\0';
             RedisModule_Log(ctx,
                             "warning",
                             "couldn't open key or key is not a Timeseries. key=%*s",
@@ -1226,6 +1227,7 @@ int TSDB_mget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                                            &series,
                                            REDISMODULE_READ);
         if (!status) {
+            currentKey[currentKeyLen] = '\0';
             RedisModule_Log(ctx,
                             "warning",
                             "couldn't open key or key is not a Timeseries. key=%*s",


### PR DESCRIPTION
Fix for valgrind leak checking like: https://app.circleci.com/pipelines/github/RedisTimeSeries/RedisTimeSeries/2267/workflows/ce8ab858-185b-4b29-bfec-653f88a44d60/jobs/5939