### PR TITLE
Optimize chunk decompress by loop unrolling Compressed_ChunkIteratorGetNext

### DIFF
--- a/src/compressed_chunk.c
+++ b/src/compressed_chunk.c
@@ -228,7 +228,7 @@ static Chunk *decompressChunk(const CompressedChunk *compressedChunk) {
 
     // 4 samples per iteration
     uint64_t i = 0;
-    uint64_t n = numSamples / 4;
+    const uint64_t n = numSamples / 4;
     for (; i < n; i += 4) {
         Compressed_ChunkIteratorGetNext(iter, samples + i);
         Compressed_ChunkIteratorGetNext(iter, samples + i + 1);

--- a/src/compressed_chunk.c
+++ b/src/compressed_chunk.c
@@ -218,7 +218,7 @@ size_t Compressed_DelRange(Chunk_t *chunk, timestamp_t startTs, timestamp_t endT
 
 // decompress chunk
 static Chunk *decompressChunk(const CompressedChunk *compressedChunk) {
-	assert(compressedChunk != NULL);
+    assert(compressedChunk != NULL);
 
     uint64_t numSamples = compressedChunk->count;
     Chunk *uncompressedChunk = Uncompressed_NewChunk(numSamples * SAMPLE_SIZE);
@@ -226,23 +226,23 @@ static Chunk *decompressChunk(const CompressedChunk *compressedChunk) {
 
     ChunkIter_t *iter = Compressed_NewChunkIterator(compressedChunk, CHUNK_ITER_OP_NONE, NULL);
 
-	// 4 samples per iteration
-	uint64_t i = 0;
-	uint64_t n = numSamples / 4;
+    // 4 samples per iteration
+    uint64_t i = 0;
+    uint64_t n = numSamples / 4;
     for (; i < n; i += 4) {
         Compressed_ChunkIteratorGetNext(iter, samples + i);
         Compressed_ChunkIteratorGetNext(iter, samples + i + 1);
         Compressed_ChunkIteratorGetNext(iter, samples + i + 2);
         Compressed_ChunkIteratorGetNext(iter, samples + i + 3);
-	}
+    }
 
-	// left-overs
+    // left-overs
     for (; i < numSamples; i++) {
-		Compressed_ChunkIteratorGetNext(iter, samples + i);
-	}
+        Compressed_ChunkIteratorGetNext(iter, samples + i);
+    }
 
     uncompressedChunk->num_samples = numSamples;
-	uncompressedChunk->base_timestamp = uncompressedChunk->samples[0].timestamp;
+    uncompressedChunk->base_timestamp = uncompressedChunk->samples[0].timestamp;
 
     Compressed_FreeChunkIterator(iter);
 

--- a/src/compressed_chunk.c
+++ b/src/compressed_chunk.c
@@ -217,57 +217,37 @@ size_t Compressed_DelRange(Chunk_t *chunk, timestamp_t startTs, timestamp_t endT
 }
 
 // decompress chunk
-static Chunk *decompressChunk
-(
-	const CompressedChunk *compressedChunk // chunk to decompress
-) {
-	// TODO: validate chuck in compressed
-	assert (compressedChunk != NULL) ;
+static Chunk *decompressChunk(const CompressedChunk *compressedChunk) {
+	assert(compressedChunk != NULL);
 
-    uint64_t numSamples = compressedChunk->count ;
-    Chunk *uncompressedChunk = Uncompressed_NewChunk(numSamples * SAMPLE_SIZE) ;
-    Sample *samples = uncompressedChunk->samples ;
+    uint64_t numSamples = compressedChunk->count;
+    Chunk *uncompressedChunk = Uncompressed_NewChunk(numSamples * SAMPLE_SIZE);
+    Sample *samples = uncompressedChunk->samples;
 
-    ChunkIter_t *iter = Compressed_NewChunkIterator (compressedChunk, CHUNK_ITER_OP_NONE, NULL) ;
+    ChunkIter_t *iter = Compressed_NewChunkIterator(compressedChunk, CHUNK_ITER_OP_NONE, NULL);
 
-	// loop unrolling, 4 samples per iteration
-	uint64_t i = 0 ;
-	uint64_t n = numSamples / 4 ;
-    for (; i < n ; i+=4)
-	{
-        Compressed_ChunkIteratorGetNext (iter, samples+i) ;
-        Compressed_ChunkIteratorGetNext (iter, samples+i+1) ;
-        Compressed_ChunkIteratorGetNext (iter, samples+i+2) ;
-        Compressed_ChunkIteratorGetNext (iter, samples+i+3) ;
-    }
-
-	// left-overs
-    for (; i < numSamples ; i++)
-	{
-		Compressed_ChunkIteratorGetNext (iter, samples+i) ;
+	// 4 samples per iteration
+	uint64_t i = 0;
+	uint64_t n = numSamples / 4;
+    for (; i < n; i += 4) {
+        Compressed_ChunkIteratorGetNext(iter, samples + i);
+        Compressed_ChunkIteratorGetNext(iter, samples + i + 1);
+        Compressed_ChunkIteratorGetNext(iter, samples + i + 2);
+        Compressed_ChunkIteratorGetNext(iter, samples + i + 3);
 	}
 
-    uncompressedChunk->num_samples = numSamples ;
-	uncompressedChunk->base_timestamp = uncompressedChunk->samples[0].timestamp ;
+	// left-overs
+    for (; i < numSamples; i++) {
+		Compressed_ChunkIteratorGetNext(iter, samples + i);
+	}
 
-    Compressed_FreeChunkIterator (iter) ;
+    uncompressedChunk->num_samples = numSamples;
+	uncompressedChunk->base_timestamp = uncompressedChunk->samples[0].timestamp;
 
-    return uncompressedChunk ;
+    Compressed_FreeChunkIterator(iter);
+
+    return uncompressedChunk;
 }
-
-//static Chunk *decompressChunk(CompressedChunk *compressedChunk) {
-//    Sample sample;
-//    uint64_t numSamples = compressedChunk->count;
-//    Chunk *uncompressedChunk = Uncompressed_NewChunk(numSamples * SAMPLE_SIZE);
-//
-//    ChunkIter_t *iter = Compressed_NewChunkIterator(compressedChunk, CHUNK_ITER_OP_NONE, NULL);
-//    for (uint64_t i = 0; i < numSamples; ++i) {
-//        Compressed_ChunkIteratorGetNext(iter, &sample);
-//        Uncompressed_AddSample(uncompressedChunk, &sample);
-//    }
-//    Compressed_FreeChunkIterator(iter);
-//    return uncompressedChunk;
-//}
 
 /************************
  *  Iterator functions  *


### PR DESCRIPTION
- Fixes #906 
- Improves the tsbs-scale100_groupby-orderby-limit query achievable ops/sec and p50 latency including RTT by approx. 15%