### PR TITLE
[fix] Fixed crash on Missing keytype check on TS.INCRBY/DECRBY

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -766,6 +766,8 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
         CreateTsKey(ctx, keyName, &cCtx, &series, &key);
         SeriesCreateRulesFromGlobalConfig(ctx, keyName, series, cCtx.labels, cCtx.labelsCount);
+    } else if (RedisModule_ModuleTypeGetType(key) != SeriesType) {
+        return RTS_ReplyGeneralError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
     }
 
     series = RedisModule_ModuleTypeGetValue(key);

--- a/tests/flow/test_negative.py
+++ b/tests/flow/test_negative.py
@@ -52,7 +52,10 @@ def test_errors():
             assert r.execute_command('TS.RANGE', 'foo', '0', '-1')
         with pytest.raises(redis.ResponseError) as excinfo:
             assert r.execute_command('TS.ALTER', 'foo')
-
+        with pytest.raises(redis.ResponseError) as excinfo:
+            assert r.execute_command('TS.INCRBY', 'foo', '1', 'timestamp', '5')
+        with pytest.raises(redis.ResponseError) as excinfo:
+            assert r.execute_command('TS.DECRBY', 'foo', '1', 'timestamp', '5')
         with pytest.raises(redis.ResponseError) as excinfo:
             assert r.execute_command('TS.ADD', 'values', 'timestamp', '5')  # string
         with pytest.raises(redis.ResponseError) as excinfo:


### PR DESCRIPTION
fixes #710 
After approval we need to backport.