### PR TITLE
CI PERF fix: redisbench-admin requires libhdf5-dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,11 +244,12 @@ commands:
           name: Install remote benchmark tool dependencies
           command: |
             VERSION=0.14.8 ./deps/readies/bin/getterraform
-            apt-get install python-dev -y
-            apt install libhdf5-dev -y
+            apt install python3-dev libhdf5-dev -y
       - run:
           name: Install remote benchmark python dependencies
-          command: python3 -m pip install -r ./tests/benchmarks/requirements.txt
+          command: |
+            python3 -m pip install --upgrade cython
+            python3 -m pip install -r ./tests/benchmarks/requirements.txt
 
       - run:
           name: Run CI benchmarks on aws for envs << parameters.allowed_envs >> 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,6 +270,7 @@ commands:
               --github_sha $CIRCLE_SHA1 \
               --github_branch $CIRCLE_BRANCH \
               --upload_results_s3 \
+              --fail_fast \
               --triggering_env << parameters.triggering_env >> \
               --push_results_redistimeseries \
               --allowed-envs << parameters.allowed_envs >> \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,6 +244,7 @@ commands:
           name: Install remote benchmark tool dependencies
           command: |
             VERSION=0.14.8 ./deps/readies/bin/getterraform
+            apt-get install python-dev -y
             apt install libhdf5-dev -y
       - run:
           name: Install remote benchmark python dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,6 +244,7 @@ commands:
           name: Install remote benchmark tool dependencies
           command: |
             VERSION=0.14.8 ./deps/readies/bin/getterraform
+            apt install libhdf5-dev -y
       - run:
           name: Install remote benchmark python dependencies
           command: python3 -m pip install -r ./tests/benchmarks/requirements.txt


### PR DESCRIPTION
Fixes: https://app.circleci.com/pipelines/github/RedisTimeSeries/RedisTimeSeries/4774/workflows/1ec114dc-e4e4-441d-bda4-6bf578242206/jobs/19556