### PR TITLE
PERF double-groupby-5: fast checking the control bits on iterator for the cases in which the delta is 0

### DIFF
--- a/src/gorilla.c
+++ b/src/gorilla.c
@@ -414,11 +414,7 @@ ChunkResult Compressed_Append(CompressedChunk *chunk, timestamp_t timestamp, dou
  * using `prevTS` and `prevDelta`.
  */
 static inline u_int64_t readInteger(Compressed_Iterator *iter, const uint64_t *bins) {
-    // control bit ‘0’
-    // Read stored double delta value
     if (Bins_bitoff(bins, iter->idx++)) {
-        return iter->prevTS += iter->prevDelta;
-    } else if (Bins_bitoff(bins, iter->idx++)) {
         iter->prevDelta += bin2int(readBits(bins, iter->idx, CMPR_L1), CMPR_L1);
         iter->idx += CMPR_L1;
     } else if (Bins_bitoff(bins, iter->idx++)) {
@@ -437,7 +433,7 @@ static inline u_int64_t readInteger(Compressed_Iterator *iter, const uint64_t *b
         iter->prevDelta += readBits(bins, iter->idx, 64);
         iter->idx += 64;
     }
-    return iter->prevTS += iter->prevDelta;
+    return iter->prevDelta;
 }
 
 /*
@@ -451,11 +447,6 @@ static inline u_int64_t readInteger(Compressed_Iterator *iter, const uint64_t *b
  * Finally, the compressed representation of the value is decoded.
  */
 static inline double readFloat(Compressed_Iterator *iter, const uint64_t *data) {
-    // Check if value was changed
-    // control bit ‘0’ (case a)
-    if (Bins_bitoff(data, iter->idx++)) {
-        return iter->prevValue.d;
-    }
     binary_t xorValue;
 
     // Check if we can use the previous block info
@@ -503,10 +494,19 @@ ChunkResult Compressed_ChunkIteratorGetNext(ChunkIter_t *abstractIter, Sample *s
     if (unlikely(iter->count == 0)) {
         sample->timestamp = iter->chunk->baseTimestamp;
         sample->value = iter->chunk->baseValue.d;
-    } else {
-        sample->timestamp = readInteger(iter, iter->chunk->data);
-        sample->value = readFloat(iter, iter->chunk->data);
+        iter->count++;
+        return CR_OK;
     }
+    const u_int64_t *bins = iter->chunk->data;
+    // We're fast checking the control bits for the cases in which the delta is 0
+    // This avoids the call to expensive readInteger and readFloat functions
+    //
+    // control bit ‘0’
+    // Read stored double delta value
+    sample->timestamp += Bins_bitoff(bins, iter->idx++) ? iter->prevDelta : readInteger(iter, bins);
+    // Check if value was changed
+    // control bit ‘0’ (case a)
+    sample->value = Bins_bitoff(bins, iter->idx++) ? iter->prevValue.d : readFloat(iter, bins);
     iter->count++;
     return CR_OK;
 }


### PR DESCRIPTION
Fast checking the control bits for the cases in which the delta is 0
This avoids the call to expensive `readInteger` and `readFloat` functions

master results on oss-standalone:
```
2021-12-01 10:30:16,184 INFO Benchmark duration 35 secs.
2021-12-01 10:30:16,184 WARNING Benchmark duration of 35 secs is bellow the considered minimum duration for a stable run (60 secs).
2021-12-01 10:30:16,184 INFO Extracting the benchmark results
2021-12-01 10:30:16,184 INFO stdout: None
2021-12-01 10:30:16,184 INFO stderr: None
# Results for tsbs-scale100_double-groupby-5 test-case on oss-standalone topology
|            Metric JSON Path            |Metric Value|
|----------------------------------------|-----------:|
|Totals.overallQuantiles.all_queries.q0  |       0.000|
|Totals.overallQuantiles.all_queries.q50 |    2296.447|
|Totals.overallQuantiles.all_queries.q95 |    2916.735|
|Totals.overallQuantiles.all_queries.q99 |    3180.031|
|Totals.overallQuantiles.all_queries.q100|    4415.231|
|Totals.overallQueryRates.all_queries    |      28.306|
```

branch results:
```
2021-12-01 14:14:49,897 INFO Benchmark duration 31 secs.
2021-12-01 14:14:49,898 WARNING Benchmark duration of 31 secs is bellow the considered minimum duration for a stable run (60 secs).
2021-12-01 14:14:49,898 INFO Extracting the benchmark results
2021-12-01 14:14:49,898 INFO stdout: None
2021-12-01 14:14:49,898 INFO stderr: None
# Results for tsbs-scale100_double-groupby-5 test-case on oss-standalone topology
|            Metric JSON Path            |Metric Value|
|----------------------------------------|-----------:|
|Totals.overallQuantiles.all_queries.q0  |       0.000|
|Totals.overallQuantiles.all_queries.q50 |    2045.887|
|Totals.overallQuantiles.all_queries.q95 |    2646.143|
|Totals.overallQuantiles.all_queries.q99 |    2948.351|
|Totals.overallQuantiles.all_queries.q100|    4040.447|
|Totals.overallQueryRates.all_queries    |      31.644|
2021-12-01 14:14:49,942 INFO Tearing down setup oss-standalone
2021-12-01 14:14:49,945 INFO Tear-down completed
```