### PR TITLE
[DO NOT MERGE] Performance: using ryu for floating-point conversion ReplyWithSample()

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "deps/readies"]
 	path = deps/readies
 	url = https://github.com/RedisLabsModules/readies.git
+[submodule "deps/ryu"]
+	path = deps/ryu
+	url = https://github.com/ulfjack/ryu

--- a/deps/apply_patch.sh
+++ b/deps/apply_patch.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+VERBOSE=${VERBOSE:-0}
+PATCH=../ryu.patch
+DIRNAME=${DIRNAME:-"ryu"}
+[[ $VERBOSE == 1 ]] && set -x
+cd $DIRNAME
+
+git apply --check $PATCH 2>/dev/null
+#If the patch has not been applied then the $? which is the exit status
+#for last command would have a success status code = 0
+if [ $? -eq 0 ]; then
+    if [ $VERBOSE -eq 1 ]; then
+        echo "Applying patch $PATCH"
+    fi
+    git apply --verbose $PATCH
+else
+
+    if [ $VERBOSE -eq 1 ]; then
+        echo "Patch $PATCH was already applied. No need to apply."
+    fi
+fi

--- a/deps/ryu.patch
+++ b/deps/ryu.patch
@@ -1,0 +1,22 @@
+diff --git a/ryu/Makefile b/ryu/Makefile
+index 1adc0e3..f757426 100644
+--- a/ryu/Makefile
++++ b/ryu/Makefile
+@@ -2,6 +2,8 @@
+ # the lib as a dependency in non-Bazel projects (e.g. CMake).
+ # Contributed by @gritzko. Supported on a best-effort basis.
+ 
++CFLAGS?= -fPIC -O3
++
+ SRC=d2fixed.c d2s.c f2s.c generic_128.c
+ 
+ OBJ = $(SRC:.c=.o)
+@@ -14,7 +16,7 @@ INCLUDES = -I..
+ 
+ default: $(ALIB)
+ 
+-.c.o:
++%.o: %.c
+ 	$(CC) $(INCLUDES) $(CFLAGS) -c $< -o $@
+ 
+ $(ALIB): $(OBJ)

--- a/src/Makefile
+++ b/src/Makefile
@@ -50,6 +50,10 @@ PAKCAGE_NAME ?= $(BINROOT)/redistimeseries.{os}-{architecture}.latest.zip
 
 # set environment variable RM_INCLUDE_DIR to the location of redismodule.h
 SDK_DIR=$(ROOT)/deps/RedisModulesSDK
+LIBRYU_LIBDIR=$(ROOT)/deps/ryu
+LIBRYU_PATH=$(LIBRYU_LIBDIR)/ryu
+LIBRYU=$(LIBRYU_PATH)/libryu.a
+
 RMUTIL_LIBDIR=$(BINROOT)/rmutil
 LIBRMUTIL=$(RMUTIL_LIBDIR)/librmutil.a
 
@@ -62,6 +66,7 @@ CC=gcc
 
 CC_FLAGS = \
 	-I$(SDK_DIR) \
+	-I$(LIBRYU_PATH) \
 	-I$(ROOT)/deps \
 	-Wall \
 	-fPIC \
@@ -74,7 +79,7 @@ CC_FLAGS = \
 	-DREDISMODULE_EXPERIMENTAL_API
 
 LD_FLAGS += 
-LD_LIBS += -lc -lm -L$(RMUTIL_LIBDIR) -lrmutil
+LD_LIBS += -lc -lm -L$(RMUTIL_LIBDIR) -lrmutil -L$(LIBRYU_PATH) -lryu
 
 ifeq ($(OS),linux)
 SO_LD_FLAGS += -shared -Bsymbolic $(LD_FLAGS)
@@ -144,7 +149,7 @@ include $(MK)/defs
 
 #----------------------------------------------------------------------------------------------
 
-.PHONY: package tests unittests clean all install uninstall docker bindirs
+.PHONY: package tests unittests clean all install uninstall docker bindirs libryu
 
 all: bindirs $(TARGET)
 
@@ -155,6 +160,13 @@ rmutil:
 	$(SHOW)$(MAKE) -C $(ROOT)/build/rmutil
 
 $(LIBRMUTIL): rmutil
+
+libryu:
+	@echo Building $@...
+	DIRNAME=$(realpath $(LIBRYU_LIBDIR)) $(ROOT)/deps/apply_patch.sh
+	$(SHOW)$(MAKE) -C ../deps/ryu/ryu libs
+
+$(LIBRYU): libryu
 
 docker_lint:
 	docker build -t llvm-toolset -f llvm.Dockerfile .
@@ -173,6 +185,7 @@ format:
 clean:
 	-$(SHOW)[ -e $(BINDIR) ] && find $(BINDIR) -name '*.[oadh]' -type f -delete
 	-$(SHOW)$(MAKE) -C $(ROOT)/build/rmutil clean
+	-$(SHOW)$(MAKE) -C $(LIBRYU_PATH) clean
 	-$(SHOW)rm -f $(TARGET) $(UNITTESTS_RUNNER)
 
 -include $(CC_DEPS)
@@ -181,7 +194,7 @@ $(BINDIR)/%.o: $(SRCDIR)/%.c
 	@echo Compiling $<...
 	$(SHOW)$(CC) $(CC_FLAGS) -c $< -o $@
 
-$(TARGET): $(BIN_DIRS) $(OBJECTS) $(LIBRMUTIL)
+$(TARGET): $(BIN_DIRS) $(OBJECTS) $(LIBRMUTIL) $(LIBRYU)
 	@echo Linking $@...
 	$(SHOW)$(CC) $(SO_LD_FLAGS) -o $@ $(OBJECTS) $(LD_LIBS)
 	$(SHOW)cd $(BINROOT)/..; ln -sf $(FULL_VARIANT)/$(notdir $(TARGET)) $(notdir $(TARGET))

--- a/src/reply.c
+++ b/src/reply.c
@@ -7,6 +7,7 @@
 #include "reply.h"
 
 #include "redismodule.h"
+#include "ryu.h"
 #include "series_iterator.h"
 #include "tsdb.h"
 
@@ -87,8 +88,9 @@ void ReplyWithSeriesLabels(RedisModuleCtx *ctx, const Series *series) {
 void ReplyWithSample(RedisModuleCtx *ctx, u_int64_t timestamp, double value) {
     RedisModule_ReplyWithArray(ctx, 2);
     RedisModule_ReplyWithLongLong(ctx, timestamp);
-    char buf[MAX_VAL_LEN];
-    snprintf(buf, MAX_VAL_LEN, "%.15g", value);
+    /* reserve space for null terminator */
+    char buf[MAX_VAL_LEN + 1];
+    d2s_buffered(value, &buf);
     RedisModule_ReplyWithSimpleString(ctx, buf);
 }
 


### PR DESCRIPTION
This PR addresses #664 within ReplyWithSample() by using `ryu`.
Just by replacing ReplyWithSample() snprintf with d2s_buffered we go from 1666 ops/sec to 1884 ops/sec in one of our TSBS queries ( which is 13% improvement in the achievable command rate ).
Given that ryu is expected to give 20X boost it makes sense that 13%/20 is barely measured now.
with RYU ( https://github.com/ulfjack/ryu )
```
Summary:
  throughput summary: 1884.52 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
       25.441     0.648    25.359    27.407    28.159    32.127
```
current master:
```
Summary:
 throughput summary: 1666.36 requests per second
 latency summary (msec):
     avg    min    p50    p95    p99    max
    28.909   0.728  28.847  30.879  31.759  36.287
```



---------------------

## Steps to reproduce:

- Dataset:  tsbs devops use case, scale 100  `wget --no-check-certificate https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/functional/scale-100-redistimeseries_data.rdb`

- Benchmark command: `redis-benchmark -e -n 100000  "TS.MRANGE" "1609613705646" "1609617305646" "WITHLABELS" "AGGREGATION" "MAX" "60000" "FILTER" "measurement=cpu" "fieldname=usage_user" "hostname=(host_49,host_3,host_35,host_39,host_75,host_15,host_21,host_11)" "GROUPBY" "hostname" "REDUCE" "max"`