### PR TITLE
Overall local benchmark runner improvements. Included 5 shards topology on CI runs.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -120,9 +120,6 @@ ifeq ($(DEBUG),1)
 CC_FLAGS += -g -ggdb -O0 -DDEBUG
 CXXFLAGS += -g -ggdb -O0 -DDEBUG
 LD_FLAGS += -g
-else ifeq ($(PROFILE),1)
-CC_FLAGS += -O2
-CXXFLAGS += -O2
 else
 CC_FLAGS += -O3
 CXXFLAGS += -O3

--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -1,1 +1,1 @@
-redisbench_admin>=0.1.78
+redisbench_admin>=0.5.11

--- a/tests/benchmarks/tsbs-scale100-cpu-max-all-1.yml
+++ b/tests/benchmarks/tsbs-scale100-cpu-max-all-1.yml
@@ -18,4 +18,4 @@ clientconfig:
   - tool: tsbs_run_queries_redistimeseries
   - parameters:
     - workers: 64
-    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_cpu-max-all-1_10000.dat"
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_cpu-max-all-1_1000000_123_2016-01-01T00:00:00Z_2016-01-04T00:00:00Z.dat"

--- a/tests/benchmarks/tsbs-scale100-cpu-max-all-1@4139rps.yml
+++ b/tests/benchmarks/tsbs-scale100-cpu-max-all-1@4139rps.yml
@@ -11,6 +11,7 @@ remote:
   - setup: redistimeseries-m5
 
 setups:
+  - oss-cluster-05-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 
@@ -28,7 +29,8 @@ clientconfig:
   - parameters:
     - workers: 32
     - max-rps: 4139
-    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_cpu-max-all-1_10000.dat"
+    - print-interval: 2500
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_cpu-max-all-1_1000000_123_2016-01-01T00:00:00Z_2016-01-04T00:00:00Z.dat"
 
 exporter:
   redistimeseries:

--- a/tests/benchmarks/tsbs-scale100-cpu-max-all-8@588rps.yml
+++ b/tests/benchmarks/tsbs-scale100-cpu-max-all-8@588rps.yml
@@ -10,6 +10,7 @@ remote:
   - setup: redistimeseries-m5
 
 setups:
+  - oss-cluster-05-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 
@@ -27,6 +28,7 @@ clientconfig:
   - parameters:
     - workers: 32
     - max-rps: 588
+    - print-interval: 2500
     - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_cpu-max-all-8_10000.dat"
 
 exporter:

--- a/tests/benchmarks/tsbs-scale100-double-groupby-1@324rps.yml
+++ b/tests/benchmarks/tsbs-scale100-double-groupby-1@324rps.yml
@@ -10,6 +10,7 @@ remote:
   - setup: redistimeseries-m5
 
 setups:
+  - oss-cluster-05-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 
@@ -27,6 +28,7 @@ clientconfig:
   - parameters:
     - workers: 32
     - max-rps: 324
+    - print-interval: 2500
     - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_double-groupby-1_10000.dat"
 
 exporter:

--- a/tests/benchmarks/tsbs-scale100-double-groupby-5@70rps.yml
+++ b/tests/benchmarks/tsbs-scale100-double-groupby-5@70rps.yml
@@ -10,6 +10,7 @@ remote:
   - setup: redistimeseries-m5
 
 setups:
+  - oss-cluster-05-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 
@@ -27,6 +28,7 @@ clientconfig:
   - parameters:
     - workers: 32
     - max-rps: 70
+    - print-interval: 2500
     - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_double-groupby-5_10000.dat"
 
 exporter:

--- a/tests/benchmarks/tsbs-scale100-double-groupby-all@35rps.yml
+++ b/tests/benchmarks/tsbs-scale100-double-groupby-all@35rps.yml
@@ -10,6 +10,7 @@ remote:
   - setup: redistimeseries-m5
 
 setups:
+  - oss-cluster-05-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 
@@ -28,6 +29,7 @@ clientconfig:
     - workers: 32
     - max-rps: 35
     - max-queries: 5000
+    - print-interval: 2500
     - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_double-groupby-all_10000.dat"
 
 exporter:

--- a/tests/benchmarks/tsbs-scale100-groupby-orderby-limit@28rps.yml
+++ b/tests/benchmarks/tsbs-scale100-groupby-orderby-limit@28rps.yml
@@ -10,6 +10,7 @@ remote:
   - setup: redistimeseries-m5
 
 setups:
+  - oss-cluster-05-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 
@@ -28,6 +29,7 @@ clientconfig:
     - workers: 32
     - max-rps: 28
     - max-queries: 2500
+    - print-interval: 1000
     - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_groupby-orderby-limit_10000.dat"
 
 exporter:

--- a/tests/benchmarks/tsbs-scale100-high-cpu-1@1816rps.yml
+++ b/tests/benchmarks/tsbs-scale100-high-cpu-1@1816rps.yml
@@ -10,6 +10,7 @@ remote:
   - setup: redistimeseries-m5
 
 setups:
+  - oss-cluster-05-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 
@@ -27,6 +28,7 @@ clientconfig:
   - parameters:
     - workers: 32
     - max-rps: 1816
+    - print-interval: 2500
     - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_high-cpu-1_10000.dat"
 
 exporter:

--- a/tests/benchmarks/tsbs-scale100-high-cpu-all@18rps.yml
+++ b/tests/benchmarks/tsbs-scale100-high-cpu-all@18rps.yml
@@ -10,6 +10,7 @@ remote:
   - setup: redistimeseries-m5
 
 setups:
+  - oss-cluster-05-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 
@@ -28,6 +29,7 @@ clientconfig:
     - workers: 32
     - max-rps: 18
     - max-queries: 2000
+    - print-interval: 1000
     - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_high-cpu-all_10000.dat"
 
 exporter:

--- a/tests/benchmarks/tsbs-scale100-lastpoint@488rps.yml
+++ b/tests/benchmarks/tsbs-scale100-lastpoint@488rps.yml
@@ -10,6 +10,7 @@ remote:
   - setup: redistimeseries-m5
 
 setups:
+  - oss-cluster-05-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 
@@ -27,6 +28,7 @@ clientconfig:
   - parameters:
     - workers: 32
     - max-rps: 488
+    - print-interval: 2500
     - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_lastpoint_10000.dat"
 
 exporter:

--- a/tests/benchmarks/tsbs-scale100-single-groupby-1-1-12@2320rps.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-1-1-12@2320rps.yml
@@ -10,6 +10,7 @@ remote:
   - setup: redistimeseries-m5
 
 setups:
+  - oss-cluster-05-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 
@@ -27,6 +28,7 @@ clientconfig:
   - parameters:
     - workers: 32
     - max-rps: 2320
+    - print-interval: 2500
     - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_single-groupby-1-1-12_10000.dat"
 
 exporter:

--- a/tests/benchmarks/tsbs-scale100-single-groupby-1-1-1@2320rps.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-1-1-1@2320rps.yml
@@ -10,6 +10,7 @@ remote:
   - setup: redistimeseries-m5
 
 setups:
+  - oss-cluster-05-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 
@@ -27,6 +28,7 @@ clientconfig:
   - parameters:
     - workers: 32
     - max-rps: 2320
+    - print-interval: 2500
     - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_single-groupby-1-1-1_10000.dat"
 
 exporter:

--- a/tests/benchmarks/tsbs-scale100-single-groupby-1-8-1@4458rps.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-1-8-1@4458rps.yml
@@ -10,6 +10,7 @@ remote:
   - setup: redistimeseries-m5
 
 setups:
+  - oss-cluster-05-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 
@@ -27,6 +28,7 @@ clientconfig:
   - parameters:
     - workers: 32
     - max-rps: 4458
+    - print-interval: 2500
     - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_single-groupby-1-8-1_10000.dat"
 
 exporter:

--- a/tests/benchmarks/tsbs-scale100-single-groupby-5-1-12@648rps.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-5-1-12@648rps.yml
@@ -10,6 +10,7 @@ remote:
   - setup: redistimeseries-m5
 
 setups:
+  - oss-cluster-05-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 
@@ -25,6 +26,7 @@ clientconfig:
   - parameters:
     - workers: 32
     - max-rps: 648
+    - print-interval: 2500
     - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_single-groupby-5-1-12_10000.dat"
 
 exporter:

--- a/tests/benchmarks/tsbs-scale100-single-groupby-5-1-1@648rps.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-5-1-1@648rps.yml
@@ -10,6 +10,7 @@ remote:
   - setup: redistimeseries-m5
 
 setups:
+  - oss-cluster-05-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 
@@ -25,6 +26,7 @@ clientconfig:
   - parameters:
     - workers: 32
     - max-rps: 648
+    - print-interval: 2500
     - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_single-groupby-5-1-1_10000.dat"
 
 exporter:

--- a/tests/benchmarks/tsbs-scale100-single-groupby-5-8-1@1158rps.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-5-8-1@1158rps.yml
@@ -10,6 +10,7 @@ remote:
   - setup: redistimeseries-m5
 
 setups:
+  - oss-cluster-05-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 
@@ -25,6 +26,7 @@ clientconfig:
   - parameters:
     - workers: 32
     - max-rps: 1158
+    - print-interval: 2500
     - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_single-groupby-5-8-1_10000.dat"
 
 exporter:


### PR DESCRIPTION
The following PR improves the overall local benchmark run experience. 
You can control the topology of the benchmark (oss-cluster,oss-standalone) and setup ( shard control ) to filter out some large benchmarks that are not suitable for dev machines.

Example of running cluster of 5 shards locally:
```
make benchmark ENV=oss-cluster BENCHMARK=tsbs-scale100-single-groupby-5-8-1@1158rps.yml SETUP=oss-cluster-05-primaries
```

Apart from it, it also enables the 5 shards variation for CI cluster benchmarks. 