### PR TITLE
ck debianfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ARG REDIS_VER
 ADD ./ /build
 WORKDIR /build
 
+RUN apt-get --allow-releaseinfo-change update
 RUN ./deps/readies/bin/getpy3
 RUN ./system-setup.py
 RUN make fetch


### PR DESCRIPTION
Debian repo location update. This is due to their deprecating older repos.

Note: This cannot, and should not merge into master. It's a byproduct of the base docker, and is unused in master today.