### PR TITLE
cherry-pick v1.4: [fix] Fixed crash on Missing keytype check on TS.INCRBY/DECRBY 

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1130,6 +1130,8 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
         CreateTsKey(ctx, keyName, &cCtx, &series, &key);
         SeriesCreateRulesFromGlobalConfig(ctx, keyName, series, cCtx.labels, cCtx.labelsCount);
+    } else if (RedisModule_ModuleTypeGetType(key) != SeriesType) {
+        return RTS_ReplyGeneralError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
     }
 
     series = RedisModule_ModuleTypeGetValue(key);

--- a/tests/flow/test_globalconfigs.py
+++ b/tests/flow/test_globalconfigs.py
@@ -6,7 +6,7 @@ from test_helper_classes import TSInfo
 class testModuleLoadTimeArguments(object):
     def __init__(self):
         self.test_variations = [(True, 'CHUNK_SIZE_BYTES 2000'),
-                                (True, 'COMPACTION_POLICY', 'max:1m:1d;min:10s:1h;avg:2h:10d;avg:3d:100d'),
+                                (True, 'COMPACTION_POLICY', 'max:1m:1d\\;min:10s:1h\\;avg:2h:10d\\;avg:3d:100d'),
                                 (True, 'DUPLICATE_POLICY MAX'),
                                 (True, 'RETENTION_POLICY 30')
                                 ]
@@ -43,7 +43,7 @@ def test_compressed():
 class testGlobalConfigTests():
 
     def __init__(self):
-        self.env = Env(moduleArgs='COMPACTION_POLICY max:1m:1d;min:10s:1h;avg:2h:10d;avg:3d:100d')
+        self.env = Env(moduleArgs='COMPACTION_POLICY max:1m:1d\\;min:10s:1h\\;avg:2h:10d\\;avg:3d:100d')
 
     def test_autocreate(self):
         with self.env.getConnection() as r:

--- a/tests/flow/test_negative.py
+++ b/tests/flow/test_negative.py
@@ -50,8 +50,11 @@ def test_errors():
         with pytest.raises(redis.ResponseError) as excinfo:
             assert r.execute_command('TS.RANGE foo 0 -1')
         with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.ALTER foo')
-
+            assert r.execute_command('TS.ALTER', 'foo')
+        with pytest.raises(redis.ResponseError) as excinfo:
+            assert r.execute_command('TS.INCRBY', 'foo', '1', 'timestamp', '5')
+        with pytest.raises(redis.ResponseError) as excinfo:
+            assert r.execute_command('TS.DECRBY', 'foo', '1', 'timestamp', '5')
         with pytest.raises(redis.ResponseError) as excinfo:
             assert r.execute_command('TS.ADD values timestamp 5')  # string
         with pytest.raises(redis.ResponseError) as excinfo:


### PR DESCRIPTION
This PR cherry-picks #711 fix to v1.4 ( fixes #710 )