### PR TITLE
bug fix: move twa enum to be the largest so the enum will be backward…

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -53,7 +53,6 @@ typedef enum {
     TS_AGG_MAX,
     TS_AGG_SUM,
     TS_AGG_AVG,
-    TS_AGG_TWA,
     TS_AGG_COUNT,
     TS_AGG_FIRST,
     TS_AGG_LAST,
@@ -62,6 +61,7 @@ typedef enum {
     TS_AGG_STD_S,
     TS_AGG_VAR_P,
     TS_AGG_VAR_S,
+    TS_AGG_TWA,
     TS_AGG_TYPES_MAX // 13
 } TS_AGG_TYPES_T;
 


### PR DESCRIPTION
… compatible (support upgrades)