### PR TITLE
Perf gorilla inline

### DIFF
--- a/src/gorilla.c
+++ b/src/gorilla.c
@@ -256,7 +256,7 @@ static inline binary_t readBits(const binary_t *bins,
     }
 }
 
-static bool isSpaceAvailable(CompressedChunk *chunk, u_int8_t size) {
+static inline bool isSpaceAvailable(CompressedChunk *chunk, u_int8_t size) {
     u_int64_t available = (chunk->size * 8) - chunk->idx;
     return size <= available;
 }


### PR DESCRIPTION
`# Comparison between master and perf_gorilla_inline for metric: Totals.overallQuantiles.all_queries.q50. Time Period from 7 days ago to 20 hours ago. (environment used: oss-cluster-30-primaries)
|                 Test Case                 |Baseline master (median obs. +- std.dev)|Comparison perf_gorilla_inline (median obs. +- std.dev)|% change (lower-better)|             Note              |
|-------------------------------------------|----------------------------------------|-------------------------------------------------------|-----------------------|-------------------------------|
|tsbs-scale100-cpu-max-all-1@4139rps        | 22 +- 4.7%  (7 datapoints)             | 22 +- nan%  (1 datapoints)                            |0.3%                   |-- no change --                |
|tsbs-scale100-cpu-max-all-8@588rps         | 63 +- 6.0%  (7 datapoints)             | 63 +- nan%  (1 datapoints)                            |0.6%                   |waterline=6.0%. -- no change --|
|tsbs-scale100-double-groupby-1@324rps      | 88 +- 10.5% UNSTABLE (7 datapoints)    | 88 +- nan%  (1 datapoints)                            |0.5%                   |UNSTABLE (very high variance)  |
|tsbs-scale100-double-groupby-5@70rps       | 247 +- 27.7% UNSTABLE (7 datapoints)   | 245 +- nan%  (1 datapoints)                           |0.6%                   |UNSTABLE (very high variance)  |
|tsbs-scale100-double-groupby-all@35rps     | 459 +- 25.5% UNSTABLE (7 datapoints)   | 465 +- nan%  (1 datapoints)                           |-1.1%                  |UNSTABLE (very high variance)  |
|tsbs-scale100-groupby-orderby-limit@28rps  | 22 +- 20.4% UNSTABLE (7 datapoints)    | 22 +- nan%  (1 datapoints)                            |0.5%                   |UNSTABLE (very high variance)  |
|tsbs-scale100-high-cpu-1@1816rps           | 142 +- 3.0%  (7 datapoints)            | 142 +- nan%  (1 datapoints)                           |0.4%                   |-- no change --                |
|tsbs-scale100-high-cpu-all@18rps           | 448 +- 91.2% UNSTABLE (7 datapoints)   | 438 +- nan%  (1 datapoints)                           |2.1%                   |UNSTABLE (very high variance)  |
|tsbs-scale100-lastpoint@488rps             | 11 +- 3.2%  (7 datapoints)             | 11 +- nan%  (1 datapoints)                            |0.4%                   |-- no change --                |
|tsbs-scale100-single-groupby-1-1-12@2320rps| 15 +- 2.5%  (5 datapoints)             | 15 +- nan%  (1 datapoints)                            |-0.8%                  |-- no change --                |
|tsbs-scale100-single-groupby-1-1-1@2320rps | 14 +- 2.4%  (5 datapoints)             | 14 +- nan%  (1 datapoints)                            |-0.9%                  |-- no change --                |
|tsbs-scale100-single-groupby-1-8-1@4458rps | 18 +- 2.9%  (5 datapoints)             | 18 +- nan%  (1 datapoints)                            |0.2%                   |-- no change --                |
|tsbs-scale100-single-groupby-5-1-12@648rps | 20 +- 5.2%  (5 datapoints)             | 20 +- nan%  (1 datapoints)                            |1.5%                   |waterline=5.2%. -- no change --|
|tsbs-scale100-single-groupby-5-1-1@648rps  | 5 +- 4.7%  (5 datapoints)              | 5 +- nan%  (1 datapoints)                             |2.2%                   |-- no change --                |
|tsbs-scale100-single-groupby-5-8-1@1158rps | 35 +- 3.4%  (5 datapoints)             | 34 +- nan%  (1 datapoints)                            |2.4%                   |-- no change --                |
|tsbs-scale100_cpu-max-all-1                | 37 +- 4.5%  (7 datapoints)             | 37 +- nan%  (1 datapoints)                            |0.3%                   |-- no change --                |
|tsbs-scale100_cpu-max-all-8                | 107 +- 6.3%  (7 datapoints)            | 106 +- nan%  (1 datapoints)                           |0.5%                   |waterline=6.3%. -- no change --|
|tsbs-scale100_double-groupby-1             | 161 +- 7.0%  (7 datapoints)            | 162 +- nan%  (1 datapoints)                           |-0.6%                  |waterline=7.0%. -- no change --|
|tsbs-scale100_double-groupby-5             | 641 +- 7.3%  (7 datapoints)            | 641 +- nan%  (1 datapoints)                           |0.1%                   |waterline=7.3%. -- no change --|
|tsbs-scale100_double-groupby-all           | 1256 +- 8.1%  (7 datapoints)           | 1253 +- nan%  (1 datapoints)                          |0.2%                   |waterline=8.1%. -- no change --|
|tsbs-scale100_groupby-orderby-limit        | 100 +- 15.6% UNSTABLE (7 datapoints)   | 100 +- nan%  (1 datapoints)                           |0.4%                   |UNSTABLE (very high variance)  |
|tsbs-scale100_high-cpu-1                   | 60 +- 16.1% UNSTABLE (7 datapoints)    | 59 +- nan%  (1 datapoints)                            |0.8%                   |UNSTABLE (very high variance)  |
|tsbs-scale100_high-cpu-all                 | 1288 +- 60.0% UNSTABLE (7 datapoints)  | 1287 +- nan%  (1 datapoints)                          |0.1%                   |UNSTABLE (very high variance)  |
|tsbs-scale100_lastpoint                    | 55 +- 1.7%  (7 datapoints)             | 56 +- nan%  (1 datapoints)                            |-0.6%                  |-- no change --                |
|tsbs-scale100_single-groupby-1-1-1         | 24 +- 2.1%  (6 datapoints)             | 25 +- nan%  (1 datapoints)                            |-0.5%                  |-- no change --                |
|tsbs-scale100_single-groupby-1-1-12        | 26 +- 2.2%  (6 datapoints)             | 26 +- nan%  (1 datapoints)                            |-0.4%                  |-- no change --                |
|tsbs-scale100_single-groupby-1-8-1         | 31 +- 2.9%  (5 datapoints)             | 31 +- nan%  (1 datapoints)                            |-0.2%                  |-- no change --                |
|tsbs-scale100_single-groupby-5-1-1         | 30 +- 2.5%  (5 datapoints)             | 30 +- nan%  (1 datapoints)                            |-0.9%                  |-- no change --                |
|tsbs-scale100_single-groupby-5-1-12        | 54 +- 2.7%  (5 datapoints)             | 54 +- nan%  (1 datapoints)                            |0.8%                   |-- no change --                |
|tsbs-scale100_single-groupby-5-8-1         | 59 +- 3.2%  (5 datapoints)             | 57 +- nan%  (1 datapoints)                            |2.3%                   |-- no change --                |`