### PR TITLE
Replicaof bug fix

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1120,6 +1120,26 @@ void swapDbEventCallback(RedisModuleCtx *ctx, RedisModuleEvent e, uint64_t sub, 
     }
 }
 
+int persistence_in_progress = 0;
+
+void persistCallback(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent, void *data) {
+    if (memcmp(&eid, &RedisModuleEvent_Persistence, sizeof(eid)) != 0) {
+        return;
+    }
+
+    if (subevent == REDISMODULE_SUBEVENT_PERSISTENCE_RDB_START ||
+        subevent == REDISMODULE_SUBEVENT_PERSISTENCE_AOF_START ||
+        subevent == REDISMODULE_SUBEVENT_PERSISTENCE_SYNC_RDB_START ||
+        subevent == REDISMODULE_SUBEVENT_PERSISTENCE_SYNC_AOF_START) {
+        persistence_in_progress++;
+    } else if (subevent == REDISMODULE_SUBEVENT_PERSISTENCE_ENDED ||
+               subevent == REDISMODULE_SUBEVENT_PERSISTENCE_FAILED) {
+        persistence_in_progress--;
+    }
+
+    return;
+}
+
 void ShardingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent, void *data) {
     /**
      * On sharding event we need to do couple of things depends on the subevent given:
@@ -1374,6 +1394,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
     RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_FlushDB, FlushEventCallback);
     RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_SwapDB, swapDbEventCallback);
+    RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_Persistence, persistCallback);
 
     Initialize_RdbNotifications(ctx);
 

--- a/src/module.h
+++ b/src/module.h
@@ -22,4 +22,6 @@ int CreateTsKey(RedisModuleCtx *ctx,
 
 bool CheckVersionForBlockedClientMeasureTime();
 
+extern int persistence_in_progress;
+
 #endif

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -15,9 +15,12 @@
 #define TS_IS_RESSETED_DUP_POLICY_RDB_VER 3
 #define TS_OVERFLOW_RDB_VER 4
 #define TS_ALIGNMENT_TS_VER 5
+#define TS_REPLICAOF_SUPPORT_VER 6
 
 // This flag should be updated whenever a new rdb version is introduced
-#define TS_LATEST_ENCVER TS_ALIGNMENT_TS_VER
+#define TS_LATEST_ENCVER TS_REPLICAOF_SUPPORT_VER
+
+extern int last_rdb_load_version;
 
 void *series_rdb_load(RedisModuleIO *io, int encver);
 void series_rdb_save(RedisModuleIO *io, void *value);

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -15,6 +15,7 @@
 #include "sample_iterator.h"
 #include "multiseries_sample_iterator.h"
 #include "multiseries_agg_dup_sample_iterator.h"
+#include "rdb.h"
 
 #include <inttypes.h>
 #include <math.h>
@@ -213,19 +214,24 @@ void RestoreKey(RedisModuleCtx *ctx, RedisModuleString *keyname) {
     }
     IndexMetric(keyname, series->labels, series->labelsCount);
 
-    // Remove references to other keys
-    if (series->srcKey) {
-        RedisModule_FreeString(NULL, series->srcKey);
-        series->srcKey = NULL;
-    }
+    if (last_rdb_load_version < TS_REPLICAOF_SUPPORT_VER) {
+        // In versions greater than TS_REPLICAOF_SUPPORT_VER we delete the reference on the dump
+        // stage
 
-    CompactionRule *rule = series->rules;
-    while (rule != NULL) {
-        CompactionRule *nextRule = rule->nextRule;
-        FreeCompactionRule(rule);
-        rule = nextRule;
+        // Remove references to other keys
+        if (series->srcKey) {
+            RedisModule_FreeString(NULL, series->srcKey);
+            series->srcKey = NULL;
+        }
+
+        CompactionRule *rule = series->rules;
+        while (rule != NULL) {
+            CompactionRule *nextRule = rule->nextRule;
+            FreeCompactionRule(rule);
+            rule = nextRule;
+        }
+        series->rules = NULL;
     }
-    series->rules = NULL;
 
     RedisModule_CloseKey(key);
 }

--- a/tests/flow/test_lazy_del.py
+++ b/tests/flow/test_lazy_del.py
@@ -53,3 +53,42 @@ def test_dump_restore_dst_rule():
         assert len(_get_ts_info(r, key1).rules) == 0
         assert _get_ts_info(r, key2).sourceKey == None
         assert len(_get_ts_info(r, key2).rules) == 0
+
+        r.execute_command('TS.CREATERULE', key1, key2, 'AGGREGATION', 'avg', 60000)
+        assert _get_ts_info(r, key2).sourceKey.decode() == key1
+        assert len(_get_ts_info(r, key1).rules) == 1
+
+        data = r.execute_command('DUMP', key1)
+        r.execute_command('DEL', key1)
+        r.execute_command('restore', key1, 0, data)
+
+        assert _get_ts_info(r, key1).sourceKey == None
+        assert len(_get_ts_info(r, key1).rules) == 0
+        assert _get_ts_info(r, key2).sourceKey == None
+        assert len(_get_ts_info(r, key2).rules) == 0
+
+def test_dump_restore_dst_rule_old_version():
+    with Env().getClusterConnectionIfNeeded() as r:
+        key1 = 'ts1{a}'
+        key2 = 'ts2{a}'
+        r.execute_command('TS.CREATE', key1)
+
+        # data was taken from test_dump_restore_dst_rule on version TS_ALIGNMENT_TS_VER
+        data = b'\x07\x81M \xc1\xf96\x0f\x10\x05\x05\x06ts2{a}\x02\x00\x02P\x00\x02\x02\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x02\x00\x02\x01\x05\x06ts1{a}\x02\x00\x02\x00\x02\x01\x02P\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02 \x02 \x05\xc36P\x00\x01\x00\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0{\x00\x01\x00\x00\x00\t\x00\x1e\x80\x04\xe3\xf0.\xfc$'
+        r.execute_command('restore', key2, 0, data)
+
+        assert _get_ts_info(r, key1).sourceKey == None
+        assert len(_get_ts_info(r, key1).rules) == 0
+        assert _get_ts_info(r, key2).sourceKey == None
+        assert len(_get_ts_info(r, key2).rules) == 0
+
+        r.execute_command('DEL', key1)
+
+        # data was taken from test_dump_restore_dst_rule on version TS_ALIGNMENT_TS_VER
+        data = b'\x07\x81M \xc1\xf96\x0f\x10\x05\x05\x06ts1{a}\x02\x00\x02P\x00\x02\x02\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x01\x05\x06ts2{a}\x02\x80\x00\x00\xea`\x02\x00\x02\x04\x02\x81\xff\xff\xff\xff\xff\xff\xff\xff\x04\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x02\x01\x02P\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02 \x02 \x05\xc36P\x00\x01\x00\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0{\x00\x01\x00\x00\x00\t\x00\xf9\x7f\x9d\xeeN\xe5\xb3/'
+        r.execute_command('restore', key1, 0, data)
+
+        assert _get_ts_info(r, key1).sourceKey == None
+        assert len(_get_ts_info(r, key1).rules) == 0
+        assert _get_ts_info(r, key2).sourceKey == None
+        assert len(_get_ts_info(r, key2).rules) == 0


### PR DESCRIPTION
Fixing bug:
https://redislabs.atlassian.net/browse/RED-78216?focusedCommentId=1589712&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1589712

In general keep cross reference on restore is wrong, there is not guarantee that the other key will ever be restored or that it might be renamed.
That said, on enterprise replica of we do want to keep the cross reference
The solution: 
Use persistence subevent to know when other than dump rdb_save is in progress and removing the references when the rdb_save is in dump context.
Inorder to handle old rdb versions on which the references exists on dump rdbs, we save the last rdb load version so that on restore keyspace notification we can tell if we should remove the cross references.

There is a limitation in the solution, which is when updating a key while replicaof is in progress the downsampled key might not be updated because it might not replicated yet. 