### PR TITLE
Fixed v1.4 rdb benchmark dataset loading

### DIFF
--- a/tests/benchmarks/tsbs-scale100-cpu-max-all-1.yml
+++ b/tests/benchmarks/tsbs-scale100-cpu-max-all-1.yml
@@ -3,7 +3,7 @@ remote:
   - type: oss-standalone
   - setup: redistimeseries-m5
 dbconfig:
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.v1.4.rdb"
 clientconfig:
   - tool: tsbs_run_queries_redistimeseries
   - parameters:

--- a/tests/benchmarks/tsbs-scale100-double-groupby-1.yml
+++ b/tests/benchmarks/tsbs-scale100-double-groupby-1.yml
@@ -3,7 +3,7 @@ remote:
   - type: oss-standalone
   - setup: redistimeseries-m5
 dbconfig:
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.v1.4.rdb"
 clientconfig:
   - tool: tsbs_run_queries_redistimeseries
   - parameters:

--- a/tests/benchmarks/tsbs-scale100-groupby-orderby-limit.yml
+++ b/tests/benchmarks/tsbs-scale100-groupby-orderby-limit.yml
@@ -3,7 +3,7 @@ remote:
   - type: oss-standalone
   - setup: redistimeseries-m5
 dbconfig:
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.v1.4.rdb"
 clientconfig:
   - tool: tsbs_run_queries_redistimeseries
   - parameters:

--- a/tests/benchmarks/tsbs-scale100-single-groupby-1-1-1.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-1-1-1.yml
@@ -3,7 +3,7 @@ remote:
   - type: oss-standalone
   - setup: redistimeseries-m5
 dbconfig:
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.v1.4.rdb"
 clientconfig:
   - tool: tsbs_run_queries_redistimeseries
   - parameters:

--- a/tests/benchmarks/tsbs-scale100-single-groupby-1-1-12.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-1-1-12.yml
@@ -3,7 +3,7 @@ remote:
   - type: oss-standalone
   - setup: redistimeseries-m5
 dbconfig:
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.v1.4.rdb"
 clientconfig:
   - tool: tsbs_run_queries_redistimeseries
   - parameters:


### PR DESCRIPTION
This PR fixes the performance flows for v1.4: https://app.circleci.com/pipelines/github/RedisTimeSeries/RedisTimeSeries/4586/workflows/89c3ee4f-82d9-4b71-b30a-2514a5c6d4a3