### PR TITLE
Fixup #655, Block align usage only for when explicit timestamps are used

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -312,8 +312,8 @@ Optional parameters:
 
 * ALIGN - Time bucket alignment control for AGGREGATION. This will control the time bucket timestamps by changing the reference timestamp on which a bucket is defined.
      Possible values:
-     * `start` or `-`: The reference timestamp will be the query start interval time (fromTimestamp).
-     * `end` or `+`: The reference timestamp will be the signed remainder of query end interval time by the AGGREGATION time bucket (toTimestamp % timeBucket).
+     * `start` or `-`: The reference timestamp will be the query start interval time (`fromTimestamp`).
+     * `end` or `+`: The reference timestamp will be the query end interval time (`toTimestamp`).
      * A specific timestamp: align the reference timestamp to a specific time.
      * **Note:** when not provided alignment is set to `0`.
 
@@ -393,8 +393,8 @@ Optional parameters:
 
 * ALIGN - Time bucket alignment control for AGGREGATION. This will control the time bucket timestamps by changing the reference timestamp on which a bucket is defined.
      Possible values:
-     * `start` or `-`: The reference timestamp will be the query start interval time (fromTimestamp).
-     * `end` or `+`: The reference timestamp will be the signed remainder of query end interval time by the AGGREGATION time bucket (toTimestamp % timeBucket).
+     * `start` or `-`: The reference timestamp will be the query start interval time (`fromTimestamp`).
+     * `end` or `+`: The reference timestamp will be the query end interval time (`toTimestamp`).
      * A specific timestamp: align the reference timestamp to a specific time.
      * **Note:** when not provided alignment is set to `0`.
 

--- a/src/gears_commands.c
+++ b/src/gears_commands.c
@@ -71,6 +71,8 @@ static void mrange_done(ExecutionPlan *gearsCtx, void *privateData) {
 
         // Do not apply the aggregation on the resultset, do apply max results on the final result
         RangeArgs minimizedArgs = data->args.rangeArgs;
+        minimizedArgs.startTimestamp = 0;
+        minimizedArgs.endTimestamp = UINT64_MAX;
         minimizedArgs.aggregationArgs.aggregationClass = NULL;
         minimizedArgs.aggregationArgs.timeDelta = 0;
         minimizedArgs.filterByValueArgs.hasValue = false;

--- a/src/gears_integration.c
+++ b/src/gears_integration.c
@@ -483,11 +483,15 @@ Series *SeriesRecord_IntoSeries(SeriesRecord *record) {
     }
     s->funcs = record->funcs;
 
+    Chunk_t *chunk;
     for (int chunk_index = 0; chunk_index < record->chunkCount; chunk_index++) {
+        chunk = record->chunks[chunk_index];
+        s->totalSamples += s->funcs->GetNumOfSample(chunk);
         dictOperator(s->chunks,
-                     s->funcs->CloneChunk(record->chunks[chunk_index]),
-                     record->funcs->GetFirstTimestamp(record->chunks[chunk_index]),
+                     s->funcs->CloneChunk(chunk),
+                     record->funcs->GetFirstTimestamp(chunk),
                      DICT_OP_SET);
     }
+    s->lastTimestamp = s->funcs->GetLastTimestamp(chunk);
     return s;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -231,6 +231,8 @@ static int replyGroupedMultiRange(RedisModuleCtx *ctx,
 
     // Do not apply the aggregation on the resultset, do apply max results on the final result
     RangeArgs minimizedArgs = args->rangeArgs;
+    minimizedArgs.startTimestamp = 0;
+    minimizedArgs.endTimestamp = UINT64_MAX;
     minimizedArgs.aggregationArgs.aggregationClass = NULL;
     minimizedArgs.aggregationArgs.timeDelta = 0;
     minimizedArgs.filterByTSArgs.hasValue = false;

--- a/src/query_language.c
+++ b/src/query_language.c
@@ -314,10 +314,13 @@ int parseRangeArguments(RedisModuleCtx *ctx,
     args.filterByValueArgs.hasValue = false;
     args.filterByTSArgs.hasValue = false;
 
+    bool startTimestampMin = false;
+    bool endTimestampMax = false;
     size_t start_len;
     const char *start = RedisModule_StringPtrLen(argv[start_index], &start_len);
     if (strcmp(start, "-") == 0) {
         args.startTimestamp = 0;
+        startTimestampMin = true;
     } else {
         if (RedisModule_StringToLongLong(argv[start_index],
                                          (long long int *)&args.startTimestamp) != REDISMODULE_OK) {
@@ -330,6 +333,7 @@ int parseRangeArguments(RedisModuleCtx *ctx,
     const char *end = RedisModule_StringPtrLen(argv[start_index + 1], &end_len);
     if (strcmp(end, "+") == 0) {
         args.endTimestamp = maxTimestamp;
+        endTimestampMax = true;
     } else {
         if (RedisModule_StringToLongLong(argv[start_index + 1],
                                          (long long int *)&args.endTimestamp) != REDISMODULE_OK) {
@@ -352,9 +356,23 @@ int parseRangeArguments(RedisModuleCtx *ctx,
         return REDISMODULE_ERR;
     }
 
-    if (args.alignment != DefaultAlignment && args.aggregationArgs.aggregationClass == NULL) {
-        RTS_ReplyGeneralError(ctx, "TSDB: ALIGN parameter can only be used with AGGREGATION");
-        return TSDB_ERROR;
+    if (args.alignment != DefaultAlignment) {
+        if (args.aggregationArgs.aggregationClass == NULL) {
+            RTS_ReplyGeneralError(ctx, "TSDB: ALIGN parameter can only be used with AGGREGATION");
+            return TSDB_ERROR;
+        }
+
+        if (args.alignment == StartAlignment && startTimestampMin) {
+            RTS_ReplyGeneralError(
+                ctx, "TSDB: start alignment can only be used with explicit start timestamp");
+            return TSDB_ERROR;
+        }
+
+        if (args.alignment == EndAlignment && endTimestampMax) {
+            RTS_ReplyGeneralError(
+                ctx, "TSDB: end alignment can only be used with explicit end timestamp");
+            return TSDB_ERROR;
+        }
     }
 
     if (parseFilterByValueArgument(ctx, argv, argc, &args.filterByValueArgs) == TSDB_ERROR) {

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -811,7 +811,11 @@ AbstractIterator *SeriesQuery(Series *series, RangeArgs *args, bool reverse) {
             timestampAlignment = max(args->startTimestamp, getFirstValidTimestamp(series, NULL));
             break;
         case EndAlignment:
-            timestampAlignment = args->endTimestamp;
+            if (args->endTimestamp != LLONG_MAX) {
+                timestampAlignment = args->endTimestamp;
+            } else {
+                timestampAlignment = series->lastTimestamp;
+            }
             break;
         case TimestampAlignment:
             timestampAlignment = args->timestampAlignment;

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -808,14 +808,10 @@ AbstractIterator *SeriesQuery(Series *series, RangeArgs *args, bool reverse) {
     switch (args->alignment) {
         case StartAlignment:
             // args-startTimestamp can hold an older timestamp than what we currently have or just 0
-            timestampAlignment = max(args->startTimestamp, getFirstValidTimestamp(series, NULL));
+            timestampAlignment = args->startTimestamp;
             break;
         case EndAlignment:
-            if (args->endTimestamp != LLONG_MAX) {
-                timestampAlignment = args->endTimestamp;
-            } else {
-                timestampAlignment = series->lastTimestamp;
-            }
+            timestampAlignment = args->endTimestamp;
             break;
         case TimestampAlignment:
             timestampAlignment = args->timestampAlignment;

--- a/tests/flow/test_negative.py
+++ b/tests/flow/test_negative.py
@@ -80,10 +80,10 @@ def test_errors():
         with pytest.raises(redis.ResponseError) as excinfo:
             assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'ALIGN', 'start')
         with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'ALIGN', 'start', 'AGGREGATION', 60000, 'max')
+            assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'ALIGN', 'start', 'AGGREGATION', 'max', 60000)
         with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', '-', '1627460206991', 'ALIGN', 'start', 'AGGREGATION', 60000, 'max')
+            assert r.execute_command('TS.RANGE', 'tester', '-', '1627460206991', 'ALIGN', 'start', 'AGGREGATION', 'max', 60000)
         with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'ALIGN', 'end', 'AGGREGATION', 60000, 'max')
+            assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'ALIGN', 'end', 'AGGREGATION', 'max', 60000)
         with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', '1627460206991', '+', 'ALIGN', 'end', 'AGGREGATION', 60000, 'max')
+            assert r.execute_command('TS.RANGE', 'tester', '1627460206991', '+', 'ALIGN', 'end', 'AGGREGATION', 'max', 60000)

--- a/tests/flow/test_negative.py
+++ b/tests/flow/test_negative.py
@@ -79,3 +79,11 @@ def test_errors():
             assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'ALIGN')
         with pytest.raises(redis.ResponseError) as excinfo:
             assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'ALIGN', 'start')
+        with pytest.raises(redis.ResponseError) as excinfo:
+            assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'ALIGN', 'start', 'AGGREGATION', 60000, 'max')
+        with pytest.raises(redis.ResponseError) as excinfo:
+            assert r.execute_command('TS.RANGE', 'tester', '-', '1627460206991', 'ALIGN', 'start', 'AGGREGATION', 60000, 'max')
+        with pytest.raises(redis.ResponseError) as excinfo:
+            assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'ALIGN', 'end', 'AGGREGATION', 60000, 'max')
+        with pytest.raises(redis.ResponseError) as excinfo:
+            assert r.execute_command('TS.RANGE', 'tester', '1627460206991', '+', 'ALIGN', 'end', 'AGGREGATION', 60000, 'max')

--- a/tests/flow/test_ts_mrange.py
+++ b/tests/flow/test_ts_mrange.py
@@ -331,10 +331,10 @@ def test_mrange_align():
             ['tester3', [], build_expected_aligned_data(start_ts, start_ts + samples_count, agg_bucket_size, end_ts)],
         ]
 
-        assert expected_start_result == r.execute_command('TS.mrange', start_ts, start_ts + samples_count, 'ALIGN', '-',
-                                          'AGGREGATION', 'COUNT', agg_bucket_size, 'FILTER', 'generation=x')
-        assert expected_end_result == r.execute_command('TS.mrange', start_ts, start_ts + samples_count, 'ALIGN', '+',
-                                                          'AGGREGATION', 'COUNT', agg_bucket_size, 'FILTER', 'generation=x')
+        assert expected_start_result == sorted(r.execute_command('TS.mrange', start_ts, start_ts + samples_count, 'ALIGN', '-',
+                                          'AGGREGATION', 'COUNT', agg_bucket_size, 'FILTER', 'generation=x'))
+        assert expected_end_result == sorted(r.execute_command('TS.mrange', start_ts, start_ts + samples_count, 'ALIGN', '+',
+                                                          'AGGREGATION', 'COUNT', agg_bucket_size, 'FILTER', 'generation=x'))
 
         def groupby(data):
             result =  defaultdict(lambda: 0)

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -357,10 +357,10 @@ def test_aggreataion_alignment():
     expected_data = build_expected_aligned_data(start_ts, start_ts + samples_count, agg_size, start_ts)
 
     assert expected_data == \
-           r.execute_command('TS.range', 'tester', '-', '+', 'ALIGN', 'start', 'AGGREGATION', 'count', agg_size)
+           r.execute_command('TS.range', 'tester', start_ts, '+', 'ALIGN', 'start', 'AGGREGATION', 'count', agg_size)
 
     assert expected_data == \
-           r.execute_command('TS.range', 'tester', '-', '+', 'ALIGN', '-', 'AGGREGATION', 'count', agg_size)
+           r.execute_command('TS.range', 'tester', start_ts, '+', 'ALIGN', '-', 'AGGREGATION', 'count', agg_size)
 
     specific_ts = start_ts + 50
     expected_data = build_expected_aligned_data(start_ts, start_ts + samples_count, agg_size, specific_ts)
@@ -370,6 +370,6 @@ def test_aggreataion_alignment():
     end_ts = start_ts + samples_count - 1
     expected_data = build_expected_aligned_data(start_ts, start_ts + samples_count, agg_size, end_ts)
     assert expected_data == \
-           r.execute_command('TS.range', 'tester', '-', '+', 'ALIGN', 'end', 'AGGREGATION', 'count', agg_size)
+           r.execute_command('TS.range', 'tester', '-', end_ts, 'ALIGN', 'end', 'AGGREGATION', 'count', agg_size)
     assert expected_data == \
-           r.execute_command('TS.range', 'tester', '-', '+', 'ALIGN', '+', 'AGGREGATION', 'count', agg_size)
+           r.execute_command('TS.range', 'tester', '-', end_ts, 'ALIGN', '+', 'AGGREGATION', 'count', agg_size)


### PR DESCRIPTION
…in gears