### PR TITLE
reply with double instead of string

### DIFF
--- a/src/reply.c
+++ b/src/reply.c
@@ -103,10 +103,7 @@ void ReplyWithSeriesLabels(RedisModuleCtx *ctx, const Series *series) {
 void ReplyWithSample(RedisModuleCtx *ctx, u_int64_t timestamp, double value) {
     RedisModule_ReplyWithArray(ctx, 2);
     RedisModule_ReplyWithLongLong(ctx, timestamp);
-    char buf[MAX_VAL_LEN + 1];
-    int str_len = fpconv_dtoa(value, buf);
-    buf[str_len] = '\0';
-    RedisModule_ReplyWithSimpleString(ctx, buf);
+    RedisModule_ReplyWithStringBuffer(ctx, (char*)&value, sizeof(double));
 }
 
 void ReplyWithSeriesLastDatapoint(RedisModuleCtx *ctx, const Series *series) {


### PR DESCRIPTION
Just running perf to see how much time we save by using binary format.