### PR TITLE
Made TS.ADD BLOCK upsert error more clear towards DUPLICATE_POLICY usage

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -417,7 +417,8 @@ static int internalAdd(RedisModuleCtx *ctx,
     if (timestamp <= series->lastTimestamp && series->totalSamples != 0) {
         if (SeriesUpsertSample(series, timestamp, value, dp_override) != REDISMODULE_OK) {
             RTS_ReplyGeneralError(ctx,
-                                  "TSDB: Error at upsert, update is not supported in BLOCK mode");
+                                  "TSDB: Error at upsert, update is not supported when "
+                                  "DUPLICATE_POLICY in set to BLOCK mode");
             return REDISMODULE_ERR;
         }
     } else {


### PR DESCRIPTION
As raised on https://gitter.im/RedisLabs/RedisTimeSeries we see that the TS.ADD error message is not clear with regards to the  DUPLICATE_POLICY usage. This PR makes the error message more clear with regards to it.