### PR TITLE
Added ENCODING series argument on TS.CREATE/TS.ADD and global config. Deprecate CHUNK_TYPE global config.

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7,7 +7,7 @@
 Create a new time-series. 
 
 ```sql
-TS.CREATE key [RETENTION retentionTime] [UNCOMPRESSED] [CHUNK_SIZE size] [DUPLICATE_POLICY policy] [LABELS label value..]
+TS.CREATE key [RETENTION retentionTime] [ENCODING [UNCOMPRESSED|COMPRESSED]] [CHUNK_SIZE size] [DUPLICATE_POLICY policy] [LABELS label value..]
 ```
 
 * key - Key name for timeseries
@@ -17,7 +17,9 @@ Optional args:
  * RETENTION - Maximum age for samples compared to last event time (in milliseconds)
     * Default: The global retention secs configuration of the database (by default, `0`)
     * When set to 0, the series is not trimmed at all
- * UNCOMPRESSED - since version 1.2, both timestamps and values are compressed by default.
+ * ENCODING - Specify the series samples encoding format.
+    * COMPRESSED: apply the DoubleDelta compression to the series samples, meaning compression of Delta of Deltas between timestamps and compression of values via XOR encoding.
+    * UNCOMPRESSED: keep the raw samples in memory.
    Adding this flag will keep data in an uncompressed form. Compression not only saves
    memory but usually improve performance due to lower number of memory accesses. 
  * CHUNK_SIZE - amount of memory, in bytes, allocated for data. Default: 4000.
@@ -128,7 +130,7 @@ TS.ALTER temperature:2:32 LABELS sensor_id 2 area_id 32 sub_area_id 15
 Append a new sample to the series. If the series has not been created yet with `TS.CREATE` it will be automatically created. 
 
 ```sql
-TS.ADD key timestamp value [RETENTION retentionTime] [UNCOMPRESSED] [CHUNK_SIZE size] [ON_DUPLICATE policy] [LABELS label value..]
+TS.ADD key timestamp value [RETENTION retentionTime] [ENCODING [COMPRESSED|UNCOMPRESSED]] [CHUNK_SIZE size] [ON_DUPLICATE policy] [LABELS label value..]
 ```
 
 * timestamp - (integer) UNIX timestamp of the sample **in milliseconds**. `*` can be used for an automatic timestamp from the system clock.
@@ -139,8 +141,10 @@ These arguments are optional because they can be set by TS.CREATE:
  * RETENTION - Maximum age for samples compared to last event time (in milliseconds)
     * Default: The global retention secs configuration of the database (by default, `0`)
     * When set to 0, the series is not trimmed at all
- * UNCOMPRESSED - Changes data storage from compressed (by default) to uncompressed
- * CHUNK_SIZE - amount of memory, in bytes, allocated for data. Default: 4000.
+ * ENCODING - Specify the series samples encoding format.
+    * COMPRESSED: apply the DoubleDelta compression to the series samples, meaning compression of Delta of Deltas between timestamps and compression of values via XOR encoding.
+    * UNCOMPRESSED: keep the raw samples in memory.
+ * CHUNK_SIZE - amount of memory, in bytes, allocated for data. Default: 4096.
  * ON_DUPLICATE - overwrite key and database configuration for `DUPLICATE_POLICY`. [See Duplicate sample policy](configuration.md#DUPLICATE_POLICY)
  * labels - Set of label-value pairs that represent metadata labels of the key
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -286,8 +286,17 @@ Note: Whenever filters need to be provided, a minimum of one `l=v` filter must b
 Query a range in forward or reverse directions.
 
 ```sql
-TS.RANGE key fromTimestamp toTimestamp [FILTER_BY_TS TS1 TS2 ..] [FILTER_BY_VALUE min max] [COUNT count] [ALIGN value] [AGGREGATION aggregationType timeBucket]
-TS.REVRANGE key fromTimestamp toTimestamp [FILTER_BY_TS TS1 TS2 ..] [FILTER_BY_VALUE min max] [COUNT count] [ALIGN value] [AGGREGATION aggregationType timeBucket]
+TS.RANGE key fromTimestamp toTimestamp
+         [FILTER_BY_TS TS1 TS2 ..]
+         [FILTER_BY_VALUE min max]
+         [COUNT count] [ALIGN value]
+         [AGGREGATION aggregationType timeBucket]
+
+TS.REVRANGE key fromTimestamp toTimestamp
+         [FILTER_BY_TS TS1 TS2 ..]
+         [FILTER_BY_VALUE min max]
+         [COUNT count] [ALIGN value]
+         [AGGREGATION aggregationType timeBucket]
 ```
 
 - key - Key name for timeseries
@@ -298,14 +307,16 @@ Optional parameters:
 
 * FILTER_BY_TS - Followed by a list of timestamps to filter the result by specific timestamps
 * FILTER_BY_VALUE - Filter result by value using minimum and maximum.
-* COUNT - Maximum number of returned samples.
-* ALIGN - Time bucket alignment control for AGGREGATION. This will control the time bucket timestamps by changing the reference timestamp on which a bucket is defined.
-  Possible values:
-  * `start` or `-`: The reference timestamp will be the query start interval time (fromTimestamp).
-  * `end` or `+`: The reference timestamp will be the signed remainder of query end interval time by the AGGREGATION time bucket (toTimestamp % timeBucket).
-  *  A specific timestamp: align the reference timestamp to a specific time.
 
-  Note: when not provided alignment is set to `0`.
+* COUNT - Maximum number of returned samples.
+
+* ALIGN - Time bucket alignment control for AGGREGATION. This will control the time bucket timestamps by changing the reference timestamp on which a bucket is defined.
+     Possible values:
+     * `start` or `-`: The reference timestamp will be the query start interval time (fromTimestamp).
+     * `end` or `+`: The reference timestamp will be the signed remainder of query end interval time by the AGGREGATION time bucket (toTimestamp % timeBucket).
+     * A specific timestamp: align the reference timestamp to a specific time.
+     * **Note:** when not provided alignment is set to `0`.
+
 * AGGREGATION - Aggregate result into time buckets (the following aggregation parameters are mandtory)
   * aggregationType - Aggregation type: avg, sum, min, max, range, count, first, last, std.p, std.s, var.p, var.s
   * timeBucket - Time bucket for aggregation in milliseconds
@@ -346,8 +357,23 @@ But because m is pretty small, we can neglect it and look at the operation as O(
 Query a range across multiple time-series by filters in forward or reverse directions.
 
 ```sql
-TS.MRANGE fromTimestamp toTimestamp [FILTER_BY_TS TS1 TS2 ..] [FILTER_BY_VALUE min max] [COUNT count] [ALIGN value] [AGGREGATION aggregationType timeBucket] [WITHLABELS] FILTER filter..
-TS.MREVRANGE fromTimestamp toTimestamp [FILTER_BY_TS TS1 TS2 ..] [FILTER_BY_VALUE min max] [COUNT count] [ALIGN value] [AGGREGATION aggregationType timeBucket] [WITHLABELS] FILTER filter..
+TS.MRANGE fromTimestamp toTimestamp
+          [FILTER_BY_TS TS1 TS2 ..]
+          [FILTER_BY_VALUE min max]
+          [WITHLABELS | SELECTED_LABELS label1 ..]
+          [COUNT count] [ALIGN value]
+          [AGGREGATION aggregationType timeBucket]
+          FILTER filter..
+          [GROUPBY <label> REDUCE <reducer>]
+
+TS.MREVRANGE fromTimestamp toTimestamp
+          [FILTER_BY_TS TS1 TS2 ..]
+          [FILTER_BY_VALUE min max]
+          [WITHLABELS | SELECTED_LABELS label1 ..]
+          [COUNT count] [ALIGN value]
+          [AGGREGATION aggregationType timeBucket]
+          FILTER filter..
+          [GROUPBY <label> REDUCE <reducer>]
 ```
 
 * fromTimestamp - Start timestamp for the range query. `-` can be used to express the minimum possible timestamp (0).
@@ -358,18 +384,32 @@ Optional parameters:
 
 * FILTER_BY_TS - Followed by a list of timestamps to filter the result by specific timestamps
 * FILTER_BY_VALUE - Filter result by value using minimum and maximum.
-* COUNT - Maximum number of returned samples per time-series.
-* ALIGN - Time bucket alignment control for AGGREGATION. This will control the time bucket timestamps by changing the reference timestamp on which a bucket is defined.
-  Possible values:
-  * `start` or `-`: The reference timestamp will be the query start interval time (fromTimestamp).
-  * `end` or `+`: The reference timestamp will be the signed remainder of query end interval time by the AGGREGATION time bucket (toTimestamp % timeBucket).
-  *  A specific timestamp: align the reference timestamp to a specific time.
 
-  Note: when not provided alignment is set to `0`.
-* WITHLABELS - Include in the reply the label-value pairs that represent metadata labels of the time-series. If this argument is not set, by default, an empty Array will be replied on the labels array position.
+* WITHLABELS - Include in the reply the label-value pairs that represent metadata labels of the time series. If `WITHLABELS` or `SELECTED_LABELS` are not set, by default, an empty Array will be replied on the labels array position.
+
+* SELECTED_LABELS - Include in the reply a subset of the label-value pairs that represent metadata labels of the time series. This is usefull when you have a large number of labels per serie but are only interested in the value of some of the labels. If `WITHLABELS` or `SELECTED_LABELS` are not set, by default, an empty Array will be replied on the labels array position.
+
+* COUNT - Maximum number of returned samples per time series.
+
+* ALIGN - Time bucket alignment control for AGGREGATION. This will control the time bucket timestamps by changing the reference timestamp on which a bucket is defined.
+     Possible values:
+     * `start` or `-`: The reference timestamp will be the query start interval time (fromTimestamp).
+     * `end` or `+`: The reference timestamp will be the signed remainder of query end interval time by the AGGREGATION time bucket (toTimestamp % timeBucket).
+     * A specific timestamp: align the reference timestamp to a specific time.
+     * **Note:** when not provided alignment is set to `0`.
+
 * AGGREGATION - Aggregate result into time buckets (the following aggregation parameters are mandtory)
     * aggregationType - Aggregation type: avg, sum, min, max, range, count, first, last, std.p, std.s, var.p, var.s
     * timeBucket - Time bucket for aggregation in milliseconds.
+
+* GROUPBY - Aggregate results across different time series, grouped by the provided label name.
+  When combined with `AGGREGATION` the groupby/reduce is applied post aggregation stage.
+    * label - label name to group series by.
+    * reducer - Reducer type used to aggregate series that share the same label value. Available reducers: sum, min, max.
+    * **Note:** The resulting series will contain 3 labels with the following label array structure:
+         * `<label>=<groupbyvalue>` : containing the label name and label value.
+         * `__reducer__=<reducer>` : containing the used reducer.
+         * `__source__=key1,key2,key3` : containing the source time series used to compute the grouped serie.
 
 #### Return Value
 
@@ -378,7 +418,9 @@ Array-reply, specifically:
 The command returns the entries with labels matching the specified filter.
 The returned entries are complete, that means that the name, labels and all the samples that match the range are returned.
 
-The returned array will contain key1,labels1,values1,...,keyN,labelsN,valuesN, with labels and values being also of array data types. By default, the labels array will be an empty Array for each of the returned time-series. If the `WITHLABELS` option is specified the labels Array will be filled with label-value pairs that represent metadata labels of the time-series.
+The returned array will contain key1,labels1,lastsample1,...,keyN,labelsN,lastsampleN, with labels and lastsample being also of array data types. By default, the labels array will be an empty Array for each of the returned time series.
+
+If the `WITHLABELS` or `SELECTED_LABELS` option is specified the labels Array will be filled with label-value pairs that represent metadata labels of the time series.
 
 
 #### Examples
@@ -464,6 +506,89 @@ The returned array will contain key1,labels1,values1,...,keyN,labelsN,valuesN, w
          2) "20"
 ```
 
+##### Query time series with metric=cpu, group them by metric_name reduce max
+
+```sql
+127.0.0.1:6379> TS.ADD ts1 1548149180000 90 labels metric cpu metric_name system
+(integer) 1
+127.0.0.1:6379> TS.ADD ts1 1548149185000 45
+(integer) 2
+127.0.0.1:6379> TS.ADD ts2 1548149180000 99 labels metric cpu metric_name user
+(integer) 2
+127.0.0.1:6379> TS.MRANGE - + WITHLABELS FILTER metric=cpu GROUPBY metric_name REDUCE max
+1) 1) "metric_name=system"
+   2) 1) 1) "metric_name"
+         2) "system"
+      2) 1) "__reducer__"
+         2) "max"
+      3) 1) "__source__"
+         2) "ts1"
+   3) 1) 1) (integer) 1548149180000
+         2) 90
+      2) 1) (integer) 1548149185000
+         2) 45
+2) 1) "metric_name=user"
+   2) 1) 1) "metric_name"
+         2) "user"
+      2) 1) "__reducer__"
+         2) "max"
+      3) 1) "__source__"
+         2) "ts2"
+   3) 1) 1) (integer) 1548149180000
+         2) 99
+```
+
+##### Query time series with metric=cpu, filter values larger or equal to 90.0 and smaller or equal to 100.0
+
+```sql
+127.0.0.1:6379> TS.ADD ts1 1548149180000 90 labels metric cpu metric_name system
+(integer) 1
+127.0.0.1:6379> TS.ADD ts1 1548149185000 45
+(integer) 2
+127.0.0.1:6379> TS.ADD ts2 1548149180000 99 labels metric cpu metric_name user
+(integer) 2
+127.0.0.1:6379> TS.MRANGE - + FILTER_BY_VALUE 90 100 WITHLABELS FILTER metric=cpu
+1) 1) "ts1"
+   2) 1) 1) "metric"
+         2) "cpu"
+      2) 1) "metric_name"
+         2) "system"
+   3) 1) 1) (integer) 1548149180000
+         2) 90
+2) 1) "ts2"
+   2) 1) 1) "metric"
+         2) "cpu"
+      2) 1) "metric_name"
+         2) "user"
+   3) 1) 1) (integer) 1548149180000
+         2) 99
+```
+
+
+##### Query time series with metric=cpu, but only reply the team label
+
+```sql
+127.0.0.1:6379> TS.ADD ts1 1548149180000 90 labels metric cpu metric_name system team NY
+(integer) 1
+127.0.0.1:6379> TS.ADD ts1 1548149185000 45
+(integer) 2
+127.0.0.1:6379> TS.ADD ts2 1548149180000 99 labels metric cpu metric_name user team SF
+(integer) 2
+127.0.0.1:6379> TS.MRANGE - + SELECTED_LABELS team FILTER metric=cpu
+1) 1) "ts1"
+   2) 1) 1) "team"
+         2) "NY"
+   3) 1) 1) (integer) 1548149180000
+         2) 90
+      2) 1) (integer) 1548149185000
+         2) 45
+2) 1) "ts2"
+   2) 1) 1) "team"
+         2) "SF"
+   3) 1) 1) (integer) 1548149180000
+         2) 99
+```
+
 ### TS.GET
 
 Get the last sample.
@@ -509,22 +634,26 @@ TS.GET complexity is O(1).
 Get the last samples matching the specific filter.
 
 ```sql
-TS.MGET [WITHLABELS] FILTER filter...
+TS.MGET [WITHLABELS | SELECTED_LABELS label1 ..] FILTER filter...
 ```
 * filter - [See Filtering](#filtering)
 
 Optional args:
 
-* WITHLABELS - Include in the reply the label-value pairs that represent metadata labels of the time-series. If this argument is not set, by default, an empty Array will be replied on the labels array position.
+* WITHLABELS - Include in the reply the label-value pairs that represent metadata labels of the time series. If `WITHLABELS` or `SELECTED_LABELS` are not set, by default, an empty Array will be replied on the labels array position.
+
+* SELECTED_LABELS - Include in the reply a subset of the label-value pairs that represent metadata labels of the time series. This is usefull when you have a large number of labels per serie but are only interested in the value of some of the labels. If `WITHLABELS` or `SELECTED_LABELS` are not set, by default, an empty Array will be replied on the labels array position.
 
 #### Return Value
 
 Array-reply, specifically:
 
 The command returns the entries with labels matching the specified filter.
-The returned entries are complete, that means that the name, labels and all the last sample of the time-serie.
+The returned entries are complete, that means that the name, labels and all the last sample of the time serie.
 
-The returned array will contain key1,labels1,lastsample1,...,keyN,labelsN,lastsampleN, with labels and lastsample being also of array data types. By default, the labels array will be an empty Array for each of the returned time-series. If the `WITHLABELS` option is specified the labels Array will be filled with label-value pairs that represent metadata labels of the time-series.
+The returned array will contain key1,labels1,lastsample1,...,keyN,labelsN,lastsampleN, with labels and lastsample being also of array data types. By default, the labels array will be an empty Array for each of the returned time series.
+
+If the `WITHLABELS` or `SELECTED_LABELS` option is specified the labels Array will be filled with label-value pairs that represent metadata labels of the time series.
 
 
 #### Complexity

--- a/src/config.h
+++ b/src/config.h
@@ -25,7 +25,7 @@ typedef struct
 extern TSConfig TSGlobalConfig;
 
 int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-
+const char *ChunkTypeToString(int options);
 typedef struct RTS_RedisVersion
 {
     int redisMajorVersion;

--- a/src/consts.h
+++ b/src/consts.h
@@ -71,6 +71,10 @@ typedef enum DuplicatePolicy {
 /* Series struct options */
 #define SERIES_OPT_UNCOMPRESSED 0x1
 
+#define SERIES_OPT_COMPRESSED_GORILLA 0x2
+
+#define SERIES_OPT_DEFAULT_COMPRESSION SERIES_OPT_COMPRESSED_GORILLA
+
 /* Chunk enum */
 typedef enum {
   CR_OK = 0,    // RM_OK
@@ -82,6 +86,8 @@ typedef enum {
 
 #define DUPLICATE_POLICY_ARG "DUPLICATE_POLICY"
 #define TS_ADD_DUPLICATE_POLICY_ARG "ON_DUPLICATE"
+#define UNCOMPRESSED_ARG_STR "uncompressed"
+#define COMPRESSED_GORILLA_ARG_STR "compressed"
 
 #define SAMPLES_TO_BYTES(size) (size * sizeof(Sample))
 

--- a/src/module.c
+++ b/src/module.c
@@ -78,11 +78,7 @@ int TSDB_info(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_ReplyWithSimpleString(ctx, "chunkSize");
     RedisModule_ReplyWithLongLong(ctx, series->chunkSizeBytes);
     RedisModule_ReplyWithSimpleString(ctx, "chunkType");
-    if (series->options & SERIES_OPT_UNCOMPRESSED) {
-        RedisModule_ReplyWithSimpleString(ctx, "uncompressed");
-    } else {
-        RedisModule_ReplyWithSimpleString(ctx, "compressed");
-    };
+    RedisModule_ReplyWithSimpleString(ctx, ChunkTypeToString(series->options));
     RedisModule_ReplyWithSimpleString(ctx, "duplicatePolicy");
     if (series->duplicatePolicy != DP_NONE) {
         RedisModule_ReplyWithSimpleString(ctx, DuplicatePolicyToString(series->duplicatePolicy));
@@ -1014,6 +1010,8 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     }
 
     if (ReadConfig(ctx, argv, argc) == TSDB_ERROR) {
+        RedisModule_Log(
+            ctx, "warning", "Failed to parse RedisTimeSeries configurations. aborting...");
         return REDISMODULE_ERR;
     }
 

--- a/src/query_language.h
+++ b/src/query_language.h
@@ -107,6 +107,8 @@ int ParseDuplicatePolicy(RedisModuleCtx *ctx,
                          const char *arg_prefix,
                          DuplicatePolicy *policy);
 
+int parseEncodingArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int *options);
+
 int parseCreateArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, CreateCtx *cCtx);
 
 int _parseAggregationArgs(RedisModuleCtx *ctx,

--- a/src/redisgears.h
+++ b/src/redisgears.h
@@ -541,13 +541,13 @@ void MODULE_API_FUNC(RedisGears_AddConfigHooks)(BeforeConfigSet before, AfterCon
 #define REDISGEARS_MODULE_INIT_FUNCTION(ctx, name) \
         RedisGears_ ## name = RedisModule_GetSharedAPI(ctx, "RedisGears_" #name);\
         if(!RedisGears_ ## name){\
-            RedisModule_Log(ctx, "warning", "could not initialize RedisGears_" #name "\r\n");\
+            RedisModule_Log(ctx, "warning", "could not initialize RedisGears_" #name);\
             return REDISMODULE_ERR; \
         }
 
 #define REDISMODULE_MODULE_INIT_FUNCTION(ctx, name) \
         if(RedisModule_GetApi("RedisModule_" #name, &RedisModule_ ## name) != REDISMODULE_OK){ \
-            RedisModule_Log(ctx, "warning", "could not initialize RedisModule_" #name "\r\n");\
+            RedisModule_Log(ctx, "warning", "could not initialize RedisModule_" #name);\
         }
 
 static int RedisGears_InitializeRedisModuleApi(RedisModuleCtx* ctx){

--- a/src/redisgears.h
+++ b/src/redisgears.h
@@ -541,13 +541,13 @@ void MODULE_API_FUNC(RedisGears_AddConfigHooks)(BeforeConfigSet before, AfterCon
 #define REDISGEARS_MODULE_INIT_FUNCTION(ctx, name) \
         RedisGears_ ## name = RedisModule_GetSharedAPI(ctx, "RedisGears_" #name);\
         if(!RedisGears_ ## name){\
-            RedisModule_Log(ctx, "warning", "could not initialize RedisGears_" #name);\
+            RedisModule_Log(ctx, "warning", "could not initialize RedisGears_" #name "\r\n");\
             return REDISMODULE_ERR; \
         }
 
 #define REDISMODULE_MODULE_INIT_FUNCTION(ctx, name) \
         if(RedisModule_GetApi("RedisModule_" #name, &RedisModule_ ## name) != REDISMODULE_OK){ \
-            RedisModule_Log(ctx, "warning", "could not initialize RedisModule_" #name);\
+            RedisModule_Log(ctx, "warning", "could not initialize RedisModule_" #name "\r\n");\
         }
 
 static int RedisGears_InitializeRedisModuleApi(RedisModuleCtx* ctx){

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -662,13 +662,11 @@ int SeriesCreateRulesFromGlobalConfig(RedisModuleCtx *ctx,
         rules_options &= ~SERIES_OPT_DEFAULT_COMPRESSION;
         rules_options &= SERIES_OPT_UNCOMPRESSED;
 
-        TSGlobalConfig.options &= SERIES_OPT_DEFAULT_COMPRESSION;
         CreateCtx cCtx = {
             .retentionTime = rule->retentionSizeMillisec,
             .chunkSizeBytes = TSGlobalConfig.chunkSizeBytes,
             .labelsCount = compactedRuleLabelCount,
             .labels = compactedLabels,
-            .options = TSGlobalConfig.options & SERIES_OPT_UNCOMPRESSED,
             .options = rules_options,
         };
         CreateTsKey(ctx, destKey, &cCtx, &compactedSeries, &compactedKey);

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -97,6 +97,7 @@ Series *NewSeries(RedisModuleString *keyName, CreateCtx *cCtx) {
         newSeries->options |= SERIES_OPT_UNCOMPRESSED;
         newSeries->funcs = GetChunkClass(CHUNK_REGULAR);
     } else {
+        newSeries->options |= SERIES_OPT_COMPRESSED_GORILLA;
         newSeries->funcs = GetChunkClass(CHUNK_COMPRESSED);
     }
 
@@ -657,12 +658,18 @@ int SeriesCreateRulesFromGlobalConfig(RedisModuleCtx *ctx,
         compactedLabels[labelsCount + 1].value =
             RedisModule_CreateStringPrintf(NULL, "%ld", rule->timeBucket);
 
+        int rules_options = TSGlobalConfig.options;
+        rules_options &= ~SERIES_OPT_DEFAULT_COMPRESSION;
+        rules_options &= SERIES_OPT_UNCOMPRESSED;
+
+        TSGlobalConfig.options &= SERIES_OPT_DEFAULT_COMPRESSION;
         CreateCtx cCtx = {
             .retentionTime = rule->retentionSizeMillisec,
             .chunkSizeBytes = TSGlobalConfig.chunkSizeBytes,
             .labelsCount = compactedRuleLabelCount,
             .labels = compactedLabels,
             .options = TSGlobalConfig.options & SERIES_OPT_UNCOMPRESSED,
+            .options = rules_options,
         };
         CreateTsKey(ctx, destKey, &cCtx, &compactedSeries, &compactedKey);
         RedisModule_CloseKey(compactedKey);

--- a/src/tsdb.h
+++ b/src/tsdb.h
@@ -95,6 +95,7 @@ size_t SeriesGetNumSamples(const Series *series);
 
 char *SeriesGetCStringLabelValue(const Series *series, const char *labelKey);
 int SeriesDelRange(Series *series, timestamp_t start_ts, timestamp_t end_ts);
+const char *SeriesChunkTypeToString(const Series *series);
 
 int SeriesCalcRange(Series *series,
                     timestamp_t start_ts,

--- a/tests/flow/test_globalconfigs.py
+++ b/tests/flow/test_globalconfigs.py
@@ -136,6 +136,17 @@ class testGlobalConfigTests():
 
 def test_negative_configuration():
     Env().skipOnCluster()
+    with pytest.raises(Exception) as excinfo:
+        env = Env(moduleArgs='CHUNK_SIZE_BYTES 100; DUPLICATE_POLICY abc')
+
+    with pytest.raises(Exception) as excinfo:
+        env = Env(moduleArgs='CHUNK_SIZE_BYTES 100; DUPLICATE_POLICY')
+
+    with pytest.raises(Exception) as excinfo:
+        env = Env(moduleArgs='CHUNK_SIZE_BYTES 100; CHUNK_TYPE')
+
+    with pytest.raises(Exception) as excinfo:
+        env = Env(moduleArgs='CHUNK_SIZE_BYTES 100; ENCODING')
 
     with pytest.raises(Exception) as excinfo:
         env = Env(moduleArgs='ENCODING; CHUNK_SIZE_BYTES 100')

--- a/tests/flow/test_ts_add.py
+++ b/tests/flow/test_ts_add.py
@@ -119,3 +119,11 @@ def test_gorilla():
                            [100002, b'1'], [100004, b'1'], [1000000, b'1'], [1000001, b'1'],
                            [10000011000001, b'1'], [10000011000002, b'1']]
         assert expected_result == r.execute_command('TS.range', 'monkey', 0, -1)
+
+
+def test_ts_add_negative():
+    with Env().getClusterConnectionIfNeeded() as r:
+        with pytest.raises(redis.ResponseError) as excinfo:
+            r.execute_command('TS.CREATE', 'tester', 'ENCODING')
+        with pytest.raises(redis.ResponseError) as excinfo:
+            r.execute_command('TS.CREATE', 'tester', 'ENCODING', 'bad-encoding')

--- a/tests/flow/test_ts_create.py
+++ b/tests/flow/test_ts_create.py
@@ -14,6 +14,10 @@ def test_create_params():
             assert r.execute_command('TS.CREATE', 'invalid', 'RETENTION', 'retention')
         with pytest.raises(redis.ResponseError) as excinfo:
             assert r.execute_command('TS.CREATE', 'invalid', 'CHUNK_SIZE', 'chunk_size')
+        with pytest.raises(redis.ResponseError) as excinfo:
+            assert r.execute_command('TS.CREATE', 'invalid', 'ENCODING')
+        with pytest.raises(redis.ResponseError) as excinfo:
+            assert r.execute_command('TS.CREATE', 'invalid', 'ENCODING', 'bad-encoding-type')
 
         r.execute_command('TS.CREATE', 'a')
         with pytest.raises(redis.ResponseError) as excinfo:

--- a/tests/flow/test_ts_create.py
+++ b/tests/flow/test_ts_create.py
@@ -4,7 +4,7 @@ import time
 import pytest
 import redis
 from RLTest import Env
-from test_helper_classes import SAMPLE_SIZE, _get_ts_info
+from test_helper_classes import SAMPLE_SIZE, _get_ts_info, TSInfo
 
 
 def test_create_params():
@@ -159,3 +159,14 @@ def test_expire():
         assert r.execute_command('expire', 'test', 1) == 1
         time.sleep(2)
         assert r.execute_command('keys', '*') == []
+
+def test_ts_create_encoding():
+    for ENCODING in ['compressed','uncompressed']:
+        e = Env()
+        e.flush()
+        with e.getClusterConnectionIfNeeded() as r:
+            r.execute_command('ts.create', 't1', 'ENCODING', ENCODING)
+            e.assertEqual(TSInfo(r.execute_command('TS.INFO', 't1')).chunk_type, ENCODING.encode())
+            # backwards compatible check
+            r.execute_command('ts.create', 't1_bc', ENCODING)
+            e.assertEqual(TSInfo(r.execute_command('TS.INFO', 't1_bc')).chunk_type, ENCODING.encode())


### PR DESCRIPTION
As discussed, this is a backwards compatible change. The usage of `CHUNK_TYPE` global configs warns the user that he is using a deprecated setting and should move towards using `ENCODING`.
Before this PR we assumed that not having the uncompressed option on a serie implied a compressed one ( this is true for now with 2 serie encodings but in the future it would make our like harder ). This is now also fixed. 
