### PR TITLE
Triggering benchmarks on `run-perf` label

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,7 +357,7 @@ workflows:
       - performance_ci_automation:
           context: common
           requires:
-            - build          
+            - build
           <<: *on-integ-branch
       - build-macos:
           <<: *on-version-tags
@@ -400,5 +400,15 @@ workflows:
     jobs:
       - build-macos
       - valgrind
+
+  nightly_performance:
+    triggers:
+      - schedule:
+          cron: "20 17 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
       - performance_ci_automation:
           context: common

--- a/.github/workflows/trigger-ci-performance.yaml
+++ b/.github/workflows/trigger-ci-performance.yaml
@@ -1,0 +1,31 @@
+# https://github.com/marketplace/actions/run-circle-ci-on-label
+name: performance_ci_automation
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  valgrind_general:
+    if: github.event.label.name == 'run-perf'
+    runs-on: ubuntu-latest
+    name: Trigger CI performance
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check CIRCLE_CI_SECRET
+        env:
+          CIRCLE_CI_SECRET: ${{ secrets.CIRCLE_CI_SECRET }}
+        run: |
+          if [[ -z "$CIRCLE_CI_SECRET" ]] ; then
+            echo "CIRCLE_CI_SECRET secret is not set"
+            exit 1
+          fi
+      - name: circle-ci job runner
+        id: curl-circle-ci
+        uses: Open-Source-Contrib/circle-ci-trigger-action@latest
+        with:
+          circle_ci_token: ${{ secrets.CIRCLE_CI_SECRET}}
+          circle_ci_job: performance_ci_automation
+          circle_ci_project_url: ${{ github.event.pull_request.head.ref }}

--- a/src/Makefile
+++ b/src/Makefile
@@ -260,7 +260,8 @@ ifneq ($(REMOTE),)
 	BENCHMARK_ARGS = redisbench-admin run-remote 
 endif
 
-BENCHMARK_ARGS += --module_path $(realpath $(TARGET))
+BENCHMARK_ARGS += --module_path $(realpath $(TARGET)) \
+				  --required-module timeseries
 ifneq ($(BENCHMARK),)
 	BENCHMARK_ARGS += --test $(BENCHMARK)
 endif

--- a/tests/benchmarks/Readme.md
+++ b/tests/benchmarks/Readme.md
@@ -1,0 +1,27 @@
+# Context
+
+The automated benchmark definitions included within `tests/benchmarks` folder, provides a framework for evaluating and comparing feature branches and catching regressions prior to letting them into the master branch.
+
+To be able to run local benchmarks you need `redisbench_admin>=0.1.71` [[tool repo for full details](https://github.com/RedisLabsModules/redisbench-admin)] and the benchmark tool specified on each configuration file . You can install redisbench-admin via PyPi as any other package.
+```
+pip3 install redisbench_admin>=0.1.71
+```
+
+## Usage
+
+- Local benchmarks: `make benchmark`
+- Remote benchmarks:  `make benchmark REMOTE=1`
+
+
+## Included benchmarks
+
+Each benchmark requires a benchmark definition yaml file to present on the current directory. The benchmark spec file is fully explained on the following link: https://github.com/RedisLabsModules/redisbench-admin/tree/master/docs
+
+
+## CI integration
+
+CI benchmarks are triggered on:
+- nightly
+- pushes to branches named `master`
+- PRs tagged with the `run-perf` label
+- version tags

--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -1,1 +1,1 @@
-redisbench_admin>=0.1.55
+redisbench_admin>=0.1.71


### PR DESCRIPTION
 This is a maintenance PR that:
 - Adds quickstart documentation for benchmark automation usage. Points to further details on tool repo.
 - Triggers only benchmark runs on master/perf/feature branches.
 - Bumps tool version and adds --required-module check to benchmark runner ( this makes us to fail faster on remote running ).