### PR TITLE
Additional aggregator types in GROUPBY

### DIFF
--- a/docs/commands/ts.mrange.md
+++ b/docs/commands/ts.mrange.md
@@ -79,11 +79,18 @@ Optional parameters:
   When combined with `AGGREGATION` the groupby/reduce is applied post aggregation stage.
     - _label_ - label name to group series by.  A new series for each value will be produced.
     - _reducer_ - Reducer type used to aggregate series that share the same label value. One of the following:
-      | reducer | description                        |
-      | ------- | ---------------------------------- |
-      | `sum`   | per label value: sum of all values |
-      | `min`   | per label value: minimum value     |
-      | `max`   | per label value: maximum value     |
+      | reducer | description                                                          |
+      | ------- | -------------------------------------------------------------------- |
+      | `avg`   | per label value: arithmetic mean of all values                       |
+      | `sum`   | per label value: sum of all values                                   |
+      | `min`   | per label value: minimum value                                       |
+      | `max`   | per label value: maximum value                                       |
+      | `range` | per label value: difference between the highest and the lowest value |
+      | `count` | per label value: number of values                                    |
+      | `std.p` | per label value: population standard deviation of the values         |
+      | `std.s` | per label value: sample standard deviation of the values             |
+      | `var.p` | per label value: population variance of the values                   |
+      | `var.s` | per label value: sample variance of the values                       |
     - **Note:** The produced time series will be named `<label>=<groupbyvalue>`
     - **Note:** The produced time series will contain 2 labels with the following label array structure:
          - `__reducer__` : the reducer used

--- a/docs/commands/ts.mrevrange.md
+++ b/docs/commands/ts.mrevrange.md
@@ -79,11 +79,18 @@ Optional parameters:
   When combined with `AGGREGATION` the groupby/reduce is applied post aggregation stage.
     - _label_ - label name to group series by.  A new series for each value will be produced.
     - _reducer_ - Reducer type used to aggregate series that share the same label value. One of the following:
-      | reducer | description                        |
-      | ------- | ---------------------------------- |
-      | `sum`   | per label value: sum of all values |
-      | `min`   | per label value: minimum value     |
-      | `max`   | per label value: maximum value     |
+      | reducer | description                                                          |
+      | ------- | -------------------------------------------------------------------- |
+      | `avg`   | per label value: arithmetic mean of all values                       |
+      | `sum`   | per label value: sum of all values                                   |
+      | `min`   | per label value: minimum value                                       |
+      | `max`   | per label value: maximum value                                       |
+      | `range` | per label value: difference between the highest and the lowest value |
+      | `count` | per label value: number of values                                    |
+      | `std.p` | per label value: population standard deviation of the values         |
+      | `std.s` | per label value: sample standard deviation of the values             |
+      | `var.p` | per label value: population variance of the values                   |
+      | `var.s` | per label value: sample variance of the values                       |
     - **Note:** The produced time series will be named `<label>=<groupbyvalue>`
     - **Note:** The produced time series will contain 2 labels with the following label array structure:
          - `__reducer__` : the reducer used

--- a/src/Makefile
+++ b/src/Makefile
@@ -184,7 +184,11 @@ _SOURCES=\
 	series_iterator.c \
 	utils/arch_features.c \
 	sample_iterator.c \
-	enriched_chunk.c
+	enriched_chunk.c \
+	utils/heap.c \
+	multiseries_sample_iterator.c \
+	multiseries_agg_dup_sample_iterator.c
+
 
 ifeq ($(ARCH), x86_64)
 _SOURCES_AVX512=compactions/compaction_avx512f.c

--- a/src/abstract_iterator.h
+++ b/src/abstract_iterator.h
@@ -25,4 +25,20 @@ typedef struct AbstractSampleIterator
     struct AbstractIterator *input;
 } AbstractSampleIterator;
 
+typedef struct AbstractMultiSeriesSampleIterator
+{
+    ChunkResult (*GetNext)(struct AbstractMultiSeriesSampleIterator *iter, Sample *sample);
+    void (*Close)(struct AbstractMultiSeriesSampleIterator *iter);
+
+    struct AbstractSampleIterator **input; // array of iterators
+} AbstractMultiSeriesSampleIterator;
+
+typedef struct AbstractMultiSeriesAggDupSampleIterator
+{
+    ChunkResult (*GetNext)(struct AbstractMultiSeriesAggDupSampleIterator *iter, Sample *sample);
+    void (*Close)(struct AbstractMultiSeriesAggDupSampleIterator *iter);
+
+    struct AbstractMultiSeriesSampleIterator *input;
+} AbstractMultiSeriesAggDupSampleIterator;
+
 #endif //ABSTRACT_ITERATOR_H

--- a/src/compaction.c
+++ b/src/compaction.c
@@ -907,6 +907,42 @@ const char *AggTypeEnumToString(TS_AGG_TYPES_T aggType) {
     return "Unknown";
 }
 
+const char *AggTypeEnumToStringLowerCase(TS_AGG_TYPES_T aggType) {
+    switch (aggType) {
+        case TS_AGG_MIN:
+            return "min";
+        case TS_AGG_MAX:
+            return "max";
+        case TS_AGG_SUM:
+            return "sum";
+        case TS_AGG_AVG:
+            return "avg";
+        case TS_AGG_TWA:
+            return "twa";
+        case TS_AGG_STD_P:
+            return "std.p";
+        case TS_AGG_STD_S:
+            return "std.s";
+        case TS_AGG_VAR_P:
+            return "var.p";
+        case TS_AGG_VAR_S:
+            return "var.s";
+        case TS_AGG_COUNT:
+            return "count";
+        case TS_AGG_FIRST:
+            return "first";
+        case TS_AGG_LAST:
+            return "last";
+        case TS_AGG_RANGE:
+            return "range";
+        case TS_AGG_NONE:
+        case TS_AGG_INVALID:
+        case TS_AGG_TYPES_MAX:
+            break;
+    }
+    return "unknown";
+}
+
 AggregationClass *GetAggClass(TS_AGG_TYPES_T aggType) {
     switch (aggType) {
         case TS_AGG_MIN:

--- a/src/compaction.h
+++ b/src/compaction.h
@@ -43,6 +43,7 @@ int StringAggTypeToEnum(const char *agg_type);
 int RMStringLenAggTypeToEnum(RedisModuleString *aggTypeStr);
 int StringLenAggTypeToEnum(const char *agg_type, size_t len);
 const char *AggTypeEnumToString(TS_AGG_TYPES_T aggType);
+const char *AggTypeEnumToStringLowerCase(TS_AGG_TYPES_T aggType);
 void initGlobalCompactionFunctions();
 
 #endif

--- a/src/libmr_commands.c
+++ b/src/libmr_commands.c
@@ -147,7 +147,7 @@ static void mrange_done(ExecutionCtx *eCtx, void *privateData) {
     if (data->args.groupByLabel) {
         // Apply the reducer
         RangeArgs args = data->args.rangeArgs;
-        ResultSet_ApplyReducer(resultset, &args, data->args.gropuByReducerOp, data->args.reverse);
+        ResultSet_ApplyReducer(resultset, &args, &data->args.gropuByReducerArgs);
 
         // Do not apply the aggregation on the resultset, do apply max results on the final result
         RangeArgs minimizedArgs = data->args.rangeArgs;
@@ -155,6 +155,7 @@ static void mrange_done(ExecutionCtx *eCtx, void *privateData) {
         minimizedArgs.endTimestamp = UINT64_MAX;
         minimizedArgs.aggregationArgs.aggregationClass = NULL;
         minimizedArgs.aggregationArgs.timeDelta = 0;
+        minimizedArgs.filterByTSArgs.hasValue = false;
         minimizedArgs.filterByValueArgs.hasValue = false;
 
         replyResultSet(rctx,

--- a/src/module.c
+++ b/src/module.c
@@ -231,7 +231,7 @@ static int replyGroupedMultiRange(RedisModuleCtx *ctx,
 
     // todo: this is duplicated in resultset.c
     // Apply the reducer
-    ResultSet_ApplyReducer(resultset, &args->rangeArgs, args->gropuByReducerOp, args->reverse);
+    ResultSet_ApplyReducer(resultset, &args->rangeArgs, &args->gropuByReducerArgs);
 
     // Do not apply the aggregation on the resultset, do apply max results on the final result
     RangeArgs minimizedArgs = args->rangeArgs;

--- a/src/multiseries_agg_dup_sample_iterator.c
+++ b/src/multiseries_agg_dup_sample_iterator.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018-2022 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
+
+#include "abstract_iterator.h"
+#include "multiseries_agg_dup_sample_iterator.h"
+#include "generic_chunk.h"
+#include <assert.h>
+
+ChunkResult MultiSeriesAggDupSampleIterator_GetNext(
+    struct AbstractMultiSeriesAggDupSampleIterator *iterator,
+    Sample *sample) {
+    MultiSeriesAggDupSampleIterator *iter = (MultiSeriesAggDupSampleIterator *)iterator;
+    if (!iter->has_next_sample) {
+        return CR_END;
+    }
+
+    *sample = iter->next_sample;
+    Sample _sample;
+    ChunkResult ret;
+    while ((ret = iter->base.input->GetNext(iter->base.input, &_sample)) == CR_OK &&
+           _sample.timestamp == iter->next_sample.timestamp) {
+        assert(handleDuplicateSample(*iter->dp, _sample, sample) == CR_OK);
+    }
+
+    iter->next_sample = _sample;
+    if (ret == CR_END) {
+        iter->has_next_sample = false;
+    }
+    return CR_OK;
+}
+
+void MultiSeriesAggDupSampleIterator_Close(
+    struct AbstractMultiSeriesAggDupSampleIterator *iterator) {
+    iterator->input->Close(iterator->input);
+    free(iterator);
+}
+
+MultiSeriesAggDupSampleIterator *MultiSeriesAggDupSampleIterator_New(
+    AbstractMultiSeriesSampleIterator *input,
+    DuplicatePolicy *dp) {
+    MultiSeriesAggDupSampleIterator *newIter = malloc(sizeof(MultiSeriesAggDupSampleIterator));
+    newIter->base.input = input;
+    newIter->base.GetNext = MultiSeriesAggDupSampleIterator_GetNext;
+    newIter->base.Close = MultiSeriesAggDupSampleIterator_Close;
+    newIter->dp = dp;
+    ChunkResult res = newIter->base.input->GetNext(newIter->base.input, &newIter->next_sample);
+    if (res != CR_OK) {
+        assert(res != CR_ERR); // we don't handle errors in this function currently
+        newIter->has_next_sample = false;
+    }
+    newIter->has_next_sample = true;
+    return newIter;
+}

--- a/src/multiseries_agg_dup_sample_iterator.c
+++ b/src/multiseries_agg_dup_sample_iterator.c
@@ -7,24 +7,44 @@
 #include "abstract_iterator.h"
 #include "multiseries_agg_dup_sample_iterator.h"
 #include "generic_chunk.h"
+#include "query_language.h"
+#include <math.h>
 #include <assert.h>
 
 ChunkResult MultiSeriesAggDupSampleIterator_GetNext(
     struct AbstractMultiSeriesAggDupSampleIterator *iterator,
     Sample *sample) {
     MultiSeriesAggDupSampleIterator *iter = (MultiSeriesAggDupSampleIterator *)iterator;
+    void *aggContext = iter->aggregationContext;
+
     if (!iter->has_next_sample) {
         return CR_END;
     }
 
-    *sample = iter->next_sample;
+    bool is_nan = isnan(iter->next_sample.value);
+    if (!is_nan) {
+        iter->aggregation->appendValue(
+            aggContext, iter->next_sample.value, iter->next_sample.timestamp);
+    }
+
     Sample _sample;
     ChunkResult ret;
     while ((ret = iter->base.input->GetNext(iter->base.input, &_sample)) == CR_OK &&
            _sample.timestamp == iter->next_sample.timestamp) {
-        assert(handleDuplicateSample(*iter->dp, _sample, sample) == CR_OK);
+        bool _is_nan = isnan(_sample.value);
+        if (!_is_nan) {
+            iter->aggregation->appendValue(aggContext, _sample.value, _sample.timestamp);
+        }
+        is_nan = is_nan && _is_nan;
     }
 
+    sample->timestamp = iter->next_sample.timestamp;
+    if (likely(!is_nan)) {
+        iter->aggregation->finalize(aggContext, &sample->value);
+        iter->aggregation->resetContext(aggContext);
+    } else {
+        sample->value = NAN;
+    }
     iter->next_sample = _sample;
     if (ret == CR_END) {
         iter->has_next_sample = false;
@@ -40,17 +60,19 @@ void MultiSeriesAggDupSampleIterator_Close(
 
 MultiSeriesAggDupSampleIterator *MultiSeriesAggDupSampleIterator_New(
     AbstractMultiSeriesSampleIterator *input,
-    DuplicatePolicy *dp) {
+    const ReducerArgs *reducerArgs) {
     MultiSeriesAggDupSampleIterator *newIter = malloc(sizeof(MultiSeriesAggDupSampleIterator));
     newIter->base.input = input;
     newIter->base.GetNext = MultiSeriesAggDupSampleIterator_GetNext;
     newIter->base.Close = MultiSeriesAggDupSampleIterator_Close;
-    newIter->dp = dp;
+    newIter->aggregation = reducerArgs->aggregationClass;
+    newIter->aggregationContext = newIter->aggregation->createContext(DC);
     ChunkResult res = newIter->base.input->GetNext(newIter->base.input, &newIter->next_sample);
+    newIter->has_next_sample = true;
     if (res != CR_OK) {
         assert(res != CR_ERR); // we don't handle errors in this function currently
+        assert(!isnan(newIter->next_sample.value));
         newIter->has_next_sample = false;
     }
-    newIter->has_next_sample = true;
     return newIter;
 }

--- a/src/multiseries_agg_dup_sample_iterator.h
+++ b/src/multiseries_agg_dup_sample_iterator.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-2022 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
+
+#ifndef REDISTIMESERIES_MULTISERIES_AGG_DUP_SAMPLE_ITERATOR_H
+#define REDISTIMESERIES_MULTISERIES_AGG_DUP_SAMPLE_ITERATOR_H
+
+#include "abstract_iterator.h"
+
+typedef struct MultiSeriesAggDupSampleIterator
+{
+    AbstractMultiSeriesAggDupSampleIterator base;
+    DuplicatePolicy *dp;
+    Sample next_sample;
+    bool has_next_sample;
+} MultiSeriesAggDupSampleIterator;
+
+MultiSeriesAggDupSampleIterator *MultiSeriesAggDupSampleIterator_New(
+    AbstractMultiSeriesSampleIterator *input,
+    DuplicatePolicy *dp);
+
+#endif // REDISTIMESERIES_MULTISERIES_AGG_DUP_SAMPLE_ITERATOR_H

--- a/src/multiseries_agg_dup_sample_iterator.h
+++ b/src/multiseries_agg_dup_sample_iterator.h
@@ -8,17 +8,19 @@
 #define REDISTIMESERIES_MULTISERIES_AGG_DUP_SAMPLE_ITERATOR_H
 
 #include "abstract_iterator.h"
+#include "query_language.h"
 
 typedef struct MultiSeriesAggDupSampleIterator
 {
     AbstractMultiSeriesAggDupSampleIterator base;
-    DuplicatePolicy *dp;
+    void *aggregationContext;
+    AggregationClass *aggregation;
     Sample next_sample;
     bool has_next_sample;
 } MultiSeriesAggDupSampleIterator;
 
 MultiSeriesAggDupSampleIterator *MultiSeriesAggDupSampleIterator_New(
     AbstractMultiSeriesSampleIterator *input,
-    DuplicatePolicy *dp);
+    const ReducerArgs *reducerArgs);
 
 #endif // REDISTIMESERIES_MULTISERIES_AGG_DUP_SAMPLE_ITERATOR_H

--- a/src/multiseries_sample_iterator.c
+++ b/src/multiseries_sample_iterator.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018-2022 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
+
+#include "abstract_iterator.h"
+#include "multiseries_sample_iterator.h"
+#include "consts.h"
+#include "assert.h"
+
+typedef struct
+{
+    Sample sample;
+    AbstractSampleIterator *iter; // The iterator this sample belongs to
+} MSSample;
+
+// implements min heap
+static int heap_cmp_func(const void *sample1, const void *sample2, __unused const void *udata) {
+    return (((MSSample *)sample1)->sample.timestamp < ((MSSample *)sample2)->sample.timestamp) ? 1
+                                                                                               : -1;
+}
+
+// implements max heap
+static int heap_cmp_func_reverse(const void *sample1,
+                                 const void *sample2,
+                                 __unused const void *udata) {
+    return (((MSSample *)sample1)->sample.timestamp > ((MSSample *)sample2)->sample.timestamp) ? 1
+                                                                                               : -1;
+}
+
+void MultiSeriesSampleIterator_Close(struct AbstractMultiSeriesSampleIterator *iterator) {
+    MultiSeriesSampleIterator *iter = (MultiSeriesSampleIterator *)iterator;
+    for (size_t i = 0; i < iter->n_series; ++i) {
+        iter->base.input[i]->Close(iter->base.input[i]);
+    }
+    MSSample *sample;
+    while ((sample = heap_peek(iter->samples_heap))) {
+        free(sample);
+    }
+    heap_free(iter->samples_heap);
+    free(iterator);
+}
+
+// Return the smallest timestamp sample and insert new sample from the same iterator if exist
+ChunkResult MultiSeriesSampleIterator_GetNext(struct AbstractMultiSeriesSampleIterator *base,
+                                              Sample *sample) {
+    MultiSeriesSampleIterator *iter = (MultiSeriesSampleIterator *)base;
+    MSSample *hsample = heap_poll(iter->samples_heap);
+
+    if (!hsample) {
+        return CR_END;
+    }
+
+    *sample = hsample->sample;
+    if (hsample->iter->GetNext(hsample->iter, &hsample->sample) == CR_OK) {
+        heap_offer(&iter->samples_heap, hsample);
+    }
+    return CR_OK;
+}
+
+MultiSeriesSampleIterator *MultiSeriesSampleIterator_New(AbstractSampleIterator **iters,
+                                                         size_t n_series,
+                                                         bool reverse) {
+    MultiSeriesSampleIterator *newIter = malloc(sizeof(MultiSeriesSampleIterator));
+    newIter->base.input = malloc(sizeof(AbstractSampleIterator *) * n_series);
+    memcpy(newIter->base.input, iters, sizeof(AbstractSampleIterator *) * n_series);
+    newIter->base.GetNext = MultiSeriesSampleIterator_GetNext;
+    newIter->base.Close = MultiSeriesSampleIterator_Close;
+    newIter->n_series = n_series;
+    newIter->samples_heap = heap_new(reverse ? heap_cmp_func_reverse : heap_cmp_func, NULL);
+    for (size_t i = 0; i < newIter->n_series; ++i) {
+        AbstractSampleIterator *sample_iter = newIter->base.input[i];
+        MSSample *sample = malloc(sizeof(MSSample));
+        if (sample_iter->GetNext(sample_iter, &sample->sample) == CR_OK) {
+            sample->iter = sample_iter;
+            assert(heap_offer(&newIter->samples_heap, sample) == 0);
+        }
+    }
+    return newIter;
+}

--- a/src/multiseries_sample_iterator.h
+++ b/src/multiseries_sample_iterator.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-2022 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
+
+#ifndef REDISTIMESERIES_MULTISERIES_SAMPLE_ITERATOR_H
+#define REDISTIMESERIES_MULTISERIES_SAMPLE_ITERATOR_H
+
+#include "abstract_iterator.h"
+#include "utils/heap.h"
+
+typedef struct MultiSeriesSampleIterator
+{
+    AbstractMultiSeriesSampleIterator base;
+    size_t n_series;
+    heap_t *samples_heap;
+} MultiSeriesSampleIterator;
+
+MultiSeriesSampleIterator *MultiSeriesSampleIterator_New(AbstractSampleIterator **iters,
+                                                         size_t n_series,
+                                                         bool reverse);
+
+#endif // REDISTIMESERIES_MULTISERIES_SAMPLE_ITERATOR_H

--- a/src/query_language.h
+++ b/src/query_language.h
@@ -32,6 +32,13 @@ typedef struct AggregationArgs
     AggregationClass *aggregationClass;
 } AggregationArgs;
 
+// GroupBy reducer args
+typedef struct ReducerArgs
+{
+    AggregationClass *aggregationClass;
+    TS_AGG_TYPES_T agg_type;
+} ReducerArgs;
+
 typedef struct FilterByValueArgs
 {
     bool hasValue;
@@ -68,13 +75,6 @@ typedef struct RangeArgs
     timestamp_t timestampAlignment;
 } RangeArgs;
 
-typedef enum MultiSeriesReduceOp
-{
-    MultiSeriesReduceOp_Min,
-    MultiSeriesReduceOp_Max,
-    MultiSeriesReduceOp_Sum,
-} MultiSeriesReduceOp;
-
 #define LIMIT_LABELS_SIZE 50
 typedef struct MRangeArgs
 {
@@ -84,7 +84,7 @@ typedef struct MRangeArgs
     RedisModuleString *limitLabels[LIMIT_LABELS_SIZE];
     QueryPredicateList *queryPredicates;
     const char *groupByLabel;
-    MultiSeriesReduceOp gropuByReducerOp;
+    ReducerArgs gropuByReducerArgs;
     bool reverse;
 } MRangeArgs;
 

--- a/src/resultset.c
+++ b/src/resultset.c
@@ -184,9 +184,12 @@ void GroupList_ApplyReducer(TS_GroupList *group,
     Series *reduced = NewSeries(RedisModule_CreateString(NULL, serie_name, serie_name_len), &cCtx);
 
     Series *source = NULL;
+
+    MultiSerieReduce(reduced, group->list, group->count, reducerOp, args, reverse);
+
+    // prepare labels
     for (int i = 0; i < group->count; i++) {
         source = group->list[i];
-        MultiSerieReduce(reduced, source, reducerOp, args, reverse);
 
         size_t keyLen = 0;
         const char *keyname = RedisModule_StringPtrLen(source->keyName, &keyLen);

--- a/src/resultset.c
+++ b/src/resultset.c
@@ -35,8 +35,7 @@ void GroupList_Free(TS_GroupList *g);
 void GroupList_ApplyReducer(TS_GroupList *group,
                             char *labelKey,
                             const RangeArgs *args,
-                            MultiSeriesReduceOp reducerOp,
-                            bool reverse);
+                            const ReducerArgs *gropuByReducerArgs);
 
 void GroupList_ReplyResultSet(RedisModuleCtx *ctx,
                               TS_GroupList *group,
@@ -107,23 +106,15 @@ void GroupList_ReplyResultSet(RedisModuleCtx *ctx,
     }
 }
 
-Label *createReducedSeriesLabels(char *labelKey, char *labelValue, MultiSeriesReduceOp reducerOp) {
+Label *createReducedSeriesLabels(char *labelKey,
+                                 char *labelValue,
+                                 const ReducerArgs *gropuByReducerArgs) {
     // Labels:
     // <label>=<groupbyvalue>
     // __reducer__=<reducer>
     // __source__=key1,key2,key3
-    char *reducer_str = NULL;
-    switch (reducerOp) {
-        case MultiSeriesReduceOp_Max:
-            reducer_str = "max";
-            break;
-        case MultiSeriesReduceOp_Min:
-            reducer_str = "min";
-            break;
-        case MultiSeriesReduceOp_Sum:
-            reducer_str = "sum";
-            break;
-    }
+    const char *reducer_str = AggTypeEnumToStringLowerCase(gropuByReducerArgs->agg_type);
+
     Label *labels = calloc(3, sizeof(Label));
     labels[0].key = RedisModule_CreateStringPrintf(NULL, "%s", labelKey);
     labels[0].value = RedisModule_CreateStringPrintf(NULL, "%s", labelValue);
@@ -153,13 +144,12 @@ int ResultSet_GroupbyLabel(TS_ResultSet *r, const char *label) {
 
 int ResultSet_ApplyReducer(TS_ResultSet *r,
                            const RangeArgs *args,
-                           MultiSeriesReduceOp reducerOp,
-                           bool reverse) {
+                           const ReducerArgs *gropuByReducerArgs) {
     // ^ seek the smallest element of the radix tree.
     RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(r->groups, "^", NULL, 0);
     TS_GroupList *groupList;
     while (RedisModule_DictNextC(iter, NULL, (void **)&groupList) != NULL) {
-        GroupList_ApplyReducer(groupList, r->labelkey, args, reducerOp, reverse);
+        GroupList_ApplyReducer(groupList, r->labelkey, args, gropuByReducerArgs);
     }
     RedisModule_DictIteratorStop(iter);
 
@@ -168,9 +158,8 @@ int ResultSet_ApplyReducer(TS_ResultSet *r,
 void GroupList_ApplyReducer(TS_GroupList *group,
                             char *labelKey,
                             const RangeArgs *args,
-                            MultiSeriesReduceOp reducerOp,
-                            bool reverse) {
-    Label *labels = createReducedSeriesLabels(labelKey, group->labelValue, reducerOp);
+                            const ReducerArgs *gropuByReducerArgs) {
+    Label *labels = createReducedSeriesLabels(labelKey, group->labelValue, gropuByReducerArgs);
     size_t serie_name_len = strlen(labelKey) + strlen(group->labelValue) + 2;
     char *serie_name = malloc(serie_name_len);
     serie_name_len = sprintf(serie_name, "%s=%s", labelKey, group->labelValue);
@@ -185,7 +174,7 @@ void GroupList_ApplyReducer(TS_GroupList *group,
 
     Series *source = NULL;
 
-    MultiSerieReduce(reduced, group->list, group->count, reducerOp, args, reverse);
+    MultiSerieReduce(reduced, group->list, group->count, gropuByReducerArgs, args);
 
     // prepare labels
     for (int i = 0; i < group->count; i++) {

--- a/src/resultset.h
+++ b/src/resultset.h
@@ -42,7 +42,8 @@ void replyResultSet(RedisModuleCtx *ctx,
 void ResultSet_Free(TS_ResultSet *r);
 
 int MultiSerieReduce(Series *dest,
-                     Series *source,
+                     Series **series,
+                     size_t n_series,
                      MultiSeriesReduceOp op,
                      const RangeArgs *args,
                      bool reverse);

--- a/src/resultset.h
+++ b/src/resultset.h
@@ -24,10 +24,11 @@ int ResultSet_SetLabelValue(TS_ResultSet *r, const char *label);
 
 int ResultSet_ApplyReducer(TS_ResultSet *r,
                            const RangeArgs *args,
-                           MultiSeriesReduceOp reducerOp,
-                           bool reverse);
+                           const ReducerArgs *gropuByReducerArgs);
 
-int parseMultiSeriesReduceOp(const char *reducerstr, MultiSeriesReduceOp *reducerOp);
+int parseMultiSeriesReduceArgs(RedisModuleCtx *ctx,
+                               RedisModuleString *reducerstr,
+                               ReducerArgs *reducerArgs);
 
 int ResultSet_AddSerie(TS_ResultSet *r, Series *serie, const char *name);
 
@@ -44,8 +45,7 @@ void ResultSet_Free(TS_ResultSet *r);
 int MultiSerieReduce(Series *dest,
                      Series **series,
                      size_t n_series,
-                     MultiSeriesReduceOp op,
-                     const RangeArgs *args,
-                     bool reverse);
+                     const ReducerArgs *gropuByReducerArgs,
+                     const RangeArgs *args);
 
 #endif // REDISTIMESERIES_RESULTSET_H

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -479,24 +479,11 @@ size_t SeriesGetNumSamples(const Series *series) {
 int MultiSerieReduce(Series *dest,
                      Series **series,
                      size_t n_series,
-                     MultiSeriesReduceOp op,
-                     const RangeArgs *args,
-                     bool reverse) {
-    DuplicatePolicy dp = DP_INVALID;
-    switch (op) {
-        case MultiSeriesReduceOp_Max:
-            dp = DP_MAX;
-            break;
-        case MultiSeriesReduceOp_Min:
-            dp = DP_MIN;
-            break;
-        case MultiSeriesReduceOp_Sum:
-            dp = DP_SUM;
-            break;
-    }
+                     const ReducerArgs *gropuByReducerArgs,
+                     RangeArgs *args) {
     Sample sample;
-    AbstractSampleIterator *iterator =
-        MultiSeriesCreateAggDupSampleIterator(series, n_series, args, reverse, true, &dp);
+    AbstractSampleIterator *iterator = MultiSeriesCreateAggDupSampleIterator(
+        series, n_series, args, false, true, gropuByReducerArgs);
     while (iterator->GetNext(iterator, &sample) == CR_OK) {
         SeriesAddSample(dest, sample.timestamp, sample.value);
     }
@@ -1214,8 +1201,8 @@ AbstractSampleIterator *MultiSeriesCreateAggDupSampleIterator(Series **series,
                                                               const RangeArgs *args,
                                                               bool reverse,
                                                               bool check_retention,
-                                                              DuplicatePolicy *dp) {
+                                                              const ReducerArgs *reducerArgs) {
     AbstractMultiSeriesSampleIterator *chain =
         MultiSeriesCreateSampleIterator(series, n_series, args, reverse, check_retention);
-    return (AbstractSampleIterator *)MultiSeriesAggDupSampleIterator_New(chain, dp);
+    return (AbstractSampleIterator *)MultiSeriesAggDupSampleIterator_New(chain, reducerArgs);
 }

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -13,6 +13,8 @@
 #include "module.h"
 #include "series_iterator.h"
 #include "sample_iterator.h"
+#include "multiseries_sample_iterator.h"
+#include "multiseries_agg_dup_sample_iterator.h"
 
 #include <inttypes.h>
 #include <math.h>
@@ -475,12 +477,11 @@ size_t SeriesGetNumSamples(const Series *series) {
 }
 
 int MultiSerieReduce(Series *dest,
-                     Series *source,
+                     Series **series,
+                     size_t n_series,
                      MultiSeriesReduceOp op,
                      const RangeArgs *args,
                      bool reverse) {
-    Sample sample;
-    AbstractSampleIterator *iterator = SeriesCreateSampleIterator(source, args, reverse, true);
     DuplicatePolicy dp = DP_INVALID;
     switch (op) {
         case MultiSeriesReduceOp_Max:
@@ -493,8 +494,11 @@ int MultiSerieReduce(Series *dest,
             dp = DP_SUM;
             break;
     }
+    Sample sample;
+    AbstractSampleIterator *iterator =
+        MultiSeriesCreateAggDupSampleIterator(series, n_series, args, reverse, true, &dp);
     while (iterator->GetNext(iterator, &sample) == CR_OK) {
-        SeriesUpsertSample(dest, sample.timestamp, sample.value, dp);
+        SeriesAddSample(dest, sample.timestamp, sample.value);
     }
     iterator->Close(iterator);
     return 1;
@@ -1187,4 +1191,31 @@ AbstractSampleIterator *SeriesCreateSampleIterator(Series *series,
                                                    bool check_retention) {
     AbstractIterator *chain = SeriesQuery(series, args, reverse, check_retention);
     return (AbstractSampleIterator *)SeriesSampleIterator_New(chain);
+}
+
+// returns sample iterator over multiple series
+AbstractMultiSeriesSampleIterator *MultiSeriesCreateSampleIterator(Series **series,
+                                                                   size_t n_series,
+                                                                   const RangeArgs *args,
+                                                                   bool reverse,
+                                                                   bool check_retention) {
+    size_t i;
+    AbstractSampleIterator *iters[n_series];
+    for (i = 0; i < n_series; ++i) {
+        iters[i] = SeriesCreateSampleIterator(series[i], args, reverse, check_retention);
+    }
+    return (AbstractMultiSeriesSampleIterator *)MultiSeriesSampleIterator_New(
+        iters, n_series, reverse);
+}
+
+// returns sample iterator over multiple series
+AbstractSampleIterator *MultiSeriesCreateAggDupSampleIterator(Series **series,
+                                                              size_t n_series,
+                                                              const RangeArgs *args,
+                                                              bool reverse,
+                                                              bool check_retention,
+                                                              DuplicatePolicy *dp) {
+    AbstractMultiSeriesSampleIterator *chain =
+        MultiSeriesCreateSampleIterator(series, n_series, args, reverse, check_retention);
+    return (AbstractSampleIterator *)MultiSeriesAggDupSampleIterator_New(chain, dp);
 }

--- a/src/tsdb.h
+++ b/src/tsdb.h
@@ -91,6 +91,19 @@ AbstractSampleIterator *SeriesCreateSampleIterator(Series *series,
                                                    bool reverse,
                                                    bool check_retention);
 
+AbstractMultiSeriesSampleIterator *MultiSeriesCreateSampleIterator(Series **series,
+                                                                   size_t n_series,
+                                                                   const RangeArgs *args,
+                                                                   bool reverse,
+                                                                   bool check_retention);
+
+AbstractSampleIterator *MultiSeriesCreateAggDupSampleIterator(Series **series,
+                                                              size_t n_series,
+                                                              const RangeArgs *args,
+                                                              bool reverse,
+                                                              bool check_retention,
+                                                              DuplicatePolicy *dp);
+
 void FreeCompactionRule(void *value);
 size_t SeriesMemUsage(const void *value);
 

--- a/src/tsdb.h
+++ b/src/tsdb.h
@@ -102,7 +102,7 @@ AbstractSampleIterator *MultiSeriesCreateAggDupSampleIterator(Series **series,
                                                               const RangeArgs *args,
                                                               bool reverse,
                                                               bool check_retention,
-                                                              DuplicatePolicy *dp);
+                                                              const ReducerArgs *reducerArgs);
 
 void FreeCompactionRule(void *value);
 size_t SeriesMemUsage(const void *value);

--- a/src/utils/heap.c
+++ b/src/utils/heap.c
@@ -1,0 +1,253 @@
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <strings.h>
+#include <string.h>
+
+#include "heap.h"
+
+#define DEFAULT_CAPACITY 13
+
+struct heap_s
+{
+    /* size of array */
+    unsigned int size;
+    /* items within heap */
+    unsigned int count;
+    /**  user data */
+    const void *udata;
+    int (*cmp)(const void *, const void *, const void *);
+    void *array[];
+};
+
+size_t heap_sizeof(unsigned int size) {
+    return sizeof(heap_t) + size * sizeof(void *);
+}
+
+static int __child_left(const int idx) {
+    return idx * 2 + 1;
+}
+
+static int __child_right(const int idx) {
+    return idx * 2 + 2;
+}
+
+static int __parent(const int idx) {
+    return (idx - 1) / 2;
+}
+
+void heap_init(heap_t *h,
+               int (*cmp)(const void *, const void *, const void *udata),
+               const void *udata,
+               unsigned int size) {
+    h->cmp = cmp;
+    h->udata = udata;
+    h->size = size;
+    h->count = 0;
+}
+
+heap_t *heap_new(int (*cmp)(const void *, const void *, const void *udata), const void *udata) {
+    heap_t *h = malloc(heap_sizeof(DEFAULT_CAPACITY));
+
+    if (!h)
+        return NULL;
+
+    heap_init(h, cmp, udata, DEFAULT_CAPACITY);
+
+    return h;
+}
+
+void heap_free(heap_t *h) {
+    free(h);
+}
+
+/**
+ * @return a new heap on success; NULL otherwise */
+static heap_t *__ensurecapacity(heap_t *h) {
+    if (h->count < h->size)
+        return h;
+
+    h->size *= 2;
+
+    return realloc(h, heap_sizeof(h->size));
+}
+
+static void __swap(heap_t *h, const int i1, const int i2) {
+    void *tmp = h->array[i1];
+
+    h->array[i1] = h->array[i2];
+    h->array[i2] = tmp;
+}
+
+static int __pushup(heap_t *h, unsigned int idx) {
+    /* 0 is the root node */
+    while (0 != idx) {
+        int parent = __parent(idx);
+
+        /* we are smaller than the parent */
+        if (h->cmp(h->array[idx], h->array[parent], h->udata) < 0)
+            return -1;
+        else
+            __swap(h, idx, parent);
+
+        idx = parent;
+    }
+
+    return idx;
+}
+
+static void __pushdown(heap_t *h, unsigned int idx) {
+    while (1) {
+        unsigned int childl, childr, child;
+
+        childl = __child_left(idx);
+        childr = __child_right(idx);
+
+        if (childr >= h->count) {
+            /* can't pushdown any further */
+            if (childl >= h->count)
+                return;
+
+            child = childl;
+        }
+        /* find biggest child */
+        else if (h->cmp(h->array[childl], h->array[childr], h->udata) < 0)
+            child = childr;
+        else
+            child = childl;
+
+        /* idx is smaller than child */
+        if (h->cmp(h->array[idx], h->array[child], h->udata) < 0) {
+            __swap(h, idx, child);
+            idx = child;
+            /* bigger than the biggest child, we stop, we win */
+        } else
+            return;
+    }
+}
+
+static void __heap_offerx(heap_t *h, void *item) {
+    h->array[h->count] = item;
+
+    /* ensure heap properties */
+    __pushup(h, h->count++);
+}
+
+int heap_offerx(heap_t *h, void *item) {
+    if (h->count == h->size)
+        return -1;
+    __heap_offerx(h, item);
+    return 0;
+}
+
+int heap_offer(heap_t **h, void *item) {
+    if (NULL == (*h = __ensurecapacity(*h)))
+        return -1;
+
+    __heap_offerx(*h, item);
+    return 0;
+}
+
+void *heap_poll(heap_t *h) {
+    if (0 == heap_count(h))
+        return NULL;
+
+    void *item = h->array[0];
+
+    h->array[0] = h->array[h->count - 1];
+    h->count--;
+
+    if (h->count > 1)
+        __pushdown(h, 0);
+
+    return item;
+}
+
+static void __heap_replacex(heap_t *h, void *item) {
+    h->array[0] = item;
+
+    /* ensure heap properties */
+    __pushdown(h, 0);
+}
+
+void heap_replace(heap_t *h, void *item) {
+    __heap_replacex(h, item);
+}
+
+void *heap_peek(const heap_t *h) {
+    if (0 == heap_count(h))
+        return NULL;
+
+    return h->array[0];
+}
+
+void heap_clear(heap_t *h) {
+    h->count = 0;
+}
+
+/**
+ * @return item's index on the heap's array; otherwise -1 */
+static int __item_get_idx(const heap_t *h, const void *item) {
+    unsigned int idx;
+
+    for (idx = 0; idx < h->count; idx++)
+        if (0 == h->cmp(h->array[idx], item, h->udata))
+            return idx;
+
+    return -1;
+}
+
+void *heap_remove_item(heap_t *h, const void *item) {
+    int idx = __item_get_idx(h, item);
+
+    if (idx == -1)
+        return NULL;
+
+    /* swap the item we found with the last item on the heap */
+    void *ret_item = h->array[idx];
+    h->array[idx] = h->array[h->count - 1];
+    h->array[h->count - 1] = NULL;
+
+    h->count -= 1;
+
+    /* ensure heap property */
+    __pushup(h, idx);
+
+    return ret_item;
+}
+
+int heap_contains_item(const heap_t *h, const void *item) {
+    return __item_get_idx(h, item) != -1;
+}
+
+int heap_count(const heap_t *h) {
+    return h->count;
+}
+
+int heap_size(const heap_t *h) {
+    return h->size;
+}
+
+void _heap_cb_child(unsigned int idx, const heap_t *h, HeapCallback cb, void *ctx) {
+    if (idx >= h->count)
+        return;
+
+    if (h->cmp(h->array[0], h->array[idx], h->udata) == 0) {
+        cb(ctx, h->array[idx]);
+        _heap_cb_child(__child_left(idx), h, cb, ctx);
+        _heap_cb_child(__child_right(idx), h, cb, ctx);
+    }
+}
+
+void heap_cb_root(const heap_t *hp, HeapCallback cb, void *ctx) {
+    void *root = heap_peek(hp);
+    if (!root)
+        return;
+
+    cb(ctx, root);
+
+    _heap_cb_child(__child_left(0), hp, cb, ctx);
+    _heap_cb_child(__child_right(0), hp, cb, ctx);
+}
+
+/*--------------------------------------------------------------79-characters-*/

--- a/src/utils/heap.h
+++ b/src/utils/heap.h
@@ -1,0 +1,123 @@
+#ifndef HEAP_H
+#define HEAP_H
+#include <stdlib.h>
+
+typedef struct heap_s heap_t;
+
+/**
+ * Create new heap and initialise it.
+ *
+ * malloc()s space for heap.
+ *
+ * @param[in] cmp Callback used to get an item's priority
+ * @param[in] udata User data passed through to cmp callback
+ * @return initialised heap */
+heap_t *heap_new(int (*cmp)(const void *, const void *, const void *udata), const void *udata);
+
+/**
+ * Initialise heap. Use memory passed by user.
+ *
+ * No malloc()s are performed.
+ *
+ * @param[in] cmp Callback used to get an item's priority
+ * @param[in] udata User data passed through to cmp callback
+ * @param[in] size Initial size of the heap's array */
+void heap_init(heap_t *h,
+               int (*cmp)(const void *, const void *, const void *udata),
+               const void *udata,
+               unsigned int size);
+
+void heap_free(heap_t *hp);
+
+/**
+ * Add item
+ *
+ * Ensures that the data structure can hold the item.
+ *
+ * NOTE:
+ *  realloc() possibly called.
+ *  The heap pointer will be changed if the heap needs to be enlarged.
+ *
+ * @param[in/out] hp_ptr Pointer to the heap. Changed when heap is enlarged.
+ * @param[in] item The item to be added
+ * @return 0 on success; -1 on failure */
+int heap_offer(heap_t **hp_ptr, void *item);
+
+/**
+ * Add item
+ *
+ * An error will occur if there isn't enough space for this item.
+ *
+ * NOTE:
+ *  no malloc()s called.
+ *
+ * @param[in] item The item to be added
+ * @return 0 on success; -1 on error */
+int heap_offerx(heap_t *hp, void *item);
+
+/**
+ * Remove the item with the top priority
+ *
+ * @return top item */
+void *heap_poll(heap_t *hp);
+
+/**
+ * Replace root item
+ *
+ * @param[in] item The item to replace item at root
+ * @return 0 on success; -1 on error */
+void heap_replace(heap_t *h, void *item);
+
+/**
+ * @return top item of the heap */
+void *heap_peek(const heap_t *hp);
+
+/**
+ * Clear all items
+ *
+ * NOTE:
+ *  Does not free items.
+ *  Only use if item memory is managed outside of heap */
+void heap_clear(heap_t *hp);
+
+/**
+ * @return number of items in heap */
+int heap_count(const heap_t *hp);
+
+/**
+ * @return size of array */
+int heap_size(const heap_t *hp);
+
+/**
+ * @return number of bytes needed for a heap of this size. */
+size_t heap_sizeof(unsigned int size);
+
+/**
+ * Remove item
+ *
+ * @param[in] item The item that is to be removed
+ * @return item to be removed; NULL if item does not exist */
+void *heap_remove_item(heap_t *hp, const void *item);
+
+/**
+ * Test membership of item
+ *
+ * @param[in] item The item to test
+ * @return 1 if the heap contains this item; otherwise 0 */
+int heap_contains_item(const heap_t *hp, const void *item);
+
+/**
+ * Called when an entry is removed
+ */
+typedef void (*HeapCallback)(void *dst, void *src);
+
+/**
+ * Run callback of all elements equal to root
+ *
+ * @param[in] callback The function to be called
+ * @param[in] ctx The data required by the callback function
+ * @return
+ */
+void heap_cb_root(const heap_t *hp, HeapCallback cb, void *ctx);
+
+#endif /* HEAP_H */


### PR DESCRIPTION
Currently GROUPBY in TS.MRANGE and TS.MREVRANGE supports only the following reducers: sum, min, max.

We would like to support the following additional aggregation functions here as well:

    avg, range, count, std.p, std.s, var.p, var.s

Further reference: https://redislabs.atlassian.net/jira/software/c/projects/PM/boards/263?modal=detail&selectedIssue=PM-1300

## Performance change over this PR
### Comparison between master and perf_groupby_more_aggregators for metric: Totals.overallQuantiles.all_queries.q50. Time Period from 7 days ago to 13 hours ago. (environment used: oss-cluster-30-primaries)
|                 Test Case                 |Baseline master (median obs. +- std.dev)|Comparison perf_groupby_more_aggregators (median obs. +- std.dev)|% change (lower-better)|             Note              |
|-------------------------------------------|----------------------------------------|-----------------------------------------------------------------|-----------------------|-------------------------------|
|tsbs-scale100-cpu-max-all-1@4139rps        | 22 +- 5.2%  (15 datapoints)            | 22 +- 1.6%  (4 datapoints)                                      |-2.0%                  |waterline=5.2%. -- no change --|
|tsbs-scale100-cpu-max-all-8@588rps         | 63 +- 6.8%  (15 datapoints)            | 64 +- 0.9%  (4 datapoints)                                      |-2.3%                  |waterline=6.8%. -- no change --|
|tsbs-scale100-double-groupby-1@324rps      | 80 +- 17.3% UNSTABLE (15 datapoints)   | 82 +- 1.9%  (4 datapoints)                                      |-3.0%                  |UNSTABLE (very high variance)  |
|tsbs-scale100-double-groupby-5@70rps       | 247 +- 13.4% UNSTABLE (15 datapoints)  | 263 +- 2.6%  (4 datapoints)                                     |-6.0%                  |UNSTABLE (very high variance)  |
|tsbs-scale100-double-groupby-all@35rps     | 463 +- 13.8% UNSTABLE (15 datapoints)  | 495 +- 2.8%  (4 datapoints)                                     |-6.4%                  |UNSTABLE (very high variance)  |
|tsbs-scale100-groupby-orderby-limit@28rps  | 21 +- 16.9% UNSTABLE (15 datapoints)   | 22 +- 0.4%  (4 datapoints)                                      |-2.9%                  |UNSTABLE (very high variance)  |
|tsbs-scale100-high-cpu-1@1816rps           | 142 +- 2.1%  (15 datapoints)           | 150 +- nan%  (1 datapoints)                                     |-5.6%                  |REGRESSION                     |
|tsbs-scale100-high-cpu-all@18rps           | 441 +- 22.0% UNSTABLE (15 datapoints)  | 433 +- nan%  (1 datapoints)                                     |1.9%                   |UNSTABLE (very high variance)  |
|tsbs-scale100-lastpoint@488rps             | 11 +- 1.7%  (15 datapoints)            | 12 +- nan%  (1 datapoints)                                      |-3.3%                  |potential REGRESSION           |
|tsbs-scale100-single-groupby-1-1-12@2320rps| 15 +- 1.2%  (15 datapoints)            | 15 +- nan%  (1 datapoints)                                      |-0.6%                  |-- no change --                |
|tsbs-scale100-single-groupby-1-1-1@2320rps | 14 +- 1.3%  (15 datapoints)            | 14 +- nan%  (1 datapoints)                                      |-0.8%                  |-- no change --                |
|tsbs-scale100-single-groupby-1-8-1@4458rps | 18 +- 5.9%  (15 datapoints)            | 18 +- nan%  (1 datapoints)                                      |-0.8%                  |waterline=5.9%. -- no change --|
|tsbs-scale100-single-groupby-5-1-12@648rps | 20 +- 2.4%  (15 datapoints)            | 12 +- nan%  (1 datapoints)                                      |62.4%                  |IMPROVEMENT                    |
|tsbs-scale100-single-groupby-5-1-1@648rps  | 5 +- 6.9%  (15 datapoints)             | 5 +- nan%  (1 datapoints)                                       |-1.1%                  |waterline=6.9%. -- no change --|
|tsbs-scale100-single-groupby-5-8-1@1158rps | 34 +- 26.7% UNSTABLE (15 datapoints)   | 34 +- nan%  (1 datapoints)                                      |-0.6%                  |UNSTABLE (very high variance)  |
|tsbs-scale100_cpu-max-all-1                | 37 +- 4.4%  (15 datapoints)            | 38 +- 1.7%  (4 datapoints)                                      |-1.7%                  |-- no change --                |
|tsbs-scale100_cpu-max-all-8                | 106 +- 6.1%  (15 datapoints)           | 108 +- 1.0%  (4 datapoints)                                     |-2.5%                  |waterline=6.1%. -- no change --|
|tsbs-scale100_double-groupby-1             | 156 +- 4.6%  (15 datapoints)           | 157 +- 1.0%  (4 datapoints)                                     |-1.1%                  |-- no change --                |
|tsbs-scale100_double-groupby-5             | 646 +- 3.8%  (15 datapoints)           | 663 +- 1.2%  (4 datapoints)                                     |-2.6%                  |-- no change --                |
|tsbs-scale100_double-groupby-all           | 1254 +- 4.1%  (15 datapoints)          | 1279 +- 0.4%  (4 datapoints)                                    |-2.0%                  |-- no change --                |
|tsbs-scale100_groupby-orderby-limit        | 100 +- 7.3%  (15 datapoints)           | 100 +- 0.9%  (4 datapoints)                                     |-0.3%                  |waterline=7.3%. -- no change --|
|tsbs-scale100_high-cpu-1                   | 59 +- 4.6%  (15 datapoints)            | 59 +- nan%  (1 datapoints)                                      |0.6%                   |-- no change --                |
|tsbs-scale100_high-cpu-all                 | 1266 +- 10.4% UNSTABLE (15 datapoints) | 1244 +- nan%  (1 datapoints)                                    |1.7%                   |UNSTABLE (very high variance)  |
|tsbs-scale100_lastpoint                    | 56 +- 1.2%  (15 datapoints)            | 58 +- nan%  (1 datapoints)                                      |-2.8%                  |-- no change --                |
|tsbs-scale100_single-groupby-1-1-1         | 25 +- 1.3%  (15 datapoints)            | 25 +- nan%  (1 datapoints)                                      |-0.7%                  |-- no change --                |
|tsbs-scale100_single-groupby-1-1-12        | 26 +- 1.2%  (15 datapoints)            | 27 +- nan%  (1 datapoints)                                      |-0.7%                  |-- no change --                |
|tsbs-scale100_single-groupby-1-8-1         | 31 +- 5.1%  (15 datapoints)            | 32 +- nan%  (1 datapoints)                                      |-0.9%                  |waterline=5.1%. -- no change --|
|tsbs-scale100_single-groupby-5-1-1         | 30 +- 3.3%  (15 datapoints)            | 30 +- nan%  (1 datapoints)                                      |-1.2%                  |-- no change --                |
|tsbs-scale100_single-groupby-5-1-12        | 54 +- 1.1%  (15 datapoints)            | 42 +- nan%  (1 datapoints)                                      |28.3%                  |IMPROVEMENT                    |
|tsbs-scale100_single-groupby-5-8-1         | 58 +- 14.0% UNSTABLE (15 datapoints)   | 58 +- nan%  (1 datapoints)                                      |-1.1%                  |UNSTABLE (very high variance)  |`