### PR TITLE
Naive support for key expiry on `create/add`

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -77,6 +77,21 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         TSGlobalConfig.retentionPolicy = RETENTION_TIME_DEFAULT;
     }
 
+    if (argc > 1 && RMUtil_ArgIndex("EXPIRY_POLICY", argv, argc) >= 0) {
+        if (RMUtil_ParseArgsAfter(
+                "EXPIRY_POLICY", argv, argc, "l", &TSGlobalConfig.expiryPolicy) !=
+            REDISMODULE_OK) {
+            RedisModule_Log(ctx, "warning", "Unable to parse argument after EXPIRY_POLICY");
+            return TSDB_ERROR;
+        }
+
+        RedisModule_Log(
+            ctx, "notice", "loaded default expiry policy: %lld", TSGlobalConfig.expiryPolicy);
+        TSGlobalConfig.hasGlobalConfig = TRUE;
+    } else {
+        TSGlobalConfig.expiryPolicy = EXPIRY_TIME_DEFAULT;
+    }
+
     if (!ValidateChunkSize(ctx, Chunk_SIZE_BYTES_SECS)) {
         return TSDB_ERROR;
     }

--- a/src/config.h
+++ b/src/config.h
@@ -21,6 +21,7 @@ typedef struct
     int hasGlobalConfig;
     DuplicatePolicy duplicatePolicy;
     long long numThreads; // number of threads used by libMR
+    long long expiryPolicy;
 } TSConfig;
 
 extern TSConfig TSGlobalConfig;

--- a/src/consts.h
+++ b/src/consts.h
@@ -33,6 +33,7 @@
 
 /* TS.CREATE Defaults */
 #define RETENTION_TIME_DEFAULT          0LL
+#define EXPIRY_TIME_DEFAULT             -1LL
 #define Chunk_SIZE_BYTES_SECS           4096LL   // fills one page 4096
 #define SPLIT_FACTOR                    1.2
 #define DEFAULT_DUPLICATE_POLICY        DP_BLOCK

--- a/src/module.c
+++ b/src/module.c
@@ -495,6 +495,9 @@ static inline int add(RedisModuleCtx *ctx,
     } else if (RedisModule_ModuleTypeGetType(key) != SeriesType) {
         return RTS_ReplyGeneralError(ctx, "TSDB: the key is not a TSDB key");
     } else {
+        if(RedisModule_SetExpire(key, 3720000) == REDISMODULE_ERR) {
+            return TSDB_ERROR;
+        }
         series = RedisModule_ModuleTypeGetValue(key);
         //  overwride key and database configuration for DUPLICATE_POLICY
         if (argv != NULL &&
@@ -573,6 +576,11 @@ int CreateTsKey(RedisModuleCtx *ctx,
     }
 
     RedisModule_RetainString(ctx, keyName);
+
+    if(RedisModule_SetExpire(*key, 3720000) == REDISMODULE_ERR) {
+        return TSDB_ERROR;
+    }
+
     *series = NewSeries(keyName, cCtx);
     if (RedisModule_ModuleTypeSetValue(*key, SeriesType, *series) == REDISMODULE_ERR) {
         return TSDB_ERROR;

--- a/src/module.c
+++ b/src/module.c
@@ -410,6 +410,11 @@ static void handleCompaction(RedisModuleCtx *ctx,
         }
         rule->aggClass->resetContext(rule->aggContext);
         rule->startCurrentTimeBucket = currentTimestamp;
+
+        if(RedisModule_SetExpire(key, 3720000) == REDISMODULE_ERR) {
+            return;
+        }
+
         RedisModule_CloseKey(key);
     }
     rule->aggClass->appendValue(rule->aggContext, value);
@@ -495,9 +500,11 @@ static inline int add(RedisModuleCtx *ctx,
     } else if (RedisModule_ModuleTypeGetType(key) != SeriesType) {
         return RTS_ReplyGeneralError(ctx, "TSDB: the key is not a TSDB key");
     } else {
+        /* we don't want to reset expiry on non-agg ts since it's handle by prom adapter
         if(RedisModule_SetExpire(key, 3720000) == REDISMODULE_ERR) {
             return TSDB_ERROR;
         }
+        */
         series = RedisModule_ModuleTypeGetValue(key);
         //  overwride key and database configuration for DUPLICATE_POLICY
         if (argv != NULL &&

--- a/src/module.c
+++ b/src/module.c
@@ -411,9 +411,7 @@ static void handleCompaction(RedisModuleCtx *ctx,
         rule->aggClass->resetContext(rule->aggContext);
         rule->startCurrentTimeBucket = currentTimestamp;
 
-        if(RedisModule_SetExpire(key, 3720000) == REDISMODULE_ERR) {
-            return;
-        }
+        RedisModule_SetExpire(key, 3720000); 
 
         RedisModule_CloseKey(key);
     }
@@ -584,16 +582,14 @@ int CreateTsKey(RedisModuleCtx *ctx,
 
     RedisModule_RetainString(ctx, keyName);
 
-    if(RedisModule_SetExpire(*key, 3720000) == REDISMODULE_ERR) {
-        return TSDB_ERROR;
-    }
-
     *series = NewSeries(keyName, cCtx);
     if (RedisModule_ModuleTypeSetValue(*key, SeriesType, *series) == REDISMODULE_ERR) {
         return TSDB_ERROR;
     }
 
     IndexMetric(keyName, (*series)->labels, (*series)->labelsCount);
+
+    RedisModule_SetExpire(*key, 3720000);
 
     return TSDB_OK;
 }

--- a/src/query_language.c
+++ b/src/query_language.c
@@ -128,6 +128,7 @@ int ParseDuplicatePolicy(RedisModuleCtx *ctx,
 
 int parseCreateArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, CreateCtx *cCtx) {
     cCtx->retentionTime = TSGlobalConfig.retentionPolicy;
+    cCtx->expiryTime = TSGlobalConfig.expiryPolicy;
     cCtx->chunkSizeBytes = TSGlobalConfig.chunkSizeBytes;
     cCtx->labelsCount = 0;
     cCtx->labels = NULL;

--- a/src/query_language.h
+++ b/src/query_language.h
@@ -96,6 +96,7 @@ typedef struct CreateCtx
     int options;
     DuplicatePolicy duplicatePolicy;
     bool skipChunkCreation;
+    long long expiryTime;
 } CreateCtx;
 
 int parseLabelsFromArgs(RedisModuleString **argv, int argc, size_t *label_count, Label **labels);

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -909,6 +909,7 @@ int SeriesCreateRulesFromGlobalConfig(RedisModuleCtx *ctx,
 
         CreateCtx cCtx = {
             .retentionTime = rule->retentionSizeMillisec,
+            .expiryTime = TSGlobalConfig.expiryPolicy,
             .chunkSizeBytes = TSGlobalConfig.chunkSizeBytes,
             .labelsCount = compactedRuleLabelCount,
             .labels = compactedLabels,


### PR DESCRIPTION
This PR implements a simply expiry mechanism of keys based on a global config parameter.

**Use-case**
We keep track of a small set of metrics inside `RedisTimeSeries` for an ephemeral set of containers of interest on our compute platform, with a few labels. The churn rate of such containers is relatively high. Given the current lack of expiry mechanism for keys, even with a relatively tight retention policy on the values, `TS.MRANGE` queries against the DB with a `FILTER` on the labels keep getting slower over time as more keys get inserted: since `RedisTimesires` never expires a key, even if all the values associated with the key fall out of the retention window, the empty key stays indexed and scanned during query.

**Solution implemented**
For our use-case, we use inserts (through `TS.ADD`) as a "heart-beat" for a given key, and reset the value of an `EXPIRE` command emitted during insertion. This keeps the key around as long as there are new data points inserted. The implementation also applies the expiry policy to the associated compaction rules of a key, though there's no atomicity guarantee: this makes this implementation slightly racy under load depending on the insertion/query patterns (ie primary key & compaction rule keys might disappear at slightly different moments).
This PR has been tested under moderate load (single `redis` instance, 100k inserts / sec, ~50 `TS.MRANGE` large-ish queries / sec with `equals` predicate on single indexed label) on real world production environment, and no performance degradation has been observed on static timeseries by the introduction of the extra `EXPIRE` commands emitted, while a very significant performance improvement has been noticed in high churn-rate scenarios.

I realize that it's a fairly specific use-case solved here, however I wanted to submit this patch for consideration - or if anything as further motivation for the need of an expiry mechanism in `RedisTimeseries`. Without such built-in mechanism, it makes it pretty hard to use this great module when there is churn of keys without resorting to building a separate client/daemon manually GC'ing the keys, which gets messy very quickly.
