### PR TITLE
Enable debug/release profiling flags on rmutil and RedisTimeSeries

### DIFF
--- a/build/rmutil/Makefile
+++ b/build/rmutil/Makefile
@@ -1,7 +1,6 @@
 
 ROOT=../..
 MK.pyver:=3
-SHOW ?= 1
 
 include $(ROOT)/deps/readies/mk/main
 
@@ -69,11 +68,11 @@ $(TARGET): $(OBJECTS)
 #----------------------------------------------------------------------------------------------
 
 $(BINDIR)/test_vector: test_vector.o vector.o
-	$(CC) -Wall -o $@ $^ -lc -lpthread -O0
-	sh -c ./$@
+	$(SHOW)$(CC) -Wall -o $@ $^ -lc -lpthread -O0
+	$(SHOW)sh -c ./$@
 
 $(BINDIR)/test_periodic: test_periodic.o periodic.o
-	$(CC) -Wall -o $@ $^ -lc -lpthread -O0
-	sh -c ./$@
+	$(SHOW)$(CC) -Wall -o $@ $^ -lc -lpthread -O0
+	$(SHOW)sh -c ./$@
 	
 test: test_periodic test_vector

--- a/build/rmutil/Makefile
+++ b/build/rmutil/Makefile
@@ -12,14 +12,26 @@ SRCDIR=$(ROOT)/deps/RedisModulesSDK/rmutil
 CC=gcc
 
 CC_FLAGS=\
-	-g \
-	-O3 \
 	-I$(SRCDIR)/.. \
 	-Wall \
 	-fPIC \
 	-Wno-unused-function \
 	-std=gnu99 \
 	-MMD -MF $(@:.o=.d)
+
+ifeq ($(PROFILE),1)
+CC_FLAGS += -g -ggdb -fno-omit-frame-pointer
+endif
+
+ifeq ($(DEBUG),1)
+CC_FLAGS += -g -ggdb -O0
+else
+ifeq ($(PROFILE),1)
+CC_FLAGS += -O2
+else
+CC_FLAGS += -O3
+endif
+endif
 
 _SOURCES=util.c strings.c sds.c vector.c alloc.c periodic.c
 
@@ -47,11 +59,11 @@ clean:
 
 $(BINDIR)/%.o: $(SRCDIR)/%.c
 	@echo Compiling $<...
-	$(SHOW)$(CC) $(CC_FLAGS) -c $< -o $@
+	$(CC) $(CC_FLAGS) -c $< -o $@
 
 $(TARGET): $(OBJECTS)
 	@echo Creating $@...
-	$(SHOW)ar rcs $@ $^
+	ar rcs $@ $^
 
 #----------------------------------------------------------------------------------------------
 

--- a/build/rmutil/Makefile
+++ b/build/rmutil/Makefile
@@ -1,6 +1,7 @@
 
 ROOT=../..
 MK.pyver:=3
+SHOW ?= 1
 
 include $(ROOT)/deps/readies/mk/main
 
@@ -59,11 +60,11 @@ clean:
 
 $(BINDIR)/%.o: $(SRCDIR)/%.c
 	@echo Compiling $<...
-	$(CC) $(CC_FLAGS) -c $< -o $@
+	$(SHOW)$(CC) $(CC_FLAGS) -c $< -o $@
 
 $(TARGET): $(OBJECTS)
 	@echo Creating $@...
-	ar rcs $@ $^
+	$(SHOW)ar rcs $@ $^
 
 #----------------------------------------------------------------------------------------------
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,8 @@
 ROOT=..
 MK.pyver:=3
+SHOW ?= 1
 
 include $(ROOT)/deps/readies/mk/main
-
 #----------------------------------------------------------------------------------------------  
 
 define HELP
@@ -191,11 +191,11 @@ clean:
 
 $(BINDIR)/%.o: $(SRCDIR)/%.c
 	@echo Compiling $<...
-	$(CC) $(CC_FLAGS) -c $< -o $@
+	$(SHOW)$(CC) $(CC_FLAGS) -c $< -o $@
 
 $(TARGET): $(BIN_DIRS) $(OBJECTS) $(LIBRMUTIL)
 	@echo Linking $@...
-	$(CC) $(SO_LD_FLAGS) -o $@ $(OBJECTS) $(LD_LIBS)
+	$(SHOW)$(CC) $(SO_LD_FLAGS) -o $@ $(OBJECTS) $(LD_LIBS)
 	$(SHOW)cd $(BINROOT)/..; ln -sf $(FULL_VARIANT)/$(notdir $(TARGET)) $(notdir $(TARGET))
 
 #----------------------------------------------------------------------------------------------

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,9 @@
+
 ROOT=..
 MK.pyver:=3
-SHOW ?= 1
 
 include $(ROOT)/deps/readies/mk/main
+
 #----------------------------------------------------------------------------------------------  
 
 define HELP
@@ -12,7 +13,7 @@ make fetch         # download and prepare dependant modules
 make build
   DEBUG=1          # build debug variant
   VARIANT=name     # use a build variant 'name'
-  PROFILE=1        # enable profiling compile flags (and debug symbols) for release type.
+  PROFILE=1        # enable profiling compile flags (and debug symbols) for release type
                    # You can consider this as build type release with debug symbols and -fno-omit-frame-pointer
   DEPS=1           # also build dependant modules
   COV=1            # perform coverage analysis (implies debug build)
@@ -101,12 +102,10 @@ endif
 ifeq ($(DEBUG),1)
 CC_FLAGS += -g -ggdb -O0 -DVALGRIND
 LD_FLAGS += -g
-else
-ifeq ($(PROFILE),1)
+else ifeq ($(PROFILE),1)
 CC_FLAGS += -O2
 else
 CC_FLAGS += -O3
-endif
 endif
 
 
@@ -169,18 +168,18 @@ rmutil:
 $(LIBRMUTIL): rmutil
 
 docker_lint:
-	docker build -t llvm-toolset -f llvm.Dockerfile .
-	docker run --rm -w /code/src -v `pwd`/..:/code llvm-toolset make lint
+	$(SHOW)docker build -t llvm-toolset -f llvm.Dockerfile .
+	$(SHOW)docker run --rm -w /code/src -v `pwd`/..:/code llvm-toolset make lint
 
 lint:
-	clang-format -Werror -n $(SOURCES)
-	clang-format -Werror -n $(HEADERS)
-	clang-format -Werror -n $(TEST_FILES)
+	$(SHOW)clang-format -Werror -n $(SOURCES)
+	$(SHOW)clang-format -Werror -n $(HEADERS)
+	$(SHOW)clang-format -Werror -n $(TEST_FILES)
 
 format:
-	clang-format -i $(SOURCES)
-	clang-format -i $(HEADERS)
-	clang-format -i $(TEST_FILES)
+	$(SHOW)clang-format -i $(SOURCES)
+	$(SHOW)clang-format -i $(HEADERS)
+	$(SHOW)clang-format -i $(TEST_FILES)
 
 clean:
 	-$(SHOW)[ -e $(BINDIR) ] && find $(BINDIR) -name '*.[oadh]' -type f -delete
@@ -293,13 +292,12 @@ docker:
 	$(SHOW)cd .. && docker build -t redis-tsdb .
 
 coverage:
-	DEBUG=1 COVERAGE=1 make tests
-	DEBUG=1 COVERAGE=1 make unittests
-	mkdir -p tmp/lcov
-	lcov -d ../bin/linux-x64-debug/src -c -o tmp/lcov/hiredis.info
-	lcov -l tmp/lcov/hiredis.info
-	genhtml --legend -o tmp/lcov/report tmp/lcov/hiredis.info > /dev/null 2>&1
-
+	$(SHOW)DEBUG=1 COVERAGE=1 make tests
+	$(SHOW)DEBUG=1 COVERAGE=1 make unittests
+	$(SHOW)mkdir -p tmp/lcov
+	$(SHOW)lcov -d ../bin/linux-x64-debug/src -c -o tmp/lcov/hiredis.info
+	$(SHOW)lcov -l tmp/lcov/hiredis.info
+	$(SHOW)genhtml --legend -o tmp/lcov/report tmp/lcov/hiredis.info > /dev/null 2>&1
 
 #----------------------------------------------------------------------------------------------
 
@@ -320,8 +318,8 @@ package: $(TARGET)
 		echo Cannot find redis-server. Aborting. ;\
 		exit 1 ;\
 	fi
-	$(call ramp_pack,latest,release)
-	$(call ramp_pack,{semantic_version},release)
+	$(SHOW)$(call ramp_pack,latest,release)
+	$(SHOW)$(call ramp_pack,{semantic_version},release)
 ifneq ($(BRANCH),)
-	$(call ramp_pack,$(BRANCH),branch)
+	$(SHOW)$(call ramp_pack,$(BRANCH),branch)
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,6 +12,8 @@ make fetch         # download and prepare dependant modules
 make build
   DEBUG=1          # build debug variant
   VARIANT=name     # use a build variant 'name'
+  PROFILE=1        # enable profiling compile flags (and debug symbols) for release type.
+                   # You can consider this as build type release with debug symbols and -fno-omit-frame-pointer
   DEPS=1           # also build dependant modules
   COV=1            # perform coverage analysis (implies debug build)
 make clean         # remove binary files
@@ -92,12 +94,21 @@ ifeq ($(VALGRIND),1)
 DEBUG ?= 1
 endif
 
+ifeq ($(PROFILE),1)
+CC_FLAGS += -g -ggdb -fno-omit-frame-pointer
+endif
+
 ifeq ($(DEBUG),1)
 CC_FLAGS += -g -ggdb -O0 -DVALGRIND
 LD_FLAGS += -g
 else
+ifeq ($(PROFILE),1)
+CC_FLAGS += -O2
+else
 CC_FLAGS += -O3
 endif
+endif
+
 
 CC_FLAGS += $(CC_FLAGS.coverage)
 LD_FLAGS += $(LD_FLAGS.coverage)
@@ -180,11 +191,11 @@ clean:
 
 $(BINDIR)/%.o: $(SRCDIR)/%.c
 	@echo Compiling $<...
-	$(SHOW)$(CC) $(CC_FLAGS) -c $< -o $@
+	$(CC) $(CC_FLAGS) -c $< -o $@
 
 $(TARGET): $(BIN_DIRS) $(OBJECTS) $(LIBRMUTIL)
 	@echo Linking $@...
-	$(SHOW)$(CC) $(SO_LD_FLAGS) -o $@ $(OBJECTS) $(LD_LIBS)
+	$(CC) $(SO_LD_FLAGS) -o $@ $(OBJECTS) $(LD_LIBS)
 	$(SHOW)cd $(BINROOT)/..; ln -sf $(FULL_VARIANT)/$(notdir $(TARGET)) $(notdir $(TARGET))
 
 #----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Enables compiler automatic vectorization reports on PROFILE=1 builds.

### Some important notes on how to profile properly on-cpu within Redis and Modules:

For a proper On-CPU analysis Redis ( and any dynamic loaded library like Redis Modules ) require stack traces to be available to tracers, which you may need to fix first.

Many compilers omit the frame pointer as a way of runtime optimization ( saving a register ), thus breaking frame pointer-based stack walking. This makes the redis executable and RedisTimeSeries shared library faster, but at the same time it makes Redis (like any other program) harder to trace, potentially wrongfully pinpointing on-CPU time to the last available frame pointer of a call stack that can get a lot deeper ( but impossible to trace ).

It's important that we ensure both for RedisTimeSeries and rmutil:

- debug information is present: compile option `-g`
- frame pointer register is present: `-fno-omit-frame-pointer`
- we still run with optimizations to get an accurate representation of production run times, meaning we will keep during profiling: `-O2`