### PR TITLE
Performance: Avoid calling ParseDuplicatePolicy() on add() with argv=NULL

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -518,7 +518,9 @@ static inline int add(RedisModuleCtx *ctx,
         return RTS_ReplyGeneralError(ctx, "TSDB: the key is not a TSDB key");
     } else {
         series = RedisModule_ModuleTypeGetValue(key);
-        if (ParseDuplicatePolicy(ctx, argv, argc, TS_ADD_DUPLICATE_POLICY_ARG, &dp) != TSDB_OK) {
+        //  overwride key and database configuration for DUPLICATE_POLICY
+        if (argv != NULL &&
+            ParseDuplicatePolicy(ctx, argv, argc, TS_ADD_DUPLICATE_POLICY_ARG, &dp) != TSDB_OK) {
             return REDISMODULE_ERR;
         }
     }


### PR DESCRIPTION
This PR avoids Avoid calling ParseDuplicatePolicy() on add() with argv=NULL. 
This optimizes command scenarios like: `TS.MADD key1 ts1 v1 ...`, given that ParseDuplicatePolicy takes 2.4% of CPU time of `add()` for useless computation given that there is no argv of interest to `ParseDuplicatePolicy`


## Top-Down tree of hotspots by CPU utilization for TS.MADD....
Please notice the 2.4% line, which we're fixing on this PR. 

Function Stack | CPU Time: Total | CPU Time: Self | Function (Full) | Source File
-- | -- | -- | -- | --
add | 96.10% | 0.122s | add | module.c
RM_OpenKey | 27.70% | 0.066s | RM_OpenKey | module.c
internalAdd | 24.80% | 0.404s | internalAdd | module.c
 RM_StringToDouble | 16.70% | 0.038s | RM_StringToDouble | module.c
RM_CloseKey | 8.30% | 0.114s | RM_CloseKey | module.c
RM_StringToLongLong | 6.80% | 0.082s | RM_StringToLongLong | module.c
zfree | 4.20% | 0.262s | zfree | zmalloc.c
 **ParseDuplicatePolicy** | **2.40%** | 0.184s | ParseDuplicatePolicy | query_language.c
RM_ModuleTypeGetType | 1.90% | 0.236s | RM_ModuleTypeGetType | module.c
__GI_ | 1.50% | 0.212s | float __GI_(long, int, bool, char) | malloc.c

