### PR TITLE
Enabled runtime precomputed mergeable aggregation per chunk: Max aggregation

### DIFF
--- a/src/abstract_iterator.h
+++ b/src/abstract_iterator.h
@@ -12,9 +12,14 @@
 typedef struct AbstractIterator
 {
     ChunkResult (*GetNext)(struct AbstractIterator *iter, Sample *currentSample);
+    bool (*GetNextBoundaryAggValue)(struct AbstractIterator *iter,
+                                    const timestamp_t timestampBoundaryStart,
+                                    const timestamp_t timestampBoundaryEnd,
+                                    int aggType,
+                                    Sample *sample);
     void (*Close)(struct AbstractIterator *iter);
 
     struct AbstractIterator *input;
 } AbstractIterator;
 
-#endif //ABSTRACT_ITERATOR_H
+#endif // ABSTRACT_ITERATOR_H

--- a/src/compressed_chunk.c
+++ b/src/compressed_chunk.c
@@ -33,6 +33,8 @@ Chunk_t *Compressed_NewChunk(size_t size) {
     chunk->prevLeading = 32;
     chunk->prevTrailing = 32;
     chunk->prevTimestamp = 0;
+    chunk->precomputedAggsIndex = 0;
+    chunk->count = 0;
     return chunk;
 }
 

--- a/src/filter_iterator.h
+++ b/src/filter_iterator.h
@@ -29,6 +29,7 @@ typedef struct AggregationIterator
 {
     AbstractIterator base;
     AggregationClass *aggregation;
+    int aggregationType;
     int64_t aggregationTimeDelta;
     timestamp_t timestampAlignment;
     void *aggregationContext;
@@ -40,6 +41,7 @@ typedef struct AggregationIterator
 } AggregationIterator;
 
 AggregationIterator *AggregationIterator_New(struct AbstractIterator *input,
+                                             int aggregationType,
                                              AggregationClass *aggregation,
                                              int64_t aggregationTimeDelta,
                                              timestamp_t timestampAlignment,

--- a/src/generic_chunk.c
+++ b/src/generic_chunk.c
@@ -34,6 +34,7 @@ ChunkIterFuncs uncompressedChunkIteratorClass = {
     .GetNext = Uncompressed_ChunkIteratorGetNext,
     .GetPrev = Uncompressed_ChunkIteratorGetPrev,
     .Reset = Uncompressed_ResetChunkIterator,
+    .GetNextBoundaryAggValue = NULL,
 };
 
 static ChunkFuncs comprChunk = {
@@ -64,6 +65,7 @@ static ChunkIterFuncs compressedChunkIteratorClass = {
     .GetNext = Compressed_ChunkIteratorGetNext,
     /*** Reverse iteration is on temporary decompressed chunk ***/
     .GetPrev = NULL,
+    .GetNextBoundaryAggValue = Compressed_ChunkIteratorGetNextBoundaryAggValue,
     .Reset = Compressed_ResetChunkIterator,
 };
 

--- a/src/generic_chunk.h
+++ b/src/generic_chunk.h
@@ -35,6 +35,9 @@ typedef void ChunkIter_t;
 // "temporary" uncompressed chunk.
 #define CHUNK_ITER_OP_FREE_CHUNK 1 << 2
 
+#define PRECOMPUTED_AGGS_LEN 1
+#define PRECOMPUTED_AGGS_POS_TS_AGG_MAX 0
+#define PRECOMPUTED_AGG_POS(r) PRECOMPUTED_AGGS_POS_##r
 typedef enum CHUNK_TYPES_T
 {
     CHUNK_REGULAR,
@@ -52,6 +55,10 @@ typedef struct ChunkIterFuncs
     void (*Free)(ChunkIter_t *iter);
     ChunkResult (*GetNext)(ChunkIter_t *iter, Sample *sample);
     ChunkResult (*GetPrev)(ChunkIter_t *iter, Sample *sample);
+    bool (*GetNextBoundaryAggValue)(ChunkIter_t *iter,
+                                    const timestamp_t boundaryStart,
+                                    const timestamp_t boundaryEnd,
+                                    Sample *sample);
     void (*Reset)(ChunkIter_t *iter, Chunk_t *chunk);
 } ChunkIterFuncs;
 

--- a/src/gorilla.h
+++ b/src/gorilla.h
@@ -42,6 +42,10 @@ typedef struct CompressedChunk
     union64bits prevValue;
     u_int8_t prevLeading;
     u_int8_t prevTrailing;
+
+    u_int64_t precomputedAggsIndex; /* if the node does not have precomputation ready, this is the
+                                       index pos. */
+    double precomputedAggs[PRECOMPUTED_AGGS_LEN];
 } CompressedChunk;
 
 typedef struct Compressed_Iterator
@@ -63,5 +67,10 @@ typedef struct Compressed_Iterator
 
 ChunkResult Compressed_Append(CompressedChunk *chunk, u_int64_t timestamp, double value);
 ChunkResult Compressed_ChunkIteratorGetNext(ChunkIter_t *iter, Sample *sample);
+bool Compressed_ChunkIteratorGetNextBoundaryAggValue(ChunkIter_t *abstractIter,
+                                                     const timestamp_t timestampBoundaryStart,
+                                                     const timestamp_t timestampBoundaryEnd,
+                                                     int aggType,
+                                                     Sample *sample);
 
 #endif

--- a/src/query_language.c
+++ b/src/query_language.c
@@ -249,11 +249,11 @@ int parseAggregationArgs(RedisModuleCtx *ctx,
                          RedisModuleString **argv,
                          int argc,
                          AggregationArgs *out) {
-    int agg_type;
     AggregationArgs aggregationArgs = { 0 };
-    int result = _parseAggregationArgs(ctx, argv, argc, &aggregationArgs.timeDelta, &agg_type);
+    int result = _parseAggregationArgs(
+        ctx, argv, argc, &aggregationArgs.timeDelta, &aggregationArgs.aggregationType);
     if (result == TSDB_OK) {
-        aggregationArgs.aggregationClass = GetAggClass(agg_type);
+        aggregationArgs.aggregationClass = GetAggClass(aggregationArgs.aggregationType);
         if (aggregationArgs.aggregationClass == NULL) {
             RTS_ReplyGeneralError(ctx, "TSDB: Failed to retrieve aggregation class");
             return TSDB_ERROR;

--- a/src/query_language.h
+++ b/src/query_language.h
@@ -20,6 +20,7 @@
 typedef struct AggregationArgs
 {
     api_timestamp_t timeDelta;
+    int aggregationType;
     AggregationClass *aggregationClass;
 } AggregationArgs;
 

--- a/src/series_iterator.c
+++ b/src/series_iterator.c
@@ -25,6 +25,7 @@ AbstractIterator *SeriesIterator_New(Series *series,
     SeriesIterator *iter = malloc(sizeof(SeriesIterator));
     iter->base.Close = SeriesIteratorClose;
     iter->base.GetNext = SeriesIteratorGetNext;
+    iter->base.GetNextBoundaryAggValue = SeriesIteratorGetNextBoundaryAggValue;
     iter->base.input = NULL;
     iter->currentChunk = NULL;
     iter->chunkIterator = NULL;
@@ -64,6 +65,18 @@ AbstractIterator *SeriesIterator_New(Series *series,
 // this is an internal function that routes the next call to the appropriate chunk iterator function
 static inline ChunkResult SeriesGetNext(SeriesIterator *iter, Sample *sample) {
     return iter->chunkIteratorFuncs.GetNext(iter->chunkIterator, sample);
+}
+
+// this is an internal function that routes the next call to the appropriate chunk iterator function
+bool SeriesIteratorGetNextBoundaryAggValue(AbstractIterator *abstractIterator,
+                                           const timestamp_t boundaryStart,
+                                           const timestamp_t boundaryEnd,
+                                           Sample *sample) {
+    SeriesIterator *iterator = (SeriesIterator *)abstractIterator;
+    if (!iterator->chunkIteratorFuncs.GetNextBoundaryAggValue)
+        return false;
+    return iterator->chunkIteratorFuncs.GetNextBoundaryAggValue(
+        iterator->chunkIterator, boundaryStart, boundaryEnd, sample);
 }
 
 // this is an internal function that routes the next call to the appropriate chunk iterator function

--- a/src/series_iterator.h
+++ b/src/series_iterator.h
@@ -33,4 +33,9 @@ ChunkResult SeriesIteratorGetNext(AbstractIterator *iterator, Sample *currentSam
 
 void SeriesIteratorClose(AbstractIterator *iterator);
 
+bool SeriesIteratorGetNextBoundaryAggValue(AbstractIterator *iterator,
+                                           const timestamp_t boundaryStart,
+                                           const timestamp_t boundaryEnd,
+                                           Sample *sample);
+
 #endif // REDIS_TIMESERIES_CLEAN_SERIES_ITERATOR_H

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -1084,6 +1084,7 @@ AbstractIterator *SeriesQuery(Series *series, const RangeArgs *args, bool revers
 
     if (args->aggregationArgs.aggregationClass != NULL) {
         chain = (AbstractIterator *)AggregationIterator_New(chain,
+                                                            args->aggregationArgs.aggregationType,
                                                             args->aggregationArgs.aggregationClass,
                                                             args->aggregationArgs.timeDelta,
                                                             timestampAlignment,

--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -30,6 +30,11 @@ def decode_if_needed(data):
         for item in data:
             ret.append(decode_if_needed(item))
         return ret
+    if isinstance(data, dict):
+        ret = {}
+        for k,v in data.items():
+            ret[decode_if_needed(k)] = decode_if_needed(v)
+        return ret
     elif isinstance(data, bytes):
         return data.decode()
     else:

--- a/tests/flow/test_globalconfigs.py
+++ b/tests/flow/test_globalconfigs.py
@@ -33,7 +33,7 @@ def test_encoding_uncompressed():
     with env.getConnection() as r:
         r.execute_command('FLUSHALL')
         r.execute_command('TS.ADD', 't1', '1', 1.0)
-        assert TSInfo(r.execute_command('TS.INFO', 't1_MAX_1000')).chunk_type == b'uncompressed'
+        assert TSInfo(r.execute_command('TS.INFO', 't1_MAX_1000')).chunk_type == 'uncompressed'
 
 
 def test_encoding_compressed():
@@ -43,7 +43,7 @@ def test_encoding_compressed():
     with env.getConnection() as r:
         r.execute_command('FLUSHALL')
         r.execute_command('TS.ADD', 't1', '1', 1.0)
-        assert TSInfo(r.execute_command('TS.INFO', 't1_MAX_1000')).chunk_type == b'compressed'
+        assert TSInfo(r.execute_command('TS.INFO', 't1_MAX_1000')).chunk_type == 'compressed'
 
 def test_uncompressed():
     Env().skipOnCluster()
@@ -52,7 +52,7 @@ def test_uncompressed():
     with env.getConnection() as r:
         r.execute_command('FLUSHALL')
         r.execute_command('TS.ADD', 't1', '1', 1.0)
-        assert TSInfo(r.execute_command('TS.INFO', 't1_MAX_1000')).chunk_type == b'uncompressed'
+        assert TSInfo(r.execute_command('TS.INFO', 't1_MAX_1000')).chunk_type == 'uncompressed'
 
 
 def test_compressed():
@@ -62,7 +62,7 @@ def test_compressed():
     with env.getConnection() as r:
         r.execute_command('FLUSHALL')
         r.execute_command('TS.ADD', 't1', '1', 1.0)
-        assert TSInfo(r.execute_command('TS.INFO', 't1_MAX_1000')).chunk_type == b'compressed'
+        assert TSInfo(r.execute_command('TS.INFO', 't1_MAX_1000')).chunk_type == 'compressed'
 
 def test_compressed_debug():
     Env().skipOnCluster()
@@ -75,7 +75,7 @@ def test_compressed_debug():
         r.execute_command('TS.ADD', 't1', '3000', 1.0)
         r.execute_command('TS.ADD', 't1', '5000', 1.0)
 
-        assert TSInfo(r.execute_command('TS.INFO', 't1_MAX_1000', 'DEBUG')).chunks == [[b'startTimestamp', 0, b'endTimestamp', 3000, b'samples', 2, b'size', 4096, b'bytesPerSample', b'2048']]
+        assert TSInfo(r.execute_command('TS.INFO', 't1_MAX_1000', 'DEBUG')).chunks == [['startTimestamp', 0, 'endTimestamp', 3000, 'samples', 2, 'size', 4096, 'bytesPerSample', '2048']]
 
 class testGlobalConfigTests():
 

--- a/tests/flow/test_helper_classes.py
+++ b/tests/flow/test_helper_classes.py
@@ -174,19 +174,20 @@ class TSInfo(object):
     chunks = None
 
     def __init__(self, args):
-        response = dict(zip(args[::2], args[1::2]))
-        if b'rules' in response: self.rules = response[b'rules']
-        if b'sourceKey' in response: self.sourceKey = response[b'sourceKey']
-        if b'chunkCount' in response: self.chunk_count = response[b'chunkCount']
-        if b'labels' in response: self.labels = list_to_dict(response[b'labels'])
-        if b'memoryUsage' in response: self.memory_usage = response[b'memoryUsage']
-        if b'totalSamples' in response: self.total_samples = response[b'totalSamples']
-        if b'retentionTime' in response: self.retention_msecs = response[b'retentionTime']
-        if b'lastTimestamp' in response: self.last_time_stamp = response[b'lastTimestamp']
-        if b'firstTimestamp' in response: self.first_time_stamp = response[b'firstTimestamp']
-        if b'chunkSize' in response: self.chunk_size_bytes = response[b'chunkSize']
-        if b'chunkType' in response: self.chunk_type = response[b'chunkType']
-        if b'Chunks' in response: self.chunks = response[b'Chunks']
+        response = dict(zip(decode_if_needed(args[::2]), args[1::2]))
+        response = decode_if_needed(response)
+        if 'rules' in response: self.rules = response['rules']
+        if 'sourceKey' in response: self.sourceKey = response['sourceKey']
+        if 'chunkCount' in response: self.chunk_count = response['chunkCount']
+        if 'labels' in response: self.labels = list_to_dict(response['labels'])
+        if 'memoryUsage' in response: self.memory_usage = response['memoryUsage']
+        if 'totalSamples' in response: self.total_samples = response['totalSamples']
+        if 'retentionTime' in response: self.retention_msecs = response['retentionTime']
+        if 'lastTimestamp' in response: self.last_time_stamp = response['lastTimestamp']
+        if 'firstTimestamp' in response: self.first_time_stamp = response['firstTimestamp']
+        if 'chunkSize' in response: self.chunk_size_bytes = response['chunkSize']
+        if 'chunkType' in response: self.chunk_type = response['chunkType']
+        if 'Chunks' in response: self.chunks = response['Chunks']
 
     def __eq__(self, other):
         if not isinstance(other, TSInfo):

--- a/tests/flow/test_lazy_del.py
+++ b/tests/flow/test_lazy_del.py
@@ -11,9 +11,9 @@ def test_lazy_del_src():
         r.execute_command("ts.create", 'dst{test}')
         r.execute_command("ts.createrule", 'src{test}', 'dst{test}', 'AGGREGATION', 'avg', 60000)
         
-        assert _get_ts_info(r, 'dst{test}').sourceKey.decode() == 'src{test}'
+        assert _get_ts_info(r, 'dst{test}').sourceKey == 'src{test}'
         assert len(_get_ts_info(r, 'src{test}').rules) == 1
-        assert _get_ts_info(r, 'src{test}').rules[0][0].decode() == 'dst{test}'
+        assert _get_ts_info(r, 'src{test}').rules[0][0] == 'dst{test}'
         r.execute_command('DEL', 'src{test}')
 
         assert _get_ts_info(r, 'dst{test}').sourceKey == None
@@ -25,9 +25,9 @@ def test_lazy_del_dst():
         r.execute_command("ts.create", 'dst{test}')
         r.execute_command('TS.CREATERULE', 'src{test}', 'dst{test}', 'AGGREGATION', 'avg', 60000)
         
-        assert _get_ts_info(r, 'dst{test}').sourceKey.decode() == 'src{test}'
+        assert _get_ts_info(r, 'dst{test}').sourceKey == 'src{test}'
         assert len(_get_ts_info(r, 'src{test}').rules) == 1
-        assert _get_ts_info(r, 'src{test}').rules[0][0].decode() == 'dst{test}'
+        assert _get_ts_info(r, 'src{test}').rules[0][0] == 'dst{test}'
         r.execute_command('DEL', 'dst{test}')
 
         assert _get_ts_info(r, 'src{test}').sourceKey == None
@@ -42,7 +42,7 @@ def test_dump_restore_dst_rule():
         r.execute_command('TS.CREATE', key2)
         r.execute_command('TS.CREATERULE', key1, key2, 'AGGREGATION', 'avg', 60000)
 
-        assert _get_ts_info(r, key2).sourceKey.decode() == key1
+        assert _get_ts_info(r, key2).sourceKey == key1
         assert len(_get_ts_info(r, key1).rules) == 1
 
         data = r.execute_command('DUMP', key2)

--- a/tests/flow/test_persistency.py
+++ b/tests/flow/test_persistency.py
@@ -141,7 +141,7 @@ def test_533_dump_rules():
         r.execute_command('TS.CREATE', key2)
         r.execute_command('TS.CREATERULE', key1, key2, 'AGGREGATION', 'avg', 60000)
 
-        assert _get_ts_info(r, key2).sourceKey.decode() == key1
+        assert _get_ts_info(r, key2).sourceKey == key1
         assert len(_get_ts_info(r, key1).rules) == 1
 
         data = r.execute_command('DUMP', key1)

--- a/tests/flow/test_rdbs.py
+++ b/tests/flow/test_rdbs.py
@@ -75,8 +75,8 @@ def testRDBCompatibility():
             keys = r.keys()
             keys.sort()
             assert keys == [b'ts1', b'ts2']
-            assert r.execute_command('ts.info', 'ts1') == [b'totalSamples', 2, b'memoryUsage', 4240, b'firstTimestamp', 100, b'lastTimestamp', 120, b'retentionTime', 0, b'chunkCount', 1, b'chunkSize', 4096, b'chunkType', b'compressed', b'duplicatePolicy', None, b'labels', [], b'sourceKey', None, b'rules', [[b'ts2', 1000, b'AVG']]]
-            assert r.execute_command('ts.info', 'ts2') == [b'totalSamples', 0, b'memoryUsage', 4184, b'firstTimestamp', 0, b'lastTimestamp', 0, b'retentionTime', 0, b'chunkCount', 1, b'chunkSize', 4096, b'chunkType', b'compressed', b'duplicatePolicy', None, b'labels', [], b'sourceKey', b'ts1', b'rules', []]
+            assert r.execute_command('ts.info', 'ts1') == [b'totalSamples', 2, b'memoryUsage', 4256, b'firstTimestamp', 100, b'lastTimestamp', 120, b'retentionTime', 0, b'chunkCount', 1, b'chunkSize', 4096, b'chunkType', b'compressed', b'duplicatePolicy', None, b'labels', [], b'sourceKey', None, b'rules', [[b'ts2', 1000, b'AVG']]]
+            assert r.execute_command('ts.info', 'ts2') == [b'totalSamples', 0, b'memoryUsage', 4200, b'firstTimestamp', 0, b'lastTimestamp', 0, b'retentionTime', 0, b'chunkCount', 1, b'chunkSize', 4096, b'chunkType', b'compressed', b'duplicatePolicy', None, b'labels', [], b'sourceKey', b'ts1', b'rules', []]
             assert r.execute_command('ts.range', 'ts1', '-', '+') == [[100, b'3'], [120, b'5']]
             assert r.execute_command('ts.range', 'ts2', '-', '+') == []
             assert r.execute_command('ts.add', 'ts1', 1500, 100)

--- a/tests/flow/test_rdbs.py
+++ b/tests/flow/test_rdbs.py
@@ -10,9 +10,9 @@ def normalize_info(data):
     info = {}
     for i in range(0, len(data), 2):
         info[data[i]] = data[i + 1]
-    info.pop('memoryUsage')
-    info.pop('chunkSize')
-    info.pop('chunkType')
+    info.pop(b'memoryUsage')
+    info.pop(b'chunkSize')
+    info.pop(b'chunkType')
     return info
 
 def testRDB():

--- a/tests/flow/test_rdbs.py
+++ b/tests/flow/test_rdbs.py
@@ -10,9 +10,9 @@ def normalize_info(data):
     info = {}
     for i in range(0, len(data), 2):
         info[data[i]] = data[i + 1]
-    info.pop(b'memoryUsage')
-    info.pop(b'chunkSize')
-    info.pop(b'chunkType')
+    info.pop('memoryUsage')
+    info.pop('chunkSize')
+    info.pop('chunkType')
     return info
 
 def testRDB():

--- a/tests/flow/test_rename.py
+++ b/tests/flow/test_rename.py
@@ -17,12 +17,12 @@ def test_rename_src():
 
         assert r.execute_command('TS.CREATERULE', 'a2{1}', 'b{1}', 'AGGREGATION', 'AVG', 5000)
         bInfo = TSInfo(r.execute_command('TS.INFO', 'b{1}'))
-        env.assertEqual(bInfo.sourceKey, b'a2{1}')
+        env.assertEqual(bInfo.sourceKey, 'a2{1}')
         env.assertEqual(bInfo.rules, [])
 
         env.assertTrue(r.execute_command('RENAME', 'a2{1}', 'a3{1}'))
         bInfo = TSInfo(r.execute_command('TS.INFO', 'b{1}'))
-        env.assertEqual(bInfo.sourceKey, b'a3{1}')
+        env.assertEqual(bInfo.sourceKey, 'a3{1}')
         env.assertEqual(bInfo.rules, [])
 
 
@@ -38,7 +38,7 @@ def test_rename_dst():
         env.assertTrue(r.execute_command('RENAME', 'b{2}', 'b1{2}'))
         aInfo = TSInfo(r.execute_command('TS.INFO', 'a{2}'))
         env.assertEqual(aInfo.sourceKey, None)
-        env.assertEqual(aInfo.rules[0][0], b'b1{2}')
+        env.assertEqual(aInfo.rules[0][0], 'b1{2}')
 
         assert r.execute_command('TS.CREATE', 'c{2}')
         assert r.execute_command('TS.CREATERULE', 'a{2}', 'c{2}', 'AGGREGATION', 'COUNT', 2000)
@@ -49,9 +49,9 @@ def test_rename_dst():
         env.assertTrue(r.execute_command('RENAME', 'c{2}', 'c1{2}'))
         aInfo = TSInfo(r.execute_command('TS.INFO', 'a{2}'))
         env.assertEqual(aInfo.sourceKey, None)
-        env.assertEqual(aInfo.rules[0][0], b'b1{2}')
-        env.assertEqual(aInfo.rules[1][0], b'c1{2}')
-        env.assertEqual(aInfo.rules[2][0], b'd{2}')
+        env.assertEqual(aInfo.rules[0][0], 'b1{2}')
+        env.assertEqual(aInfo.rules[1][0], 'c1{2}')
+        env.assertEqual(aInfo.rules[2][0], 'd{2}')
 
 
 def test_rename_indexed():

--- a/tests/flow/test_ts_add.py
+++ b/tests/flow/test_ts_add.py
@@ -50,13 +50,13 @@ def test_add_create_key():
         info = _get_ts_info(r, 'tester1')
         assert info.total_samples == 1
         assert info.retention_msecs == 666
-        assert info.labels == {b'name': b'blabla'}
+        assert info.labels == {'name': 'blabla'}
 
         assert r.execute_command('TS.ADD', 'tester2', str(int(ts)), str(ts), 'LABELS', 'name', 'blabla2', 'location',
                                  'earth')
         info = _get_ts_info(r, 'tester2')
         assert info.total_samples == 1
-        assert info.labels == {b'location': b'earth', b'name': b'blabla2'}
+        assert info.labels == {'location': 'earth', 'name': 'blabla2'}
 
 def test_ts_add_encoding():
     for ENCODING in ['compressed','uncompressed']:
@@ -64,10 +64,10 @@ def test_ts_add_encoding():
         e.flush()
         with e.getClusterConnectionIfNeeded() as r:
             r.execute_command('ts.add', 't1', '*', '5.0', 'ENCODING', ENCODING)
-            e.assertEqual(TSInfo(r.execute_command('TS.INFO', 't1')).chunk_type, ENCODING.encode())
+            e.assertEqual(TSInfo(r.execute_command('TS.INFO', 't1')).chunk_type, ENCODING)
             # backwards compatible check
             r.execute_command('ts.add', 't1_bc', '*', '5.0', ENCODING)
-            e.assertEqual(TSInfo(r.execute_command('TS.INFO', 't1_bc')).chunk_type, ENCODING.encode())
+            e.assertEqual(TSInfo(r.execute_command('TS.INFO', 't1_bc')).chunk_type, ENCODING)
 
 
 def test_different_chunk_size():

--- a/tests/flow/test_ts_alter.py
+++ b/tests/flow/test_ts_alter.py
@@ -19,7 +19,7 @@ def test_alter_cmd():
         expected_data = [[start_ts + i, str(5).encode('ascii')] for i in range(samples_count)]
 
         # test alter retention, chunk size and labels
-        expected_labels = [[b'A', b'1'], [b'B', b'2'], [b'C', b'3']]
+        expected_labels = [['A', '1'], ['B', '2'], ['C', '3']]
         expected_retention = 500
         expected_chunk_size = 104
         _ts_alter_cmd(r, key, expected_retention, expected_chunk_size, expected_labels)
@@ -34,13 +34,13 @@ def test_alter_cmd():
 
         # test alter chunk size
         expected_chunk_size = 104
-        expected_labels = [[b'A', b'1'], [b'B', b'2'], [b'C', b'3']]
+        expected_labels = [['A', '1'], ['B', '2'], ['C', '3']]
         _ts_alter_cmd(r, key, set_chunk_size=expected_chunk_size)
         _assert_alter_cmd(r, key, end_ts - 201, end_ts, expected_data[-201:], expected_retention,
                           expected_chunk_size, expected_labels)
 
         # test alter labels
-        expected_labels = [[b'A', b'1']]
+        expected_labels = [['A', '1']]
         _ts_alter_cmd(r, key, expected_retention, set_labels=expected_labels)
         _assert_alter_cmd(r, key, end_ts - 201, end_ts, expected_data[-201:], expected_retention,
                           expected_chunk_size, expected_labels)

--- a/tests/flow/test_ts_create.py
+++ b/tests/flow/test_ts_create.py
@@ -185,7 +185,7 @@ def test_ts_create_encoding():
         e.flush()
         with e.getClusterConnectionIfNeeded() as r:
             r.execute_command('ts.create', 't1', 'ENCODING', ENCODING)
-            e.assertEqual(TSInfo(r.execute_command('TS.INFO', 't1')).chunk_type, ENCODING.encode())
+            e.assertEqual(TSInfo(r.execute_command('TS.INFO', 't1')).chunk_type, ENCODING)
             # backwards compatible check
             r.execute_command('ts.create', 't1_bc', ENCODING)
-            e.assertEqual(TSInfo(r.execute_command('TS.INFO', 't1_bc')).chunk_type, ENCODING.encode())
+            e.assertEqual(TSInfo(r.execute_command('TS.INFO', 't1_bc')).chunk_type, ENCODING)

--- a/tests/flow/test_ts_createrule.py
+++ b/tests/flow/test_ts_createrule.py
@@ -34,7 +34,7 @@ def test_compaction_rules(self):
         assert len(actual_result) == samples_count / 10
 
         info = _get_ts_info(r, key_name)
-        assert info.rules == [[agg_key_name.encode('ascii'), 10, b'AVG']]
+        assert info.rules == [[agg_key_name, 10, 'AVG']]
 
 
 def test_create_compaction_rule_with_wrong_aggregation():
@@ -144,7 +144,7 @@ def test_delete_key():
 
         assert r.execute_command('TS.CREATE', key_name)
         assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'avg', 12)
-        assert _get_ts_info(r, key_name).rules == [[agg_key_name.encode('ascii'), 12, b'AVG']]
+        assert _get_ts_info(r, key_name).rules == [[agg_key_name, 12, 'AVG']]
 
 
 def test_downsampling_current():

--- a/tests/flow/test_ts_mrange.py
+++ b/tests/flow/test_ts_mrange.py
@@ -190,8 +190,17 @@ def test_mrange_withlabels():
         actual_result = r.execute_command('TS.mrange', start_ts + 1, start_ts + samples_count, 'WITHLABELS',
                                           'AGGREGATION', 'COUNT', 1, 'FILTER', 'generation=x')
         # assert the labels length is 3 (name,class,generation) for each of the returned time-series
-        if(len(actual_result[0][1]) != 3 or len(actual_result[1][1]) != 3 or len(actual_result[2][1]) != 3):
-            print(str(actual_result))
+        try:
+            assert len(actual_result[0][1]) != 3 or len(actual_result[1][1]) != 3 or len(actual_result[2][1]) == 3
+        except Exception as ex:
+                print(str(actual_result))
+                res = r.execute_command('TS.INFO', 'tester1')
+                print(str(res))
+                res = r.execute_command('TS.INFO', 'tester2')
+                print(str(res))
+                res = r.execute_command('TS.INFO', 'tester3')
+                print(str(res))
+                raise ex
         assert len(actual_result[0][1]) == 3
         assert len(actual_result[1][1]) == 3
         assert len(actual_result[2][1]) == 3

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -299,7 +299,7 @@ def test_sanity():
         actual_result = r.execute_command('TS.range', 'tester', start_ts, start_ts + samples_count)
         assert expected_result == actual_result
         expected_result = [
-            b'totalSamples', 1500, b'memoryUsage', 1166,
+            b'totalSamples', 1500, b'memoryUsage', 1182,
             b'firstTimestamp', start_ts, b'chunkCount', 1,
             b'labels', [[b'name', b'brown'], [b'color', b'pink']],
             b'lastTimestamp', start_ts + samples_count - 1,


### PR DESCRIPTION
The documentation of `Compressed_ChunkIteratorGetNextBoundaryAggValue` is self-explanatory about this feature:
```
/*
 * Check if we can use precomputed aggregations for the entire chunk instead of going through every
 * value. This is only used when the aggregation range [C,D[ is larger than the chunk time interval
 * [A,B] and we have the precomputed aggregation for [A,B].
 * This can save a large number of iterations given we have detected use-cases with chunks with >300
 * samples, meaning instead of doing 300 aggregations, we use the already computed aggregation for
 * the entire chunk.
 *
 * Currently, the following aggregations are possible to use this optimization:
 *    - Maximum: the MAX between [C,D[ is equal to the MAX( [C,B'], MAX( MAX([A,B]), MAX([A'',D])).
 *               given that we can use the precomputed MAX of [A,B] we reduce the total MAX
 *               comparisons by N-1.
 *
 *
 *                  C: timestamp range start                     D: time range end
 *                  │                                            │
 *   A'             │   B'  A                             B  A'' │
 *   ┌──────────────┼────┐ ┌───────────────────────────────┐ ┌───┼────────────────────┐
 *   │              │    │ │                               │ │   │                    │
 *   │ Previous     │    │ │  Chunk (N samples)            │ │   │ Next               │
 *   │ Chunk        │    │ │   baseTimeStamp: A            │ │   │ Chunk              │
 *   │              │    │ │   endTimeStamp: B             │ │   │                    │
 *   └──────────────┼────┘ └───────────────────────────────┘ └───┼────────────────────┘
 *                  │                                            │
 */
```

## Measured improvements in `cpu-max-all-1` and `cpu-max-all-8`


### Comparison between master and perf.aggregators for metric: Totals.overallQueryRates.all_queries. Time Period from 7 days ago to now
|             Test Case             |Baseline (median obs. +- std.dev)|Comparison (median obs. +- std.dev)|% change (higher-better)|                Note                |
|-----------------------------------|---------------------------------|-----------------------------------|------------------------|------------------------------------|
|tsbs-scale100_cpu-max-all-1        | 1543.806 +- 3.5%                | 2161.718 +- 5.3%                  |40.0%                   |waterline=5.3%. IMPROVEMENT         |
|tsbs-scale100_cpu-max-all-8        | 206.841 +- 3.0%                 | 325.507 +- 1.4%                   |57.4%                   |IMPROVEMENT                         |


### Comparison between master and perf.aggregators for metric: Totals.overallQuantiles.all_queries.q50. Time Period from 7 days ago to now
|             Test Case             |Baseline (median obs. +- std.dev)|Comparison (median obs. +- std.dev)|% change (lower-better)|                Note                 |
|-----------------------------------|---------------------------------|-----------------------------------|-----------------------|-------------------------------------|
|tsbs-scale100_cpu-max-all-1        | 41.816 +- 4.3%                  | 28.670 +- 5.2%                    |45.9%                  |waterline=5.2%. IMPROVEMENT          |
|tsbs-scale100_cpu-max-all-8        | 245.895 +- 4.6%                 | 155.639 +- 2.0%                   |58.0%                  |IMPROVEMENT                          |
