### PR TITLE
Enable tracking OSS standalone redis ingestion performance over CI

### DIFF
--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -1,1 +1,1 @@
-redisbench_admin>=0.1.74
+redisbench_admin>=0.1.76

--- a/tests/benchmarks/tsbs-devops-ingestion-scale100-4days.yml
+++ b/tests/benchmarks/tsbs-devops-ingestion-scale100-4days.yml
@@ -1,0 +1,16 @@
+name: "tsbs-devops-ingestion-scale100-4days"
+remote:
+  - type: oss-standalone
+  - setup: redistimeseries-m5
+clientconfig:
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
+exporter:
+  redistimeseries:
+    timemetric: "$.StartTime"
+    metrics:
+      - "$.Totals.metricRate"
+      - "$.Totals.rowRate"


### PR DESCRIPTION
This PR enables keeping track of the scale100 ( 4 days timeframe ) ingestion. We should add an additional 30 days timeframe benchmark afterwards.