### PR TITLE
fixing link to modules download center

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -25,7 +25,7 @@ docker run -p 6379:6379 -it --rm redislabs/redistimeseries
 
 ### Download and running binaries
 
-First download the pre-compiled version from the [Redis download center](https://redis.com/redis-enterprise-software/download-center/modules/).
+First download the pre-compiled version from the [Redis download center](https://app.redislabs.com/#/rlec-downloads).
 
 Next, run Redis with RedisTimeSeries: 
 


### PR DESCRIPTION
Fixing a link to the modules download center, current link is dead.