### PR TITLE
Revert "supress valgrind mem leak warning, on the static context whic…

### DIFF
--- a/tests/redis_valgrind.sup
+++ b/tests/redis_valgrind.sup
@@ -183,16 +183,3 @@
     fun:connSocketEventHandler
     fun:aeProcessEvents
 }
-
-{
-    <redis_get_context_superssions>
-    Memcheck:Leak
-    fun:malloc
-    fun:ztrymalloc_usable (zmalloc.c:101)
-    fun:zmalloc (zmalloc.c:119)
-    fun:RM_GetDetachedThreadSafeContext (module.c:5811)
-    fun:???
-    fun:moduleLoad (module.c:8594)
-    fun:moduleLoadFromQueue (module.c:8521)
-    fun:main (server.c:6414)
-}


### PR DESCRIPTION
…h is allocated on module load and never being freed"

This reverts commit bc10647d6fde943e337970101073d06988469eff.