### PR TITLE
Updated documentation of TS.ALTER parameters

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -92,6 +92,26 @@
                 "optional": true
             },
             {
+                "type": "integer",
+                "command": "CHUNK_SIZE",
+                "name": "size",
+                "optional": true
+            },
+            {
+                "type": "enum",
+                "command": "DUPLICATE_POLICY",
+                "name": "policy",
+                "enum": [
+                    "BLOCK",
+                    "FIRST",
+                    "LAST",
+                    "MIN",
+                    "MAX",
+                    "SUM"
+                ],
+                "optional": true
+            },
+            {
                 "command": "LABELS",
                 "name": [
                     "label",

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -110,10 +110,10 @@ TS.DEL complexity is O(N) where N is the number of data points that will be remo
 
 ### TS.ALTER
 
-Update the retention, labels of an existing key. The parameters are the same as TS.CREATE.
+Update the retention, chunk size, duplicate policy, and labels of an existing key. The parameters are the same as TS.CREATE.
 
 ```sql
-TS.ALTER key [RETENTION retentionTime] [LABELS label value..]
+TS.ALTER key [RETENTION retentionTime] [CHUNK_SIZE size] [DUPLICATE_POLICY policy] [LABELS label value..]
 ```
 
 #### Alter Example


### PR DESCRIPTION
The current documentation of `TS.ALTER` only mentions `RETENTION` and `LABELS` as parameters. However, according to the source `TS.ALTER` can be used to alter `CHUNK_SIZE` and `DUPLICATE_POLICY` as well.

https://github.com/RedisTimeSeries/RedisTimeSeries/blob/eb7ec095f7d5ff0c018ed778c596eb2b85a800e0/src/module.c#L641-L662

Fixes #888 