### PR TITLE
Performance`cpu-max-all-1` +6%: using __bultin_expect within SeriesIteratorGetNext. Remove _seriesIteratorGetNext call

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -9,6 +9,15 @@
 #include <sys/types.h>
 #include <stdbool.h>
 
+
+  #if defined(__GNUC__)
+#define likely(x)       __builtin_expect((x),1)
+#define unlikely(x)     __builtin_expect((x),0)
+  #elif _MSC_VER
+#define likely(x)       (x)
+#define unlikely(x)     (x)
+  #endif
+
 #define TRUE 1
 #define FALSE 0
 

--- a/src/gorilla.c
+++ b/src/gorilla.c
@@ -498,7 +498,7 @@ ChunkResult Compressed_ReadNext(Compressed_Iterator *iter, timestamp_t *timestam
     if (iter->count >= iter->chunk->count)
         return CR_END;
     // First sample
-    if (__builtin_expect(iter->count == 0, 0)) {
+    if (unlikely(iter->count == 0)) {
         *timestamp = iter->chunk->baseTimestamp;
         *value = iter->chunk->baseValue.d;
 


### PR DESCRIPTION
Fixes #786 

### standalone improvements over `cpu-max-all-1`:
-  from 1457.90 to 1545.33 queries/sec **(~=6%)**
-  from p50 40.83ms to 38.59ms **(~=5.5%)**

To reproduce:
```
make clean build benchmark BENCHMARK=tsbs-scale100-cpu-max-all-1.yml
```

**master `cpu-max-all-1`:**
```
Run complete after 10000 queries with 64 workers (Overall query rate 1457.90 queries/sec):
RedisTimeSeries max of all CPU metrics, random    1 hosts, random 8h0m0s by 1h:
min:     0.93ms, med:    40.83ms, mean:    43.75ms, max:  104.28ms, stddev:    11.03ms, sum: 437.5sec, count: 10000
all queries                                                                   :
min:     0.93ms, med:    40.83ms, mean:    43.75ms, max:  104.28ms, stddev:    11.03ms, sum: 437.5sec, count: 10000
```

series.iterator.perf `cpu-max-all-1`:
```
Run complete after 10000 queries with 64 workers (Overall query rate 1545.33 queries/sec):
RedisTimeSeries max of all CPU metrics, random    1 hosts, random 8h0m0s by 1h:
min:     1.62ms, med:    38.59ms, mean:    41.28ms, max:   80.97ms, stddev:    10.20ms, sum: 412.8sec, count: 10000
all queries                                                                   :
min:     1.62ms, med:    38.59ms, mean:    41.28ms, max:   80.97ms, stddev:    10.20ms, sum: 412.8sec, count: 10000
```