### PR TITLE
Introduce `ts_range_90k_datapoints` benchmark

### DIFF
--- a/tests/benchmarks/ts_range_90k_datapoints.yml
+++ b/tests/benchmarks/ts_range_90k_datapoints.yml
@@ -1,0 +1,31 @@
+version: 0.2
+name: "ts_range_90k_datapoints"
+description: "TS.RANGE ts - + || Replying the entire contents of a serie with 90K datapoints"
+remote:
+ - type: oss-standalone
+ - setup: redistimeseries-m5
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/1_serie_90k_datapoints.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 10000
+    - threads: 2
+    - pipeline: 1
+    - command: 'TS.RANGE ts - +'
+exporter:
+  redistimeseries:
+    break_by:
+      - version
+      - commit
+    timemetric: "$.StartTime"
+    metrics:
+      - "$.Tests.Overall.rps"
+      - "$.Tests.Overall.avg_latency_ms"
+      - "$.Tests.Overall.p50_latency_ms"
+      - "$.Tests.Overall.p95_latency_ms"
+      - "$.Tests.Overall.p99_latency_ms"
+      - "$.Tests.Overall.max_latency_ms"
+      - "$.Tests.Overall.min_latency_ms"


### PR DESCRIPTION
Introduce `ts_range_90k_datapoints` benchmark: a TS.RANGE large range benchmark (90K datapoints)

To benchmark this use case (assuming a Linux machine is being used ):
```
make benchmark PROFILE=1 BENCHMARK=ts_range_90k_datapoints.yml
```