### PR TITLE
Performance `_seriesIteratorGetNext`: Remove unecessary free/alloc on end of each chunk 

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -172,19 +172,13 @@ size_t Uncompressed_DelRange(Chunk_t *chunk, timestamp_t startTs, timestamp_t en
     return deleted_count;
 }
 
-void Uncompressed_ResetChunkIterator(ChunkIter_t *iterator,
-                                     Chunk_t *chunk,
-                                     int options,
-                                     ChunkIterFuncs *retChunkIterClass) {
+void Uncompressed_ResetChunkIterator(ChunkIter_t *iterator, Chunk_t *chunk) {
     ChunkIterator *iter = (ChunkIterator *)iterator;
     iter->chunk = chunk;
-    if (options & CHUNK_ITER_OP_REVERSE) { // iterate from last to first
+    if (iter->options & CHUNK_ITER_OP_REVERSE) { // iterate from last to first
         iter->currentIndex = iter->chunk->num_samples - 1;
     } else { // iterate from first to last
         iter->currentIndex = 0;
-    }
-    if (retChunkIterClass != NULL) {
-        *retChunkIterClass = *GetChunkIteratorClass(CHUNK_REGULAR);
     }
 }
 
@@ -193,7 +187,10 @@ ChunkIter_t *Uncompressed_NewChunkIterator(Chunk_t *chunk,
                                            ChunkIterFuncs *retChunkIterClass) {
     ChunkIterator *iter = (ChunkIterator *)calloc(1, sizeof(ChunkIterator));
     iter->options = options;
-    Uncompressed_ResetChunkIterator(iter, chunk, options, retChunkIterClass);
+    if (retChunkIterClass != NULL) {
+        *retChunkIterClass = *GetChunkIteratorClass(CHUNK_REGULAR);
+    }
+    Uncompressed_ResetChunkIterator(iter, chunk);
     return (ChunkIter_t *)iter;
 }
 

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -172,22 +172,28 @@ size_t Uncompressed_DelRange(Chunk_t *chunk, timestamp_t startTs, timestamp_t en
     return deleted_count;
 }
 
-ChunkIter_t *Uncompressed_NewChunkIterator(Chunk_t *chunk,
-                                           int options,
-                                           ChunkIterFuncs *retChunkIterClass) {
-    ChunkIterator *iter = (ChunkIterator *)calloc(1, sizeof(ChunkIterator));
+void Uncompressed_ResetChunkIterator(ChunkIter_t *iterator,
+                                     Chunk_t *chunk,
+                                     int options,
+                                     ChunkIterFuncs *retChunkIterClass) {
+    ChunkIterator *iter = (ChunkIterator *)iterator;
     iter->chunk = chunk;
-    iter->options = options;
     if (options & CHUNK_ITER_OP_REVERSE) { // iterate from last to first
         iter->currentIndex = iter->chunk->num_samples - 1;
     } else { // iterate from first to last
         iter->currentIndex = 0;
     }
-
     if (retChunkIterClass != NULL) {
         *retChunkIterClass = *GetChunkIteratorClass(CHUNK_REGULAR);
     }
+}
 
+ChunkIter_t *Uncompressed_NewChunkIterator(Chunk_t *chunk,
+                                           int options,
+                                           ChunkIterFuncs *retChunkIterClass) {
+    ChunkIterator *iter = (ChunkIterator *)calloc(1, sizeof(ChunkIterator));
+    iter->options = options;
+    Uncompressed_ResetChunkIterator(iter, chunk, options, retChunkIterClass);
     return (ChunkIter_t *)iter;
 }
 

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -64,6 +64,10 @@ timestamp_t Uncompressed_GetFirstTimestamp(Chunk_t *chunk);
 ChunkIter_t *Uncompressed_NewChunkIterator(Chunk_t *chunk,
                                            int options,
                                            ChunkIterFuncs *retChunkIterClass);
+void Uncompressed_ResetChunkIterator(ChunkIter_t *iterator,
+                                     Chunk_t *chunk,
+                                     int options,
+                                     ChunkIterFuncs *retChunkIterClass);
 ChunkResult Uncompressed_ChunkIteratorGetNext(ChunkIter_t *iterator, Sample *sample);
 ChunkResult Uncompressed_ChunkIteratorGetPrev(ChunkIter_t *iterator, Sample *sample);
 void Uncompressed_FreeChunkIterator(ChunkIter_t *iter);

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -64,10 +64,7 @@ timestamp_t Uncompressed_GetFirstTimestamp(Chunk_t *chunk);
 ChunkIter_t *Uncompressed_NewChunkIterator(Chunk_t *chunk,
                                            int options,
                                            ChunkIterFuncs *retChunkIterClass);
-void Uncompressed_ResetChunkIterator(ChunkIter_t *iterator,
-                                     Chunk_t *chunk,
-                                     int options,
-                                     ChunkIterFuncs *retChunkIterClass);
+void Uncompressed_ResetChunkIterator(ChunkIter_t *iterator, Chunk_t *chunk);
 ChunkResult Uncompressed_ChunkIteratorGetNext(ChunkIter_t *iterator, Sample *sample);
 ChunkResult Uncompressed_ChunkIteratorGetPrev(ChunkIter_t *iterator, Sample *sample);
 void Uncompressed_FreeChunkIterator(ChunkIter_t *iter);

--- a/src/compressed_chunk.c
+++ b/src/compressed_chunk.c
@@ -234,6 +234,25 @@ u_int64_t getIterIdx(ChunkIter_t *iter) {
 }
 // LCOV_EXCL_STOP
 
+void Compressed_ResetChunkIterator(ChunkIter_t *iterator,
+                                   Chunk_t *chunk,
+                                   int options,
+                                   ChunkIterFuncs *retChunkIterClass) {
+    CompressedChunk *compressedChunk = chunk;
+    Compressed_Iterator *iter = (Compressed_Iterator *)iterator;
+    iter->chunk = compressedChunk;
+    iter->idx = 0;
+    iter->count = 0;
+
+    iter->prevDelta = 0;
+    iter->prevTS = compressedChunk->baseTimestamp;
+    iter->prevValue.d = compressedChunk->baseValue.d;
+    iter->leading = 32;
+    iter->trailing = 32;
+    iter->blocksize = 0;
+    iterator = (ChunkIter_t *)iter;
+}
+
 ChunkIter_t *Compressed_NewChunkIterator(Chunk_t *chunk,
                                          int options,
                                          ChunkIterFuncs *retChunkIterClass) {
@@ -246,26 +265,11 @@ ChunkIter_t *Compressed_NewChunkIterator(Chunk_t *chunk,
         return Uncompressed_NewChunkIterator(
             uncompressedChunk, uncompressed_options, retChunkIterClass);
     }
-
+    Compressed_Iterator *iter = (Compressed_Iterator *)calloc(1, sizeof(Compressed_Iterator));
+    Compressed_ResetChunkIterator(iter, compressedChunk, options, retChunkIterClass);
     if (retChunkIterClass != NULL) {
         *retChunkIterClass = *GetChunkIteratorClass(CHUNK_COMPRESSED);
-        ;
     }
-
-    Compressed_Iterator *iter = (Compressed_Iterator *)calloc(1, sizeof(Compressed_Iterator));
-
-    iter->chunk = compressedChunk;
-    iter->idx = 0;
-    iter->count = 0;
-
-    iter->prevTS = compressedChunk->baseTimestamp;
-    iter->prevDelta = 0;
-
-    iter->prevValue.d = compressedChunk->baseValue.d;
-    iter->leading = 32;
-    iter->trailing = 32;
-    iter->blocksize = 0;
-
     return (ChunkIter_t *)iter;
 }
 

--- a/src/compressed_chunk.c
+++ b/src/compressed_chunk.c
@@ -234,10 +234,7 @@ u_int64_t getIterIdx(ChunkIter_t *iter) {
 }
 // LCOV_EXCL_STOP
 
-void Compressed_ResetChunkIterator(ChunkIter_t *iterator,
-                                   Chunk_t *chunk,
-                                   int options,
-                                   ChunkIterFuncs *retChunkIterClass) {
+void Compressed_ResetChunkIterator(ChunkIter_t *iterator, Chunk_t *chunk) {
     CompressedChunk *compressedChunk = chunk;
     Compressed_Iterator *iter = (Compressed_Iterator *)iterator;
     iter->chunk = compressedChunk;
@@ -266,7 +263,7 @@ ChunkIter_t *Compressed_NewChunkIterator(Chunk_t *chunk,
             uncompressedChunk, uncompressed_options, retChunkIterClass);
     }
     Compressed_Iterator *iter = (Compressed_Iterator *)calloc(1, sizeof(Compressed_Iterator));
-    Compressed_ResetChunkIterator(iter, compressedChunk, options, retChunkIterClass);
+    Compressed_ResetChunkIterator(iter, compressedChunk);
     if (retChunkIterClass != NULL) {
         *retChunkIterClass = *GetChunkIteratorClass(CHUNK_COMPRESSED);
     }

--- a/src/compressed_chunk.h
+++ b/src/compressed_chunk.h
@@ -28,6 +28,10 @@ size_t Compressed_DelRange(Chunk_t *chunk, timestamp_t startTs, timestamp_t endT
 ChunkIter_t *Compressed_NewChunkIterator(Chunk_t *chunk,
                                          int options,
                                          ChunkIterFuncs *retChunkIterClass);
+void Compressed_ResetChunkIterator(ChunkIter_t *iterator,
+                                   Chunk_t *chunk,
+                                   int options,
+                                   ChunkIterFuncs *retChunkIterClass);
 ChunkResult Compressed_ChunkIteratorGetNext(ChunkIter_t *iter, Sample *sample);
 void Compressed_FreeChunkIterator(ChunkIter_t *iter);
 

--- a/src/compressed_chunk.h
+++ b/src/compressed_chunk.h
@@ -28,10 +28,7 @@ size_t Compressed_DelRange(Chunk_t *chunk, timestamp_t startTs, timestamp_t endT
 ChunkIter_t *Compressed_NewChunkIterator(Chunk_t *chunk,
                                          int options,
                                          ChunkIterFuncs *retChunkIterClass);
-void Compressed_ResetChunkIterator(ChunkIter_t *iterator,
-                                   Chunk_t *chunk,
-                                   int options,
-                                   ChunkIterFuncs *retChunkIterClass);
+void Compressed_ResetChunkIterator(ChunkIter_t *iterator, Chunk_t *chunk);
 ChunkResult Compressed_ChunkIteratorGetNext(ChunkIter_t *iter, Sample *sample);
 void Compressed_FreeChunkIterator(ChunkIter_t *iter);
 

--- a/src/generic_chunk.c
+++ b/src/generic_chunk.c
@@ -16,6 +16,7 @@ static ChunkFuncs regChunk = {
     .DelRange = Uncompressed_DelRange,
 
     .NewChunkIterator = Uncompressed_NewChunkIterator,
+    .ResetChunkIterator = Uncompressed_ResetChunkIterator,
 
     .GetChunkSize = Uncompressed_GetChunkSize,
     .GetNumOfSample = Uncompressed_NumOfSample,
@@ -45,6 +46,7 @@ static ChunkFuncs comprChunk = {
     .DelRange = Compressed_DelRange,
 
     .NewChunkIterator = Compressed_NewChunkIterator,
+    .ResetChunkIterator = Compressed_ResetChunkIterator,
 
     .GetChunkSize = Compressed_GetChunkSize,
     .GetNumOfSample = Compressed_ChunkNumOfSample,

--- a/src/generic_chunk.c
+++ b/src/generic_chunk.c
@@ -16,7 +16,6 @@ static ChunkFuncs regChunk = {
     .DelRange = Uncompressed_DelRange,
 
     .NewChunkIterator = Uncompressed_NewChunkIterator,
-    .ResetChunkIterator = Uncompressed_ResetChunkIterator,
 
     .GetChunkSize = Uncompressed_GetChunkSize,
     .GetNumOfSample = Uncompressed_NumOfSample,
@@ -33,6 +32,7 @@ ChunkIterFuncs uncompressedChunkIteratorClass = {
     .Free = Uncompressed_FreeChunkIterator,
     .GetNext = Uncompressed_ChunkIteratorGetNext,
     .GetPrev = Uncompressed_ChunkIteratorGetPrev,
+    .Reset = Uncompressed_ResetChunkIterator,
 };
 
 static ChunkFuncs comprChunk = {
@@ -46,7 +46,6 @@ static ChunkFuncs comprChunk = {
     .DelRange = Compressed_DelRange,
 
     .NewChunkIterator = Compressed_NewChunkIterator,
-    .ResetChunkIterator = Compressed_ResetChunkIterator,
 
     .GetChunkSize = Compressed_GetChunkSize,
     .GetNumOfSample = Compressed_ChunkNumOfSample,
@@ -64,6 +63,7 @@ static ChunkIterFuncs compressedChunkIteratorClass = {
     .GetNext = Compressed_ChunkIteratorGetNext,
     /*** Reverse iteration is on temporary decompressed chunk ***/
     .GetPrev = NULL,
+    .Reset = Compressed_ResetChunkIterator,
 };
 
 // This function will decide according to the policy how to handle duplicate sample, the `newSample`

--- a/src/generic_chunk.h
+++ b/src/generic_chunk.h
@@ -67,6 +67,10 @@ typedef struct ChunkFuncs
     ChunkIter_t *(*NewChunkIterator)(Chunk_t *chunk,
                                      int options,
                                      ChunkIterFuncs *retChunkIterClass);
+    void (*ResetChunkIterator)(ChunkIter_t *iterator,
+                               Chunk_t *chunk,
+                               int options,
+                               ChunkIterFuncs *retChunkIterClass);
 
     size_t (*GetChunkSize)(Chunk_t *chunk, bool includeStruct);
     u_int64_t (*GetNumOfSample)(Chunk_t *chunk);

--- a/src/generic_chunk.h
+++ b/src/generic_chunk.h
@@ -51,6 +51,7 @@ typedef struct ChunkIterFuncs
     void (*Free)(ChunkIter_t *iter);
     ChunkResult (*GetNext)(ChunkIter_t *iter, Sample *sample);
     ChunkResult (*GetPrev)(ChunkIter_t *iter, Sample *sample);
+    void (*Reset)(ChunkIter_t *iter, Chunk_t *chunk);
 } ChunkIterFuncs;
 
 typedef struct ChunkFuncs
@@ -67,10 +68,6 @@ typedef struct ChunkFuncs
     ChunkIter_t *(*NewChunkIterator)(Chunk_t *chunk,
                                      int options,
                                      ChunkIterFuncs *retChunkIterClass);
-    void (*ResetChunkIterator)(ChunkIter_t *iterator,
-                               Chunk_t *chunk,
-                               int options,
-                               ChunkIterFuncs *retChunkIterClass);
 
     size_t (*GetChunkSize)(Chunk_t *chunk, bool includeStruct);
     u_int64_t (*GetNumOfSample)(Chunk_t *chunk);

--- a/src/series_iterator.c
+++ b/src/series_iterator.c
@@ -100,10 +100,7 @@ static inline ChunkResult _seriesIteratorGetNext(SeriesIterator *iterator, Sampl
                     funcs->GetLastTimestamp(currentChunk) < itt_min_ts) {
                     return CR_END; // No more chunks or they out of range
                 }
-                funcs->ResetChunkIterator(iterator->chunkIterator,
-                                          currentChunk,
-                                          SeriesChunkIteratorOptions(iterator),
-                                          &iterator->chunkIteratorFuncs);
+                iterator->chunkIteratorFuncs.Reset(iterator->chunkIterator, currentChunk);
                 if (SeriesGetNext(iterator, currentSample) != CR_OK) {
                     return CR_END;
                 }
@@ -132,10 +129,11 @@ static inline ChunkResult _seriesIteratorGetNext(SeriesIterator *iterator, Sampl
                     funcs->GetLastTimestamp(currentChunk) < itt_min_ts) {
                     return CR_END; // No more chunks or they out of range
                 }
-                funcs->ResetChunkIterator(iterator->chunkIterator,
-                                          currentChunk,
-                                          SeriesChunkIteratorOptions(iterator),
-                                          &iterator->chunkIteratorFuncs);
+                iterator->chunkIteratorFuncs.Free(iterator->chunkIterator);
+                iterator->chunkIterator =
+                    funcs->NewChunkIterator(currentChunk,
+                                            SeriesChunkIteratorOptions(iterator),
+                                            &iterator->chunkIteratorFuncs);
                 if (SeriesGetPrevious(iterator, currentSample) != CR_OK) {
                     return CR_END;
                 }

--- a/src/series_iterator.c
+++ b/src/series_iterator.c
@@ -81,14 +81,6 @@ void SeriesIteratorClose(AbstractIterator *iterator) {
     free(iterator);
 }
 
-static inline void resetChunkIterator(SeriesIterator *iterator,
-                                      const ChunkFuncs *funcs,
-                                      void *currentChunk) {
-    iterator->chunkIteratorFuncs.Free(iterator->chunkIterator);
-    iterator->chunkIterator = funcs->NewChunkIterator(
-        currentChunk, SeriesChunkIteratorOptions(iterator), &iterator->chunkIteratorFuncs);
-}
-
 // Fills sample from chunk. If all samples were extracted from the chunk, we
 // move to the next chunk.
 static inline ChunkResult _seriesIteratorGetNext(SeriesIterator *iterator, Sample *currentSample) {
@@ -108,7 +100,10 @@ static inline ChunkResult _seriesIteratorGetNext(SeriesIterator *iterator, Sampl
                     funcs->GetLastTimestamp(currentChunk) < itt_min_ts) {
                     return CR_END; // No more chunks or they out of range
                 }
-                resetChunkIterator(iterator, funcs, currentChunk);
+                funcs->ResetChunkIterator(iterator->chunkIterator,
+                                          currentChunk,
+                                          SeriesChunkIteratorOptions(iterator),
+                                          &iterator->chunkIteratorFuncs);
                 if (SeriesGetNext(iterator, currentSample) != CR_OK) {
                     return CR_END;
                 }
@@ -137,7 +132,10 @@ static inline ChunkResult _seriesIteratorGetNext(SeriesIterator *iterator, Sampl
                     funcs->GetLastTimestamp(currentChunk) < itt_min_ts) {
                     return CR_END; // No more chunks or they out of range
                 }
-                resetChunkIterator(iterator, funcs, currentChunk);
+                funcs->ResetChunkIterator(iterator->chunkIterator,
+                                          currentChunk,
+                                          SeriesChunkIteratorOptions(iterator),
+                                          &iterator->chunkIteratorFuncs);
                 if (SeriesGetPrevious(iterator, currentSample) != CR_OK) {
                     return CR_END;
                 }


### PR DESCRIPTION
This PR removes some unecessary work on `_seriesIteratorGetNext`. We've seen on https://github.com/RedisTimeSeries/RedisTimeSeries/issues/753 and https://github.com/RedisTimeSeries/RedisTimeSeries/issues/747 that  `_seriesIteratorGetNext` is on the top2/3 hotspots. 
We should further iterate on this hotspot prior considering the overhead of 17.56% minimized! ( more PRs to come :) )

Overall impact on standalone numbers:
- `cpu-max-all-1`: from **1085.14 queries/sec** (p50=56.22 ms) to **1104.53 queries/sec** (p50=55.22 ms)
- `double-groupby-5`: from 19.86 queries/sec **(p50=3236.22 ms)** to 20.06 queries/sec **(p50=3184.00 ms)**

To trigger benchmarks again:
```
make clean build benchmark BENCHMARK_REPETITIONS=3 BENCHMARK=tsbs-scale100-cpu-max-all-1.yml
make clean build benchmark BENCHMARK_REPETITIONS=3 BENCHMARK=tsbs-scale100-double-groupby-5.yml

```


## master

```
# cpu-max-all-1:

Run complete after 10000 queries with 64 workers (Overall query rate 1085.14 queries/sec):
RedisTimeSeries max of all CPU metrics, random    1 hosts, random 8h0m0s by 1h:
min:     1.47ms, med:    56.22ms, mean:    58.85ms, max:  149.77ms, stddev:    11.83ms, sum: 588.5sec, count: 10000

# double-groupby-5:
Run complete after 1000 queries with 64 workers (Overall query rate 19.86 queries/sec):
RedisTimeSeries mean of 5 metrics, all hosts, random 12h0m0s by 1h:
min:    48.86ms, med:  3236.22ms, mean:  3181.02ms, max: 4448.26ms, stddev:   500.46ms, sum: 3181.0sec, count: 1000
```

## branch:
```
# cpu-max-all-1:

Run complete after 10000 queries with 64 workers (Overall query rate 1104.53 queries/sec):
RedisTimeSeries max of all CPU metrics, random    1 hosts, random 8h0m0s by 1h:
min:     1.09ms, med:    55.22ms, mean:    57.75ms, max:  130.25ms, stddev:    11.91ms, sum: 577.5sec, count: 10000

# double-groupby-5:
Run complete after 1000 queries with 64 workers (Overall query rate 20.06 queries/sec):
RedisTimeSeries mean of 5 metrics, all hosts, random 12h0m0s by 1h:
min:    49.49ms, med:  3184.00ms, mean:  3147.11ms, max: 4370.18ms, stddev:   494.50ms, sum: 3147.1sec, count: 1000
```