### PR TITLE
skip on key space notification tests on redis older than 6.2 since it…

### DIFF
--- a/tests/flow/test_ts_keyspace.py
+++ b/tests/flow/test_ts_keyspace.py
@@ -15,6 +15,7 @@ def assert_msg(env, msg, expected_type, expected_data):
 
 def test_keyspace():
     Env().skipOnCluster()
+    Env().skipOnVersionSmaller("6.2.0")
     skip_on_rlec()
     sample_len = 1024
     env = Env()
@@ -60,6 +61,7 @@ def test_keyspace():
 
 def test_keyspace_create_rules():
     Env().skipOnCluster()
+    Env().skipOnVersionSmaller("6.2.0")
     skip_on_rlec()
     sample_len = 1024
     env = Env()
@@ -97,6 +99,7 @@ def test_keyspace_create_rules():
 
 def test_keyspace_rules_send():
     Env().skipOnCluster()
+    Env().skipOnVersionSmaller("6.2.0")
     skip_on_rlec()
     sample_len = 1024
     env = Env()


### PR DESCRIPTION
…'s not fully supported