### PR TITLE
Performance improvement: Using uncompressed series for temporary series on ApplySerieRangeIntoNewSerie

### DIFF
--- a/src/resultset.c
+++ b/src/resultset.c
@@ -98,9 +98,10 @@ int ApplySerieRangeIntoNewSerie(Series **dest,
                                 long long maxResults,
                                 bool rev) {
     Sample sample;
-    CreateCtx cCtx = { 0 };
-    cCtx.labels = NULL;
-    cCtx.labelsCount = 0;
+    CreateCtx cCtx = {
+        .labels = NULL, .labelsCount = 0, .chunkSizeBytes = Chunk_SIZE_BYTES_SECS, .options = 0
+    };
+    cCtx.options |= SERIES_OPT_UNCOMPRESSED;
 
     Series *new = NewSeries(RedisModule_CreateStringFromString(NULL, source->keyName), &cCtx);
     long long arraylen = 0;


### PR DESCRIPTION
This PR uses uncompressed series for temporary series on ApplySerieRangeIntoNewSerie given that we're seeing some significant overhead on compressed data reading and addition to temp series. 

The reading from the original series we can't (should not) change given it's a must, but for the temporary series, we can use uncompressed series.  Please notice that the 20% of SeriesAddSample is on temporary series.

**Results of optimization:** As you will see on the results output we moved from 1134.29 requests per second (p50=42.559ms) to 1713.24 requests per second (p50=27.455ms), leading to 30% improvement on the `single-groupby-1-8-1` TSBS query.

### TS.MRANGE Hotspots Top-Down detail
![image](https://user-images.githubusercontent.com/5832149/110550293-4e2bc400-812b-11eb-98f1-72bdb9ba8297.png)

### Results current master 
```
====== TS.MRANGE 1609613705646 1609617305646 WITHLABELS AGGREGATION MAX 60000 FILTER measurement=cpu fieldname=usage_user hostname=(host_49,host_3,host_35,host_39,host_75,host_15,host_21,host_11) GROUPBY hostname REDUCE max ======
  100000 requests completed in 88.16 seconds
  50 parallel clients
  304 bytes payload
  keep alive: 1
  host configuration "save": 
  host configuration "appendonly": no
  multi-thread: yes
  threads: 2

Latency by percentile distribution:
0.000% <= 0.999 milliseconds (cumulative count 1)
50.000% <= 42.559 milliseconds (cumulative count 50360)
75.000% <= 43.487 milliseconds (cumulative count 75303)
87.500% <= 43.935 milliseconds (cumulative count 88127)
93.750% <= 44.319 milliseconds (cumulative count 93936)
96.875% <= 44.991 milliseconds (cumulative count 96881)
98.438% <= 45.503 milliseconds (cumulative count 98498)
99.219% <= 45.663 milliseconds (cumulative count 99314)
99.609% <= 45.759 milliseconds (cumulative count 99618)
99.805% <= 45.887 milliseconds (cumulative count 99825)
99.902% <= 45.983 milliseconds (cumulative count 99913)
99.951% <= 46.079 milliseconds (cumulative count 99956)
99.976% <= 46.175 milliseconds (cumulative count 99978)
99.988% <= 46.367 milliseconds (cumulative count 99988)
99.994% <= 46.623 milliseconds (cumulative count 99995)
99.997% <= 46.783 milliseconds (cumulative count 99997)
99.998% <= 46.975 milliseconds (cumulative count 99999)
99.999% <= 47.135 milliseconds (cumulative count 100000)
100.000% <= 47.135 milliseconds (cumulative count 100000)

Cumulative distribution of latencies:
0.000% <= 0.103 milliseconds (cumulative count 0)
0.001% <= 1.007 milliseconds (cumulative count 1)
0.002% <= 4.103 milliseconds (cumulative count 2)
0.003% <= 5.103 milliseconds (cumulative count 3)
0.007% <= 6.103 milliseconds (cumulative count 7)
0.027% <= 40.127 milliseconds (cumulative count 27)
10.036% <= 41.119 milliseconds (cumulative count 10036)
37.356% <= 42.111 milliseconds (cumulative count 37356)
66.217% <= 43.103 milliseconds (cumulative count 66217)
91.607% <= 44.127 milliseconds (cumulative count 91607)
97.473% <= 45.119 milliseconds (cumulative count 97473)
99.968% <= 46.111 milliseconds (cumulative count 99968)
99.999% <= 47.103 milliseconds (cumulative count 99999)
100.000% <= 48.127 milliseconds (cumulative count 100000)

Summary:
  throughput summary: 1134.29 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
       42.597     0.992    42.559    44.447    45.599    47.135
```

### Results with the optimization
```
====== TS.MRANGE 1609613705646 1609617305646 WITHLABELS AGGREGATION MAX 60000 FILTER measurement=cpu fieldname=usage_user hostname=(host_49,host_3,host_35,host_39,host_75,host_15,host_21,host_11) GROUPBY hostname REDUCE max ======
  100000 requests completed in 58.37 seconds
  50 parallel clients
  304 bytes payload
  keep alive: 1
  host configuration "save": 
  host configuration "appendonly": no
  multi-thread: yes
  threads: 2

Latency by percentile distribution:
0.000% <= 0.823 milliseconds (cumulative count 1)
50.000% <= 27.455 milliseconds (cumulative count 50193)
75.000% <= 28.287 milliseconds (cumulative count 75306)
87.500% <= 28.911 milliseconds (cumulative count 87512)
93.750% <= 29.407 milliseconds (cumulative count 93783)
96.875% <= 30.415 milliseconds (cumulative count 96893)
98.438% <= 30.655 milliseconds (cumulative count 98523)
99.219% <= 30.799 milliseconds (cumulative count 99225)
99.609% <= 30.991 milliseconds (cumulative count 99665)
99.805% <= 31.039 milliseconds (cumulative count 99828)
99.902% <= 31.103 milliseconds (cumulative count 99905)
99.951% <= 31.215 milliseconds (cumulative count 99953)
99.976% <= 31.519 milliseconds (cumulative count 99976)
99.988% <= 31.951 milliseconds (cumulative count 99988)
99.994% <= 32.399 milliseconds (cumulative count 99994)
99.997% <= 32.623 milliseconds (cumulative count 99997)
99.998% <= 32.831 milliseconds (cumulative count 99999)
99.999% <= 32.927 milliseconds (cumulative count 100000)
100.000% <= 32.927 milliseconds (cumulative count 100000)

Cumulative distribution of latencies:
0.000% <= 0.103 milliseconds (cumulative count 0)
0.001% <= 0.903 milliseconds (cumulative count 1)
0.004% <= 3.103 milliseconds (cumulative count 4)
0.006% <= 4.103 milliseconds (cumulative count 6)
0.013% <= 15.103 milliseconds (cumulative count 13)
0.020% <= 16.103 milliseconds (cumulative count 20)
0.027% <= 17.103 milliseconds (cumulative count 27)
0.032% <= 18.111 milliseconds (cumulative count 32)
0.035% <= 19.103 milliseconds (cumulative count 35)
11.124% <= 26.111 milliseconds (cumulative count 11124)
39.699% <= 27.103 milliseconds (cumulative count 39699)
70.112% <= 28.111 milliseconds (cumulative count 70112)
90.149% <= 29.103 milliseconds (cumulative count 90149)
95.956% <= 30.111 milliseconds (cumulative count 95956)
99.905% <= 31.103 milliseconds (cumulative count 99905)
99.991% <= 32.111 milliseconds (cumulative count 99991)
100.000% <= 33.119 milliseconds (cumulative count 100000)

Summary:
  throughput summary: 1713.24 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
       27.529     0.816    27.455    29.599    30.735    32.927

```