### PR TITLE
TS.ADD documentation improvements

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -68,7 +68,7 @@ TS.ALTER temperature:2:32 LABELS sensor_id 2 area_id 32 sub_area_id 15
 
 ### TS.ADD
 
-Append, or create and append, a new sample to the series that has been created earlier with TS.CREATE. 
+Append a new sample to the series. If the series has not been created yet with `TS.CREATE` it will be automatically created. 
 
 ```sql
 TS.ADD key timestamp value [RETENTION retentionTime] [UNCOMPRESSED] [CHUNK_SIZE size] [ON_DUPLICATE policy] [LABELS label value..]

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -68,14 +68,14 @@ TS.ALTER temperature:2:32 LABELS sensor_id 2 area_id 32 sub_area_id 15
 
 ### TS.ADD
 
-Append (or create and append) a new sample to the series.
+Append, or create and append, a new sample to the series that has been created earlier with TS.CREATE. 
 
 ```sql
 TS.ADD key timestamp value [RETENTION retentionTime] [UNCOMPRESSED] [CHUNK_SIZE size] [ON_DUPLICATE policy] [LABELS label value..]
 ```
 
-* timestamp - UNIX timestamp of the sample. `*` can be used for automatic timestamp (using the system clock)
-* value - numeric data value of the sample (double)
+* timestamp - (integer) UNIX timestamp of the sample **in milliseconds**. `*` can be used for an automatic timestamp from the system clock.
+* value - (double) numeric data value of the sample 
 
 These arguments are optional because they can be set by TS.CREATE:
 


### PR DESCRIPTION
Clarify that the timestamp must be in milliseconds. This was undocumented before.

Improved the language overall for TS.ADD section.

