### PR TITLE
Added support for binary data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,16 @@ pack:
 run:
 	@$(MAKE) -C src run
 
+valgrind:
+	@$(MAKE) -C src $@
+
+run:
+	@$(MAKE) -C src $@
+
+gdb:
+	@$(MAKE) -C src $@
+
+
 benchmark:
 	@$(MAKE) -C src benchmark
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,28 @@ OK
    2) "42"
 ```
 
+It is also possible to store binary data (with redis-cli, we illustrate this with character strings).
+For doing this, simply add the **BLOB** keyword when creating the key.
+Since creating the key is also feasible with TS.ADD, the **BLOB** keyword can be added as an option to this command, too.
+
+Aggregation works with binary data as well, but obviously, only types of "last" and "first" are supported in this case.
+
+```sh
+$ redis-cli
+127.0.0.1:6379> TS.CREATE blob1 BLOB
+OK
+127.0.0.1:6379> TS.ADD blob1 * value1
+(integer) 1600765694862
+127.0.0.1:6379> TS.ADD blob1 * value2
+(integer) 1600765708510
+127.0.0.1:6379> TS.RANGE blob1 - +
+1) 1) (integer) 1600765694862
+   2) "value1"
+2) 1) (integer) 1600765708510
+   2) "value2"
+
+```
+
 ### Client libraries
 
 Some languages have client libraries that provide support for RedisTimeSeries commands:

--- a/src/Makefile
+++ b/src/Makefile
@@ -153,6 +153,7 @@ CC_FLAGS += $(CC_FLAGS.coverage)
 LD_FLAGS += $(LD_FLAGS.coverage)
 
 _SOURCES=\
+	blob.c \
 	chunk.c \
 	compaction.c \
 	compressed_chunk.c \

--- a/src/blob.c
+++ b/src/blob.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018-2019 Redis Labs Ltd. and Contributors
+ * Copyright 2020 IoT.BzH
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
+
+#include "blob.h"
+
+#include "redismodule.h"
+
+#include <string.h>
+#include "rmutil/alloc.h"
+
+static int nbBlobs = 0;
+static int nbData = 0;
+
+TSBlob *NewBlob(const char *data, size_t len) {
+    TSBlob *blob = RedisModule_Calloc(1, sizeof(TSBlob));
+    memset(blob, 0, sizeof(TSBlob));
+    nbBlobs++;
+
+    if (data == NULL || len == 0)
+        return blob;
+
+    blob->len = len;
+    blob->data = RedisModule_Alloc(blob->len);
+    nbData++;
+    memcpy(blob->data, data, blob->len);
+
+    return blob;
+}
+
+TSBlob *BlobDup(const TSBlob *src) {
+    TSBlob *blob = RedisModule_Alloc(sizeof(TSBlob));
+    memset(blob, 0, sizeof(TSBlob));
+    nbBlobs++;
+    BlobCopy(blob, src);
+
+    return blob;
+}
+
+void BlobCopy(TSBlob *dst, const TSBlob *src) {
+    dst->len = src->len;
+
+    if (dst->data) {
+        RedisModule_Free(dst->data);
+        nbData--;
+    }
+
+    dst->data = RedisModule_Alloc(src->len);
+
+    nbData++;
+    memcpy(dst->data, src->data, src->len);
+}
+
+void FreeBlob(TSBlob *blob) {
+    if (blob->data) {
+        nbData--;
+        RedisModule_Free(blob->data);
+    }
+
+    RedisModule_Free(blob);
+    nbBlobs--;
+}
+
+void RedisModule_SaveBlob(RedisModuleIO *io, const TSBlob *blob) {
+    if (!blob) {
+        RedisModule_SaveStringBuffer(io, EMPTY_BLOB, EMPTY_BLOB_SIZE);
+        return;
+    }
+    RedisModule_SaveStringBuffer(io, blob->data, blob->len);
+}
+
+TSBlob *RedisModule_LoadBlob(RedisModuleIO *io) {
+    size_t len;
+    char *data = RedisModule_LoadStringBuffer(io, &len);
+    return NewBlob(data, len);
+}

--- a/src/blob.h
+++ b/src/blob.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-2019 Redis Labs Ltd. and Contributors
+ * Copyright 2020 IoT.BzH
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
+#ifndef BLOB_H
+#define BLOB_H
+
+#include "redismodule.h"
+
+typedef struct
+{
+    size_t len;
+    char *data;
+} TSBlob;
+
+TSBlob *NewBlob(const char *data, size_t len);
+TSBlob *BlobDup(const TSBlob *src);
+
+void BlobCopy(TSBlob *dst, const TSBlob *src);
+
+void FreeBlob(TSBlob *blob);
+
+void RedisModule_SaveBlob(RedisModuleIO *io, const TSBlob *blob);
+TSBlob *RedisModule_LoadBlob(RedisModuleIO *io);
+
+#define EMPTY_BLOB ""
+#define EMPTY_BLOB_SIZE 1
+
+#endif /* BLOB_H */

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -17,6 +17,7 @@ typedef struct Chunk
     Sample *samples;
     unsigned int num_samples;
     size_t size;
+    bool isBlob;
 } Chunk;
 
 typedef struct ChunkIterator
@@ -28,7 +29,7 @@ typedef struct ChunkIterator
     int options;
 } ChunkIterator;
 
-Chunk_t *Uncompressed_NewChunk(size_t sampleCount);
+Chunk_t *Uncompressed_NewChunk(bool isBlob, size_t sampleCount);
 void Uncompressed_FreeChunk(Chunk_t *chunk);
 
 /**
@@ -71,12 +72,12 @@ ChunkResult Uncompressed_ChunkIteratorGetPrev(ChunkIter_t *iterator, Sample *sam
 void Uncompressed_FreeChunkIterator(ChunkIter_t *iter);
 
 // RDB
-void Uncompressed_SaveToRDB(Chunk_t *chunk, struct RedisModuleIO *io);
-int Uncompressed_LoadFromRDB(Chunk_t **chunk, struct RedisModuleIO *io);
+void Uncompressed_SaveToRDB(Chunk_t *chunk, struct RedisModuleIO *io, bool isBlob);
+int Uncompressed_LoadFromRDB(Chunk_t **chunk, struct RedisModuleIO *io, bool isBlob);
 
 // LibMR
-void Uncompressed_MRSerialize(Chunk_t *chunk, WriteSerializationCtx *sctx);
-int Uncompressed_MRDeserialize(Chunk_t **chunk, ReaderSerializationCtx *sctx);
+void Uncompressed_MRSerialize(Chunk_t *chunk, WriteSerializationCtx *sctx, bool isBlob);
+int Uncompressed_MRDeserialize(Chunk_t **chunk, ReaderSerializationCtx *sctx, bool isBlob);
 
 // this is just a temporary wrapper function that ignores error in order to preserve the common api
 void MR_SerializationCtxWriteLongLongWrapper(WriteSerializationCtx *sctx, long long val);

--- a/src/compaction.h
+++ b/src/compaction.h
@@ -28,4 +28,10 @@ int RMStringLenAggTypeToEnum(RedisModuleString *aggTypeStr);
 int StringLenAggTypeToEnum(const char *agg_type, size_t len);
 const char *AggTypeEnumToString(TS_AGG_TYPES_T aggType);
 
+bool IsCompactionBlobFriendly(TS_AGG_TYPES_T aggType);
+
+AggregationClass *BlobAggClass(AggregationClass *class);
+bool aggClassIsBlob(const AggregationClass *class);
+TS_AGG_TYPES_T BlobAggType(TS_AGG_TYPES_T aggType);
+
 #endif

--- a/src/compressed_chunk.h
+++ b/src/compressed_chunk.h
@@ -14,7 +14,7 @@
 #include <sys/types.h> // u_int_t
 
 // Initialize compressed chunk
-Chunk_t *Compressed_NewChunk(size_t size);
+Chunk_t *Compressed_NewChunk(bool, size_t size);
 void Compressed_FreeChunk(Chunk_t *chunk);
 Chunk_t *Compressed_CloneChunk(const Chunk_t *chunk);
 Chunk_t *Compressed_SplitChunk(Chunk_t *chunk);
@@ -38,12 +38,12 @@ timestamp_t Compressed_GetFirstTimestamp(Chunk_t *chunk);
 timestamp_t Compressed_GetLastTimestamp(Chunk_t *chunk);
 
 // RDB
-void Compressed_SaveToRDB(Chunk_t *chunk, struct RedisModuleIO *io);
-int Compressed_LoadFromRDB(Chunk_t **chunk, struct RedisModuleIO *io);
+void Compressed_SaveToRDB(Chunk_t *chunk, struct RedisModuleIO *io, bool isBlob);
+int Compressed_LoadFromRDB(Chunk_t **chunk, struct RedisModuleIO *io, bool isBlob);
 
 // LibMR
-void Compressed_MRSerialize(Chunk_t *chunk, WriteSerializationCtx *sctx);
-int Compressed_MRDeserialize(Chunk_t **chunk, ReaderSerializationCtx *sctx);
+void Compressed_MRSerialize(Chunk_t *chunk, WriteSerializationCtx *sctx, bool isBlob);
+int Compressed_MRDeserialize(Chunk_t **chunk, ReaderSerializationCtx *sctx, bool isBlob);
 
 /* Used in tests */
 u_int64_t getIterIdx(ChunkIter_t *iter);

--- a/src/consts.h
+++ b/src/consts.h
@@ -53,7 +53,10 @@ typedef enum {
     TS_AGG_STD_S,
     TS_AGG_VAR_P,
     TS_AGG_VAR_S,
-    TS_AGG_TYPES_MAX // 13
+    TS_AGG_BLOB_COUNT,
+    TS_AGG_BLOB_FIRST,
+    TS_AGG_BLOB_LAST,
+    TS_AGG_TYPES_MAX // 16
 } TS_AGG_TYPES_T;
 
 
@@ -70,8 +73,8 @@ typedef enum DuplicatePolicy {
 
 /* Series struct options */
 #define SERIES_OPT_UNCOMPRESSED 0x1
-
 #define SERIES_OPT_COMPRESSED_GORILLA 0x2
+#define SERIES_OPT_BLOB 0x4
 
 #define SERIES_OPT_DEFAULT_COMPRESSION SERIES_OPT_COMPRESSED_GORILLA
 

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -13,7 +13,8 @@ static bool check_sample_value(Sample sample, FilterByValueArgs byValueArgs) {
         return true;
     }
 
-    if (sample.value >= byValueArgs.min && sample.value <= byValueArgs.max) {
+    if (VALUE_DOUBLE(&sample.value) >= byValueArgs.min &&
+        VALUE_DOUBLE(&sample.value) <= byValueArgs.max) {
         return true;
     } else {
         return false;
@@ -93,7 +94,7 @@ static bool finalizeBucket(Sample *currentSample, const AggregationIterator *sel
     double value;
     if (self->aggregation->finalize(self->aggregationContext, &value) == TSDB_OK) {
         currentSample->timestamp = self->aggregationLastTimestamp;
-        currentSample->value = value;
+        VALUE_DOUBLE(&currentSample->value) = value;
         hasSample = TRUE;
         self->aggregation->resetContext(self->aggregationContext);
     }
@@ -145,8 +146,7 @@ ChunkResult AggregationIterator_GetNext(struct AbstractIterator *iter, Sample *c
             contextScope = self->aggregationLastTimestamp + aggregationTimeDelta;
         }
         self->aggregationIsFirstSample = FALSE;
-
-        appendValue(aggregationContext, internalSample.value);
+        appendValue(self->aggregationContext, VALUE_DOUBLE(&internalSample.value));
         if (hasSample) {
             return CR_OK;
         }
@@ -160,7 +160,7 @@ ChunkResult AggregationIterator_GetNext(struct AbstractIterator *iter, Sample *c
             double value;
             if (aggregation->finalize(aggregationContext, &value) == TSDB_OK) {
                 currentSample->timestamp = self->aggregationLastTimestamp;
-                currentSample->value = value;
+                VALUE_DOUBLE(&currentSample->value) = value;
             }
             self->aggregationIsFinalized = TRUE;
             return CR_OK;

--- a/src/generic_chunk.c
+++ b/src/generic_chunk.c
@@ -79,15 +79,15 @@ ChunkResult handleDuplicateSample(DuplicatePolicy policy, Sample oldSample, Samp
         case DP_LAST:
             return CR_OK;
         case DP_MIN:
-            if (oldSample.value < newSample->value)
-                newSample->value = oldSample.value;
+            if (VALUE_DOUBLE(&oldSample.value) < VALUE_DOUBLE(&newSample->value))
+                VALUE_DOUBLE(&newSample->value) = VALUE_DOUBLE(&oldSample.value);
             return CR_OK;
         case DP_MAX:
-            if (oldSample.value > newSample->value)
-                newSample->value = oldSample.value;
+            if (VALUE_DOUBLE(&oldSample.value) > VALUE_DOUBLE(&newSample->value))
+                VALUE_DOUBLE(&newSample->value) = VALUE_DOUBLE(&oldSample.value);
             return CR_OK;
         case DP_SUM:
-            newSample->value += oldSample.value;
+            VALUE_DOUBLE(&newSample->value) += VALUE_DOUBLE(&oldSample.value);
             return CR_OK;
         default:
             return CR_ERR;
@@ -167,6 +167,7 @@ DuplicatePolicy DuplicatePolicyFromString(const char *input, size_t len) {
     }
     return DP_INVALID;
 }
+
 int timestamp_binary_search(const uint64_t *array, int size, uint64_t key) {
     int l = 0, r = size;
     while (l <= r) {
@@ -220,4 +221,16 @@ void MR_SerializationCtxWriteBufferWrapper(WriteSerializationCtx *sctx,
                                            size_t len) {
     MRError *err;
     MR_SerializationCtxWriteBuffer(sctx, buff, len, &err);
+}
+
+void updateSampleValue(bool isblob, SampleValue *dest, const SampleValue *src) {
+    if (!isblob) {
+        VALUE_DOUBLE(dest) = VALUE_DOUBLE(src);
+        return;
+    }
+
+    TSBlob *dstBlob = VALUE_BLOB(dest);
+    TSBlob *srcBlob = VALUE_BLOB(src);
+
+    BlobCopy(dstBlob, srcBlob);
 }

--- a/src/gorilla.c
+++ b/src/gorilla.c
@@ -493,7 +493,7 @@ ChunkResult Compressed_ChunkIteratorGetNext(ChunkIter_t *abstractIter, Sample *s
     // First sample
     if (unlikely(iter->count == 0)) {
         sample->timestamp = iter->chunk->baseTimestamp;
-        sample->value = iter->chunk->baseValue.d;
+        VALUE_DOUBLE(&sample->value) = iter->chunk->baseValue.d;
         iter->count++;
         return CR_OK;
     }
@@ -507,7 +507,8 @@ ChunkResult Compressed_ChunkIteratorGetNext(ChunkIter_t *abstractIter, Sample *s
         Bins_bitoff(bins, iter->idx++) ? iter->prevDelta : readInteger(iter, bins);
     // Check if value was changed
     // control bit ‘0’ (case a)
-    sample->value = Bins_bitoff(bins, iter->idx++) ? iter->prevValue.d : readFloat(iter, bins);
+    VALUE_DOUBLE(&sample->value) =
+        Bins_bitoff(bins, iter->idx++) ? iter->prevValue.d : readFloat(iter, bins);
     iter->count++;
     return CR_OK;
 }

--- a/src/load_io_error_macros.h
+++ b/src/load_io_error_macros.h
@@ -38,5 +38,13 @@
         (res);                                                                                     \
     })
 
+#define LoadBlob_IOError(rdb, cleanup_exp)                                                         \
+    __extension__({                                                                                \
+        TSBlob *res = RedisModule_LoadBlob((rdb));                                                   \
+        if (RedisModule_IsIOError(rdb)) {                                                          \
+            cleanup_exp;                                                                           \
+        }                                                                                          \
+        (res);                                                                                     \
+    })
 
 #endif //REDIS_TIMESERIES_LOAD_IO_ERROR_MACROS_H

--- a/src/query_language.c
+++ b/src/query_language.c
@@ -134,6 +134,9 @@ int parseCreateArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, Cre
         goto err_exit;
     }
 
+    if (RMUtil_ArgIndex("BLOB", argv, argc) > 0) {
+        cCtx->options |= SERIES_OPT_UNCOMPRESSED | SERIES_OPT_BLOB;
+    }
     return REDISMODULE_OK;
 err_exit:
     if (cCtx->labelsCount > 0 && cCtx->labels != NULL) {
@@ -230,6 +233,7 @@ int parseAggregationArgs(RedisModuleCtx *ctx,
             RTS_ReplyGeneralError(ctx, "TSDB: Failed to retrieve aggregation class");
             return TSDB_ERROR;
         }
+        aggregationArgs.type = agg_type;
         *out = aggregationArgs;
         return TSDB_OK;
     } else {

--- a/src/query_language.h
+++ b/src/query_language.h
@@ -20,6 +20,7 @@
 typedef struct AggregationArgs
 {
     api_timestamp_t timeDelta;
+    int type;
     AggregationClass *aggregationClass;
 } AggregationArgs;
 

--- a/src/reply.h
+++ b/src/reply.h
@@ -32,7 +32,7 @@ void ReplyWithSeriesLabelsWithLimitC(RedisModuleCtx *ctx,
                                      const char **limitLabels,
                                      ushort limitLabelsSize);
 
-void ReplyWithSample(RedisModuleCtx *ctx, u_int64_t timestamp, double value);
+void ReplyWithSample(RedisModuleCtx *ctx, bool isBlob, u_int64_t timestamp, SampleValue value);
 
 void ReplyWithSeriesLastDatapoint(RedisModuleCtx *ctx, const Series *series);
 

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -22,6 +22,18 @@
 static Series *lastDeletedSeries = NULL;
 static RedisModuleString *renameFromKey = NULL;
 
+void updateSeriesLastValue(Series *series, const SampleValue *src) {
+    SampleValue *dest = &series->lastValue;
+
+    if (!SeriesIsBlob(series)) {
+        VALUE_DOUBLE(dest) = VALUE_DOUBLE(src);
+        return;
+    }
+
+    // For the lastValue, we need another copy of incoming data
+    BlobCopy(VALUE_BLOB(dest), VALUE_BLOB(src));
+}
+
 int GetSeries(RedisModuleCtx *ctx,
               RedisModuleString *keyName,
               RedisModuleKey **key,
@@ -79,6 +91,9 @@ int dictOperator(RedisModuleDict *d, void *chunk, timestamp_t ts, DictOp op) {
 
 Series *NewSeries(RedisModuleString *keyName, CreateCtx *cCtx) {
     Series *newSeries = (Series *)calloc(1, sizeof(Series));
+
+    bool isBlob = ((cCtx->options & SERIES_OPT_BLOB) == SERIES_OPT_BLOB);
+
     newSeries->keyName = keyName;
     newSeries->chunks = RedisModule_CreateDict(NULL);
     newSeries->chunkSizeBytes = cCtx->chunkSizeBytes;
@@ -86,7 +101,14 @@ Series *NewSeries(RedisModuleString *keyName, CreateCtx *cCtx) {
     newSeries->srcKey = NULL;
     newSeries->rules = NULL;
     newSeries->lastTimestamp = 0;
-    newSeries->lastValue = 0;
+    if (!isBlob)
+        VALUE_DOUBLE(&newSeries->lastValue) = 0;
+    else {
+        // Having an empty lastValue would make issues at rdb load time
+        VALUE_BLOB(&newSeries->lastValue) = NewBlob("", 1);
+        // Only 'last' policy is supported
+        cCtx->duplicatePolicy = DP_LAST;
+    }
     newSeries->totalSamples = 0;
     newSeries->labels = cCtx->labels;
     newSeries->labelsCount = cCtx->labelsCount;
@@ -103,7 +125,7 @@ Series *NewSeries(RedisModuleString *keyName, CreateCtx *cCtx) {
     }
 
     if (!cCtx->skipChunkCreation) {
-        Chunk_t *newChunk = newSeries->funcs->NewChunk(newSeries->chunkSizeBytes);
+        Chunk_t *newChunk = newSeries->funcs->NewChunk(isBlob, newSeries->chunkSizeBytes);
         dictOperator(newSeries->chunks, newChunk, 0, DICT_OP_SET);
         newSeries->lastChunk = newChunk;
     } else {
@@ -403,6 +425,7 @@ void *CopySeries(RedisModuleString *fromkey, RedisModuleString *tokey, const voi
 // notification.
 void FreeSeries(void *value) {
     Series *currentSeries = (Series *)value;
+
     RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(currentSeries->chunks, "^", NULL, 0);
     Chunk_t *currentChunk;
     while (RedisModule_DictNextC(iter, NULL, (void *)&currentChunk) != NULL) {
@@ -413,6 +436,10 @@ void FreeSeries(void *value) {
     FreeLabels(currentSeries->labels, currentSeries->labelsCount);
 
     RedisModule_FreeDict(NULL, currentSeries->chunks);
+
+    if (SeriesIsBlob(currentSeries)) {
+        FreeBlob(VALUE_BLOB(&currentSeries->lastValue));
+    }
 
     if (currentSeries->isTemporary) {
         RedisModule_FreeString(NULL, currentSeries->keyName);
@@ -521,10 +548,12 @@ static bool RuleSeriesUpsertSample(RedisModuleCtx *ctx,
         return false;
     }
 
+    SampleValue value = { .d.value = val };
+
     if (destSeries->totalSamples == 0) {
-        SeriesAddSample(destSeries, start, val);
+        SeriesAddSample(destSeries, start, value);
     } else {
-        SeriesUpsertSample(destSeries, start, val, DP_LAST);
+        SeriesUpsertSample(destSeries, start, value, DP_LAST);
     }
     RedisModule_CloseKey(key);
 
@@ -571,7 +600,7 @@ static void upsertCompaction(Series *series, UpsertCtx *uCtx) {
 
 int SeriesUpsertSample(Series *series,
                        api_timestamp_t timestamp,
-                       double value,
+                       SampleValue value,
                        DuplicatePolicy dp_override) {
     bool latestChunk = true;
     void *chunkKey = NULL;
@@ -615,10 +644,9 @@ int SeriesUpsertSample(Series *series,
         }
     }
 
-    UpsertCtx uCtx = {
-        .inChunk = chunk,
-        .sample = { .timestamp = timestamp, .value = value },
-    };
+    UpsertCtx uCtx = { .inChunk = chunk,
+                       .sample = { .timestamp = timestamp, .value = value },
+                       .isBlob = SeriesIsBlob(series) };
 
     int size = 0;
 
@@ -636,7 +664,7 @@ int SeriesUpsertSample(Series *series,
     if (rv == CR_OK) {
         series->totalSamples += size;
         if (timestamp == series->lastTimestamp) {
-            series->lastValue = uCtx.sample.value;
+            updateSeriesLastValue(series, &uCtx.sample.value);
         }
         timestamp_t chunkFirstTSAfterOp = funcs->GetFirstTimestamp(uCtx.inChunk);
         if (chunkFirstTSAfterOp != chunkFirstTS) {
@@ -649,10 +677,11 @@ int SeriesUpsertSample(Series *series,
 
         upsertCompaction(series, &uCtx);
     }
+
     return rv;
 }
 
-int SeriesAddSample(Series *series, api_timestamp_t timestamp, double value) {
+int SeriesAddSample(Series *series, api_timestamp_t timestamp, SampleValue value) {
     // backfilling or update
     Sample sample = { .timestamp = timestamp, .value = value };
     ChunkResult ret = series->funcs->AddSample(series->lastChunk, &sample);
@@ -661,14 +690,17 @@ int SeriesAddSample(Series *series, api_timestamp_t timestamp, double value) {
         // When a new chunk is created trim the series
         SeriesTrim(series, 0, 0);
 
-        Chunk_t *newChunk = series->funcs->NewChunk(series->chunkSizeBytes);
+        Chunk_t *newChunk = series->funcs->NewChunk(SeriesIsBlob(series), series->chunkSizeBytes);
         dictOperator(series->chunks, newChunk, timestamp, DICT_OP_SET);
         ret = series->funcs->AddSample(newChunk, &sample);
         series->lastChunk = newChunk;
     }
     series->lastTimestamp = timestamp;
-    series->lastValue = value;
+
+    updateSeriesLastValue(series, &value);
+
     series->totalSamples++;
+
     return TSDB_OK;
 }
 
@@ -838,6 +870,9 @@ CompactionRule *SeriesAddRule(Series *series,
                               RedisModuleString *destKeyStr,
                               int aggType,
                               uint64_t timeBucket) {
+    if (SeriesIsBlob(series))
+        aggType = BlobAggType(aggType);
+
     CompactionRule *rule = NewRule(destKeyStr, aggType, timeBucket);
     if (rule == NULL) {
         return NULL;
@@ -974,6 +1009,10 @@ int SeriesDeleteSrcRule(Series *series, RedisModuleString *srctKey) {
     return FALSE;
 }
 
+bool SeriesIsBlob(const Series *series) {
+    return (series->options & SERIES_OPT_BLOB) == SERIES_OPT_BLOB;
+}
+
 /*
  * This function calculate aggregation value of a range.
  *
@@ -993,7 +1032,7 @@ int SeriesCalcRange(Series *series,
     bool _is_empty = true;
 
     while (SeriesIteratorGetNext(iterator, &sample) == CR_OK) {
-        aggObject->appendValue(context, sample.value);
+        aggObject->appendValue(context, VALUE_DOUBLE(&sample.value));
         _is_empty = false;
     }
     if (is_empty) {

--- a/src/tsdb.h
+++ b/src/tsdb.h
@@ -34,7 +34,7 @@ typedef struct Series
     short options;
     CompactionRule *rules;
     timestamp_t lastTimestamp;
-    double lastValue;
+    SampleValue lastValue;
     Label *labels;
     RedisModuleString *keyName;
     size_t labelsCount;
@@ -75,10 +75,10 @@ AbstractIterator *SeriesQuery(Series *series, const RangeArgs *args, bool reserv
 void FreeCompactionRule(void *value);
 size_t SeriesMemUsage(const void *value);
 
-int SeriesAddSample(Series *series, api_timestamp_t timestamp, double value);
+int SeriesAddSample(Series *series, api_timestamp_t timestamp, SampleValue value);
 int SeriesUpsertSample(Series *series,
                        api_timestamp_t timestamp,
-                       double value,
+                       SampleValue value,
                        DuplicatePolicy dp_override);
 
 int SeriesDeleteRule(Series *series, RedisModuleString *destKey);
@@ -113,6 +113,8 @@ timestamp_t CalcWindowStart(timestamp_t timestamp, size_t window);
 // return first timestamp in retention window, and set `skipped` to number of samples outside of
 // retention
 timestamp_t getFirstValidTimestamp(Series *series, long long *skipped);
+
+bool SeriesIsBlob(const Series *series);
 
 CompactionRule *NewRule(RedisModuleString *destKey, int aggType, uint64_t timeBucket);
 

--- a/tests/flow/test_helper_classes.py
+++ b/tests/flow/test_helper_classes.py
@@ -172,6 +172,22 @@ class TSInfo(object):
     chunk_size_bytes = None
     chunk_type = None
     chunks = None
+    type = None
+
+    def __str__(self):
+        return "rules:" + str(self.rules) + \
+               ",labels:"+str(self.labels) +\
+               ",sourceKey:"+str(self.sourceKey)+\
+               ",chunk_count:"+str(self.chunk_count)+\
+               ",memory_usage:"+str(self.memory_usage)+\
+               ",total_samples:"+str(self.total_samples)+\
+               ",retention_msecs:"+str(self.retention_msecs)+\
+               ",last_time_stamp:"+str(self.last_time_stamp)+\
+               ",first_time_stamp:"+str(self.first_time_stamp)+\
+               ",chunk_size_bytes:"+str(self.chunk_size_bytes)+\
+               ",chunk_type:"+str(self.chunk_type)+\
+               ",Chunks:"+str(self.chunks)+\
+               ",type:"+str(self.type)
 
     def __init__(self, args):
         response = dict(zip(args[::2], args[1::2]))
@@ -187,6 +203,7 @@ class TSInfo(object):
         if b'chunkSize' in response: self.chunk_size_bytes = response[b'chunkSize']
         if b'chunkType' in response: self.chunk_type = response[b'chunkType']
         if b'Chunks' in response: self.chunks = response[b'Chunks']
+        if b'type' in response: self.type = response[b'type']
 
     def __eq__(self, other):
         if not isinstance(other, TSInfo):
@@ -200,4 +217,5 @@ class TSInfo(object):
                self.last_time_stamp == other.last_time_stamp and \
                self.first_time_stamp == other.first_time_stamp and \
                self.chunk_size_bytes == other.chunk_size_bytes and \
-               self.chunks == other.chunks
+               self.chunks == other.chunks and \
+               self.type == other.type

--- a/tests/flow/test_ts_blob.py
+++ b/tests/flow/test_ts_blob.py
@@ -1,0 +1,152 @@
+import math
+import time
+
+import sys
+
+import pytest
+import redis
+from RLTest import Env
+from test_helper_classes import SAMPLE_SIZE, _get_ts_info
+
+
+
+def test_blob(self):
+
+    with Env().getClusterConnectionIfNeeded() as r:
+
+        r.execute_command('ts.create', 'blob1', 'BLOB')
+
+        assert b'blob' == _get_ts_info(r, 'blob1').type
+        r.execute_command('ts.add', 'blob2', 1, 'value1', 'BLOB')
+        assert b'blob' == _get_ts_info(r, 'blob1').type
+        res = r.execute_command('ts.range', 'blob2', '-', '+')
+
+        assert len(res) == 1
+        assert res[0][0] == 1
+        assert res[0][1] == b'value1'
+        r.execute_command('ts.add', 'blob2', 2, 'value2' )
+        r.execute_command('ts.add', 'blob2', 3, 'value3' )
+        res = r.execute_command('ts.range', 'blob2', '-', '+')
+
+        assert len(res) == 3
+        ### upsert ###
+        r.execute_command('ts.add', 'blob2', 2, 'new_value2')
+        res = r.execute_command('ts.range', 'blob2', '-', '+')
+
+        assert len(res) == 3
+
+        assert res[0][0] == 1
+        assert res[0][1] == b'value1'
+        assert res[1][0] == 2
+        assert res[1][1] == b'new_value2'
+        assert res[2][0] == 3
+        assert res[2][1] == b'value3'
+
+        ### aggregation count ###
+        res = r.execute_command('ts.range', 'blob2', '-', '+', 'AGGREGATION', 'count', 10)
+
+        assert res[0][1] == b'3'
+
+        ### Forbidden commands ###
+        forbidden = False;
+
+        try:
+            res = r.execute_command('ts.incrby', 'blob2', 1)
+        except:
+            forbidden = True;
+
+        assert forbidden == True
+
+        forbidden = False;
+
+        try:
+	        res = r.execute_command('ts.decrby', 'blob2', 1)
+        except:
+            forbidden = True;
+
+        assert forbidden == True
+
+        key_name='blob3{abc}'
+
+        first_agg_key_name = '{}_first'.format(key_name)
+        last_agg_key_name = '{}_last'.format(key_name)
+        count_agg_key_name = '{}_count'.format(key_name)
+
+        ### downsampling ###
+        res = r.execute_command('ts.create', key_name, 'BLOB')
+        res = r.execute_command('ts.create', first_agg_key_name, 'BLOB')
+        res = r.execute_command('ts.create', last_agg_key_name, 'BLOB')
+        res = r.execute_command('ts.create', count_agg_key_name, 'BLOB')
+
+        assert r.execute_command('ts.createrule', key_name, first_agg_key_name, 'AGGREGATION', 'first', 3)
+        assert r.execute_command('ts.createrule', key_name, last_agg_key_name, 'AGGREGATION', 'last', 3)
+
+        forbidden = False;
+        try:
+            res = r.execute_command('ts.createrule', key_name, count_agg_key_name, 'AGGREGATION', 'count', 3)
+        except:
+            # must catch 'TSDB: the destination key is of binary type and cannot hold an aggregation count'
+            forbidden = True;
+
+        assert forbidden == True
+
+        # re-create it with scalar type
+        r.execute_command('del', count_agg_key_name)
+
+        res = r.execute_command('ts.create', count_agg_key_name)
+
+        res = r.execute_command('ts.createrule', key_name, count_agg_key_name, 'AGGREGATION', 'count', 3)
+        # test save of empty aggregated count
+
+        for i in range(1,10):
+            r.execute_command('ts.add', key_name, i, 'value'+str(i) )
+
+        res = r.execute_command('ts.range', last_agg_key_name, '-', '+')
+
+        assert res[0][0] == 0
+        assert res[0][1] == b'value2'
+
+        assert res[1][0] == 3
+        assert res[1][1] == b'value5'
+
+        assert res[2][0] == 6
+        assert res[2][1] == b'value8'
+
+        res = r.execute_command('ts.range', first_agg_key_name, '-', '+')
+
+        assert res[0][0] == 0
+        assert res[0][1] == b'value1'
+
+        assert res[1][0] == 3
+        assert res[1][1] == b'value3'
+
+        assert res[2][0] == 6
+        assert res[2][1] == b'value6'
+
+        res = r.execute_command('ts.range', count_agg_key_name, '-', '+')
+        assert len(res) == 3
+
+        # test save of empty blob
+        res = r.execute_command('ts.create', 'empty', 'BLOB')
+
+        # When server is started with slaves, a
+        # "Background save already in progress" can happen.
+
+        while True:
+            try:
+                res = r.execute_command('SAVE')
+            except Exception as err:
+                print(str(err), " -> retrying")
+                time.sleep(1);
+            else:
+                break;
+
+        r.execute_command('DUMP', key_name)
+        r.execute_command('del', key_name)
+
+        res = r.execute_command('ts.range', last_agg_key_name, '-', '+')
+        ### Test after deletion of source (blob must be unchanged) ###
+
+        assert res[0][1] == b'value2'
+        assert res[1][1] == b'value5'
+        assert res[2][1] == b'value8'

--- a/tests/flow/test_ts_create.py
+++ b/tests/flow/test_ts_create.py
@@ -96,7 +96,7 @@ def test_uncompressed():
         assert [[1, b'3.5'], [2, b'4.5'], [3, b'5.5']] == \
                r.execute_command('ts.range', 'not_compressed', 0, '+')
         info = _get_ts_info(r, 'not_compressed')
-        assert info.total_samples == 3 and info.memory_usage == 4136
+        assert info.total_samples == 3 and info.memory_usage == 4144
 
         # rdb load
         data = r.execute_command('dump', 'not_compressed')
@@ -107,7 +107,7 @@ def test_uncompressed():
         assert [[1, b'3.5'], [2, b'4.5'], [3, b'5.5']] == \
                r.execute_command('ts.range', 'not_compressed', 0, "+")
         info = _get_ts_info(r, 'not_compressed')
-        assert info.total_samples == 3 and info.memory_usage == 4136
+        assert info.total_samples == 3 and info.memory_usage == 4144
         # test deletion
         assert r.delete('not_compressed')
 

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -268,6 +268,7 @@ def test_sanity():
         actual_result = r.execute_command('TS.range', 'tester', start_ts, start_ts + samples_count)
         assert expected_result == actual_result
         expected_result = [
+            b'type', b'numeric',
             b'totalSamples', 1500, b'memoryUsage', 1166,
             b'firstTimestamp', start_ts, b'chunkCount', 1,
             b'labels', [[b'name', b'brown'], [b'color', b'pink']],

--- a/tests/unit/unittests_compressed_chunk.c
+++ b/tests/unit/unittests_compressed_chunk.c
@@ -23,11 +23,11 @@ MU_TEST(test_compressed_upsert) {
     float minV = 0.0;
     float maxV = 100.0;
     for (size_t chunk_size = 2; chunk_size < max_chunk_size; chunk_size += 64) {
-        CompressedChunk *chunk = Compressed_NewChunk(chunk_size);
+        CompressedChunk *chunk = Compressed_NewChunk(false, chunk_size);
         mu_assert(chunk != NULL, "create compressed chunk");
         for (size_t i = 1; i <= total_data_points; i++) {
             float value = minV + (float)rand() / ((float)RAND_MAX / maxV);
-            Sample sample = { .timestamp = i, .value = value };
+            Sample sample = { .timestamp = i, .value.d.value = value };
             total_upserts++;
             UpsertCtx uCtx = {
                 .inChunk = chunk,
@@ -46,10 +46,10 @@ MU_TEST(test_compressed_fail_appendInteger) {
     // ensureAddSample -> Compressed_AddSample -> Compressed_Append -> appendInteger
     srand((unsigned int)time(NULL));
     const size_t chunk_size = 4096; // 4096 bytes (data) chunck
-    CompressedChunk *chunk = Compressed_NewChunk(chunk_size);
+    CompressedChunk *chunk = Compressed_NewChunk(false, chunk_size);
     mu_assert(chunk != NULL, "create compressed chunk");
-    Sample s1 = { .timestamp = 10, .value = 5.0 };
-    Sample s2 = { .timestamp = 6, .value = 10.0 };
+    Sample s1 = { .timestamp = 10, .value.d.value = 5.0 };
+    Sample s2 = { .timestamp = 6, .value.d.value = 10.0 };
     Compressed_AddSample(chunk, &s1);
     mu_assert_int_eq(1, Compressed_ChunkNumOfSample(chunk));
     int size = 0;
@@ -68,7 +68,7 @@ MU_TEST(test_compressed_fail_appendInteger) {
     mu_assert_int_eq(6, Compressed_GetFirstTimestamp(chunk));
     mu_assert_int_eq(10, Compressed_GetLastTimestamp(chunk));
     for (size_t i = 0; i < 10; i++) {
-        s2.value = minV + (float)rand() / ((float)RAND_MAX / maxV);
+        VALUE_DOUBLE(&s2.value) = minV + (float)rand() / (float)(RAND_MAX / maxV);
         Compressed_UpsertSample(&uCtx, &size, DP_LAST);
         // ensure we're not adding more datapoints and only overwritting previous ones
         mu_assert_int_eq(2, Compressed_ChunkNumOfSample(chunk));
@@ -86,7 +86,8 @@ MU_TEST(test_compressed_fail_appendInteger) {
     mu_assert_int_eq(10, Compressed_GetLastTimestamp(chunk2));
 
     for (size_t i = 1; i < 6; i++) {
-        Sample s3 = { .timestamp = i, .value = minV + (float)rand() / ((float)RAND_MAX / maxV) };
+        Sample s3 = { .timestamp = i,
+                      .value.d.value = minV + (float)rand() / (float)(RAND_MAX / maxV) };
         UpsertCtx uCtxS3 = {
             .inChunk = chunk,
             .sample = s3,
@@ -104,7 +105,7 @@ MU_TEST(test_compressed_fail_appendInteger) {
 MU_TEST(test_Compressed_SplitChunk_empty) {
     srand((unsigned int)time(NULL));
     const size_t chunk_size = 4096; // 4096 bytes (data) chunck
-    CompressedChunk *chunk = Compressed_NewChunk(chunk_size);
+    CompressedChunk *chunk = Compressed_NewChunk(false, chunk_size);
     mu_assert(chunk != NULL, "create compressed chunk");
 
     CompressedChunk *chunk2 = Compressed_SplitChunk(chunk);
@@ -119,12 +120,12 @@ MU_TEST(test_Compressed_SplitChunk_empty) {
 MU_TEST(test_Compressed_SplitChunk_odd) {
     srand((unsigned int)time(NULL));
     const size_t chunk_size = 4096; // 4096 bytes (data) chunck
-    CompressedChunk *chunk = Compressed_NewChunk(chunk_size);
+    CompressedChunk *chunk = Compressed_NewChunk(false, chunk_size);
     mu_assert(chunk != NULL, "create compressed chunk");
 
-    Sample s1 = { .timestamp = 4, .value = 5.0 };
-    Sample s2 = { .timestamp = 50, .value = 10.0 };
-    Sample s3 = { .timestamp = 100, .value = 10.0 };
+    Sample s1 = { .timestamp = 4, .value.d.value = 5.0 };
+    Sample s2 = { .timestamp = 50, .value.d.value = 10.0 };
+    Sample s3 = { .timestamp = 100, .value.d.value = 10.0 };
     ChunkResult rv = Compressed_AddSample(chunk, &s1);
     mu_assert(rv == CR_OK, "add sample s1");
 
@@ -148,7 +149,7 @@ MU_TEST(test_Compressed_SplitChunk_odd) {
 MU_TEST(test_Compressed_SplitChunk_force_realloc) {
     srand((unsigned int)time(NULL));
     const size_t chunk_size = 4096; // 4096 bytes (data) chunck
-    CompressedChunk *chunk = Compressed_NewChunk(chunk_size);
+    CompressedChunk *chunk = Compressed_NewChunk(false, chunk_size);
     mu_assert(chunk != NULL, "create compressed chunk");
     ChunkResult rv = CR_OK;
     int64_t ts = 1;
@@ -157,7 +158,7 @@ MU_TEST(test_Compressed_SplitChunk_force_realloc) {
     // adding 1,3,5....
     while (rv != CR_END) {
         double tsv = ts * 1.0;
-        Sample s1 = { .timestamp = ts, .value = tsv };
+        Sample s1 = { .timestamp = ts, .value.d.value = tsv };
         rv = Compressed_AddSample(chunk, &s1);
         mu_assert(rv == CR_OK || rv == CR_END, "add sample");
         if (rv != CR_END) {
@@ -172,7 +173,7 @@ MU_TEST(test_Compressed_SplitChunk_force_realloc) {
     mu_assert_int_eq(chunk_size, chunk->size);
 
     // Now we're at the max of the chunck's capacity
-    Sample s3 = { .timestamp = 2, .value = 10.0 };
+    Sample s3 = { .timestamp = 2, .value.d.value = 10.0 };
     UpsertCtx uCtxS3 = {
         .inChunk = chunk,
         .sample = s3,


### PR DESCRIPTION
The RedisTimeSeries API is cool, but makes a strong presumption on the
fact that the timestamped data is of type double, that allows simple
maths on aggregation functions. All the rest of the API (range
queries, labelling, downsampling, rules ... ) is of interest for
non-scalar data.
This commit adds support for binary data. In can coexist with
scalar data, so that the API remains 100% compatible.
Just like scalar time series, binary time series can be created with
'TS.CREATE' or 'TS.ADD', just by adding the 'BLOB' keyword in the command.

Aggregation is supported but obviously, performing maths on blob
is nonsense, so that only aggregation types of 'count', 'first'
and 'last' are allowed.

Persistence on disk is also supported.

The testsuite has been completed with the test of the new
features, and passes 100%

Signed-off-by: Thierry Bultel <thierry.bultel@iot.bzh>