### PR TITLE
Performance: Only get and release thread safe context within upsertCompaction() if the serie has compaction rules.

### DIFF
--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -299,6 +299,9 @@ int MultiSerieReduce(Series *dest, Series *source, MultiSeriesReduceOp op) {
 
 static void upsertCompaction(Series *series, UpsertCtx *uCtx) {
     CompactionRule *rule = series->rules;
+    if (rule == NULL) {
+        return;
+    }
     RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
     const timestamp_t upsertTimestamp = uCtx->sample.timestamp;
     const timestamp_t seriesLastTimestamp = series->lastTimestamp;


### PR DESCRIPTION
This PR improves any command that relies on datapoints upsert ( meaning TS.ADD with out-of-order data, TS.MRANGE with GROUPBY clause, and equivalents... ). Fixes #666 

**The fix/improvement is quite simple:** we only get and release thread safe context within upsertCompaction() if the serie has compaction rules.

**Results of optimization:** As you will see on the results output we moved from 363.27 requests per second (p50=135.807ms) to 492.13 requests per second (p50=99.711ms), leading to 35% improvement on the `single-groupby-5-8-1` TSBS query ( and equivalents ).

**Used dataset:**   tsbs devops use case, scale 100 
```
wget --no-check-certificate https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/functional/scale-100-redistimeseries_data.rdb
```

**Used benchmark command:**
```
redis-benchmark -e -n 10000 "TS.MRANGE" "1609613705646" "1609617305646" "WITHLABELS" "AGGREGATION" "MAX" "60000" "FILTER" "measurement=cpu" "fieldname=(usage_user,usage_system,usage_idle,usage_nice,usage_iowait)" "hostname=(host_49,host_3,host_35,host_39,host_75,host_15,host_21,host_11)" "GROUPBY" "hostname" "REDUCE" "max"
```

**Results current master**
```
====== TS.MRANGE 1609613705646 1609617305646 WITHLABELS AGGREGATION MAX 60000 FILTER measurement=cpu fieldname=(usage_user,usage_system,usage_idle,usage_nice,usage_iowait) hostname=(host_49,host_3,host_35,host_39,host_75,host_15,host_21,host_11) GROUPBY hostname REDUCE max ======
  10000 requests completed in 27.53 seconds
  50 parallel clients
  354 bytes payload
  keep alive: 1
  host configuration "save": 
  host configuration "appendonly": no
  multi-thread: no

Latency by percentile distribution:
0.000% <= 3.007 milliseconds (cumulative count 1)
50.000% <= 135.807 milliseconds (cumulative count 5091)
75.000% <= 137.087 milliseconds (cumulative count 7645)
87.500% <= 137.855 milliseconds (cumulative count 8823)
93.750% <= 139.391 milliseconds (cumulative count 9408)
96.875% <= 140.159 milliseconds (cumulative count 9705)
98.438% <= 140.671 milliseconds (cumulative count 9891)
99.219% <= 140.799 milliseconds (cumulative count 9944)
99.609% <= 140.927 milliseconds (cumulative count 9964)
99.805% <= 141.311 milliseconds (cumulative count 9983)
99.902% <= 141.951 milliseconds (cumulative count 9991)
99.951% <= 142.591 milliseconds (cumulative count 9996)
99.976% <= 142.847 milliseconds (cumulative count 9998)
99.988% <= 142.975 milliseconds (cumulative count 9999)
99.994% <= 143.103 milliseconds (cumulative count 10000)
100.000% <= 143.103 milliseconds (cumulative count 10000)

Cumulative distribution of latencies:
0.000% <= 0.103 milliseconds (cumulative count 0)
0.010% <= 3.103 milliseconds (cumulative count 1)
0.020% <= 14.103 milliseconds (cumulative count 2)
0.030% <= 15.103 milliseconds (cumulative count 3)
0.040% <= 16.103 milliseconds (cumulative count 4)
0.060% <= 17.103 milliseconds (cumulative count 6)
0.170% <= 132.223 milliseconds (cumulative count 17)
0.340% <= 133.119 milliseconds (cumulative count 34)
15.070% <= 134.143 milliseconds (cumulative count 1507)
37.230% <= 135.167 milliseconds (cumulative count 3723)
59.170% <= 136.191 milliseconds (cumulative count 5917)
79.050% <= 137.215 milliseconds (cumulative count 7905)
89.480% <= 138.111 milliseconds (cumulative count 8948)
93.440% <= 139.135 milliseconds (cumulative count 9344)
97.050% <= 140.159 milliseconds (cumulative count 9705)
99.760% <= 141.183 milliseconds (cumulative count 9976)
99.930% <= 142.207 milliseconds (cumulative count 9993)
100.000% <= 143.103 milliseconds (cumulative count 10000)

Summary:
  throughput summary: 363.27 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
      135.887     3.000   135.807   139.647   140.799   143.103
```

**Results with the optimization**
```
====== TS.MRANGE 1609613705646 1609617305646 WITHLABELS AGGREGATION MAX 60000 FILTER measurement=cpu fieldname=(usage_user,usage_system,usage_idle,usage_nice,usage_iowait) hostname=(host_49,host_3,host_35,host_39,host_75,host_15,host_21,host_11) GROUPBY hostname REDUCE max ======
  10000 requests completed in 20.32 seconds
  50 parallel clients
  354 bytes payload
  keep alive: 1
  host configuration "save": 
  host configuration "appendonly": no
  multi-thread: no

Latency by percentile distribution:
0.000% <= 2.447 milliseconds (cumulative count 1)
50.000% <= 99.711 milliseconds (cumulative count 5133)
75.000% <= 100.863 milliseconds (cumulative count 7529)
87.500% <= 101.823 milliseconds (cumulative count 8767)
93.750% <= 103.423 milliseconds (cumulative count 9404)
96.875% <= 104.191 milliseconds (cumulative count 9705)
98.438% <= 104.639 milliseconds (cumulative count 9858)
99.219% <= 104.831 milliseconds (cumulative count 9931)
99.609% <= 105.215 milliseconds (cumulative count 9961)
99.805% <= 105.919 milliseconds (cumulative count 9981)
99.902% <= 106.943 milliseconds (cumulative count 9991)
99.951% <= 107.583 milliseconds (cumulative count 9996)
99.976% <= 107.903 milliseconds (cumulative count 9998)
99.988% <= 108.031 milliseconds (cumulative count 9999)
99.994% <= 108.159 milliseconds (cumulative count 10000)
100.000% <= 108.159 milliseconds (cumulative count 10000)

Cumulative distribution of latencies:
0.000% <= 0.103 milliseconds (cumulative count 0)
0.010% <= 3.103 milliseconds (cumulative count 1)
0.020% <= 9.103 milliseconds (cumulative count 2)
0.040% <= 10.103 milliseconds (cumulative count 4)
0.050% <= 11.103 milliseconds (cumulative count 5)
0.070% <= 96.127 milliseconds (cumulative count 7)
0.560% <= 97.151 milliseconds (cumulative count 56)
16.600% <= 98.111 milliseconds (cumulative count 1660)
38.920% <= 99.135 milliseconds (cumulative count 3892)
61.180% <= 100.159 milliseconds (cumulative count 6118)
78.570% <= 101.119 milliseconds (cumulative count 7857)
89.100% <= 102.143 milliseconds (cumulative count 8910)
93.040% <= 103.103 milliseconds (cumulative count 9304)
96.780% <= 104.127 milliseconds (cumulative count 9678)
99.600% <= 105.151 milliseconds (cumulative count 9960)
99.820% <= 106.111 milliseconds (cumulative count 9982)
99.920% <= 107.135 milliseconds (cumulative count 9992)
100.000% <= 108.159 milliseconds (cumulative count 10000)

Summary:
  throughput summary: 492.13 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
       99.836     2.440    99.711   103.679   104.767   108.159

```
 