### PR TITLE
queryindex, madd, and mget edits

### DIFF
--- a/docs/commands/ts.madd.md
+++ b/docs/commands/ts.madd.md
@@ -1,26 +1,53 @@
-### TS.MADD
+---
+syntax: 
+---
 
-Append new samples to one or more time series.
+Append new samples to one or more time series
 
-```sql
+{{< highlight bash >}}
 TS.MADD {key timestamp value}...
-```
+{{< / highlight >}}
 
-- _key_ - Key name for time series
-- _timestamp_ - (integer) UNIX sample timestamp **in milliseconds** or `*` to set the timestamp based on the server's clock.
-- _value_ - numeric data value of the sample (double). We expect the double number to follow [RFC 7159](https://tools.ietf.org/html/rfc7159) (JSON standard). In particular, the parser will reject overly large values that would not fit in binary64. It will not accept NaN or infinite values.
+[**Examples**](#examples)
 
-#### Examples
-```sql
-127.0.0.1:6379>TS.MADD temperature:2:32 1548149180000 26 cpu:2:32 1548149183000 54
-1) (integer) 1548149180000
-2) (integer) 1548149183000
-127.0.0.1:6379>TS.MADD temperature:2:32 1548149181000 45 cpu:2:32 1548149180000 30
-1) (integer) 1548149181000
-2) (integer) 1548149180000
-```
+## Required arguments
 
-#### Complexity
+`key` is the key name for the time series.
+
+`timestamp` is (integer) UNIX sample timestamp in milliseconds or `*` to set the timestamp to the server clock.
+
+`value` is numeric data value of the sample (double). The double number should follow [RFC 7159](https://tools.ietf.org/html/rfc7159) (JSON standard). The parser rejects overly large values that would not fit in binary64. It does not accept NaN or infinite values.
+
+## Complexity
 
 If a compaction rule exits on a time series, `TS.MADD` performance might be reduced.
-The complexity of `TS.MADD` is always O(N*M) when N is the amount of series updated and M is the amount of compaction rules or O(N) with no compaction.
+The complexity of `TS.MADD` is always O(N*M), where N is the amount of series updated and M is the amount of compaction rules or O(N) with no compaction.
+
+## Examples
+
+### Add stock prices at different timestamps
+
+Create two stocks and add their prices at three different timestamps.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.CREATE stock:A LABELS type stock name A
+OK
+127.0.0.1:6379> TS.CREATE stock:B LABELS type stock name B
+OK
+127.0.0.1:6379> TS.MADD stock:A 1000 100 stock:A 1010 110 stock:A 1020 120
+1) (integer) 1000
+2) (integer) 1010
+3) (integer) 1020
+127.0.0.1:6379> TS.MADD stock:B 1000 120 stock:B 1010 110 stock:B 1020 100
+1) (integer) 1000
+2) (integer) 1010
+3) (integer) 1020
+{{< / highlight >}}
+
+## See also
+
+`TS.MRANGE` | `TS.RANGE` | `TS.MREVRANGE` | `TS.REVRANGE`
+
+## Related topics
+
+[RedisTimeSeries](/docs/stack/timeseries)

--- a/docs/commands/ts.madd.md
+++ b/docs/commands/ts.madd.md
@@ -8,24 +8,35 @@ Append new samples to one or more time series
 TS.MADD {key timestamp value}...
 {{< / highlight >}}
 
-[**Examples**](#examples)
+[:arrow_down_small:**Examples**](#examples)
 
 ## Required arguments
 
-`key` is the key name for the time series.
+<details>
+<summary><code>key</code></summary> 
+is the key name for the time series.
 
-`timestamp` is (integer) UNIX sample timestamp in milliseconds or `*` to set the timestamp to the server clock.
+</details>
 
-`value` is numeric data value of the sample (double). The double number should follow [RFC 7159](https://tools.ietf.org/html/rfc7159) (JSON standard). The parser rejects overly large values that would not fit in binary64. It does not accept NaN or infinite values.
+<details>
+<summary><code>timestamp</code></summary>
+is (integer) UNIX sample timestamp in milliseconds or <code>*</code> to set the timestamp to the server clock.
+</details>
+
+<details>
+<summary><code>value</code></summary>
+is numeric data value of the sample (double). The double number should follow <a href="https://tools.ietf.org/html/rfc7159">RFC 7159</a> (a JSON standard). The parser rejects overly large values that would not fit in binary64. It does not accept NaN or infinite values.
+</details>
 
 ## Complexity
 
-If a compaction rule exits on a time series, `TS.MADD` performance might be reduced.
-The complexity of `TS.MADD` is always O(N*M), where N is the amount of series updated and M is the amount of compaction rules or O(N) with no compaction.
+If a compaction rule exits on a time series, TS.MADD performance might be reduced.
+The complexity of TS.MADD is always `O(N*M)`, where `N` is the amount of series updated and `M` is the amount of compaction rules or `O(N)` with no compaction.
 
 ## Examples
 
-### Add stock prices at different timestamps
+<details>
+<summary><b>Add stock prices at different timestamps</b></summary>
 
 Create two stocks and add their prices at three different timestamps.
 
@@ -43,6 +54,7 @@ OK
 2) (integer) 1010
 3) (integer) 1020
 {{< / highlight >}}
+</details>
 
 ## See also
 

--- a/docs/commands/ts.madd.md
+++ b/docs/commands/ts.madd.md
@@ -4,6 +4,8 @@ syntax:
 
 Append new samples to one or more time series
 
+## Syntax
+
 {{< highlight bash >}}
 TS.MADD {key timestamp value}...
 {{< / highlight >}}
@@ -14,17 +16,19 @@ TS.MADD {key timestamp value}...
 
 <details open>
 <summary><code>key</code></summary> 
-is the key name for the time series.
 
+is the key name for the time series.
 </details>
 
 <details open>
 <summary><code>timestamp</code></summary>
+
 is (integer) UNIX sample timestamp in milliseconds or <code>*</code> to set the timestamp to the server clock.
 </details>
 
 <details open>
 <summary><code>value</code></summary>
+
 is numeric data value of the sample (double). The double number should follow <a href="https://tools.ietf.org/html/rfc7159">RFC 7159</a> (a JSON standard). The parser rejects overly large values that would not fit in binary64. It does not accept NaN or infinite values.
 </details>
 

--- a/docs/commands/ts.madd.md
+++ b/docs/commands/ts.madd.md
@@ -8,22 +8,22 @@ Append new samples to one or more time series
 TS.MADD {key timestamp value}...
 {{< / highlight >}}
 
-[:arrow_down_small:**Examples**](#examples)
+[Examples](#examples)
 
 ## Required arguments
 
-<details>
+<details open>
 <summary><code>key</code></summary> 
 is the key name for the time series.
 
 </details>
 
-<details>
+<details open>
 <summary><code>timestamp</code></summary>
 is (integer) UNIX sample timestamp in milliseconds or <code>*</code> to set the timestamp to the server clock.
 </details>
 
-<details>
+<details open>
 <summary><code>value</code></summary>
 is numeric data value of the sample (double). The double number should follow <a href="https://tools.ietf.org/html/rfc7159">RFC 7159</a> (a JSON standard). The parser rejects overly large values that would not fit in binary64. It does not accept NaN or infinite values.
 </details>
@@ -35,7 +35,7 @@ The complexity of TS.MADD is always `O(N*M)`, where `N` is the amount of series 
 
 ## Examples
 
-<details>
+<details open>
 <summary><b>Add stock prices at different timestamps</b></summary>
 
 Create two stocks and add their prices at three different timestamps.

--- a/docs/commands/ts.madd.md
+++ b/docs/commands/ts.madd.md
@@ -45,14 +45,13 @@ Create two stocks and add their prices at three different timestamps.
 OK
 127.0.0.1:6379> TS.CREATE stock:B LABELS type stock name B
 OK
-127.0.0.1:6379> TS.MADD stock:A 1000 100 stock:A 1010 110 stock:A 1020 120
+127.0.0.1:6379> TS.MADD stock:A 1000 100 stock:A 1010 110 stock:A 1020 120 stock:B 1000 120 stock:B 1010 110 stock:B 1020 100
 1) (integer) 1000
 2) (integer) 1010
 3) (integer) 1020
-127.0.0.1:6379> TS.MADD stock:B 1000 120 stock:B 1010 110 stock:B 1020 100
-1) (integer) 1000
-2) (integer) 1010
-3) (integer) 1020
+4) (integer) 1000
+5) (integer) 1010
+6) (integer) 1020
 {{< / highlight >}}
 </details>
 

--- a/docs/commands/ts.mget.md
+++ b/docs/commands/ts.mget.md
@@ -8,11 +8,14 @@ Get the last samples matching a specific filter.
 TS.MGET [LATEST] [WITHLABELS | SELECTED_LABELS label...] FILTER filter...
 {{< / highlight >}}
 
-[**Examples**](#examples)
+[:arrow_down_small:**Examples**](#examples)
 
 ## Required arguments
 
-`FILTER filter..` uses these filters:
+<details>
+<summary><code>FILTER filter..</code></summary> 
+
+uses these filters:
 
   - `label = value`, where `label` equals `value`
   - `label != value`, where `label` does not equal `value`
@@ -21,20 +24,34 @@ TS.MGET [LATEST] [WITHLABELS | SELECTED_LABELS label...] FILTER filter...
   - `label = (_value1_,_value2_,...)`, where `key` with label `label` equals one of the values in the list
   - `label != (value1,value2,...)` is key with label `label` that does not equal any of the values in the list
 
-  > **NOTE:** When using filters, apply a minimum of one `label = value` filter.
+  <note><b>NOTE:</b> When using filters, apply a minimum of one `label = value` filter.</note>
+
+  </details>
 
 ## Optional arguments
 
-`LATEST` (since RedisTimeSeries v1.8), used when a time series is a compaction. With `LATEST`, TS.MGET also reports the compacted value of the latest possibly partial bucket, given that this bucket's start time falls within `[fromTimestamp, toTimestamp]`. Without `LATEST`, TS.RANGE does not report the latest possibly partial bucket. When a time series is not a compaction, `LATEST` is ignored.
+<details>
+<summary><code>LATEST</code> (since RedisTimeSeries v1.8)</summary> 
+
+is used when a time series is a compaction. With `LATEST`, TS.MGET also reports the compacted value of the latest possibly partial bucket, given that this bucket's start time falls within `[fromTimestamp, toTimestamp]`. Without `LATEST`, TS.MGET does not report the latest possibly partial bucket. When a time series is not a compaction, `LATEST` is ignored.
   
 The data in the latest bucket of a compaction is possibly partial. A bucket is _closed_ and compacted only upon arrival of a new sample that _opens_ a new _latest_ bucket. There are cases, however, when the compacted value of the latest possibly partial bucket is also required. In such a case, use `LATEST`.
+</details>
 
-`WITHLABELS` includes in the reply all label-value pairs representing metadata labels of the time series. 
+<details>
+<summary><code>WITHLABELS</code></summary> 
+
+includes in the reply all label-value pairs representing metadata labels of the time series. 
 If `WITHLABELS` or `SELECTED_LABELS` are not specified, by default, an empty list is reported as label-value pairs.
+</details>
 
-`SELECTED_LABELS label...` (since RedisTimeSeries v1.6) returns a subset of the label-value pairs that represent metadata labels of the time series. 
+<details>
+<summary><code>SELECTED_LABELS label...</code> (since RedisTimeSeries v1.6)</summary> 
+
+returns a subset of the label-value pairs that represent metadata labels of the time series. 
 Use when a large number of labels exists per series, but only the values of some of the labels are required. 
 If `WITHLABELS` or `SELECTED_LABELS` are not specified, by default, an empty list is reported as label-value pairs.
+</details>
 
 ## Return value
 
@@ -46,11 +63,12 @@ For each time series matching the specified filters, the following is reported:
   - If `SELECTED_LABELS label...` is specified, the selected labels are reported
 - Timestamp-value pairs for all samples/aggregations matching the range
 
-> **NOTE:** The `MGET` command cannot be part of transaction when running on a Redis cluster.
+<note><b>NOTE:</b> The `MGET` command cannot be part of transaction when running on a Redis cluster.</note>
 
 ## Examples
 
-### Select labels to retrieve
+<details>
+<summary><b>Select labels to retrieve</b></summary>
 
 Consider a metric where acceptable values are between -100 and 100, and the value 9999 is used as an indication of bad measurement.
 
@@ -87,6 +105,7 @@ To get the location only, use `SELECTED_LABELS`.
    3) 1) (integer) 1030
       2) 40
 {{< / highlight >}}
+</details>
 
 ## See also
 

--- a/docs/commands/ts.mget.md
+++ b/docs/commands/ts.mget.md
@@ -73,23 +73,37 @@ For each time series matching the specified filters, the following is reported:
 <details open>
 <summary><b>Select labels to retrieve</b></summary>
 
-Create a time series for temperature in Tel Aviv, then add different temperature samples.
+Create time series for temperature in Tel Aviv and Jerusalem, then add different temperature samples.
 
 {{< highlight bash >}}
 127.0.0.1:6379> TS.CREATE temp:TLV LABELS type temp location TLV
+OK
+127.0.0.1:6379> TS.CREATE temp:JLM LABELS type temp location JLM
 OK
 127.0.0.1:6379> TS.MADD temp:TLV 1000 30 temp:TLV 1010 35 temp:TLV 1020 9999 temp:TLV 1030 40
 1) (integer) 1000
 2) (integer) 1010
 3) (integer) 1020
 4) (integer) 1030
+127.0.0.1:6379> TS.MADD temp:JLM 1005 30 temp:JLM 1015 35 temp:TLM 1025 9999 temp:JLM 1035 40
+1) (integer) 1005
+2) (integer) 1015
+3) (integer) 1025
+4) (integer) 1035
 {{< / highlight >}}
 
 Get all the labels associated with the last sample.
 
 {{< highlight bash >}}
 127.0.0.1:6379> TS.MGET WITHLABELS FILTER type=temp
-1) 1) "temp:TLV"
+1) 1) "temp:JLM"
+   2) 1) 1) "type"
+         2) "temp"
+      2) 1) "location"
+         2) "JLM"
+   3) 1) (integer) 1035
+      2) 40
+2) 1) "temp:TLV"
    2) 1) 1) "type"
          2) "temp"
       2) 1) "location"
@@ -98,11 +112,16 @@ Get all the labels associated with the last sample.
       2) 40
 {{< / highlight >}}
 
-To get the location of the last sample, use `SELECTED_LABELS`.
+To get only the `location` label for each last sample, use `SELECTED_LABELS`.
 
 {{< highlight bash >}}
 127.0.0.1:6379> TS.MGET SELECTED_LABELS location FILTER type=temp
-1) 1) "temp:TLV"
+1) 1) "temp:JLM"
+   2) 1) 1) "location"
+         2) "JLM"
+   3) 1) (integer) 1035
+      2) 40
+2) 1) "temp:TLV"
    2) 1) 1) "location"
          2) "TLV"
    3) 1) (integer) 1030

--- a/docs/commands/ts.mget.md
+++ b/docs/commands/ts.mget.md
@@ -1,87 +1,98 @@
-### TS.MGET
+---
+syntax: 
+---
+
 Get the last samples matching a specific filter.
 
-```sql
+{{< highlight bash >}}
 TS.MGET [LATEST] [WITHLABELS | SELECTED_LABELS label...] FILTER filter...
-```
-### Arguments
+{{< / highlight >}}
 
-#### Mandatory arguments
+[**Examples**](#examples)
 
-- FILTER _filter_...
+## Required arguments
 
-  This is the list of possible filters:
-  - _label_`=`_value_ - _label_ equals _value_
-  - _label_`!=`_value_ - label doesn't equal _value_
-  - _label_`=` - _key_ does not have the label _label_
-  - _label_`!=` - _key_ has label _label_
-  - _label_`=(`_value1_`,`_value2_`,`...`)` - key with label _label_ that equals one of the values in the list
-  - _lable_`!=(`_value1_`,`_value2_`,`...`)` - key with label _label_ that doesn't equal any of the values in the list
+`FILTER filter..` uses these filters:
 
-  Note: Whenever filters need to be provided, a minimum of one _label_`=`_value_ filter must be applied.
+  - `label = value`, where `label` equals `value`
+  - `label != value`, where `label` does not equal `value`
+  - `label = `, where `key` does not have label `label`
+  - `label != `, where `key` has label `label`
+  - `label = (_value1_,_value2_,...)`, where `key` with label `label` equals one of the values in the list
+  - `label != (value1,value2,...)` is key with label `label` that does not equal any of the values in the list
 
-#### Optional Arguments
+  > **NOTE:** When using filters, apply a minimum of one `label = value` filter.
 
-- `LATEST` (since RedisTimeSeries v1.8)
+## Optional arguments
 
-  When a time series is a compaction: With `LATEST`, TS.MGET will report the compacted value of the latest (possibly partial) bucket. Without `LATEST`, TS.MGET will report the compacted value of the last 'closed' bucket. When a series is not a compaction: `LATEST` is ignored.
+`LATEST` (since RedisTimeSeries v1.8), used when a time series is a compaction. With `LATEST`, TS.MGET also reports the compacted value of the latest possibly partial bucket, given that this bucket's start time falls within `[fromTimestamp, toTimestamp]`. Without `LATEST`, TS.RANGE does not report the latest possibly partial bucket. When a time series is not a compaction, `LATEST` is ignored.
   
-  The data in the latest bucket of a compaction is possibly partial. A bucket is 'closed' and compacted only upon arrival of a new sample that 'opens' a 'new latest' bucket. There are cases, however, when the compacted value of the latest (possibly partial) bucket is required instead of the compacted value of the last 'closed' bucket. `LATEST` can be used when this is required.  
+The data in the latest bucket of a compaction is possibly partial. A bucket is _closed_ and compacted only upon arrival of a new sample that _opens_ a new _latest_ bucket. There are cases, however, when the compacted value of the latest possibly partial bucket is also required. In such a case, use `LATEST`.
 
-- `WITHLABELS` - Include in the reply all label-value pairs representing metadata labels of the time series. 
+`WITHLABELS` includes in the reply all label-value pairs representing metadata labels of the time series. 
+If `WITHLABELS` or `SELECTED_LABELS` are not specified, by default, an empty list is reported as label-value pairs.
 
-- `SELECTED_LABELS` _label_... - Include in the reply a subset of the label-value pairs that represent metadata labels of the time series. This is usefull when there is a large number of labels per series, but only the values of some of the labels are required.
- 
-If `WITHLABELS` or `SELECTED_LABELS` are not specified, by default, an empty list is reported as the label-value pairs.
+`SELECTED_LABELS label...` (since RedisTimeSeries v1.6) returns a subset of the label-value pairs that represent metadata labels of the time series. 
+Use when a large number of labels exists per series, but only the values of some of the labels are required. 
+If `WITHLABELS` or `SELECTED_LABELS` are not specified, by default, an empty list is reported as label-value pairs.
 
-### Return Value
+## Return value
 
 For each time series matching the specified filters, the following is reported:
 - The key name
 - A list of label-value pairs
   - By default, an empty list is reported
   - If `WITHLABELS` is specified, all labels associated with this time series are reported
-  - If `SELECTED_LABELS` _label_... is specified, the selected labels are reported
-- The last sample's timetag-value pair
+  - If `SELECTED_LABELS label...` is specified, the selected labels are reported
+- Timestamp-value pairs for all samples/aggregations matching the range
 
-Note: MGET command can't be part of transaction when running on Redis cluster.
+> **NOTE:** The `MGET` command cannot be part of transaction when running on a Redis cluster.
 
-### Complexity
+## Examples
 
-TS.MGET complexity is O(n).
+### Select labels to retrieve
 
-n = Number of time series that match the filters
+Consider a metric where acceptable values are between -100 and 100, and the value 9999 is used as an indication of bad measurement.
 
-### Examples
+{{< highlight bash >}}
+127.0.0.1:6379> TS.CREATE temp:TLV LABELS type temp location TLV
+OK
+127.0.0.1:6379> TS.MADD temp:TLV 1000 30 temp:TLV 1010 35 temp:TLV 1020 9999 temp:TLV 1030 40
+1) (integer) 1000
+2) (integer) 1010
+3) (integer) 1020
+4) (integer) 1030
+{{< / highlight >}}
 
-#### MGET Example with default behaviour
-```sql
-127.0.0.1:6379> TS.MGET FILTER area_id=32
-1) 1) "temperature:2:32"
-   2) (empty list or set)
-   3) 1) (integer) 1548149181000
-      2) "30"
-2) 1) "temperature:3:32"
-   2) (empty list or set)
-   3) 1) (integer) 1548149181000
-      2) "29"
-```
+Get all the labels associated with the time series.
 
-#### MGET Example with WITHLABELS option
-```sql
-127.0.0.1:6379> TS.MGET WITHLABELS FILTER area_id=32
-1) 1) "temperature:2:32"
-   2) 1) 1) "sensor_id"
-         2) "2"
-      2) 1) "area_id"
-         2) "32"
-   3) 1) (integer) 1548149181000
-      2) "30"
-2) 1) "temperature:3:32"
-   2) 1) 1) "sensor_id"
-         2) "2"
-      2) 1) "area_id"
-         2) "32"
-   3) 1) (integer) 1548149181000
-      2) "29"
-```
+{{< highlight bash >}}
+127.0.0.1:6379> TS.MGET WITHLABELS FILTER type=temp
+1) 1) "temp:TLV"
+   2) 1) 1) "type"
+         2) "temp"
+      2) 1) "location"
+         2) "TLV"
+   3) 1) (integer) 1030
+      2) 40
+{{< / highlight >}}
+
+To get the location only, use `SELECTED_LABELS`.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.MGET SELECTED_LABELS location FILTER type=temp
+1) 1) "temp:TLV"
+   2) 1) 1) "location"
+         2) "TLV"
+   3) 1) (integer) 1030
+      2) 40
+{{< / highlight >}}
+
+## See also
+
+`TS.MRANGE` | `TS.RANGE` | `TS.MREVRANGE` | `TS.REVRANGE`
+
+## Related topics
+
+[RedisTimeSeries](/docs/stack/timeseries)
+

--- a/docs/commands/ts.mget.md
+++ b/docs/commands/ts.mget.md
@@ -8,11 +8,11 @@ Get the last samples matching a specific filter.
 TS.MGET [LATEST] [WITHLABELS | SELECTED_LABELS label...] FILTER filter...
 {{< / highlight >}}
 
-[:arrow_down_small:**Examples**](#examples)
+[Examples](#examples)
 
 ## Required arguments
 
-<details>
+<details open>
 <summary><code>FILTER filter..</code></summary> 
 
 uses these filters:
@@ -30,7 +30,7 @@ uses these filters:
 
 ## Optional arguments
 
-<details>
+<details open>
 <summary><code>LATEST</code> (since RedisTimeSeries v1.8)</summary> 
 
 is used when a time series is a compaction. With `LATEST`, TS.MGET also reports the compacted value of the latest possibly partial bucket, given that this bucket's start time falls within `[fromTimestamp, toTimestamp]`. Without `LATEST`, TS.MGET does not report the latest possibly partial bucket. When a time series is not a compaction, `LATEST` is ignored.
@@ -38,14 +38,14 @@ is used when a time series is a compaction. With `LATEST`, TS.MGET also reports 
 The data in the latest bucket of a compaction is possibly partial. A bucket is _closed_ and compacted only upon arrival of a new sample that _opens_ a new _latest_ bucket. There are cases, however, when the compacted value of the latest possibly partial bucket is also required. In such a case, use `LATEST`.
 </details>
 
-<details>
+<details open>
 <summary><code>WITHLABELS</code></summary> 
 
 includes in the reply all label-value pairs representing metadata labels of the time series. 
 If `WITHLABELS` or `SELECTED_LABELS` are not specified, by default, an empty list is reported as label-value pairs.
 </details>
 
-<details>
+<details open>
 <summary><code>SELECTED_LABELS label...</code> (since RedisTimeSeries v1.6)</summary> 
 
 returns a subset of the label-value pairs that represent metadata labels of the time series. 
@@ -67,7 +67,7 @@ For each time series matching the specified filters, the following is reported:
 
 ## Examples
 
-<details>
+<details open>
 <summary><b>Select labels to retrieve</b></summary>
 
 Consider a metric where acceptable values are between -100 and 100, and the value 9999 is used as an indication of bad measurement.

--- a/docs/commands/ts.mget.md
+++ b/docs/commands/ts.mget.md
@@ -15,16 +15,19 @@ TS.MGET [LATEST] [WITHLABELS | SELECTED_LABELS label...] FILTER filter...
 <details open>
 <summary><code>FILTER filter..</code></summary> 
 
-uses these filters:
+filters time series based on their labels and label values, with these options:
 
   - `label = value`, where `label` equals `value`
   - `label != value`, where `label` does not equal `value`
   - `label = `, where `key` does not have label `label`
   - `label != `, where `key` has label `label`
   - `label = (_value1_,_value2_,...)`, where `key` with label `label` equals one of the values in the list
-  - `label != (value1,value2,...)` is key with label `label` that does not equal any of the values in the list
+  - `label != (value1,value2,...)` where key with label `label` does not equal any of the values in the list
 
-  <note><b>NOTE:</b> When using filters, apply a minimum of one `label = value` filter.</note>
+  <note><b>NOTES:</b> 
+   - When using filters, apply a minimum of one `label = value` filter.
+   - Filters are conjunctive. For example, the FILTER `type = temperature room = study` means the a time series is a temperature time series of a study room.
+   </note>
 
   </details>
 
@@ -70,7 +73,7 @@ For each time series matching the specified filters, the following is reported:
 <details open>
 <summary><b>Select labels to retrieve</b></summary>
 
-Consider a metric where acceptable values are between -100 and 100, and the value 9999 is used as an indication of bad measurement.
+Create a time series for temperature in Tel Aviv, then add different temperature samples.
 
 {{< highlight bash >}}
 127.0.0.1:6379> TS.CREATE temp:TLV LABELS type temp location TLV
@@ -82,7 +85,7 @@ OK
 4) (integer) 1030
 {{< / highlight >}}
 
-Get all the labels associated with the time series.
+Get all the labels associated with the last sample.
 
 {{< highlight bash >}}
 127.0.0.1:6379> TS.MGET WITHLABELS FILTER type=temp
@@ -95,7 +98,7 @@ Get all the labels associated with the time series.
       2) 40
 {{< / highlight >}}
 
-To get the location only, use `SELECTED_LABELS`.
+To get the location of the last sample, use `SELECTED_LABELS`.
 
 {{< highlight bash >}}
 127.0.0.1:6379> TS.MGET SELECTED_LABELS location FILTER type=temp

--- a/docs/commands/ts.mget.md
+++ b/docs/commands/ts.mget.md
@@ -2,7 +2,9 @@
 syntax: 
 ---
 
-Get the last samples matching a specific filter.
+Get the last samples matching a specific filter
+
+## Syntax
 
 {{< highlight bash >}}
 TS.MGET [LATEST] [WITHLABELS | SELECTED_LABELS label...] FILTER filter...
@@ -66,7 +68,7 @@ For each time series matching the specified filters, the following is reported:
   - If `SELECTED_LABELS label...` is specified, the selected labels are reported
 - Timestamp-value pairs for all samples/aggregations matching the range
 
-<note><b>NOTE:</b> The `MGET` command cannot be part of transaction when running on a Redis cluster.</note>
+<note><b>Note:</b> The `MGET` command cannot be part of transaction when running on a Redis cluster.</note>
 
 ## Examples
 
@@ -85,7 +87,7 @@ OK
 2) (integer) 1010
 3) (integer) 1020
 4) (integer) 1030
-127.0.0.1:6379> TS.MADD temp:JLM 1005 30 temp:JLM 1015 35 temp:TLM 1025 9999 temp:JLM 1035 40
+127.0.0.1:6379> TS.MADD temp:JLM 1005 30 temp:JLM 1015 35 temp:JLM 1025 9999 temp:JLM 1035 40
 1) (integer) 1005
 2) (integer) 1015
 3) (integer) 1025

--- a/docs/commands/ts.mrange.md
+++ b/docs/commands/ts.mrange.md
@@ -18,59 +18,92 @@ TS.MRANGE fromTimestamp toTimestamp
           [GROUPBY label REDUCE reducer]
 {{< / highlight >}}
 
-[**Examples**](#examples)
+[:arrow_down_small:**Examples**](#examples)
 
 ## Required arguments
 
-`fromTimestamp` is start timestamp for the range query. Use `-` to express the minimum possible timestamp (0).
+<details>
+<summary><code>fromTimestamp</code></summary>
+is start timestamp for the range query. Use `-` to express the minimum possible timestamp (0).
+</details>
 
-`toTimestamp` is end timestamp for range query. Use `+` to express the maximum possible timestamp.
+<details>
+<summary><code>toTimestamp</code></summary>
+is end timestamp for range query. Use `+` to express the maximum possible timestamp.
+</details>
 
-`FILTER filter..` uses these filters:
+<details>
+<summary><code>FILTER filter..</code></summary>
+uses these filters:
 
   - `label = value`, where `label` equals `value`
   - `label != value`, where `label` does not equal `value`
   - `label = `, where `key` does not have label `label`
   - `label != `, where `key` has label `label`
   - `label = (_value1_,_value2_,...)`, where `key` with label `label` equals one of the values in the list
-  - `label != (value1,value2,...)` is key with label `label` that does not equal any of the values in the list
+  - `label != (value1,value2,...)`, where key with label `label` does not equal any of the values in the list
 
-  > **NOTE:** When using filters, apply a minimum of one `label = value` filter.
+<note><b>NOTE:</b> When using filters, apply a minimum of one `label = value` filter.</note>
+</details>
 
 ## Optional arguments
 
-`LATEST` (since RedisTimeSeries v1.8), used when a time series is a compaction. With `LATEST`, TS.MRANGE also reports the compacted value of the latest possibly partial bucket, given that this bucket's start time falls within `[fromTimestamp, toTimestamp]`. Without `LATEST`, TS.MRANGE does not report the latest possibly partial bucket. When a time series is not a compaction, `LATEST` is ignored.
+<details>
+<summary><code>LATEST</code> (since RedisTimeSeries v1.8)</summary>
+is used when a time series is a compaction. With `LATEST`, TS.MRANGE also reports the compacted value of the latest possibly partial bucket, given that this bucket's start time falls within `[fromTimestamp, toTimestamp]`. Without `LATEST`, TS.MRANGE does not report the latest possibly partial bucket. When a time series is not a compaction, `LATEST` is ignored.
   
 The data in the latest bucket of a compaction is possibly partial. A bucket is _closed_ and compacted only upon arrival of a new sample that _opens_ a new _latest_ bucket. There are cases, however, when the compacted value of the latest possibly partial bucket is also required. In such a case, use `LATEST`.
+</details>
 
-`FILTER_BY_TS ts...` (since RedisTimeSeries v1.6) followed by a list of timestamps filters results by specific timestamps.
+<details>
+<summary><code>FILTER_BY_TS ts...</code> (since RedisTimeSeries v1.6)</summary>
+followed by a list of timestamps filters results by specific timestamps.
+</details>
 
-`FILTER_BY_VALUE min max` (since RedisTimeSeries v1.6) filters results by minimum and maximum values.
+<details>
+<summary><code>FILTER_BY_VALUE min max</code> (since RedisTimeSeries v1.6)</summary>
+filters results by minimum and maximum values.
+</details>
 
-`WITHLABELS` includes in the reply all label-value pairs representing metadata labels of the time series. 
+<details>
+<summary><code>WITHLABELS</code></summary>
+includes in the reply all label-value pairs representing metadata labels of the time series. 
 If `WITHLABELS` or `SELECTED_LABELS` are not specified, by default, an empty list is reported as label-value pairs.
+</details>
 
-`SELECTED_LABELS label...` (since RedisTimeSeries v1.6) returns a subset of the label-value pairs that represent metadata labels of the time series. 
+<details>
+<summary><code>SELECTED_LABELS label...</code> (since RedisTimeSeries v1.6)</summary>
+returns a subset of the label-value pairs that represent metadata labels of the time series. 
 Use when a large number of labels exists per series, but only the values of some of the labels are required. 
 If `WITHLABELS` or `SELECTED_LABELS` are not specified, by default, an empty list is reported as label-value pairs.
+</details>
 
-`COUNT count` limits the number of returned samples.
+<details>
+<summary><code>COUNT count</code></summary>
+limits the number of returned samples.
+</details>
 
-`ALIGN value` (since RedisTimeSeries v1.6) is a time bucket alignment control for `AGGREGATION`. 
+<details>
+<summary><code>ALIGN value</code> (since RedisTimeSeries v1.6)</summary>
+is a time bucket alignment control for `AGGREGATION`. 
 It controls the time bucket timestamps by changing the reference timestamp on which a bucket is defined. 
+
 Values include:
    
  - `start` or `-`: The reference timestamp will be the query start interval time (`fromTimestamp`) which can't be `-`
  - `end` or `+`: The reference timestamp will be the query end interval time (`toTimestamp`) which can't be `+`
  - A specific timestamp: align the reference timestamp to a specific time
    
-> **NOTE:** When not provided, alignment is set to `0`.
+<note><b>NOTE:</b> When not provided, alignment is set to `0`.</note>
+</details>
 
-`AGGREGATION aggregator bucketDuration` aggregates results into time buckets, where:
+<details>
+<summary><code>AGGREGATION aggregator bucketDuration</code></summary>
+aggregates results into time buckets, where:
 
   - `aggregator` takes one of the following aggregation types:
 
-    | `aggregator` | Description                                                      |
+    | `aggregator` &nbsp; &nbsp; &nbsp; | Description                                                      |
     | ------------ | ---------------------------------------------------------------- |
     | `avg`        | Arithmetic mean of all values                                    |
     | `sum`        | Sum of all values                                                |
@@ -87,29 +120,38 @@ Values include:
     | `twa`        | Time-weighted average of all values (since RedisTimeSeries v1.8) |
 
   - `bucketDuration` is duration of each bucket, in milliseconds.
+</details>
 
-`[BUCKETTIMESTAMP bt]` (since RedisTimeSeries v1.8) controls how bucket timestamps are reported.
+<details>
+<summary><code>[BUCKETTIMESTAMP bt]></code> (since RedisTimeSeries v1.8)</summary>
+controls how bucket timestamps are reported.
 
 | `bt`         | Description                                                |
 | ------------ | ---------------------------------------------------------- |
 | `-` or `low` | Timestamp is the start time (default)                      |
-| `+` or `high`| Timestamp is the end time                                  |
+| `+` or `high` &nbsp; &nbsp; &nbsp;| Timestamp is the end time                                  |
 | `~` or `mid` | Timestamp is the mid time (rounded down if not an integer) |
+</details>
 
-`[EMPTY]` (since RedisTimeSeries v1.8) is a flag, which, when specified, reports aggregations for empty buckets.
+<details>
+<summary><code>[EMPTY]</code> (since RedisTimeSeries v1.8)</summary>
+is a flag, which, when specified, reports aggregations for empty buckets.
 
 | `aggregator`         | Value reported for each empty bucket |
 | -------------------- | ------------------------------------ |
 | `sum`, `count`       | `0`                                  |
-| `min`, `max`, `range`, `avg` | Based on linear interpolation of the last value before the bucket’s start time and the first value on or after the bucket’s end time, calculates the min/max/range/avg within the bucket. Returns `NaN` if no values exist before or after the bucket.       |
+| `min`, `max`, `range`, `avg` &nbsp; &nbsp; &nbsp; | Based on linear interpolation of the last value before the bucket’s start time and the first value on or after the bucket’s end time, calculates the min/max/range/avg within the bucket. Returns `NaN` if no values exist before or after the bucket.       |
 | `first`              | Last value before the bucket’s start time. Returns `NaN` if no such value exists.     |
 | `last`               | The first value on or after the bucket’s end time. Returns NaN if no such value exists. |
 | `std.p`, `std.s`         | `NaN` |
 | `twa` | Based on linear interpolation or extrapolation. Returns `NaN` when it cannot interpolate or extrapolate. |
 
 Regardless of the values of fromTimestamp and toTimestamp, no data is reported for buckets that end before the oldest available raw sample, or begin after the newest available raw sample.
+</details>
 
-`GROUPBY label REDUCE reducer` (since RedisTimeSeries v1.6) aggregates results across different time series, grouped by the provided label name. 
+<details>
+<summary><code>GROUPBY label REDUCE reducer</code> (since RedisTimeSeries v1.6)</summary>
+aggregates results across different time series, grouped by the provided label name. 
 When combined with `AGGREGATION` the groupby/reduce is applied post aggregation stage.
 
   - `label` is label name to group a series by. A new series for each value is produced.
@@ -122,18 +164,20 @@ When combined with `AGGREGATION` the groupby/reduce is applied post aggregation 
     | `sum`     | per label value: sum of all values  |
     | `min`     | per label value: minimum value      |
     | `max`     | per label value: maximum value      |
-    | `range`   | per label value: difference between the highest and the lowest value (since RedisTimeSeries v1.8) |
+    | `range` &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;  | per label value: difference between the highest and the lowest value (since RedisTimeSeries v1.8) |
     | `count`   | per label value: number of values (since RedisTimeSeries v1.8) |
     | `std.p`   | per label value: population standard deviation of the values (since RedisTimeSeries v1.8) |
     | `std.s`   | per label value: sample standard deviation of the values (since RedisTimeSeries v1.8) |
     | `var.p`   | per label value: population variance of the values (since RedisTimeSeries v1.8) |
     | `var.s`   | per label value: sample variance of the values (since RedisTimeSeries v1.8) |
 
-> **NOTES:** 
+<note><b>NOTES:</b> 
   - The produced time series is named `<label>=<groupbyvalue>`
   - The produced time series contains two labels with these label array structures:
     - `reducer`, the reducer used
-    - `source`, the time series keys used to compute the grouped series ("key1,key2,key3,...")
+    - `source`, the time series keys used to compute the grouped series (`key1,key2,key3,...`)
+</note>
+</details>
 
 ## Return value
 
@@ -145,11 +189,12 @@ For each time series matching the specified filters, the following is reported:
   - If `SELECTED_LABELS label...` is specified, the selected labels are reported
 - Timestamp-value pairs for all samples/aggregations matching the range
 
-> **NOTE:** The `MRANGE` command cannot be part of transaction when running on a Redis cluster.
+<note><b>NOTE:</b> The `MRANGE` command cannot be part of transaction when running on a Redis cluster.</note>
 
 ## Examples
 
-### Retrieve maximum stock price per timestamp
+<details>
+<summary><b>Retrieve maximum stock price per timestamp</b></summary>
 
 Create two stocks and add their prices at three different timestamps.
 
@@ -188,8 +233,10 @@ You can now retrieve the maximum stock price per timestamp.
 {{< / highlight >}}
 
 The `FILTER type=stock` clause returns a single time series representing stock prices. The `GROUPBY type REDUCE max` clause splits the time series into groups with identical type values, and then, for each timestamp, aggregates all series that share the same type value using the max aggregator.
+</details>
 
-### Calculate average stock price and retrieve maximum average 
+<details>
+<summary><b>Calculate average stock price and retrieve maximum average</b></summary> 
 
 Create two stocks and add their prices at nine different timestamps.
 
@@ -242,8 +289,10 @@ Now, for each stock, calculate the average stock price per a 1000-millisecond ti
       3) 1) (integer) 3000
          2) 310
 {{< / highlight >}}
+</details>
 
-### Group query results
+<details>
+<summary><b>Group query results</b></summary>
 
 Query a time series using `metric=cpu`, then group results by `metric_name REDUCE max`.
 
@@ -276,8 +325,10 @@ Query a time series using `metric=cpu`, then group results by `metric_name REDUC
    3) 1) 1) (integer) 1548149180000
          2) 99
 {{< / highlight >}}
+</details>
 
-### Filter query by value
+<details>
+<summary><b>Filter query by value</b></summary>
 
 Query a time series using `metric=cpu`, then filter values larger or equal to 90.0 and smaller or equal to 100.0.
 
@@ -304,8 +355,10 @@ Query a time series using `metric=cpu`, then filter values larger or equal to 90
    3) 1) 1) (integer) 1548149180000
          2) 99
 {{< / highlight >}}
+</details>
 
-### Query using a label
+<details>
+<summary><b>Query using a label</b></summary>
 
 Query a time series using `metric=cpu`, but only return the team label.
 
@@ -330,6 +383,7 @@ Query a time series using `metric=cpu`, but only return the team label.
    3) 1) 1) (integer) 1548149180000
          2) 99
 {{< / highlight >}}
+</details>
 
 ## See also
 

--- a/docs/commands/ts.mrange.md
+++ b/docs/commands/ts.mrange.md
@@ -43,7 +43,7 @@ filters time series based on their labels and label values, with these options:
   - `label = (_value1_,_value2_,...)`, where `key` with label `label` equals one of the values in the list
   - `label != (value1,value2,...)`, where key with label `label` does not equal any of the values in the list
 
-<note><b>NOTES:</b> 
+<note><b>Notes:</b> 
    - When using filters, apply a minimum of one `label = value` filter.
    - Filters are conjunctive. For example, the FILTER `type = temperature room = study` means the a time series is a temperature time series of a study room.
    </note>
@@ -97,7 +97,7 @@ Values include:
  - `end` or `+`: The reference timestamp will be the query end interval time (`toTimestamp`) which can't be `+`
  - A specific timestamp: align the reference timestamp to a specific time
    
-<note><b>NOTE:</b> When not provided, alignment is set to `0`.</note>
+<note><b>Note:</b> When not provided, alignment is set to `0`.</note>
 </details>
 
 <details open>
@@ -174,7 +174,7 @@ When combined with `AGGREGATION` the groupby/reduce is applied post aggregation 
     | `var.p`   | per label value: population variance of the values (since RedisTimeSeries v1.8) |
     | `var.s`   | per label value: sample variance of the values (since RedisTimeSeries v1.8) |
 
-<note><b>NOTES:</b> 
+<note><b>Notes:</b> 
   - The produced time series is named `<label>=<groupbyvalue>`
   - The produced time series contains two labels with these label array structures:
     - `reducer`, the reducer used
@@ -192,7 +192,7 @@ For each time series matching the specified filters, the following is reported:
   - If `SELECTED_LABELS label...` is specified, the selected labels are reported
 - Timestamp-value pairs for all samples/aggregations matching the range
 
-<note><b>NOTE:</b> The `MRANGE` command cannot be part of transaction when running on a Redis cluster.</note>
+<note><b>Note:</b> The `MRANGE` command cannot be part of transaction when running on a Redis cluster.</note>
 
 ## Examples
 

--- a/docs/commands/ts.mrange.md
+++ b/docs/commands/ts.mrange.md
@@ -18,21 +18,21 @@ TS.MRANGE fromTimestamp toTimestamp
           [GROUPBY label REDUCE reducer]
 {{< / highlight >}}
 
-[:arrow_down_small:**Examples**](#examples)
+[Examples](#examples)
 
 ## Required arguments
 
-<details>
+<details open>
 <summary><code>fromTimestamp</code></summary>
 is start timestamp for the range query. Use `-` to express the minimum possible timestamp (0).
 </details>
 
-<details>
+<details open>
 <summary><code>toTimestamp</code></summary>
 is end timestamp for range query. Use `+` to express the maximum possible timestamp.
 </details>
 
-<details>
+<details open>
 <summary><code>FILTER filter..</code></summary>
 uses these filters:
 
@@ -48,42 +48,42 @@ uses these filters:
 
 ## Optional arguments
 
-<details>
+<details open>
 <summary><code>LATEST</code> (since RedisTimeSeries v1.8)</summary>
 is used when a time series is a compaction. With `LATEST`, TS.MRANGE also reports the compacted value of the latest possibly partial bucket, given that this bucket's start time falls within `[fromTimestamp, toTimestamp]`. Without `LATEST`, TS.MRANGE does not report the latest possibly partial bucket. When a time series is not a compaction, `LATEST` is ignored.
   
 The data in the latest bucket of a compaction is possibly partial. A bucket is _closed_ and compacted only upon arrival of a new sample that _opens_ a new _latest_ bucket. There are cases, however, when the compacted value of the latest possibly partial bucket is also required. In such a case, use `LATEST`.
 </details>
 
-<details>
+<details open>
 <summary><code>FILTER_BY_TS ts...</code> (since RedisTimeSeries v1.6)</summary>
 followed by a list of timestamps filters results by specific timestamps.
 </details>
 
-<details>
+<details open>
 <summary><code>FILTER_BY_VALUE min max</code> (since RedisTimeSeries v1.6)</summary>
 filters results by minimum and maximum values.
 </details>
 
-<details>
+<details open>
 <summary><code>WITHLABELS</code></summary>
 includes in the reply all label-value pairs representing metadata labels of the time series. 
 If `WITHLABELS` or `SELECTED_LABELS` are not specified, by default, an empty list is reported as label-value pairs.
 </details>
 
-<details>
+<details open>
 <summary><code>SELECTED_LABELS label...</code> (since RedisTimeSeries v1.6)</summary>
 returns a subset of the label-value pairs that represent metadata labels of the time series. 
 Use when a large number of labels exists per series, but only the values of some of the labels are required. 
 If `WITHLABELS` or `SELECTED_LABELS` are not specified, by default, an empty list is reported as label-value pairs.
 </details>
 
-<details>
+<details open>
 <summary><code>COUNT count</code></summary>
 limits the number of returned samples.
 </details>
 
-<details>
+<details open>
 <summary><code>ALIGN value</code> (since RedisTimeSeries v1.6)</summary>
 is a time bucket alignment control for `AGGREGATION`. 
 It controls the time bucket timestamps by changing the reference timestamp on which a bucket is defined. 
@@ -97,7 +97,7 @@ Values include:
 <note><b>NOTE:</b> When not provided, alignment is set to `0`.</note>
 </details>
 
-<details>
+<details open>
 <summary><code>AGGREGATION aggregator bucketDuration</code></summary>
 aggregates results into time buckets, where:
 
@@ -122,7 +122,7 @@ aggregates results into time buckets, where:
   - `bucketDuration` is duration of each bucket, in milliseconds.
 </details>
 
-<details>
+<details open>
 <summary><code>[BUCKETTIMESTAMP bt]></code> (since RedisTimeSeries v1.8)</summary>
 controls how bucket timestamps are reported.
 
@@ -133,7 +133,7 @@ controls how bucket timestamps are reported.
 | `~` or `mid` | Timestamp is the mid time (rounded down if not an integer) |
 </details>
 
-<details>
+<details open>
 <summary><code>[EMPTY]</code> (since RedisTimeSeries v1.8)</summary>
 is a flag, which, when specified, reports aggregations for empty buckets.
 
@@ -149,7 +149,7 @@ is a flag, which, when specified, reports aggregations for empty buckets.
 Regardless of the values of fromTimestamp and toTimestamp, no data is reported for buckets that end before the oldest available raw sample, or begin after the newest available raw sample.
 </details>
 
-<details>
+<details open>
 <summary><code>GROUPBY label REDUCE reducer</code> (since RedisTimeSeries v1.6)</summary>
 aggregates results across different time series, grouped by the provided label name. 
 When combined with `AGGREGATION` the groupby/reduce is applied post aggregation stage.
@@ -193,7 +193,7 @@ For each time series matching the specified filters, the following is reported:
 
 ## Examples
 
-<details>
+<details open>
 <summary><b>Retrieve maximum stock price per timestamp</b></summary>
 
 Create two stocks and add their prices at three different timestamps.
@@ -235,7 +235,7 @@ You can now retrieve the maximum stock price per timestamp.
 The `FILTER type=stock` clause returns a single time series representing stock prices. The `GROUPBY type REDUCE max` clause splits the time series into groups with identical type values, and then, for each timestamp, aggregates all series that share the same type value using the max aggregator.
 </details>
 
-<details>
+<details open>
 <summary><b>Calculate average stock price and retrieve maximum average</b></summary> 
 
 Create two stocks and add their prices at nine different timestamps.
@@ -291,7 +291,7 @@ Now, for each stock, calculate the average stock price per a 1000-millisecond ti
 {{< / highlight >}}
 </details>
 
-<details>
+<details open>
 <summary><b>Group query results</b></summary>
 
 Query a time series using `metric=cpu`, then group results by `metric_name REDUCE max`.
@@ -327,7 +327,7 @@ Query a time series using `metric=cpu`, then group results by `metric_name REDUC
 {{< / highlight >}}
 </details>
 
-<details>
+<details open>
 <summary><b>Filter query by value</b></summary>
 
 Query a time series using `metric=cpu`, then filter values larger or equal to 90.0 and smaller or equal to 100.0.
@@ -357,7 +357,7 @@ Query a time series using `metric=cpu`, then filter values larger or equal to 90
 {{< / highlight >}}
 </details>
 
-<details>
+<details open>
 <summary><b>Query using a label</b></summary>
 
 Query a time series using `metric=cpu`, but only return the team label.

--- a/docs/commands/ts.mrange.md
+++ b/docs/commands/ts.mrange.md
@@ -34,7 +34,7 @@ is end timestamp for range query. Use `+` to express the maximum possible timest
 
 <details open>
 <summary><code>FILTER filter..</code></summary>
-uses these filters:
+filters time series based on their labels and label values, with these options:
 
   - `label = value`, where `label` equals `value`
   - `label != value`, where `label` does not equal `value`
@@ -43,7 +43,10 @@ uses these filters:
   - `label = (_value1_,_value2_,...)`, where `key` with label `label` equals one of the values in the list
   - `label != (value1,value2,...)`, where key with label `label` does not equal any of the values in the list
 
-<note><b>NOTE:</b> When using filters, apply a minimum of one `label = value` filter.</note>
+<note><b>NOTES:</b> 
+   - When using filters, apply a minimum of one `label = value` filter.
+   - Filters are conjunctive. For example, the FILTER `type = temperature room = study` means the a time series is a temperature time series of a study room.
+   </note>
 </details>
 
 ## Optional arguments
@@ -294,7 +297,7 @@ Now, for each stock, calculate the average stock price per a 1000-millisecond ti
 <details open>
 <summary><b>Group query results</b></summary>
 
-Query a time series using `metric=cpu`, then group results by `metric_name REDUCE max`.
+Query all time series with the metric label equal to `cpu`, then group the time series by the value of their `metric_name` label value and for each group return the maximum value and the time series keys (_source_) with that value.
 
 {{< highlight bash >}}
 127.0.0.1:6379> TS.ADD ts1 1548149180000 90 labels metric cpu metric_name system
@@ -330,7 +333,7 @@ Query a time series using `metric=cpu`, then group results by `metric_name REDUC
 <details open>
 <summary><b>Filter query by value</b></summary>
 
-Query a time series using `metric=cpu`, then filter values larger or equal to 90.0 and smaller or equal to 100.0.
+Query all time series with the metric label equal to `cpu`, then filter values larger or equal to 90.0 and smaller or equal to 100.0.
 
 {{< highlight bash >}}
 127.0.0.1:6379> TS.ADD ts1 1548149180000 90 labels metric cpu metric_name system
@@ -360,7 +363,7 @@ Query a time series using `metric=cpu`, then filter values larger or equal to 90
 <details open>
 <summary><b>Query using a label</b></summary>
 
-Query a time series using `metric=cpu`, but only return the team label.
+Query all time series with the metric label equal to `cpu`, but only return the team label.
 
 {{< highlight bash >}}
 127.0.0.1:6379> TS.ADD ts1 1548149180000 90 labels metric cpu metric_name system team NY

--- a/docs/commands/ts.mrevrange.md
+++ b/docs/commands/ts.mrevrange.md
@@ -18,59 +18,103 @@ TS.MREVRANGE fromTimestamp toTimestamp
           [GROUPBY label REDUCE reducer]
 {{< / highlight >}}
 
-[**Examples**](#examples)
+[:arrow_down_small:**Examples**](#examples)
 
 ## Required arguments
 
-`fromTimestamp` is start timestamp for the range query. Use `-` to express the minimum possible timestamp (0).
+<details>
+<summary><code>fromTimestamp</code></summary> 
 
-`toTimestamp` is end timestamp for range query. Use `+` to express the maximum possible timestamp.
+is start timestamp for the range query. Use `-` to express the minimum possible timestamp (0).
+</details>
 
-`FILTER filter..` uses these filters:
+<details>
+<summary><code>toTimestamp</code></summary> 
+
+is end timestamp for range query. Use `+` to express the maximum possible timestamp.
+</details>
+
+<details>
+<summary><code>FILTER filter..</code></summary> 
+
+uses these filters:
 
   - `label = value`, where `label` equals `value`
   - `label != value`, where `label` does not equal `value`
   - `label = `, where `key` does not have label `label`
   - `label != `, where `key` has label `label`
   - `label = (_value1_,_value2_,...)`, where `key` with label `label` equals one of the values in the list
-  - `label != (value1,value2,...)` is key with label `label` that does not equal any of the values in the list
+  - `label != (value1,value2,...)`, where key with label `label` does not equal any of the values in the list
 
-  > **NOTE:** When using filters, apply a minimum of one `label = value` filter.
+  <note><b>NOTE:</b> When using filters, apply a minimum of one `label = value` filter.</note>
+</details>
 
 ## Optional arguments
 
-`LATEST` (since RedisTimeSeries v1.8), used when a time series is a compaction. With `LATEST`, TS.MREVRANGE also reports the compacted value of the latest possibly partial bucket, given that this bucket's start time falls within `[fromTimestamp, toTimestamp]`. Without `LATEST`, TS.MREVRANGE does not report the latest possibly partial bucket. When a time series is not a compaction, `LATEST` is ignored.
+<details>
+<summary><code>LATEST</code> (since RedisTimeSeries v1.8)</summary> 
+
+is used when a time series is a compaction. With `LATEST`, TS.MREVRANGE also reports the compacted value of the latest possibly partial bucket, given that this bucket's start time falls within `[fromTimestamp, toTimestamp]`. Without `LATEST`, TS.MREVRANGE does not report the latest possibly partial bucket. When a time series is not a compaction, `LATEST` is ignored.
   
 The data in the latest bucket of a compaction is possibly partial. A bucket is _closed_ and compacted only upon arrival of a new sample that _opens_ a new _latest_ bucket. There are cases, however, when the compacted value of the latest possibly partial bucket is also required. In such a case, use `LATEST`.
+</details>
 
-`FILTER_BY_TS ts...` (since RedisTimeSeries v1.6) followed by a list of timestamps filters results by specific timestamps.
+<details>
+<summary><code>FILTER_BY_TS ts...</code> (since RedisTimeSeries v1.6)</summary> 
 
-`FILTER_BY_VALUE min max` (since RedisTimeSeries v1.6) filters results by minimum and maximum values.
+followed by a list of timestamps filters results by specific timestamps.
+</details>
 
-`WITHLABELS` includes in the reply all label-value pairs representing metadata labels of the time series. 
+<details>
+<summary><code>FILTER_BY_VALUE min max</code> (since RedisTimeSeries v1.6)</summary> 
+
+filters results by minimum and maximum values.
+</details>
+
+<details>
+<summary><code>WITHLABELS</code></summary> 
+
+includes in the reply all label-value pairs representing metadata labels of the time series. 
 If `WITHLABELS` or `SELECTED_LABELS` are not specified, by default, an empty list is reported as label-value pairs.
+</details>
 
-`SELECTED_LABELS label...` (since RedisTimeSeries v1.6) returns a subset of the label-value pairs that represent metadata labels of the time series. 
+<details>
+<summary><code>SELECTED_LABELS label...</code> (since RedisTimeSeries v1.6)</summary>
+
+returns a subset of the label-value pairs that represent metadata labels of the time series. 
 Use when a large number of labels exists per series, but only the values of some of the labels are required. 
 If `WITHLABELS` or `SELECTED_LABELS` are not specified, by default, an empty list is reported as label-value pairs.
+</details>
 
-`COUNT count` limits the number of returned samples.
+<details>
+<summary><code>COUNT count</code></summary> 
 
-`ALIGN value` (since RedisTimeSeries v1.6) is a time bucket alignment control for `AGGREGATION`. 
+limits the number of returned samples.
+</details>
+
+<details>
+<summary><code>ALIGN value</code> (since RedisTimeSeries v1.6)</summary> 
+
+is a time bucket alignment control for `AGGREGATION`. 
 It controls the time bucket timestamps by changing the reference timestamp on which a bucket is defined. 
+
 Values include:
    
  - `start` or `-`: The reference timestamp will be the query start interval time (`fromTimestamp`) which can't be `-`
  - `end` or `+`: The reference timestamp will be the query end interval time (`toTimestamp`) which can't be `+`
  - A specific timestamp: align the reference timestamp to a specific time
    
-> **NOTE:** When not provided, alignment is set to `0`.
+<note><b>NOTE:</b> When not provided, alignment is set to `0`.</note>
+</details>
 
-`AGGREGATION aggregator bucketDuration` aggregates results into time buckets, where:
+<details>
+<summary><code>AGGREGATION aggregator bucketDuration</code></summary> 
+
+aggregates results into time buckets, where:
 
   - `aggregator` takes one of the following aggregation types:
 
-    | `aggregator` | Description                                                      |
+    | `aggregator` &nbsp; &nbsp; &nbsp; | Description                                                      |
     | ------------ | ---------------------------------------------------------------- |
     | `avg`        | Arithmetic mean of all values                                    |
     | `sum`        | Sum of all values                                                |
@@ -87,34 +131,47 @@ Values include:
     | `twa`        | Time-weighted average of all values (since RedisTimeSeries v1.8) |
 
   - `bucketDuration` is duration of each bucket, in milliseconds.
+</details>
 
-`[BUCKETTIMESTAMP bt]` (since RedisTimeSeries v1.8) controls how bucket timestamps are reported.
+<details>
+<summary><code>[BUCKETTIMESTAMP bt]</code> (since RedisTimeSeries v1.8)</summary> 
+
+controls how bucket timestamps are reported.
 
 | `bt`         | Description                                                |
 | ------------ | ---------------------------------------------------------- |
 | `-` or `low` | Timestamp is the start time (default)                      |
-| `+` or `high`| Timestamp is the end time                                  |
+| `+` or `high` &nbsp; &nbsp; &nbsp;| Timestamp is the end time                                  |
 | `~` or `mid` | Timestamp is the mid time (rounded down if not an integer) |
+</details>
 
-`[EMPTY]` (since RedisTimeSeries v1.8) is a flag, which, when specified, reports aggregations for empty buckets.
+<details>
+<summary><code>[EMPTY]</code> (since RedisTimeSeries v1.8)</summary> 
+
+is a flag, which, when specified, reports aggregations for empty buckets.
 
 | `aggregator`         | Value reported for each empty bucket |
 | -------------------- | ------------------------------------ |
 | `sum`, `count`       | `0`                                  |
-| `min`, `max`, `range`, `avg` | Based on linear interpolation of the last value before the bucket’s start time and the first value on or after the bucket’s end time, calculates the min/max/range/avg within the bucket. Returns `NaN` if no values exist before or after the bucket.       |
+| `min`, `max`, `range`, `avg` &nbsp; &nbsp; &nbsp; | Based on linear interpolation of the last value before the bucket’s start time and the first value on or after the bucket’s end time, calculates the min/max/range/avg within the bucket. Returns `NaN` if no values exist before or after the bucket.       |
 | `first`              | Last value before the bucket’s start time. Returns `NaN` if no such value exists.     |
 | `last`               | The first value on or after the bucket’s end time. Returns NaN if no such value exists. |
 | `std.p`, `std.s`         | `NaN` |
 | `twa` | Based on linear interpolation or extrapolation. Returns `NaN` when it cannot interpolate or extrapolate. |
 
-Regardless of the values of fromTimestamp and toTimestamp, no data is reported for buckets that end before the oldest available raw sample, or begin after the newest available raw sample.
+Regardless of the values of `fromTimestamp` and `toTimestamp`, no data is reported for buckets that end before the oldest available raw sample, or begin after the newest available raw sample.
+</details>
 
-`GROUPBY label REDUCE reducer` (since RedisTimeSeries v1.6) aggregates results across different time series, grouped by the provided label name. 
+<details>
+<summary><code>GROUPBY label REDUCE reducer</code> (since RedisTimeSeries v1.6)</summary>
+
+aggregates results across different time series, grouped by the provided label name. 
 When combined with `AGGREGATION` the groupby/reduce is applied post aggregation stage.
 
   - `label` is label name to group a series by. A new series for each value is produced.
 
   - `reducer` is reducer type used to aggregate series that share the same label value.
+
 
     | `reducer` | Description                         |
     | --------- | ----------------------------------- |
@@ -122,18 +179,20 @@ When combined with `AGGREGATION` the groupby/reduce is applied post aggregation 
     | `sum`     | per label value: sum of all values  |
     | `min`     | per label value: minimum value      |
     | `max`     | per label value: maximum value      |
-    | `range`   | per label value: difference between the highest and the lowest value (since RedisTimeSeries v1.8) |
+    | `range` &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp;  | per label value: difference between the highest and the lowest value (since RedisTimeSeries v1.8) |
     | `count`   | per label value: number of values (since RedisTimeSeries v1.8) |
     | `std.p`   | per label value: population standard deviation of the values (since RedisTimeSeries v1.8) |
     | `std.s`   | per label value: sample standard deviation of the values (since RedisTimeSeries v1.8) |
     | `var.p`   | per label value: population variance of the values (since RedisTimeSeries v1.8) |
     | `var.s`   | per label value: sample variance of the values (since RedisTimeSeries v1.8) |
 
-> **NOTES:** 
+<note><b>NOTES:</b> 
   - The produced time series is named `<label>=<groupbyvalue>`
   - The produced time series contains two labels with these label array structures:
     - `reducer`, the reducer used
-    - `source`, the time series keys used to compute the grouped series ("key1,key2,key3,...")
+    - `source`, the time series keys used to compute the grouped series (`key1,key2,key3,...`)
+</note>
+</details>
 
 ## Return value
 
@@ -145,11 +204,12 @@ For each time series matching the specified filters, the following is reported:
   - If `SELECTED_LABELS label...` is specified, the selected labels are reported
 - Timestamp-value pairs for all samples/aggregations matching the range
 
-> **NOTE:** The `MRANGE` command cannot be part of transaction when running on a Redis cluster.
+<note><b>NOTE:</b> The `MREVRANGE` command cannot be part of transaction when running on a Redis cluster.</note>
 
 ## Examples
 
-### Retrieve maximum stock price per timestamp
+<details>
+<summary><b>Retrieve maximum stock price per timestamp</b></summary>
 
 Create two stocks and add their prices at three different timestamps.
 
@@ -188,8 +248,10 @@ You can now retrieve the maximum stock price per timestamp.
 {{< / highlight >}}
 
 The `FILTER type=stock` clause returns a single time series representing stock prices. The `GROUPBY type REDUCE max` clause splits the time series into groups with identical type values, and then, for each timestamp, aggregates all series that share the same type value using the max aggregator.
+</details>
 
-### Calculate average stock price and retrieve maximum average 
+<details>
+<summary><b>Calculate average stock price and retrieve maximum average</b></summary> 
 
 Create two stocks and add their prices at nine different timestamps.
 
@@ -242,8 +304,10 @@ Now, for each stock, calculate the average stock price per a 1000-millisecond ti
       3) 1) (integer) 1000
          2) 110
 {{< / highlight >}}
+</details>
 
-### Group query results
+<details>
+<summary><b>Group query results</b></summary>
 
 Query a time series using `metric=cpu`, then group results by `metric_name REDUCE max`.
 
@@ -276,8 +340,10 @@ Query a time series using `metric=cpu`, then group results by `metric_name REDUC
    3) 1) 1) (integer) 1548149180000
          2) 99
 {{< / highlight >}}
+</details>
 
-### Filter query by value
+<details>
+<summary><b>Filter query by value</b></summary>
 
 Query a time series using `metric=cpu`, then filter values larger or equal to 90.0 and smaller or equal to 100.0.
 
@@ -304,8 +370,10 @@ Query a time series using `metric=cpu`, then filter values larger or equal to 90
    3) 1) 1) (integer) 1548149180000
          2) 99
 {{< / highlight >}}
+</details>
 
-### Query using a label
+<details>
+<summary><b>Query using a label</b></summary>
 
 Query a time series using `metric=cpu`, but only return the team label.
 
@@ -330,10 +398,11 @@ Query a time series using `metric=cpu`, but only return the team label.
    3) 1) 1) (integer) 1548149180000
          2) 99
 {{< / highlight >}}
+</details>
 
 ## See also
 
-`TS.MRANGE` | `TS.RANGE` | `TS.REVRANGE` |
+`TS.MRANGE` | `TS.RANGE` | `TS.REVRANGE` 
 
 ## Related topics
 

--- a/docs/commands/ts.mrevrange.md
+++ b/docs/commands/ts.mrevrange.md
@@ -18,23 +18,23 @@ TS.MREVRANGE fromTimestamp toTimestamp
           [GROUPBY label REDUCE reducer]
 {{< / highlight >}}
 
-[:arrow_down_small:**Examples**](#examples)
+[Examples](#examples)
 
 ## Required arguments
 
-<details>
+<details open>
 <summary><code>fromTimestamp</code></summary> 
 
 is start timestamp for the range query. Use `-` to express the minimum possible timestamp (0).
 </details>
 
-<details>
+<details open>
 <summary><code>toTimestamp</code></summary> 
 
 is end timestamp for range query. Use `+` to express the maximum possible timestamp.
 </details>
 
-<details>
+<details open>
 <summary><code>FILTER filter..</code></summary> 
 
 uses these filters:
@@ -51,7 +51,7 @@ uses these filters:
 
 ## Optional arguments
 
-<details>
+<details open>
 <summary><code>LATEST</code> (since RedisTimeSeries v1.8)</summary> 
 
 is used when a time series is a compaction. With `LATEST`, TS.MREVRANGE also reports the compacted value of the latest possibly partial bucket, given that this bucket's start time falls within `[fromTimestamp, toTimestamp]`. Without `LATEST`, TS.MREVRANGE does not report the latest possibly partial bucket. When a time series is not a compaction, `LATEST` is ignored.
@@ -59,26 +59,26 @@ is used when a time series is a compaction. With `LATEST`, TS.MREVRANGE also rep
 The data in the latest bucket of a compaction is possibly partial. A bucket is _closed_ and compacted only upon arrival of a new sample that _opens_ a new _latest_ bucket. There are cases, however, when the compacted value of the latest possibly partial bucket is also required. In such a case, use `LATEST`.
 </details>
 
-<details>
+<details open>
 <summary><code>FILTER_BY_TS ts...</code> (since RedisTimeSeries v1.6)</summary> 
 
 followed by a list of timestamps filters results by specific timestamps.
 </details>
 
-<details>
+<details open>
 <summary><code>FILTER_BY_VALUE min max</code> (since RedisTimeSeries v1.6)</summary> 
 
 filters results by minimum and maximum values.
 </details>
 
-<details>
+<details open>
 <summary><code>WITHLABELS</code></summary> 
 
 includes in the reply all label-value pairs representing metadata labels of the time series. 
 If `WITHLABELS` or `SELECTED_LABELS` are not specified, by default, an empty list is reported as label-value pairs.
 </details>
 
-<details>
+<details open>
 <summary><code>SELECTED_LABELS label...</code> (since RedisTimeSeries v1.6)</summary>
 
 returns a subset of the label-value pairs that represent metadata labels of the time series. 
@@ -86,13 +86,13 @@ Use when a large number of labels exists per series, but only the values of some
 If `WITHLABELS` or `SELECTED_LABELS` are not specified, by default, an empty list is reported as label-value pairs.
 </details>
 
-<details>
+<details open>
 <summary><code>COUNT count</code></summary> 
 
 limits the number of returned samples.
 </details>
 
-<details>
+<details open>
 <summary><code>ALIGN value</code> (since RedisTimeSeries v1.6)</summary> 
 
 is a time bucket alignment control for `AGGREGATION`. 
@@ -107,7 +107,7 @@ Values include:
 <note><b>NOTE:</b> When not provided, alignment is set to `0`.</note>
 </details>
 
-<details>
+<details open>
 <summary><code>AGGREGATION aggregator bucketDuration</code></summary> 
 
 aggregates results into time buckets, where:
@@ -133,7 +133,7 @@ aggregates results into time buckets, where:
   - `bucketDuration` is duration of each bucket, in milliseconds.
 </details>
 
-<details>
+<details open>
 <summary><code>[BUCKETTIMESTAMP bt]</code> (since RedisTimeSeries v1.8)</summary> 
 
 controls how bucket timestamps are reported.
@@ -145,7 +145,7 @@ controls how bucket timestamps are reported.
 | `~` or `mid` | Timestamp is the mid time (rounded down if not an integer) |
 </details>
 
-<details>
+<details open>
 <summary><code>[EMPTY]</code> (since RedisTimeSeries v1.8)</summary> 
 
 is a flag, which, when specified, reports aggregations for empty buckets.
@@ -162,7 +162,7 @@ is a flag, which, when specified, reports aggregations for empty buckets.
 Regardless of the values of `fromTimestamp` and `toTimestamp`, no data is reported for buckets that end before the oldest available raw sample, or begin after the newest available raw sample.
 </details>
 
-<details>
+<details open>
 <summary><code>GROUPBY label REDUCE reducer</code> (since RedisTimeSeries v1.6)</summary>
 
 aggregates results across different time series, grouped by the provided label name. 
@@ -208,7 +208,7 @@ For each time series matching the specified filters, the following is reported:
 
 ## Examples
 
-<details>
+<details open>
 <summary><b>Retrieve maximum stock price per timestamp</b></summary>
 
 Create two stocks and add their prices at three different timestamps.
@@ -250,7 +250,7 @@ You can now retrieve the maximum stock price per timestamp.
 The `FILTER type=stock` clause returns a single time series representing stock prices. The `GROUPBY type REDUCE max` clause splits the time series into groups with identical type values, and then, for each timestamp, aggregates all series that share the same type value using the max aggregator.
 </details>
 
-<details>
+<details open>
 <summary><b>Calculate average stock price and retrieve maximum average</b></summary> 
 
 Create two stocks and add their prices at nine different timestamps.
@@ -306,7 +306,7 @@ Now, for each stock, calculate the average stock price per a 1000-millisecond ti
 {{< / highlight >}}
 </details>
 
-<details>
+<details open>
 <summary><b>Group query results</b></summary>
 
 Query a time series using `metric=cpu`, then group results by `metric_name REDUCE max`.
@@ -342,7 +342,7 @@ Query a time series using `metric=cpu`, then group results by `metric_name REDUC
 {{< / highlight >}}
 </details>
 
-<details>
+<details open>
 <summary><b>Filter query by value</b></summary>
 
 Query a time series using `metric=cpu`, then filter values larger or equal to 90.0 and smaller or equal to 100.0.
@@ -372,7 +372,7 @@ Query a time series using `metric=cpu`, then filter values larger or equal to 90
 {{< / highlight >}}
 </details>
 
-<details>
+<details open>
 <summary><b>Query using a label</b></summary>
 
 Query a time series using `metric=cpu`, but only return the team label.

--- a/docs/commands/ts.mrevrange.md
+++ b/docs/commands/ts.mrevrange.md
@@ -2,7 +2,7 @@
 syntax: 
 ---
 
-Query a range across multiple time series by filters in reverse direction.
+Query a range across multiple time series by filters in reverse direction
 
 ## Syntax
 
@@ -45,12 +45,12 @@ uses these filters:
   - `label != `, where `key` has label `label`
   - `label = (_value1_,_value2_,...)`, where `key` with label `label` equals one of the values in the list
   - `label != (value1,value2,...)`, where key with label `label` does not equal any of the values in the list
+</details>
 
- <note><b>NOTES:</b> 
+<note><b>Notes:</b> 
    - When using filters, apply a minimum of one `label = value` filter.
    - Filters are conjunctive. For example, the FILTER `type = temperature room = study` means the a time series is a temperature time series of a study room.
    </note>
-</details>
 
 ## Optional arguments
 
@@ -107,7 +107,7 @@ Values include:
  - `end` or `+`: The reference timestamp will be the query end interval time (`toTimestamp`) which can't be `+`
  - A specific timestamp: align the reference timestamp to a specific time
    
-<note><b>NOTE:</b> When not provided, alignment is set to `0`.</note>
+<note><b>Note:</b> When not provided, alignment is set to `0`.</note>
 </details>
 
 <details open>
@@ -189,7 +189,7 @@ When combined with `AGGREGATION` the groupby/reduce is applied post aggregation 
     | `var.p`   | per label value: population variance of the values (since RedisTimeSeries v1.8) |
     | `var.s`   | per label value: sample variance of the values (since RedisTimeSeries v1.8) |
 
-<note><b>NOTES:</b> 
+<note><b>Notes:</b> 
   - The produced time series is named `<label>=<groupbyvalue>`
   - The produced time series contains two labels with these label array structures:
     - `reducer`, the reducer used
@@ -207,7 +207,7 @@ For each time series matching the specified filters, the following is reported:
   - If `SELECTED_LABELS label...` is specified, the selected labels are reported
 - Timestamp-value pairs for all samples/aggregations matching the range
 
-<note><b>NOTE:</b> The `MREVRANGE` command cannot be part of transaction when running on a Redis cluster.</note>
+<note><b>Note:</b> The `MREVRANGE` command cannot be part of transaction when running on a Redis cluster.</note>
 
 ## Examples
 

--- a/docs/commands/ts.mrevrange.md
+++ b/docs/commands/ts.mrevrange.md
@@ -46,7 +46,10 @@ uses these filters:
   - `label = (_value1_,_value2_,...)`, where `key` with label `label` equals one of the values in the list
   - `label != (value1,value2,...)`, where key with label `label` does not equal any of the values in the list
 
-  <note><b>NOTE:</b> When using filters, apply a minimum of one `label = value` filter.</note>
+ <note><b>NOTES:</b> 
+   - When using filters, apply a minimum of one `label = value` filter.
+   - Filters are conjunctive. For example, the FILTER `type = temperature room = study` means the a time series is a temperature time series of a study room.
+   </note>
 </details>
 
 ## Optional arguments
@@ -309,7 +312,7 @@ Now, for each stock, calculate the average stock price per a 1000-millisecond ti
 <details open>
 <summary><b>Group query results</b></summary>
 
-Query a time series using `metric=cpu`, then group results by `metric_name REDUCE max`.
+Query all time series with the metric label equal to `cpu`, then group the time series by the value of their `metric_name` label value and for each group return the maximum value and the time series keys (_source_) with that value.
 
 {{< highlight bash >}}
 127.0.0.1:6379> TS.ADD ts1 1548149180000 90 labels metric cpu metric_name system
@@ -345,7 +348,7 @@ Query a time series using `metric=cpu`, then group results by `metric_name REDUC
 <details open>
 <summary><b>Filter query by value</b></summary>
 
-Query a time series using `metric=cpu`, then filter values larger or equal to 90.0 and smaller or equal to 100.0.
+Query all time series with the metric label equal to `cpu`, then filter values larger or equal to 90.0 and smaller or equal to 100.0.
 
 {{< highlight bash >}}
 127.0.0.1:6379> TS.ADD ts1 1548149180000 90 labels metric cpu metric_name system
@@ -375,7 +378,7 @@ Query a time series using `metric=cpu`, then filter values larger or equal to 90
 <details open>
 <summary><b>Query using a label</b></summary>
 
-Query a time series using `metric=cpu`, but only return the team label.
+Query all time series with the metric label equal to `cpu`, but only return the team label.
 
 {{< highlight bash >}}
 127.0.0.1:6379> TS.ADD ts1 1548149180000 90 labels metric cpu metric_name system team NY

--- a/docs/commands/ts.queryindex.md
+++ b/docs/commands/ts.queryindex.md
@@ -2,7 +2,7 @@
 syntax: 
 ---
 
-Get all time series keys matching a filter list.
+Get all time series keys matching a filter list
 
 ## Syntax
 
@@ -25,7 +25,7 @@ filters time series based on their labels and label values, with these options:
   - `label = (_value1_,_value2_,...)`, where `key` with label `label` equals one of the values in the list
   - `label != (value1,value2,...)`, where key with label `label` does not equal any of the values in the list
 
-<note><b>NOTES:</b>
+<note><b>Notes:</b>
  - When using filters, apply a minimum of one `label = value` filter. 
  - `QUERYINDEX` cannot be part of a transaction that runs on a Redis cluster.
  - Filters are conjunctive. For example, the FILTER `type = temperature room = study` means the a time series is a temperature time series of a study room.

--- a/docs/commands/ts.queryindex.md
+++ b/docs/commands/ts.queryindex.md
@@ -14,7 +14,7 @@ TS.QUERYINDEX filter...
 
 ## Required arguments
 
-FILTER filter..` uses these filters:
+`FILTER filter..` returns results for the time series that pass these filtering criteria:
 
   - `label = value`, where `label` equals `value`
   - `label != value`, where `label` does not equal `value`
@@ -31,12 +31,12 @@ FILTER filter..` uses these filters:
 
 ### Find keys by location and sensor type
 
-Create a set of sensors to measure temperature and humidity in your office and kitchen.
+Create a set of sensors to measure temperature and humidity in your study and kitchen.
 
 {{< highlight bash >}}
-127.0.0.1:6379> TS.CREATE telemetry:office:temperature LABELS room office type temperature
+127.0.0.1:6379> TS.CREATE telemetry:study:temperature LABELS room office type temperature
 OK
-127.0.0.1:6379> TS.CREATE telemetry:office:humidity LABELS room office type humidity
+127.0.0.1:6379> TS.CREATE telemetry:study:humidity LABELS room office type humidity
 OK
 127.0.0.1:6379> TS.CREATE telemetry:kitchen:temperature LABELS room kitchen type temperature
 OK
@@ -57,7 +57,7 @@ To monitor all the keys for temperature, use this query:
 {{< highlight bash >}}
 127.0.0.1:6379> TS.QUERYINDEX type=temperature
 1) "telemetry:kitchen:temperature"
-2) "telemetry:office:temperature"
+2) "telemetry:study:temperature"
 {{< / highlight >}}
 
 ## See also

--- a/docs/commands/ts.queryindex.md
+++ b/docs/commands/ts.queryindex.md
@@ -10,11 +10,11 @@ Get all time series keys matching a filter list.
 TS.QUERYINDEX filter...
 {{< / highlight >}}
 
-[:arrow_down_small:**Examples**](#examples)
+[Examples](#examples)
 
 ## Required arguments
 
-<details>
+<details open>
 <summary><code>FILTER filter..</code></summary>
 returns results for the time series that pass these filtering criteria:
 
@@ -34,7 +34,7 @@ returns results for the time series that pass these filtering criteria:
 
 ## Examples
 
-<details>
+<details open>
 <summary><b>Find keys by location and sensor type</b></summary>
 
 Create a set of sensors to measure temperature and humidity in your study and kitchen.

--- a/docs/commands/ts.queryindex.md
+++ b/docs/commands/ts.queryindex.md
@@ -10,33 +10,39 @@ Get all time series keys matching a filter list.
 TS.QUERYINDEX filter...
 {{< / highlight >}}
 
-[**Examples**](#examples)
+[:arrow_down_small:**Examples**](#examples)
 
 ## Required arguments
 
-`FILTER filter..` returns results for the time series that pass these filtering criteria:
+<details>
+<summary><code>FILTER filter..</code></summary>
+returns results for the time series that pass these filtering criteria:
 
   - `label = value`, where `label` equals `value`
   - `label != value`, where `label` does not equal `value`
   - `label = `, where `key` does not have label `label`
   - `label != `, where `key` has label `label`
   - `label = (_value1_,_value2_,...)`, where `key` with label `label` equals one of the values in the list
-  - `label != (value1,value2,...)` is key with label `label` that does not equal any of the values in the list
+  - `label != (value1,value2,...)`, where key with label `label` does not equal any of the values in the list
 
-**NOTES:** 
+<note><b>NOTES:</b>
  - When using filters, apply a minimum of one `label = value` filter. 
  - `QUERYINDEX` cannot be part of a transaction that runs on a Redis cluster.
+ - Filters are conjunctive. For example, the FILTER `type = temperature room = study` means the a time series is a temperature time series of a study room.
+ </note>
+ </details>
 
 ## Examples
 
-### Find keys by location and sensor type
+<details>
+<summary><b>Find keys by location and sensor type</b></summary>
 
 Create a set of sensors to measure temperature and humidity in your study and kitchen.
 
 {{< highlight bash >}}
-127.0.0.1:6379> TS.CREATE telemetry:study:temperature LABELS room office type temperature
+127.0.0.1:6379> TS.CREATE telemetry:study:temperature LABELS room study type temperature
 OK
-127.0.0.1:6379> TS.CREATE telemetry:study:humidity LABELS room office type humidity
+127.0.0.1:6379> TS.CREATE telemetry:study:humidity LABELS room study type humidity
 OK
 127.0.0.1:6379> TS.CREATE telemetry:kitchen:temperature LABELS room kitchen type temperature
 OK
@@ -59,6 +65,7 @@ To monitor all the keys for temperature, use this query:
 1) "telemetry:kitchen:temperature"
 2) "telemetry:study:temperature"
 {{< / highlight >}}
+</details>
 
 ## See also
 

--- a/docs/commands/ts.queryindex.md
+++ b/docs/commands/ts.queryindex.md
@@ -1,28 +1,69 @@
-### TS.QUERYINDEX
+---
+syntax: 
+---
 
 Get all time series keys matching a filter list.
 
-```sql
+## Syntax
+
+{{< highlight bash >}}
 TS.QUERYINDEX filter...
-```
+{{< / highlight >}}
 
-- _filter_...
+[**Examples**](#examples)
 
-  This is the list of possible filters:
-  - _label_`=`_value_ - _label_ equals _value_
-  - _label_`!=`_value_ - label doesn't equal _value_
-  - _label_`=` - _key_ does not have the label _label_
-  - _label_`!=` - _key_ has label _label_
-  - _label_`=(`_value1_`,`_value2_`,`...`)` - key with label _label_ that equals one of the values in the list
-  - _lable_`!=(`_value1_`,`_value2_`,`...`)` - key with label _label_ that doesn't equal any of the values in the list
+## Required arguments
 
-  Note: Whenever filters need to be provided, a minimum of one _label_`=`_value_ filter must be applied.
+FILTER filter..` uses these filters:
 
-Note: QUERYINDEX command can't be part of transaction when running on Redis cluster.
+  - `label = value`, where `label` equals `value`
+  - `label != value`, where `label` does not equal `value`
+  - `label = `, where `key` does not have label `label`
+  - `label != `, where `key` has label `label`
+  - `label = (_value1_,_value2_,...)`, where `key` with label `label` equals one of the values in the list
+  - `label != (value1,value2,...)` is key with label `label` that does not equal any of the values in the list
 
-### Query index example
-```sql
-127.0.0.1:6379> TS.QUERYINDEX sensor_id=2
-1) "temperature:2:32"
-2) "temperature:2:33"
-```
+**NOTES:** 
+ - When using filters, apply a minimum of one `label = value` filter. 
+ - `QUERYINDEX` cannot be part of a transaction that runs on a Redis cluster.
+
+## Examples
+
+### Find keys by location and sensor type
+
+Create a set of sensors to measure temperature and humidity in your office and kitchen.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.CREATE telemetry:office:temperature LABELS room office type temperature
+OK
+127.0.0.1:6379> TS.CREATE telemetry:office:humidity LABELS room office type humidity
+OK
+127.0.0.1:6379> TS.CREATE telemetry:kitchen:temperature LABELS room kitchen type temperature
+OK
+127.0.0.1:6379> TS.CREATE telemetry:kitchen:humidity LABELS room kitchen type humidity
+OK
+{{< / highlight >}}
+
+Query the sensors in the kitchen to find all the keys associated with that room. 
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.QUERYINDEX room=kitchen
+1) "telemetry:kitchen:humidity"
+2) "telemetry:kitchen:temperature"
+{{< / highlight >}}
+
+To monitor all the keys for temperature, use this query:
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.QUERYINDEX type=temperature
+1) "telemetry:kitchen:temperature"
+2) "telemetry:office:temperature"
+{{< / highlight >}}
+
+## See also
+
+`TS.CREATE` | `TS.MRANGE` | `TS.MREVRANGE` | `MGET`
+
+## Related topics
+
+[RedisTimeSeries](/docs/stack/timeseries)

--- a/docs/commands/ts.queryindex.md
+++ b/docs/commands/ts.queryindex.md
@@ -16,7 +16,7 @@ TS.QUERYINDEX filter...
 
 <details open>
 <summary><code>FILTER filter..</code></summary>
-returns results for the time series that pass these filtering criteria:
+filters time series based on their labels and label values, with these options:
 
   - `label = value`, where `label` equals `value`
   - `label != value`, where `label` does not equal `value`
@@ -50,7 +50,7 @@ OK
 OK
 {{< / highlight >}}
 
-Query the sensors in the kitchen to find all the keys associated with that room. 
+Retrieve keys of all time series representing sensors located in the kitchen. 
 
 {{< highlight bash >}}
 127.0.0.1:6379> TS.QUERYINDEX room=kitchen
@@ -58,7 +58,7 @@ Query the sensors in the kitchen to find all the keys associated with that room.
 2) "telemetry:kitchen:temperature"
 {{< / highlight >}}
 
-To monitor all the keys for temperature, use this query:
+To retrieve the keys of all time series representing sensors that measure temperature, use this query:
 
 {{< highlight bash >}}
 127.0.0.1:6379> TS.QUERYINDEX type=temperature

--- a/docs/commands/ts.range.md
+++ b/docs/commands/ts.range.md
@@ -2,7 +2,9 @@
 syntax: 
 ---
 
-Query a range in forward direction.
+Query a range in forward direction
+
+## Syntax
 
 {{< highlight bash >}}
 TS.RANGE key fromTimestamp toTimestamp
@@ -36,7 +38,7 @@ is start timestamp for the range query. Use `-` to express the minimum possible 
 
 is end timestamp for the range query. Use `+` to express the maximum possible timestamp.
 
-<note><b>NOTE:</b>    When the time series is a compaction, the last compacted value may aggregate raw values with timestamp beyond `toTimestamp`. That is because `toTimestamp` only limits the timestamp of the compacted value, which is the start time of the raw bucket that was compacted.</note>
+<note><b>Note:</b>    When the time series is a compaction, the last compacted value may aggregate raw values with timestamp beyond `toTimestamp`. That is because `toTimestamp` only limits the timestamp of the compacted value, which is the start time of the raw bucket that was compacted.</note>
 
 </details>
 
@@ -83,7 +85,7 @@ Values include:
  - `end` or `+`: The reference timestamp will be the query end interval time (`toTimestamp`) which can't be `+`
  - A specific timestamp: align the reference timestamp to a specific time
    
-<note><b>NOTE:</b> When not provided, alignment is set to `0`.</note>
+<note><b>Note:</b> When not provided, alignment is set to `0`.</note>
 
 </details>
 

--- a/docs/commands/ts.range.md
+++ b/docs/commands/ts.range.md
@@ -13,25 +13,25 @@ TS.RANGE key fromTimestamp toTimestamp
          [[ALIGN value] AGGREGATION aggregator bucketDuration [BUCKETTIMESTAMP bt] [EMPTY]]
 {{< / highlight >}}
 
-[:arrow_down_small:**Examples**](#examples)
+[Examples](#examples)
 
 ## Required arguments
 
-<details>
+<details open>
 <summary><code>key</code></summary> 
 
 is the key name for the time series.
 
 </details>
 
-<details>
+<details open>
 <summary><code>fromTimestamp</code></summary> 
 
 is start timestamp for the range query. Use `-` to express the minimum possible timestamp (0).
 
 </details>
 
-<details>
+<details open>
 <summary><code>toTimestamp</code></summary> 
 
 is end timestamp for the range query. Use `+` to express the maximum possible timestamp.
@@ -42,7 +42,7 @@ is end timestamp for the range query. Use `+` to express the maximum possible ti
 
 ## Optional arguments
 
-<details>
+<details open>
 <summary><code>LATEST</code> (since RedisTimeSeries v1.8)</summary>
 
 is used when a time series is a compaction. With `LATEST`, TS.RANGE also reports the compacted value of the latest possibly partial bucket, given that this bucket's start time falls within `[fromTimestamp, toTimestamp]`. Without `LATEST`, TS.RANGE does not report the latest possibly partial bucket. When a time series is not a compaction, `LATEST` is ignored.
@@ -51,28 +51,28 @@ The data in the latest bucket of a compaction is possibly partial. A bucket is _
 
 </details>
 
-<details>
+<details open>
 <summary><code>FILTER_BY_TS ts...</code> (since RedisTimeSeries v1.6)</summary> 
 
 followed by a list of timestamps filters results by specific timestamps.
 
 </details>
 
-<details>
+<details open>
 <summary><code>FILTER_BY_VALUE min max</code> (since RedisTimeSeries v1.6)</summary> 
 
 filters results by minimum and maximum values.
 
 </details>
 
-<details>
+<details open>
 <summary><code>COUNT count</code></summary> 
 
 limits the number of returned samples.
 
 </details>
 
-<details>
+<details open>
 <summary><code>ALIGN value</code> (since RedisTimeSeries v1.6)</summary> 
 
 is a time bucket alignment control for `AGGREGATION`. It controls the time bucket timestamps by changing the reference timestamp on which a bucket is defined.
@@ -87,7 +87,7 @@ Values include:
 
 </details>
 
-<details>
+<details open>
 <summary><code>AGGREGATION aggregator bucketDuration</code></summary> 
 
 aggregates results into time buckets, where:
@@ -115,7 +115,7 @@ aggregates results into time buckets, where:
 
 </details>
 
-<details>
+<details open>
 <summary><code>[BUCKETTIMESTAMP bt]</code> (since RedisTimeSeries v1.8)</summary> 
 
 controls how bucket timestamps are reported.
@@ -128,7 +128,7 @@ controls how bucket timestamps are reported.
 
 </details>
 
-<details>
+<details open>
 <summary><code>[EMPTY]</code> (since RedisTimeSeries v1.8)</summary> 
 
 is a flag, which, when specified, reports aggregations for empty buckets.
@@ -154,7 +154,7 @@ But, because `m` is small, you can disregard it and look at the operation as `O(
 
 ## Examples
 
-<details><summary><b>Filter results by timestamp or sample value</b></summary>
+<details open><summary><b>Filter results by timestamp or sample value</b></summary>
 
 Consider a metric where acceptable values are between -100 and 100, and the value 9999 is used as an indication of bad measurement.
 
@@ -189,7 +189,7 @@ TS.RANGE temp:TLV - + FILTER_BY_VALUE -100 100 AGGREGATION avg 1000
 {{< / highlight >}}
 </details>
 
-<details><summary><b>Align aggregation buckets</b></summary>
+<details open><summary><b>Align aggregation buckets</b></summary>
 
 To demonstrate alignment, let’s create a stock and add prices at nine different timestamps.
 

--- a/docs/commands/ts.range.md
+++ b/docs/commands/ts.range.md
@@ -13,46 +13,89 @@ TS.RANGE key fromTimestamp toTimestamp
          [[ALIGN value] AGGREGATION aggregator bucketDuration [BUCKETTIMESTAMP bt] [EMPTY]]
 {{< / highlight >}}
 
-[**Examples**](#examples)
+[:arrow_down_small:**Examples**](#examples)
 
 ## Required arguments
 
-`key` is the key name for the time series.
+<details>
+<summary><code>key</code></summary> 
 
-`fromTimestamp` is start timestamp for the range query. Use `-` to express the minimum possible timestamp (0).
+is the key name for the time series.
 
-`toTimestamp` is end timestamp for the range query. Use `+` to express the maximum possible timestamp.
-    
-    > **NOTE:** When the time series is a compaction, the last compacted value may aggregate raw values with timestamp beyond `toTimestamp`. That is because `toTimestamp` only limits the timestamp of the compacted value, which is the start time of the raw bucket that was compacted.
+</details>
+
+<details>
+<summary><code>fromTimestamp</code></summary> 
+
+is start timestamp for the range query. Use `-` to express the minimum possible timestamp (0).
+
+</details>
+
+<details>
+<summary><code>toTimestamp</code></summary> 
+
+is end timestamp for the range query. Use `+` to express the maximum possible timestamp.
+
+<note><b>NOTE:</b>    When the time series is a compaction, the last compacted value may aggregate raw values with timestamp beyond `toTimestamp`. That is because `toTimestamp` only limits the timestamp of the compacted value, which is the start time of the raw bucket that was compacted.</note>
+
+</details>
 
 ## Optional arguments
 
-`LATEST` (since RedisTimeSeries v1.8), used when a time series is a compaction. With `LATEST`, TS.RANGE also reports the compacted value of the latest possibly partial bucket, given that this bucket's start time falls within `[fromTimestamp, toTimestamp]`. Without `LATEST`, TS.RANGE does not report the latest possibly partial bucket. When a time series is not a compaction, `LATEST` is ignored.
+<details>
+<summary><code>LATEST</code> (since RedisTimeSeries v1.8)</summary>
+
+is used when a time series is a compaction. With `LATEST`, TS.RANGE also reports the compacted value of the latest possibly partial bucket, given that this bucket's start time falls within `[fromTimestamp, toTimestamp]`. Without `LATEST`, TS.RANGE does not report the latest possibly partial bucket. When a time series is not a compaction, `LATEST` is ignored.
   
 The data in the latest bucket of a compaction is possibly partial. A bucket is _closed_ and compacted only upon arrival of a new sample that _opens_ a new _latest_ bucket. There are cases, however, when the compacted value of the latest possibly partial bucket is also required. In such a case, use `LATEST`.
 
-`FILTER_BY_TS ts...` (since RedisTimeSeries v1.6) followed by a list of timestamps filters results by specific timestamps.
+</details>
 
-`FILTER_BY_VALUE min max` (since RedisTimeSeries v1.6) filters results by minimum and maximum values.
+<details>
+<summary><code>FILTER_BY_TS ts...</code> (since RedisTimeSeries v1.6)</summary> 
 
-`COUNT count` limits the number of returned samples.
+followed by a list of timestamps filters results by specific timestamps.
 
-`ALIGN value` (since RedisTimeSeries v1.6) is a time bucket alignment control for `AGGREGATION`. 
-It controls the time bucket timestamps by changing the reference timestamp on which a bucket is defined. 
+</details>
+
+<details>
+<summary><code>FILTER_BY_VALUE min max</code> (since RedisTimeSeries v1.6)</summary> 
+
+filters results by minimum and maximum values.
+
+</details>
+
+<details>
+<summary><code>COUNT count</code></summary> 
+
+limits the number of returned samples.
+
+</details>
+
+<details>
+<summary><code>ALIGN value</code> (since RedisTimeSeries v1.6)</summary> 
+
+is a time bucket alignment control for `AGGREGATION`. It controls the time bucket timestamps by changing the reference timestamp on which a bucket is defined.
+
 Values include:
    
  - `start` or `-`: The reference timestamp will be the query start interval time (`fromTimestamp`) which can't be `-`
  - `end` or `+`: The reference timestamp will be the query end interval time (`toTimestamp`) which can't be `+`
  - A specific timestamp: align the reference timestamp to a specific time
    
-> **NOTE:** When not provided, alignment is set to `0`.
+<note><b>NOTE:</b> When not provided, alignment is set to `0`.</note>
 
-`AGGREGATION aggregator bucketDuration` aggregates results into time buckets, where:
+</details>
+
+<details>
+<summary><code>AGGREGATION aggregator bucketDuration</code></summary> 
+
+aggregates results into time buckets, where:
 
   - `aggregator` takes one of the following aggregation types:
 
-    | `aggregator` | Description                                                      |
-    | ------------ | ---------------------------------------------------------------- |
+    | `aggregator `&nbsp; &nbsp; &nbsp; | Description                                                      |
+    | :----------- | :--------------------------------------------------------------- |
     | `avg`        | Arithmetic mean of all values                                    |
     | `sum`        | Sum of all values                                                |
     | `min`        | Minimum value                                                    |
@@ -66,18 +109,29 @@ Values include:
     | `var.p`      | Population variance of the values                                |
     | `var.s`      | Sample variance of the values                                    |
     | `twa`        | Time-weighted average of all values (since RedisTimeSeries v1.8) |
+ 
 
   - `bucketDuration` is duration of each bucket, in milliseconds.
 
-`[BUCKETTIMESTAMP bt]` (since RedisTimeSeries v1.8) controls how bucket timestamps are reported.
+</details>
 
-| `bt`         | Description                                                |
-| ------------ | ---------------------------------------------------------- |
-| `-` or `low` | Timestamp is the start time (default)                      |
-| `+` or `high`| Timestamp is the end time                                  |
-| `~` or `mid` | Timestamp is the mid time (rounded down if not an integer) |
+<details>
+<summary><code>[BUCKETTIMESTAMP bt]</code> (since RedisTimeSeries v1.8)</summary> 
 
-`[EMPTY]` (since RedisTimeSeries v1.8) is a flag, which, when specified, reports aggregations for empty buckets.
+controls how bucket timestamps are reported.
+
+| `bt`             | Description                                                |
+| ---------------- | ---------------------------------------------------------- |
+| `-` or `low`   `&nbsp; &nbsp; &nbsp;   | Timestamp is the start time (default)                      |
+| `+` or `high`    | Timestamp is the end time                                  |
+| `~` or `mid`     | Timestamp is the mid time (rounded down if not an integer) |
+
+</details>
+
+<details>
+<summary><code>[EMPTY]</code> (since RedisTimeSeries v1.8)</summary> 
+
+is a flag, which, when specified, reports aggregations for empty buckets.
 
 | `aggregator`         | Value reported for each empty bucket |
 | -------------------- | ------------------------------------ |
@@ -85,25 +139,22 @@ Values include:
 | `min`, `max`, `range`, `avg` | Based on linear interpolation of the last value before the bucket’s start time and the first value on or after the bucket’s end tim, calculates the min/max/range/avg within the bucket. Returns `NaN` if no values exist before or after the bucket.       |
 | `first`              | Last value before the bucket’s start time. Returns `NaN` if no such value exists.     |
 | `last`               | The first value on or after the bucket’s end time. Returns NaN if no such value exists. |
-| `std.p`, `std.s`         | `NaN` |
+| `std.p`, `std.s`    &nbsp; &nbsp; &nbsp;      | `NaN` |
 | `twa` | Based on linear interpolation or extrapolation. Returns `NaN` when it cannot interpolate or extrapolate. |
+
 
 Regardless of the values of `fromTimestamp` and `toTimestamp`, no data is reported for buckets that end before the oldest available raw sample, or begin after the newest available raw sample.
 
+</details>
+
 ## Complexity
 
-TS.RANGE complexity is `O(n/m+k)`, where:
-
-  - `n` is number of data points.
-  - `m` is chunk size (data points per chunk).
-  - `k` is number of data points that are in the requested range
-
-This can be improved in the future by using binary search to find the start of the range, which makes this `O(Log(n/m)+k*m)`.
-But, because `m` is small, you can disregard it and look at the operation as O(Log(n)+k).
+TS.RANGE complexity can be improved in the future by using binary search to find the start of the range, which makes this `O(Log(n/m)+k*m)`.
+But, because `m` is small, you can disregard it and look at the operation as `O(Log(n)+k)`.
 
 ## Examples
 
-### Filter results by timestamp or sample value
+<details><summary><b>Filter results by timestamp or sample value</b></summary>
 
 Consider a metric where acceptable values are between -100 and 100, and the value 9999 is used as an indication of bad measurement.
 
@@ -136,8 +187,9 @@ TS.RANGE temp:TLV - + FILTER_BY_VALUE -100 100 AGGREGATION avg 1000
 1) 1) (integer) 1000
    2) 35
 {{< / highlight >}}
+</details>
 
-### Align aggregation buckets
+<details><summary><b>Align aggregation buckets</b></summary>
 
 To demonstrate alignment, let’s create a stock and add prices at nine different timestamps.
 
@@ -192,7 +244,7 @@ And now set `ALIGN` to 10 to have a bucket start at time 10, and align all the b
    2) 310
 {{< / highlight >}}
 
-When the start timestamp for the range query is explicitly stated (not `-`), you can set ALIGN to that time by setting align to `-` or to `start`.
+When the start timestamp for the range query is explicitly stated (not `-`), you can set `ALIGN` to that time by setting align to `-` or to `start`.
 
 {{< highlight bash >}}
 127.0.0.1:6379> TS.RANGE stock:A 5 + ALIGN - AGGREGATION min 20
@@ -210,7 +262,8 @@ When the start timestamp for the range query is explicitly stated (not `-`), you
    2) 310
 {{< / highlight >}}
 
-Similarly, when the end timestamp for the range query is explicitly stated, you can set ALIGN to that time by setting align to `+` or to `end`.
+Similarly, when the end timestamp for the range query is explicitly stated, you can set `ALIGN` to that time by setting align to `+` or to `end`.
+</details>
 
 ## See also
 

--- a/docs/commands/ts.revrange.md
+++ b/docs/commands/ts.revrange.md
@@ -15,23 +15,23 @@ TS.REVRANGE key fromTimestamp toTimestamp
          [[ALIGN value] AGGREGATION aggregator bucketDuration [BUCKETTIMESTAMP bt] [EMPTY]]
 {{< / highlight >}}
 
-[:arrow_down_small:**Examples**](#examples)
+[Examples](#examples)
 
 ## Required arguments
 
-<details>
+<details open>
 <summary><code>key</code></summary>
 is the key name for the time series.
 </details>
 
-<details>
+<details open>
 <summary><code>fromTimestamp</code></summary>
 
 is start timestamp for the range query. Use `-` to express the minimum possible timestamp (0).
 
 </details>
 
-<details>
+<details open>
 <summary><code>toTimestamp</code></summary>
 
 is end timestamp for range query. Use `+` to express the maximum possible timestamp.
@@ -42,7 +42,7 @@ is end timestamp for range query. Use `+` to express the maximum possible timest
 
 ## Optional arguments
 
-<details>
+<details open>
 <summary><code>LATEST</code> (since RedisTimeSeries v1.8)</summary>
 
 is used when a time series is a compaction. With `LATEST`, TS.REVRANGE also reports the compacted value of the latest possibly partial bucket, given that this bucket's start time falls within `[fromTimestamp, toTimestamp]`. Without `LATEST`, TS.REVRANGE does not report the latest possibly partial bucket. When a time series is not a compaction, `LATEST` is ignored.
@@ -50,22 +50,22 @@ is used when a time series is a compaction. With `LATEST`, TS.REVRANGE also repo
 The data in the latest bucket of a compaction is possibly partial. A bucket is _closed_ and compacted only upon arrival of a new sample that _opens_ a new _latest_ bucket. There are cases, however, when the compacted value of the latest possibly partial bucket is also required. In such a case, use `LATEST`.
 </details>
 
-<details>
+<details open>
 <summary><code>FILTER_BY_TS ts...</code> (since RedisTimeSeries v1.6)</summary>
 
 followed by a list of timestamps filters results by specific timestamps.
 </details>
 
-<details>
+<details open>
 <summary><code>FILTER_BY_VALUE min max</code> (since RedisTimeSeries v1.6)</summary> filters results by minimum and maximum values.
 </details>
 
-<details>
+<details open>
 <summary><code>COUNT count</code></summary>
 limits the number of returned samples.
 </details>
 
-<details>
+<details open>
 <summary><code>ALIGN value</code> (since RedisTimeSeries v1.6)</summary>
 is a time bucket alignment control for `AGGREGATION`. It controls the time bucket timestamps by changing the reference timestamp on which a bucket is defined. 
 Values include:
@@ -78,7 +78,7 @@ Values include:
 
 </details>
 
-<details>
+<details open>
 <summary><code>AGGREGATION aggregator bucketDuration</code></summary>
 aggregates results into time buckets, where:
 
@@ -103,7 +103,7 @@ aggregates results into time buckets, where:
   - `bucketDuration` is duration of each bucket, in milliseconds.
 </details>
 
-<details>
+<details open>
 <summary><code>[BUCKETTIMESTAMP bt]</code> (since RedisTimeSeries v1.8)</summary>
 controls how bucket timestamps are reported.
 
@@ -114,7 +114,7 @@ controls how bucket timestamps are reported.
 | `~` or `mid` | Timestamp is the mid time (rounded down if not an integer) |
 </details>
 
-<details>
+<details open>
 <summary><code>[EMPTY]</code> (since RedisTimeSeries v1.8)</summary>
 is a flag, which, when specified, reports aggregations for empty buckets.
 
@@ -137,7 +137,7 @@ But, because `m` is small, you can disregard it and look at the operation as `O(
 
 ## Examples
 
-<details>
+<details open>
 <summary><b>Filter results by timestamp or sample value</b></summary>
 
 Consider a metric where acceptable values are between -100 and 100, and the value 9999 is used as an indication of bad measurement.
@@ -173,7 +173,7 @@ TS.REVRANGE temp:TLV - + FILTER_BY_VALUE -100 100 AGGREGATION avg 1000
 {{< / highlight >}}
 </details>
 
-<details>
+<details open>
 <summary><b>Align aggregation buckets</b></summary>
 
 To demonstrate alignment, let’s create a stock and add prices at three different timestamps.

--- a/docs/commands/ts.revrange.md
+++ b/docs/commands/ts.revrange.md
@@ -15,45 +15,76 @@ TS.REVRANGE key fromTimestamp toTimestamp
          [[ALIGN value] AGGREGATION aggregator bucketDuration [BUCKETTIMESTAMP bt] [EMPTY]]
 {{< / highlight >}}
 
-[**Examples**](#examples)
+[:arrow_down_small:**Examples**](#examples)
 
 ## Required arguments
 
-`key` is the key name for the time series.
+<details>
+<summary><code>key</code></summary>
+is the key name for the time series.
+</details>
 
-`fromTimestamp` is start timestamp for the range query. Use `-` to express the minimum possible timestamp (0).
+<details>
+<summary><code>fromTimestamp</code></summary>
 
-`toTimestamp` is end timestamp for range query. Use `+` to express the maximum possible timestamp.
+is start timestamp for the range query. Use `-` to express the minimum possible timestamp (0).
 
-> **NOTE:** When the time series is a compaction, the last compacted value may aggregate raw values with timestamp beyond `toTimestamp`. That is because `toTimestamp` only limits the timestamp of the compacted value, which is the start time of the raw bucket that was compacted.
+</details>
+
+<details>
+<summary><code>toTimestamp</code></summary>
+
+is end timestamp for range query. Use `+` to express the maximum possible timestamp.
+
+<note><b>NOTE:</b>  When the time series is a compaction, the last compacted value may aggregate raw values with timestamp beyond `toTimestamp`. That is because `toTimestamp` limits only the timestamp of the compacted value, which is the start time of the raw bucket that was compacted.</note>
+
+</details>
 
 ## Optional arguments
 
-`LATEST` (since RedisTimeSeries v1.8), used when a time series is a compaction. With `LATEST`, TS.REVRANGE also reports the compacted value of the latest possibly partial bucket, given that this bucket's start time falls within `[fromTimestamp, toTimestamp]`. Without `LATEST`, TS.REVRANGE does not report the latest possibly partial bucket. When a time series is not a compaction, `LATEST` is ignored.
+<details>
+<summary><code>LATEST</code> (since RedisTimeSeries v1.8)</summary>
+
+is used when a time series is a compaction. With `LATEST`, TS.REVRANGE also reports the compacted value of the latest possibly partial bucket, given that this bucket's start time falls within `[fromTimestamp, toTimestamp]`. Without `LATEST`, TS.REVRANGE does not report the latest possibly partial bucket. When a time series is not a compaction, `LATEST` is ignored.
   
 The data in the latest bucket of a compaction is possibly partial. A bucket is _closed_ and compacted only upon arrival of a new sample that _opens_ a new _latest_ bucket. There are cases, however, when the compacted value of the latest possibly partial bucket is also required. In such a case, use `LATEST`.
+</details>
 
-`FILTER_BY_TS ts...` (since RedisTimeSeries v1.6) followed by a list of timestamps filters results by specific timestamps.
+<details>
+<summary><code>FILTER_BY_TS ts...</code> (since RedisTimeSeries v1.6)</summary>
 
-`FILTER_BY_VALUE min max` (since RedisTimeSeries v1.6) filters results by minimum and maximum values.
+followed by a list of timestamps filters results by specific timestamps.
+</details>
 
-`COUNT count` limits the number of returned samples.
+<details>
+<summary><code>FILTER_BY_VALUE min max</code> (since RedisTimeSeries v1.6)</summary> filters results by minimum and maximum values.
+</details>
 
-`ALIGN value` (since RedisTimeSeries v1.6) is a time bucket alignment control for `AGGREGATION`. 
-It controls the time bucket timestamps by changing the reference timestamp on which a bucket is defined. 
+<details>
+<summary><code>COUNT count</code></summary>
+limits the number of returned samples.
+</details>
+
+<details>
+<summary><code>ALIGN value</code> (since RedisTimeSeries v1.6)</summary>
+is a time bucket alignment control for `AGGREGATION`. It controls the time bucket timestamps by changing the reference timestamp on which a bucket is defined. 
 Values include:
    
  - `start` or `-`: The reference timestamp will be the query start interval time (`fromTimestamp`) which can't be `-`
  - `end` or `+`: The reference timestamp will be the query end interval time (`toTimestamp`) which can't be `+`
  - A specific timestamp: align the reference timestamp to a specific time
    
-> **NOTE:** When not provided, alignment is set to `0`.
+<note><b>NOTE:</b> When not provided, alignment is set to `0`.</note>
 
-`AGGREGATION aggregator bucketDuration` aggregates results into time buckets, where:
+</details>
+
+<details>
+<summary><code>AGGREGATION aggregator bucketDuration</code></summary>
+aggregates results into time buckets, where:
 
   - `aggregator` takes one of the following aggregation types:
 
-    | `aggregator` | Description                                                      |
+    | `aggregator` &nbsp; &nbsp; &nbsp; | Description                                                      |
     | ------------ | ---------------------------------------------------------------- |
     | `avg`        | Arithmetic mean of all values                                    |
     | `sum`        | Sum of all values                                                |
@@ -70,43 +101,44 @@ Values include:
     | `twa`        | Time-weighted average of all values (since RedisTimeSeries v1.8) |
 
   - `bucketDuration` is duration of each bucket, in milliseconds.
+</details>
 
-`[BUCKETTIMESTAMP bt]` (since RedisTimeSeries v1.8) controls how bucket timestamps are reported.
+<details>
+<summary><code>[BUCKETTIMESTAMP bt]</code> (since RedisTimeSeries v1.8)</summary>
+controls how bucket timestamps are reported.
 
 | `bt`         | Description                                                |
 | ------------ | ---------------------------------------------------------- |
 | `-` or `low` | Timestamp is the start time (default)                      |
-| `+` or `high`| Timestamp is the end time                                  |
+| `+` or `high` &nbsp; &nbsp; &nbsp;| Timestamp is the end time                                  |
 | `~` or `mid` | Timestamp is the mid time (rounded down if not an integer) |
+</details>
 
-`[EMPTY]` (since RedisTimeSeries v1.8) is a flag, which, when specified, reports aggregations for empty buckets.
+<details>
+<summary><code>[EMPTY]</code> (since RedisTimeSeries v1.8)</summary>
+is a flag, which, when specified, reports aggregations for empty buckets.
 
 | `aggregator`         | Value reported for each empty bucket |
 | -------------------- | ------------------------------------ |
 | `sum`, `count`       | `0`                                  |
-| `min`, `max`, `range`, `avg` | Based on linear interpolation of the last value before the bucket’s start time and the first value on or after the bucket’s end time, calculates the min/max/range/avg within the bucket. Returns `NaN` if no values exist before or after the bucket.       |
+| `min`, `max`, `range`, `avg` &nbsp; &nbsp; &nbsp;| Based on linear interpolation of the last value before the bucket’s start time and the first value on or after the bucket’s end time, calculates the min/max/range/avg within the bucket. Returns `NaN` if no values exist before or after the bucket.       |
 | `first`              | Last value before the bucket’s start time. Returns `NaN` if no such value exists.     |
 | `last`               | The first value on or after the bucket’s end time. Returns NaN if no such value exists. |
 | `std.p`, `std.s`         | `NaN` |
 | `twa` | Based on linear interpolation or extrapolation. Returns `NaN` when it cannot interpolate or extrapolate. |
 
-Regardless of the values of fromTimestamp and toTimestamp, no data is reported for buckets that end before the oldest available raw sample, or begin after the newest available raw sample.
-
+Regardless of the values of `fromTimestamp` and `toTimestamp`, no data is reported for buckets that end before the oldest available raw sample, or begin after the newest available raw sample.
+</details>
 
 ## Complexity
 
-TS.REVRANGE complexity is O(n/m+k), where:
-
- - `n` is number of data points.
- - `m` is chunk size (data points per chunk).
- - `k` is number of data points that are in the requested range.
-
-This can be improved in the future by using binary search to find the start of the range, which makes this `O(Log(n/m)+k*m)`.
-But, because `m` is small, you can disregard it and look at the operation as O(Log(n)+k).
+TS.REVRANGE complexity can be improved in the future by using binary search to find the start of the range, which makes this `O(Log(n/m)+k*m)`.
+But, because `m` is small, you can disregard it and look at the operation as `O(Log(n)+k)`.
 
 ## Examples
 
-### Filter results by timestamp or sample value
+<details>
+<summary><b>Filter results by timestamp or sample value</b></summary>
 
 Consider a metric where acceptable values are between -100 and 100, and the value 9999 is used as an indication of bad measurement.
 
@@ -139,8 +171,10 @@ TS.REVRANGE temp:TLV - + FILTER_BY_VALUE -100 100 AGGREGATION avg 1000
 1) 1) (integer) 1000
    2) 35
 {{< / highlight >}}
+</details>
 
-### Align aggregation buckets
+<details>
+<summary><b>Align aggregation buckets</b></summary>
 
 To demonstrate alignment, let’s create a stock and add prices at three different timestamps.
 
@@ -216,6 +250,7 @@ When the start timestamp for the range query is explicitly stated (not `-`), you
 {{< / highlight >}}
 
 Similarly, when the end timestamp for the range query is explicitly stated, you can set ALIGN to that time by setting align to `+` or to `end`.
+</details>
 
 ## See also
 

--- a/docs/commands/ts.revrange.md
+++ b/docs/commands/ts.revrange.md
@@ -2,7 +2,7 @@
 syntax: 
 ---
 
-Query a range in reverse direction.
+Query a range in reverse direction
 
 ## Syntax
 
@@ -36,7 +36,7 @@ is start timestamp for the range query. Use `-` to express the minimum possible 
 
 is end timestamp for range query. Use `+` to express the maximum possible timestamp.
 
-<note><b>NOTE:</b>  When the time series is a compaction, the last compacted value may aggregate raw values with timestamp beyond `toTimestamp`. That is because `toTimestamp` limits only the timestamp of the compacted value, which is the start time of the raw bucket that was compacted.</note>
+<note><b>Note:</b>  When the time series is a compaction, the last compacted value may aggregate raw values with timestamp beyond `toTimestamp`. That is because `toTimestamp` limits only the timestamp of the compacted value, which is the start time of the raw bucket that was compacted.</note>
 
 </details>
 


### PR DESCRIPTION
Updated structure, wording, and examples