### PR TITLE
Fixed parseLabelListFromArgs() for label-value pairs with size larger than 255 bytes

### DIFF
--- a/src/indexer.h
+++ b/src/indexer.h
@@ -46,7 +46,8 @@ typedef struct QueryPredicateList
 } QueryPredicateList;
 
 int parsePredicate(RedisModuleCtx *ctx,
-                   RedisModuleString *label,
+                   const char *label_value_pair,
+                   size_t label_value_pair_size,
                    QueryPredicate *retQuery,
                    const char *separator);
 void QueryPredicate_Free(QueryPredicate *predicate, size_t count);

--- a/src/query_language.c
+++ b/src/query_language.c
@@ -327,36 +327,50 @@ QueryPredicateList *parseLabelListFromArgs(RedisModuleCtx *ctx,
     *response = TSDB_OK;
 
     for (int i = start; i < start + query_count; i++) {
-        size_t _s;
+        size_t label_value_pair_size;
         QueryPredicate *query = &queries->list[current_index];
-        const char *str2 = RedisModule_StringPtrLen(argv[i], &_s);
-        if (strstr(str2, "!=(") != NULL) { // order is important! Must be before "!=".
+        const char *label_value_pair = RedisModule_StringPtrLen(argv[i], &label_value_pair_size);
+        // l!=(v1,v2,...) key with label l that doesn't equal any of the values in the list
+        // Note: order is important! Must be before "!=".
+        if (strstr(label_value_pair, "!=(") != NULL) {
             query->type = LIST_NOTMATCH;
-            if (parsePredicate(ctx, argv[i], query, "!=(") == TSDB_ERROR) {
+            if (parsePredicate(ctx, label_value_pair, label_value_pair_size, query, "!=(") ==
+                TSDB_ERROR) {
                 *response = TSDB_ERROR;
                 break;
             }
-        } else if (strstr(str2, "!=") != NULL) {
+            // l!= key has label l
+        } else if (strstr(label_value_pair, "!=") != NULL) {
             query->type = NEQ;
-            if (parsePredicate(ctx, argv[i], query, "!=") == TSDB_ERROR) {
+            if (parsePredicate(ctx, label_value_pair, label_value_pair_size, query, "!=") ==
+                TSDB_ERROR) {
                 *response = TSDB_ERROR;
                 break;
             }
             if (query->valueListCount == 0) {
                 query->type = CONTAINS;
             }
-        } else if (strstr(str2, "=(") != NULL) { // order is important! Must be before "=".
+            // l=(v1,v2,...) key with label l that equals one of the values in the list
+            // Note: order is important! Must be before "=".
+        } else if (strstr(label_value_pair, "=(") != NULL) {
             query->type = LIST_MATCH;
-            if (parsePredicate(ctx, argv[i], query, "=(") == TSDB_ERROR) {
+            if (parsePredicate(ctx, label_value_pair, label_value_pair_size, query, "=(") ==
+                TSDB_ERROR) {
                 *response = TSDB_ERROR;
                 break;
             }
-        } else if (strstr(str2, "=") != NULL) {
+            // When we reach this check, it's due to:
+            // option 1) l=v label equals value
+            // option 2) l= key does not have the label l
+        } else if (strstr(label_value_pair, "=") != NULL) {
             query->type = EQ;
-            if (parsePredicate(ctx, argv[i], query, "=") == TSDB_ERROR) {
+            // option 1) l=v label equals value
+            if (parsePredicate(ctx, label_value_pair, label_value_pair_size, query, "=") ==
+                TSDB_ERROR) {
                 *response = TSDB_ERROR;
                 break;
             }
+            // option 2) l= key does not have the label l
             if (query->valueListCount == 0) {
                 query->type = NCONTAINS;
             }

--- a/tests/flow/test_ts_mget.py
+++ b/tests/flow/test_ts_mget.py
@@ -86,3 +86,18 @@ def test_mget_cmd():
             assert r.execute_command('TS.MGET', 'filter', 'k!=5')
         with pytest.raises(redis.ResponseError) as excinfo:
             assert r.execute_command('TS.MGET', 'retlif', 'k!=5')
+
+def test_large_key_value_pairs():
+     with Env().getClusterConnectionIfNeeded() as r:
+        number_series = 100
+        for i in range(0,number_series):
+            assert r.execute_command('TS.CREATE', 'ts-{}'.format(i), 'LABELS', 'baseAsset', '17049', 'counterAsset', '840', 'source', '1000', 'dataType', 'PRICE_TICK')
+
+        kv_label1 = 'baseAsset=(13830,10249,16019,10135,17049,10777,10138,11036,11292,15778,11043,10025,11436,12207,13359,10807,12216,11833,10170,10811,12864,12738,10053,11334,12487,12619,12364,13266,11219,15827,12374,11223,10071,12249,11097,14430,13282,16226,13667,11365,12261,12646,12650,12397,12785,13941,10231,16254,12159,15103)'
+        kv_label2 = 'counterAsset=(840)'
+        kv_label3 = 'source=(1000)'
+        kv_label4 = 'dataType=(PRICE_TICK)'
+        kv_labels = [kv_label1, kv_label2, kv_label3, kv_label4]
+        for kv_label in kv_labels:
+            res = r.execute_command('TS.MGET', 'FILTER', kv_label1)
+            assert len(res) == number_series

--- a/tests/flow/test_ts_mrange.py
+++ b/tests/flow/test_ts_mrange.py
@@ -195,3 +195,18 @@ def test_multilabel_filter():
 
         actual_result = r.execute_command('TS.mget', 'WITHLABELS', 'FILTER', 'name=(bob,rudy)', 'class!=(middle,top)')
         assert actual_result[0][0] == b'tester2'
+
+def test_large_key_value_pairs():
+     with Env().getClusterConnectionIfNeeded() as r:
+        number_series = 100
+        for i in range(0,number_series):
+            assert r.execute_command('TS.CREATE', 'ts-{}'.format(i), 'LABELS', 'baseAsset', '17049', 'counterAsset', '840', 'source', '1000', 'dataType', 'PRICE_TICK')
+
+        kv_label1 = 'baseAsset=(13830,10249,16019,10135,17049,10777,10138,11036,11292,15778,11043,10025,11436,12207,13359,10807,12216,11833,10170,10811,12864,12738,10053,11334,12487,12619,12364,13266,11219,15827,12374,11223,10071,12249,11097,14430,13282,16226,13667,11365,12261,12646,12650,12397,12785,13941,10231,16254,12159,15103)'
+        kv_label2 = 'counterAsset=(840)'
+        kv_label3 = 'source=(1000)'
+        kv_label4 = 'dataType=(PRICE_TICK)'
+        kv_labels = [kv_label1, kv_label2, kv_label3, kv_label4]
+        for kv_label in kv_labels:
+            res = r.execute_command('TS.MRANGE', '-', '+', 'FILTER', kv_label1)
+            assert len(res) == number_series

--- a/tests/flow/test_ts_queryindex.py
+++ b/tests/flow/test_ts_queryindex.py
@@ -39,3 +39,18 @@ def test_label_index():
             assert r.execute_command('TS.QUERYINDEX', 'generation=x', 'class=(ab')
         with pytest.raises(redis.ResponseError):
             assert r.execute_command('TS.QUERYINDEX', 'generation!=(x,y)')
+
+def test_large_key_value_pairs():
+     with Env().getClusterConnectionIfNeeded() as r:
+        number_series = 100
+        for i in range(0,number_series):
+            assert r.execute_command('TS.CREATE', 'ts-{}'.format(i), 'LABELS', 'baseAsset', '17049', 'counterAsset', '840', 'source', '1000', 'dataType', 'PRICE_TICK')
+
+        kv_label1 = 'baseAsset=(13830,10249,16019,10135,17049,10777,10138,11036,11292,15778,11043,10025,11436,12207,13359,10807,12216,11833,10170,10811,12864,12738,10053,11334,12487,12619,12364,13266,11219,15827,12374,11223,10071,12249,11097,14430,13282,16226,13667,11365,12261,12646,12650,12397,12785,13941,10231,16254,12159,15103)'
+        kv_label2 = 'counterAsset=(840)'
+        kv_label3 = 'source=(1000)'
+        kv_label4 = 'dataType=(PRICE_TICK)'
+        kv_labels = [kv_label1, kv_label2, kv_label3, kv_label4]
+        for kv_label in kv_labels:
+            res = r.execute_command('TS.QUERYINDEX', kv_label1)
+            assert len(res) == number_series


### PR DESCRIPTION
This PR fixes #776 . It's important to state that this impacts not only queryindex but also, ts.mget and ts.mrange.