### PR TITLE
system setup fix 4

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -107,7 +107,7 @@ SO_LD_FLAGS += -shared -Bsymbolic $(LD_FLAGS)
 endif
 
 ifeq ($(OS),macos)
-LD_LIBS += -L/usr/local/Cellar/openssl@3/3.0.0_1/lib/ -lssl -lcrypto
+LD_LIBS += -L/usr/local/opt/openssl/lib/ -lssl -lcrypto
 SO_LD_FLAGS += -bundle -undefined dynamic_lookup $(LD_FLAGS)
 endif
 

--- a/system-setup.py
+++ b/system-setup.py
@@ -22,39 +22,24 @@ class RedisTimeSeriesSetup(paella.Setup):
         self.install("git jq curl")
         self.run("%s/bin/enable-utf8" % READIES)
 
-        self.install("autoconf libtool")
-
-        if self.os == 'linux':
-            if self.dist == 'fedora':  # also include centos 8
-                self.install("openssl-devel")
-            elif self.platform.is_debian_compat():
-                self.install("libssl-dev")
-            elif self.platform.is_redhat_compat():
-                self.install("openssl-devel")
-            elif self.dist == 'suse':
-                self.install("openssl")
-            elif self.dist == 'arch':
-                self.install("openssl")
-            elif self.dist == 'alpine':
-                self.install("openssl")
-        elif self.os == 'macos':
-            self.install("openssl")
-        elif self.os == 'freebsd':
-            self.install("openssl")
+        self.install("autoconf libtool m4 automake")
+        self.install("openssl")
 
     def debian_compat(self):
         self.run("%s/bin/getgcc --modern" % READIES)
+        self.install("libssl-dev")
 
     def redhat_compat(self):
         self.install("redhat-lsb-core")
         self.run("%s/bin/getepel" % READIES)
+        self.install("openssl-devel")
         self.run("%s/bin/getgcc --modern" % READIES)
 
     def arch_compat(self):
         self.install("lcov-git", aur=True)
 
     def fedora(self):
-        self.install(openssl-devel)
+        self.install("openssl-devel")
         self.run("%s/bin/getgcc" % READIES)
         self.install("python3-networkx")
 

--- a/system-setup.py
+++ b/system-setup.py
@@ -38,7 +38,7 @@ class RedisTimeSeriesSetup(paella.Setup):
             elif self.dist == 'alpine':
                 self.install("openssl")
         elif self.os == 'macos':
-            self.install("openssl@3.0.0_1")
+            self.install("openssl")
         elif self.os == 'freebsd':
             self.install("openssl")
 


### PR DESCRIPTION
on mac libssl is keg only, so needs to link to /usr/local/opt/openssl/lib/libssl.a which is a link to the cellar one.