### PR TITLE
[1.4] Disable macOS build as dependency to deploy (#727)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,7 +360,7 @@ workflows:
           context: common
           requires:
             - build
-            - build-macos
+            # - build-macos
             - valgrind
           <<: *on-integ-branch
       - deploy_package:
@@ -369,7 +369,7 @@ workflows:
           context: common
           requires:
             - build
-            - build-macos
+            # - build-macos
             - valgrind
           <<: *on-version-tags
       - release-automation:


### PR DESCRIPTION
(cherry picked from commit a68a39198aa94f26cb1b9951e6610a1539e0be02)