### PR TITLE
Compressed chunk performance improvements: Further improvement on precomputed LSB bits

### DIFF
--- a/src/gorilla.c
+++ b/src/gorilla.c
@@ -139,32 +139,18 @@ static uint64_t bitmask[] = {
     (1ULL << 45) - 1, (1ULL << 46) - 1, (1ULL << 47) - 1, (1ULL << 48) - 1, (1ULL << 49) - 1,
     (1ULL << 50) - 1, (1ULL << 51) - 1, (1ULL << 52) - 1, (1ULL << 53) - 1, (1ULL << 54) - 1,
     (1ULL << 55) - 1, (1ULL << 56) - 1, (1ULL << 57) - 1, (1ULL << 58) - 1, (1ULL << 59) - 1,
-    (1ULL << 60) - 1, (1ULL << 61) - 1, (1ULL << 62) - 1, (1ULL << 63) - 1,
+    (1ULL << 60) - 1, (1ULL << 61) - 1, (1ULL << 62) - 1, (1ULL << 63) - 1, (0ULL - 1)
 
 };
 
 // 2^bit
 static inline u_int64_t BIT(u_int64_t bit) {
-    if (__builtin_expect(bit > 63, 0)) {
-        return 0ULL;
-    }
     return bittt[bit];
-}
-
-// the LSB `bits` turned on
-static inline u_int64_t MASK(u_int64_t bits) {
-    if (__builtin_expect(bits > 63, 0)) {
-        return 0ULL - 1;
-    }
-    return bitmask[bits];
 }
 
 // Logic to check Least Significant Bit (LSB) of a number
 // Clear most significant bits from position `bits`
 static inline u_int64_t LSB(u_int64_t x, u_int64_t bits) {
-    if (__builtin_expect(bits > 63, 0)) {
-        return x & (0ULL - 1);
-    }
     return x & bitmask[bits];
 }
 


### PR DESCRIPTION
This PR should improve any tsbs read benchmark that is impacted by compressed chuncks performance.


Example of one of the queries impact:
```
make clean build benchmark BENCHMARK=tsbs-scale100-single-groupby-5-8-1.yml
```

master
```
Run complete after 10000 queries with 64 workers (Overall query rate 430.55 queries/sec):
RedisTimeSeries MAX of 5 metrics,random    8 hosts, random � by 1m:
min:     4.09ms, med:   134.81ms, mean:   148.29ms, max:  362.96ms, stddev:    42.86ms, sum: 1482.9sec, count: 10000
all queries                                                         :
min:     4.09ms, med:   134.81ms, mean:   148.29ms, max:  362.96ms, stddev:    42.86ms, sum: 1482.9sec, count: 10000
wall clock time: 23.244326sec
```

branch
```
Run complete after 10000 queries with 64 workers (Overall query rate 448.26 queries/sec):
RedisTimeSeries MAX of 5 metrics,random    8 hosts, random � by 1m:
min:    27.45ms, med:   128.36ms, mean:   142.44ms, max:  305.41ms, stddev:    40.78ms, sum: 1424.4sec, count: 10000
all queries                                                         :
min:    27.45ms, med:   128.36ms, mean:   142.44ms, max:  305.41ms, stddev:    40.78ms, sum: 1424.4sec, count: 10000
```