### PR TITLE
Fixed GroupList_ApplyReducer() __source__ label building

### DIFF
--- a/tests/flow/test_ts_mrange_groupby.py
+++ b/tests/flow/test_ts_mrange_groupby.py
@@ -45,6 +45,10 @@ def test_groupby_reduce():
         env.assertEqual(serie2_name, b'metric_name=user')
         env.assertEqual(serie2_labels[0][0], b'metric_name')
         env.assertEqual(serie2_labels[0][1], b'user')
+        env.assertEqual(serie2_labels[1][0], b'__reducer__')
+        env.assertEqual(serie2_labels[1][1], b'max')
+        env.assertEqual(serie2_labels[2][0], b'__source__')
+        env.assertEqual(serie2_labels[2][1], b's1,s2')
         env.assertEqual(serie2_values, [[1, b'100'], [2, b'95']])
 
         actual_result = r.execute_command(

--- a/tests/flow/test_ts_mrange_groupby.py
+++ b/tests/flow/test_ts_mrange_groupby.py
@@ -80,3 +80,38 @@ def test_groupby_reduce_empty():
         actual_result = r.execute_command(
             'TS.mrange - + WITHLABELS FILTER metric_family=cpu GROUPBY labelX REDUCE max')
         env.assertEqual(actual_result, [])
+
+def test_groupby_reduce_multiple_groups():
+    env = Env()
+    with env.getConnection() as r:
+        assert r.execute_command('TS.ADD s1 1 100 LABELS HOST A REGION EU PROVIDER AWS')
+        assert r.execute_command('TS.ADD s2 1 55 LABELS HOST B REGION EU PROVIDER AWS')
+        assert r.execute_command('TS.ADD s2 2 90 LABELS HOST B REGION EU PROVIDER AWS')
+        assert r.execute_command('TS.ADD s3 2 40 LABELS HOST C REGION US PROVIDER AWS')
+
+        actual_result = r.execute_command(
+            'TS.mrange - + WITHLABELS FILTER PROVIDER=AWS GROUPBY REGION REDUCE max')
+        serie1 = actual_result[0]
+        serie1_name = serie1[0]
+        serie1_labels = serie1[1]
+        serie1_values = serie1[2]
+        env.assertEqual(serie1_values, [[1, b'100'],[2, b'90']])
+        env.assertEqual(serie1_name, b'REGION=EU')
+        env.assertEqual(serie1_labels[0][0], b'REGION')
+        env.assertEqual(serie1_labels[0][1], b'EU')
+        env.assertEqual(serie1_labels[1][0], b'__reducer__')
+        env.assertEqual(serie1_labels[1][1], b'max')
+        env.assertEqual(serie1_labels[2][0], b'__source__')
+        env.assertEqual(serie1_labels[2][1], b's1,s2')
+        serie2 = actual_result[1]
+        serie2_name = serie2[0]
+        serie2_labels = serie2[1]
+        serie2_values = serie2[2]
+        env.assertEqual(serie2_values, [[2, b'40']])
+        env.assertEqual(serie2_name, b'REGION=US')
+        env.assertEqual(serie2_labels[0][0], b'REGION')
+        env.assertEqual(serie2_labels[0][1], b'US')
+        env.assertEqual(serie2_labels[1][0], b'__reducer__')
+        env.assertEqual(serie2_labels[1][1], b'max')
+        env.assertEqual(serie2_labels[2][0], b'__source__')
+        env.assertEqual(serie2_labels[2][1], b's3')


### PR DESCRIPTION
This PR addresses the issue that causes RTS to crash with the following set of commands (added test https://github.com/RedisTimeSeries/RedisTimeSeries/commit/0524018a1b118f29db2c3f7b086d1639203a2e60 )

```
127.0.0.1:6379> ts.add ts1 * 1 labels HOST A REGION US
(integer) 1613385172000
127.0.0.1:6379> ts.add ts2 * 1 labels HOST B REGION US
(integer) 1613385178496
127.0.0.1:6379> ts.add ts3 * 1 labels HOST C REGION US
(integer) 1613385182992
127.0.0.1:6379> ts.mrange - + WITHLABELS FILTER REGION=US GROUPBY REGION REDUCE SUM
Could not connect to Redis at 127.0.0.1:6379: Connection refused
```
