### PR TITLE
Revert "set default libmr threadpool size to 3"

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -145,7 +145,7 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             return TSDB_ERROR;
         }
     } else {
-        TSGlobalConfig.numThreads = 3;
+        TSGlobalConfig.numThreads = 1;
     }
     RedisModule_Log(ctx,
                     "notice",


### PR DESCRIPTION
This reverts commit 20ed1e30dcdaab9f8f916e5932c0bcfc45c596c7.