### PR TITLE
Introduce further benchmarks to test scale-up

### DIFF
--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -9,6 +9,15 @@ exporter:
       - "$.Totals.overallQuantiles.all_queries.q99"
       - "$.Totals.overallQuantiles.all_queries.q100"
       - "$.Totals.overallQueryRates.all_queries"
+      - "$.Tests.Overall.rps"
+      - "$.Tests.Overall.avg_latency_ms"
+      - "$.Tests.Overall.p50_latency_ms"
+      - "$.Tests.Overall.p95_latency_ms"
+      - "$.Tests.Overall.p99_latency_ms"
+      - "$.Tests.Overall.max_latency_ms"
+      - "$.Tests.Overall.min_latency_ms"
+      - '$."ALL STATS".*."Ops/sec"'
+      - '$."ALL STATS".*."Latency"'
 
 clusterconfig:
   init_commands:

--- a/tests/benchmarks/ts_mrange_tsbs_alike_cpu-max-all-1.yml
+++ b/tests/benchmarks/ts_mrange_tsbs_alike_cpu-max-all-1.yml
@@ -1,0 +1,57 @@
+version: 0.2
+name: "ts_mrange_tsbs_alike_cpu-max-all-1"
+
+description: '
+  use case: tsbs devops scale 100 use-case
+  query: ALTERED cpu-max-all-1 to avoid using aggregation
+  tsbs query detail: Aggregate across all CPU metrics per hour over 1 hour for a single host
+  sample tsbs query: "TS.MRANGE" "1451695614264" "1451724414264" "WITHLABELS" "AGGREGATION" "MAX" "3600000" "FILTER" "measurement=cpu" "hostname=host_7"
+  the query we are using: "TS.MRANGE" "1451695614264" "1451724414264" "WITHLABELS" "FILTER" "measurement=cpu" "hostname=host_7"
+  '
+
+remote:
+ - type: oss-standalone
+ - setup: redistimeseries-m5
+
+setups:
+  - oss-standalone
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
+
+dbconfig:
+  - dataset_name: "data_redistimeseries_cpu-only_100"
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
+  - check:
+      keyspacelen: 1000
+  - module-configuration-parameters:
+      redistimeseries:
+        CHUNK_SIZE_BYTES: 128
+
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 10000
+    - threads: 2
+    - pipeline: 1
+    - command: '"TS.MRANGE" "1451695614264" "1451724414264" "WITHLABELS" "FILTER" "measurement=cpu" "hostname=host_7"'
+exporter:
+  redistimeseries:
+    break_by:
+      - version
+      - commit
+    timemetric: "$.StartTime"
+    metrics:
+      - "$.Tests.Overall.rps"
+      - "$.Tests.Overall.avg_latency_ms"
+      - "$.Tests.Overall.p50_latency_ms"
+      - "$.Tests.Overall.p95_latency_ms"
+      - "$.Tests.Overall.p99_latency_ms"
+      - "$.Tests.Overall.max_latency_ms"
+      - "$.Tests.Overall.min_latency_ms"

--- a/tests/benchmarks/ts_queryindex_100K-series-tsbs-devops.yml
+++ b/tests/benchmarks/ts_queryindex_100K-series-tsbs-devops.yml
@@ -1,0 +1,35 @@
+name: "ts_queryindex_100K-series-tsbs-devops"
+
+metadata:
+  labels:
+    test_type: query
+
+description: '
+  uses tsbs generated time-series at scale 10000 (100K series)
+  and issues TS.QUERYINDEX with a filter that will reply with only 10 series.
+  sample query: "TS.QUERYINDEX" "measurement=cpu" "hostname=host_7"
+  '
+
+remote:
+  - type: oss-standalone
+  - setup: redistimeseries-m5
+
+setups:
+  - oss-standalone
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
+
+dbconfig:
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/devops/bulk_data_redistimeseries/data_redistimeseries_cpu-only_10000_2016-01-01T00:00:00Z_2016-01-01T00:01:00Z_10s_123.dat"
+  - check:
+      keyspacelen: 100000
+  - module-configuration-parameters:
+      redistimeseries:
+        CHUNK_SIZE_BYTES: 128
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TS.QUERYINDEX measurement=cpu hostname=host_7'"

--- a/tests/benchmarks/ts_queryindex_100K-series-tsbs-devops.yml
+++ b/tests/benchmarks/ts_queryindex_100K-series-tsbs-devops.yml
@@ -16,6 +16,10 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 

--- a/tests/benchmarks/ts_queryindex_10M-series-tsbs-devops.yml
+++ b/tests/benchmarks/ts_queryindex_10M-series-tsbs-devops.yml
@@ -16,6 +16,10 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 

--- a/tests/benchmarks/ts_queryindex_10M-series-tsbs-devops.yml
+++ b/tests/benchmarks/ts_queryindex_10M-series-tsbs-devops.yml
@@ -1,0 +1,35 @@
+name: "ts_queryindex_10M-series-tsbs-devops"
+
+metadata:
+  labels:
+    test_type: query
+
+description: '
+  uses tsbs generated time-series at scale 1000000 (10M series)
+  and issues TS.QUERYINDEX with a filter that will reply with only 10 series.
+  sample query: "TS.QUERYINDEX" "measurement=cpu" "hostname=host_7"
+  '
+
+remote:
+  - type: oss-standalone
+  - setup: redistimeseries-m5
+
+setups:
+  - oss-standalone
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
+
+dbconfig:
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/devops/bulk_data_redistimeseries/data_redistimeseries_cpu-only_1000000_2016-01-01T00:00:00Z_2016-01-01T00:01:00Z_10s_123.dat"
+  - check:
+      keyspacelen: 10000000
+  - module-configuration-parameters:
+      redistimeseries:
+        CHUNK_SIZE_BYTES: 128
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TS.QUERYINDEX measurement=cpu hostname=host_7'"

--- a/tests/benchmarks/ts_queryindex_1M-series-tsbs-devops.yml
+++ b/tests/benchmarks/ts_queryindex_1M-series-tsbs-devops.yml
@@ -16,6 +16,10 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 

--- a/tests/benchmarks/ts_queryindex_1M-series-tsbs-devops.yml
+++ b/tests/benchmarks/ts_queryindex_1M-series-tsbs-devops.yml
@@ -1,0 +1,35 @@
+name: "ts_queryindex_1M-series-tsbs-devops"
+
+metadata:
+  labels:
+    test_type: query
+
+description: '
+  uses tsbs generated time-series at scale 100000 (1M series)
+  and issues TS.QUERYINDEX with a filter that will reply with only 10 series.
+  sample query: "TS.QUERYINDEX" "measurement=cpu" "hostname=host_7"
+  '
+
+remote:
+  - type: oss-standalone
+  - setup: redistimeseries-m5
+
+setups:
+  - oss-standalone
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
+
+dbconfig:
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/devops/bulk_data_redistimeseries/data_redistimeseries_cpu-only_100000_2016-01-01T00:00:00Z_2016-01-01T00:01:00Z_10s_123.dat"
+  - check:
+      keyspacelen: 1000000
+  - module-configuration-parameters:
+      redistimeseries:
+        CHUNK_SIZE_BYTES: 128
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TS.QUERYINDEX measurement=cpu hostname=host_7'"

--- a/tests/benchmarks/tsbs-scale100-cpu-max-all-1.yml
+++ b/tests/benchmarks/tsbs-scale100-cpu-max-all-1.yml
@@ -13,10 +13,14 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
 
 dbconfig:
   - dataset_name: "data_redistimeseries_cpu-only_100"
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
   - check:
       keyspacelen: 1000
 

--- a/tests/benchmarks/tsbs-scale100-cpu-max-all-1.yml
+++ b/tests/benchmarks/tsbs-scale100-cpu-max-all-1.yml
@@ -13,6 +13,10 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 

--- a/tests/benchmarks/tsbs-scale100-cpu-max-all-8.yml
+++ b/tests/benchmarks/tsbs-scale100-cpu-max-all-8.yml
@@ -13,10 +13,14 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
 
 dbconfig:
   - dataset_name: "data_redistimeseries_cpu-only_100"
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
   - check:
       keyspacelen: 1000
 

--- a/tests/benchmarks/tsbs-scale100-cpu-max-all-8.yml
+++ b/tests/benchmarks/tsbs-scale100-cpu-max-all-8.yml
@@ -13,6 +13,10 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 

--- a/tests/benchmarks/tsbs-scale100-double-groupby-1.yml
+++ b/tests/benchmarks/tsbs-scale100-double-groupby-1.yml
@@ -13,10 +13,14 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
 
 dbconfig:
   - dataset_name: "data_redistimeseries_cpu-only_100"
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
   - check:
       keyspacelen: 1000
 

--- a/tests/benchmarks/tsbs-scale100-double-groupby-1.yml
+++ b/tests/benchmarks/tsbs-scale100-double-groupby-1.yml
@@ -13,6 +13,10 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 

--- a/tests/benchmarks/tsbs-scale100-double-groupby-5.yml
+++ b/tests/benchmarks/tsbs-scale100-double-groupby-5.yml
@@ -12,10 +12,14 @@ remote:
   - setup: redistimeseries-m5
 setups:
   - oss-standalone
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
 
 dbconfig:
   - dataset_name: "data_redistimeseries_cpu-only_100"
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
   - check:
       keyspacelen: 1000
 

--- a/tests/benchmarks/tsbs-scale100-double-groupby-5.yml
+++ b/tests/benchmarks/tsbs-scale100-double-groupby-5.yml
@@ -12,6 +12,10 @@ remote:
   - setup: redistimeseries-m5
 setups:
   - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 

--- a/tests/benchmarks/tsbs-scale100-double-groupby-all.yml
+++ b/tests/benchmarks/tsbs-scale100-double-groupby-all.yml
@@ -13,10 +13,14 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
 
 dbconfig:
   - dataset_name: "data_redistimeseries_cpu-only_100"
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
   - check:
       keyspacelen: 1000
 

--- a/tests/benchmarks/tsbs-scale100-double-groupby-all.yml
+++ b/tests/benchmarks/tsbs-scale100-double-groupby-all.yml
@@ -13,6 +13,10 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 

--- a/tests/benchmarks/tsbs-scale100-groupby-orderby-limit.yml
+++ b/tests/benchmarks/tsbs-scale100-groupby-orderby-limit.yml
@@ -13,10 +13,14 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
 
 dbconfig:
   - dataset_name: "data_redistimeseries_cpu-only_100"
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
   - check:
       keyspacelen: 1000
 

--- a/tests/benchmarks/tsbs-scale100-groupby-orderby-limit.yml
+++ b/tests/benchmarks/tsbs-scale100-groupby-orderby-limit.yml
@@ -13,6 +13,10 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 

--- a/tests/benchmarks/tsbs-scale100-high-cpu-1.yml
+++ b/tests/benchmarks/tsbs-scale100-high-cpu-1.yml
@@ -17,10 +17,14 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
 
 dbconfig:
   - dataset_name: "data_redistimeseries_cpu-only_100"
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
   - check:
       keyspacelen: 1000
 

--- a/tests/benchmarks/tsbs-scale100-high-cpu-1.yml
+++ b/tests/benchmarks/tsbs-scale100-high-cpu-1.yml
@@ -17,6 +17,10 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 

--- a/tests/benchmarks/tsbs-scale100-high-cpu-all.yml
+++ b/tests/benchmarks/tsbs-scale100-high-cpu-all.yml
@@ -18,6 +18,10 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 

--- a/tests/benchmarks/tsbs-scale100-high-cpu-all.yml
+++ b/tests/benchmarks/tsbs-scale100-high-cpu-all.yml
@@ -18,10 +18,14 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
 
 dbconfig:
   - dataset_name: "data_redistimeseries_cpu-only_100"
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
   - check:
       keyspacelen: 1000
 

--- a/tests/benchmarks/tsbs-scale100-lastpoint.yml
+++ b/tests/benchmarks/tsbs-scale100-lastpoint.yml
@@ -13,10 +13,14 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
 
 dbconfig:
   - dataset_name: "data_redistimeseries_cpu-only_100"
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
   - check:
       keyspacelen: 1000
 

--- a/tests/benchmarks/tsbs-scale100-lastpoint.yml
+++ b/tests/benchmarks/tsbs-scale100-lastpoint.yml
@@ -13,6 +13,10 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 

--- a/tests/benchmarks/tsbs-scale100-single-groupby-1-1-1.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-1-1-1.yml
@@ -13,10 +13,14 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
 
 dbconfig:
   - dataset_name: "data_redistimeseries_cpu-only_100"
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
   - check:
       keyspacelen: 1000
 

--- a/tests/benchmarks/tsbs-scale100-single-groupby-1-1-1.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-1-1-1.yml
@@ -13,6 +13,10 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 

--- a/tests/benchmarks/tsbs-scale100-single-groupby-1-1-12.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-1-1-12.yml
@@ -13,10 +13,14 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
 
 dbconfig:
   - dataset_name: "data_redistimeseries_cpu-only_100"
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
   - check:
       keyspacelen: 1000
 

--- a/tests/benchmarks/tsbs-scale100-single-groupby-1-1-12.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-1-1-12.yml
@@ -13,6 +13,10 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 

--- a/tests/benchmarks/tsbs-scale100-single-groupby-1-8-1.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-1-8-1.yml
@@ -13,10 +13,14 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
 
 dbconfig:
   - dataset_name: "data_redistimeseries_cpu-only_100"
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
   - check:
       keyspacelen: 1000
 

--- a/tests/benchmarks/tsbs-scale100-single-groupby-1-8-1.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-1-8-1.yml
@@ -13,6 +13,10 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 

--- a/tests/benchmarks/tsbs-scale100-single-groupby-5-1-1.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-5-1-1.yml
@@ -13,10 +13,14 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
 
 dbconfig:
   - dataset_name: "data_redistimeseries_cpu-only_100"
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
   - check:
       keyspacelen: 1000
 

--- a/tests/benchmarks/tsbs-scale100-single-groupby-5-1-1.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-5-1-1.yml
@@ -13,6 +13,10 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 

--- a/tests/benchmarks/tsbs-scale100-single-groupby-5-1-12.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-5-1-12.yml
@@ -13,10 +13,14 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
 
 dbconfig:
   - dataset_name: "data_redistimeseries_cpu-only_100"
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
   - check:
       keyspacelen: 1000
 

--- a/tests/benchmarks/tsbs-scale100-single-groupby-5-1-12.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-5-1-12.yml
@@ -13,6 +13,10 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 

--- a/tests/benchmarks/tsbs-scale100-single-groupby-5-8-1.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-5-8-1.yml
@@ -13,10 +13,14 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
 
 dbconfig:
   - dataset_name: "data_redistimeseries_cpu-only_100"
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/devops-scale100-4days.rdb"
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
   - check:
       keyspacelen: 1000
 

--- a/tests/benchmarks/tsbs-scale100-single-groupby-5-8-1.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-5-8-1.yml
@@ -13,6 +13,10 @@ remote:
 
 setups:
   - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-03-primaries
+  - oss-cluster-05-primaries
+  - oss-cluster-09-primaries
   - oss-cluster-15-primaries
   - oss-cluster-30-primaries
 


### PR DESCRIPTION
This PR:
- introduces 3 new benchmarks, that test TS.QUERYINDEX performance over 1M, 10M, and 100M time series, across different setups.
- Furthermore, it enables the tsbs benchmarks without rate-limiting on the cluster. 
- Added 02,03,05,and 09 primary shards variants to benchmark spec. (by default they are not run on CI)