### PR TITLE
Updated Redis Cloud Section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,9 +45,9 @@ You can either get RedisTimeSeries setup in the cloud, in a Docker container or 
 
 ### Redis Cloud
 
-RedisTimeSeries is available on all Redis Cloud managed services. Redis Cloud Essentials offers a completely free managed database up to 30MB.
+RedisTimeSeries is available on all Redis Cloud managed services, including a completely free managed database up to 30MB.
 
-[Get started here](https://redislabs.com/try-free/)
+[Get started here](https://redislabs.com/redis-enterprise-cloud/pricing/)
 
 
 ### Docker

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ You can either get RedisTimeSeries setup in the cloud, in a Docker container or 
 
 RedisTimeSeries is available on all Redis Cloud managed services, including a completely free managed database up to 30MB.
 
-[Get started here](https://redislabs.com/redis-enterprise-cloud/pricing/)
+[Get started here](https://redislabs.com/redis-enterprise-cloud/try-free/)
 
 
 ### Docker

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ You can either get RedisTimeSeries setup in the cloud, in a Docker container or 
 
 RedisTimeSeries is available on all Redis Cloud managed services, including a completely free managed database up to 30MB.
 
-[Get started here](https://redislabs.com/redis-enterprise-cloud/try-free/)
+[Get started here](https://redislabs.com/try-free/)
 
 
 ### Docker


### PR DESCRIPTION
Redis Cloud section should be updated - 'essentials' plans no longer exists. I also changed the link to the 'pricing' page so folks are not only directed to the free model, but can choose from ALL of the plans (potential opportunity to acquire new customers)