### PR TITLE
Bug fix 1421

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ define _SOURCES
 	compaction.c
 	compressed_chunk.c
 	config.c
+	consts.c
 	endianconv.c
 	filter_iterator.c
 	generic_chunk.c

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -83,6 +83,7 @@ static Sample *ChunkGetSample(Chunk *chunk, int index) {
 timestamp_t Uncompressed_GetLastTimestamp(Chunk_t *chunk) {
     if (unlikely(((Chunk *)chunk)->num_samples == 0)) { // empty chunks are being removed
         RedisModule_Log(mr_staticCtx, "error", "Trying to get the last timestamp of empty chunk");
+        return 0;
     }
     return ChunkGetSample(chunk, ((Chunk *)chunk)->num_samples - 1)->timestamp;
 }
@@ -90,6 +91,7 @@ timestamp_t Uncompressed_GetLastTimestamp(Chunk_t *chunk) {
 double Uncompressed_GetLastValue(Chunk_t *chunk) {
     if (unlikely(((Chunk *)chunk)->num_samples == 0)) { // empty chunks are being removed
         RedisModule_Log(mr_staticCtx, "error", "Trying to get the last value of empty chunk");
+        return 0;
     }
     return ChunkGetSample(chunk, ((Chunk *)chunk)->num_samples - 1)->value;
 }

--- a/src/compaction.h
+++ b/src/compaction.h
@@ -35,7 +35,7 @@ typedef struct AggregationClass
         timestamp_t ts); // Should be called after appended all the rest of the samples.
     void (*getLastSample)(void *contextPtr,
                           Sample *sample); // Returns the last sample appended to the context
-    void (*finalize)(void *context, double *value);
+    int (*finalize)(void *context, double *value);
     void (*finalizeEmpty)(void *contextPtr, double *value); // assigns empty value to value
     void *(*cloneContext)(void *contextPtr);                // return cloned context
 } AggregationClass;

--- a/src/config.c
+++ b/src/config.c
@@ -180,6 +180,28 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             TSGlobalConfig.forceSaveCrossRef = false;
         }
     }
+    TSGlobalConfig.dontAssertOnFailiure = false;
+    if (argc > 1 && RMUtil_ArgIndex("DONT_ASSERT_ON_FAILIURE", argv, argc) >= 0) {
+        RedisModuleString *dontAssertOnFailiure;
+        if (RMUtil_ParseArgsAfter(
+                "DONT_ASSERT_ON_FAILIURE", argv, argc, "s", &dontAssertOnFailiure) !=
+            REDISMODULE_OK) {
+            RedisModule_Log(
+                ctx, "warning", "Unable to parse argument after DONT_ASSERT_ON_FAILIURE");
+            return TSDB_ERROR;
+        }
+        size_t dontAssertOnFailiure_len;
+        const char *dontAssertOnFailiure_cstr =
+            RedisModule_StringPtrLen(dontAssertOnFailiure, &dontAssertOnFailiure_len);
+        if (!strcasecmp(dontAssertOnFailiure_cstr, "enable")) {
+            TSGlobalConfig.dontAssertOnFailiure = true;
+        } else if (!strcasecmp(dontAssertOnFailiure_cstr, "disable")) {
+            TSGlobalConfig.dontAssertOnFailiure = false;
+        }
+
+        extern bool _dontAssertOnFailiure;
+        _dontAssertOnFailiure = TSGlobalConfig.dontAssertOnFailiure;
+    }
     RedisModule_Log(ctx,
                     "notice",
                     "Setting default series ENCODING to: %s",

--- a/src/config.h
+++ b/src/config.h
@@ -20,9 +20,10 @@ typedef struct
     short options;
     int hasGlobalConfig;
     DuplicatePolicy duplicatePolicy;
-    long long numThreads;   // number of threads used by libMR
-    bool forceSaveCrossRef; // Internal debug configuration param
-    char *password;         // tls password which used by libmr
+    long long numThreads;      // number of threads used by libMR
+    bool forceSaveCrossRef;    // Internal debug configuration param
+    char *password;            // tls password which used by libmr
+    bool dontAssertOnFailiure; // Internal debug configuration param
 } TSConfig;
 
 extern TSConfig TSGlobalConfig;

--- a/src/consts.c
+++ b/src/consts.c
@@ -1,0 +1,9 @@
+/*
+ *copyright redis ltd. 2017 - present
+ *licensed under your choice of the redis source available license 2.0 (rsalv2) or
+ *the server side public license v1 (ssplv1).
+ */
+
+#include <stdbool.h>
+
+bool _dontAssertOnFailiure = false;

--- a/src/consts.h
+++ b/src/consts.h
@@ -8,20 +8,19 @@
 
 #include "redismodule.h"
 
-
 #include <sys/types.h>
 #include <stdbool.h>
 #include <string.h>
 #include <ctype.h>
 #include <assert.h>
 
-  #if defined(__GNUC__)
-#define likely(x)       __builtin_expect((x),1)
-#define unlikely(x)     __builtin_expect((x),0)
-  #elif _MSC_VER
-#define likely(x)       (x)
-#define unlikely(x)     (x)
-  #endif
+#if defined(__GNUC__)
+#define likely(x) __builtin_expect((x), 1)
+#define unlikely(x) __builtin_expect((x), 0)
+#elif _MSC_VER
+#define likely(x) (x)
+#define unlikely(x) (x)
+#endif
 
 #define TRUE 1
 #define FALSE 0
@@ -45,13 +44,14 @@
 #define TSDB_ERR_TIMESTAMP_OCCUPIED -2
 
 /* TS.CREATE Defaults */
-#define RETENTION_TIME_DEFAULT          0LL
-#define Chunk_SIZE_BYTES_SECS           4096LL   // fills one page 4096
-#define SPLIT_FACTOR                    1.2
-#define DEFAULT_DUPLICATE_POLICY        DP_BLOCK
+#define RETENTION_TIME_DEFAULT 0LL
+#define Chunk_SIZE_BYTES_SECS 4096LL // fills one page 4096
+#define SPLIT_FACTOR 1.2
+#define DEFAULT_DUPLICATE_POLICY DP_BLOCK
 
 /* TS.Range Aggregation types */
-typedef enum {
+typedef enum
+{
     TS_AGG_INVALID = -1,
     TS_AGG_NONE = 0,
     TS_AGG_MIN,
@@ -70,8 +70,8 @@ typedef enum {
     TS_AGG_TYPES_MAX // 13
 } TS_AGG_TYPES_T;
 
-
-typedef enum DuplicatePolicy {
+typedef enum DuplicatePolicy
+{
     DP_INVALID = -1,
     DP_NONE = 0,
     DP_BLOCK = 1,
@@ -90,10 +90,11 @@ typedef enum DuplicatePolicy {
 #define SERIES_OPT_DEFAULT_COMPRESSION SERIES_OPT_COMPRESSED_GORILLA
 
 /* Chunk enum */
-typedef enum {
-  CR_OK = 0,    // RM_OK
-  CR_ERR = 1,   // RM_ERR
-  CR_END = 2,   // END_OF_CHUNK
+typedef enum
+{
+    CR_OK = 0,  // RM_OK
+    CR_ERR = 1, // RM_ERR
+    CR_END = 2, // END_OF_CHUNK
 } ChunkResult;
 
 /* parsing */
@@ -103,21 +104,22 @@ typedef enum {
 #define UNCOMPRESSED_ARG_STR "uncompressed"
 #define COMPRESSED_GORILLA_ARG_STR "compressed"
 
-// DC - Don't Care (Arbitrary value) 
+// DC - Don't Care (Arbitrary value)
 #define DC 0
 
 #define SAMPLES_TO_BYTES(size) (size * sizeof(Sample))
 
-#define min(a,b) (((a)<(b))?(a):(b))
+#define min(a, b) (((a) < (b)) ? (a) : (b))
 
-#define max(a,b) (((a)>(b))?(a):(b))
+#define max(a, b) (((a) > (b)) ? (a) : (b))
 
-#define __SWAP(x,y) do {  \
-  typeof(x) _x = x;      \
-  typeof(y) _y = y;      \
-  x = _y;                \
-  y = _x;                \
-} while(0)
+#define __SWAP(x, y)                                                                               \
+    do {                                                                                           \
+        typeof(x) _x = x;                                                                          \
+        typeof(y) _y = y;                                                                          \
+        x = _y;                                                                                    \
+        y = _x;                                                                                    \
+    } while (0)
 
 static inline int RMStringStrCmpUpper(RedisModuleString *rm_str, const char *str) {
     size_t str_len;
@@ -130,17 +132,28 @@ static inline int RMStringStrCmpUpper(RedisModuleString *rm_str, const char *str
     return strcmp(input_upper, str);
 }
 
+extern bool _dontAssertOnFailiure;
+
 #ifdef DEBUG
-  #define _log_if(cond, format, ...) assert(!(cond))
+#define _log_if(cond, ...)                                                                         \
+    do {                                                                                           \
+        if (!_dontAssertOnFailiure) {                                                              \
+            assert(!(cond));                                                                       \
+        } else {                                                                                   \
+            extern RedisModuleCtx *rts_staticCtx;                                                  \
+            if (unlikely(cond)) {                                                                  \
+                RedisModule_Log(rts_staticCtx, "warning", ##__VA_ARGS__);                          \
+            }                                                                                      \
+        }                                                                                          \
+    } while (0)
 #else
-#define _log_if(cond, format, ...) do {          \
-  extern RedisModuleCtx *rts_staticCtx;          \
-  if(unlikely(cond)){                            \
-    RedisModule_Log(rts_staticCtx,               \
-                    "warning",                   \
-                    format, ##__VA_ARGS__);      \
-  }                                              \
-} while(0)
+#define _log_if(cond, ...)                                                                         \
+    do {                                                                                           \
+        extern RedisModuleCtx *rts_staticCtx;                                                      \
+        if (unlikely(cond)) {                                                                      \
+            RedisModule_Log(rts_staticCtx, "warning", ##__VA_ARGS__);                              \
+        }                                                                                          \
+    } while (0)
 #endif
 
 #endif

--- a/src/enriched_chunk.h
+++ b/src/enriched_chunk.h
@@ -4,10 +4,10 @@
  *the server side public license v1 (ssplv1).
  */
 
-#include "consts.h"
-
 #ifndef ENRICHED_CHUNK_H
 #define ENRICHED_CHUNK_H
+
+#include "consts.h"
 
 typedef struct Samples
 {

--- a/src/module.c
+++ b/src/module.c
@@ -1108,7 +1108,7 @@ static inline bool verify_compaction_del_possible(RedisModuleCtx *ctx,
                                                   const Series *series,
                                                   const RangeArgs *args) {
     bool is_valid = true;
-    if (!series->rules)
+    if (!series->rules || !series->retentionTime)
         return true;
 
     // Verify startTimestamp in retention period

--- a/src/module.c
+++ b/src/module.c
@@ -1131,8 +1131,8 @@ static inline bool verify_compaction_del_possible(RedisModuleCtx *ctx,
 
     if (unlikely(!is_valid)) {
         RTS_ReplyGeneralError(ctx,
-                              "TSDB: Can't delete samples because raw samples expired and "
-                              "compacted data cannot be recalculated");
+                              "TSDB: When a series has compactions, deleting samples or compaction "
+                              "buckets beyond the series retention period is not possible");
     }
 
     return is_valid;

--- a/src/parse_policies.h
+++ b/src/parse_policies.h
@@ -6,8 +6,7 @@
 #ifndef PARSE_POLICIES_H
 #define PARSE_POLICIES_H
 
-#include "generic_chunk.h"
-
+#include "consts.h"
 #include <stdint.h>
 #include <sys/types.h>
 

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -710,18 +710,56 @@ static int ContinuousDeletion(RedisModuleCtx *ctx,
     return TSDB_OK;
 }
 
-void CompactionDelRange(Series *series, timestamp_t start_ts, timestamp_t end_ts) {
+static bool delete_sample_before(RedisModuleCtx *ctx,
+                                 RedisModuleString *series_name,
+                                 timestamp_t ts,
+                                 timestamp_t *deleted) {
+    RedisModuleKey *key;
+    Series *series;
+    bool rv = true;
+    if (!GetSeries(
+            ctx, series_name, &key, &series, REDISMODULE_READ | REDISMODULE_WRITE, false, false)) {
+        RedisModule_Log(ctx, "verbose", "%s", "Failed to retrieve downsample series");
+        return false;
+    }
+
+    timestamp_t rax_key;
+    Chunk_t *chunk;
+    seriesEncodeTimestamp(&rax_key, ts);
+    RedisModuleDictIter *dictIter =
+        RedisModule_DictIteratorStartC(series->chunks, "<", &rax_key, sizeof(rax_key));
+    void *chunkKey = RedisModule_DictNextC(dictIter, NULL, (void *)&chunk);
+    if (chunkKey == NULL || series->funcs->GetNumOfSample(chunk) == 0) {
+        rv = false;
+        goto _out;
+    }
+
+    *deleted = Uncompressed_GetLastTimestamp(chunk);
+    SeriesDelRange(series, *deleted, *deleted);
+
+_out:
+    RedisModule_CloseKey(key);
+    RedisModule_DictIteratorStop(dictIter);
+    return rv;
+}
+
+static void CompactionDelRange(Series *series,
+                               timestamp_t start_ts,
+                               timestamp_t end_ts,
+                               timestamp_t last_ts_before_deletion) {
     if (!series->rules)
         return;
 
     deleteReferenceToDeletedSeries(rts_staticCtx, series);
     CompactionRule *rule = series->rules;
+    bool is_empty;
 
     while (rule) {
         const timestamp_t ruleTimebucket = rule->bucketDuration;
         const timestamp_t curAggWindowStart =
-            CalcBucketStart(series->lastTimestamp, ruleTimebucket, rule->timestampAlignment);
+            CalcBucketStart(last_ts_before_deletion, ruleTimebucket, rule->timestampAlignment);
         const timestamp_t curAggWindowStartNormalized = BucketStartNormalize(curAggWindowStart);
+        bool latest_timebucket_deleted = false;
 
         if (start_ts >= curAggWindowStartNormalized) {
             // All deletion range in latest timebucket - only update the context on the rule
@@ -730,11 +768,15 @@ void CompactionDelRange(Series *series, timestamp_t start_ts, timestamp_t end_ts
                                            curAggWindowStart + ruleTimebucket - 1,
                                            rule,
                                            NULL,
-                                           NULL);
+                                           &is_empty);
             if (rv == TSDB_ERROR) {
                 RedisModule_Log(
                     rts_staticCtx, "verbose", "%s", "Failed to calculate range for downsample");
                 continue;
+            }
+
+            if (is_empty) {
+                latest_timebucket_deleted = true;
             }
         } else {
             const timestamp_t startTSWindowStart =
@@ -747,7 +789,6 @@ void CompactionDelRange(Series *series, timestamp_t start_ts, timestamp_t end_ts
             timestamp_t continuous_deletion_start;
             timestamp_t continuous_deletion_end;
             double val = 0;
-            bool is_empty;
             int rv;
 
             // ---- handle start bucket ----
@@ -781,12 +822,17 @@ void CompactionDelRange(Series *series, timestamp_t start_ts, timestamp_t end_ts
             if (end_ts >= curAggWindowStartNormalized) {
                 // deletion in latest timebucket
                 const int rv = SeriesCalcRange(
-                    series, curAggWindowStartNormalized, UINT64_MAX, rule, NULL, NULL);
+                    series, curAggWindowStartNormalized, UINT64_MAX, rule, NULL, &is_empty);
                 if (rv == TSDB_ERROR) {
                     RedisModule_Log(
                         rts_staticCtx, "verbose", "%s", "Failed to calculate range for downsample");
                     continue;
                 }
+
+                if (is_empty) {
+                    latest_timebucket_deleted = true;
+                }
+
                 // continuous deletion ends one bucket before endTSWindowStart
                 continuous_deletion_end = BucketStartNormalize(endTSWindowStart - ruleTimebucket);
             } else {
@@ -826,6 +872,34 @@ void CompactionDelRange(Series *series, timestamp_t start_ts, timestamp_t end_ts
                                    continuous_deletion_start,
                                    continuous_deletion_end);
             }
+        }
+
+        // If the latest timebucket was deleted, we need to update the context to be the
+        // previous timebucket
+        if (latest_timebucket_deleted) {
+            timestamp_t last_ts;
+            // delete the last sample in the downsampled series
+            if (!delete_sample_before(
+                    rts_staticCtx, rule->destKey, last_ts_before_deletion, &last_ts)) {
+                // The compaction series is empty
+                last_ts = 0;
+            }
+
+            const timestamp_t wind_start =
+                CalcBucketStart(last_ts, ruleTimebucket, rule->timestampAlignment);
+            const timestamp_t wind_start_normalized = BucketStartNormalize(wind_start);
+
+            // update the context to be the latest timebucket
+            SeriesCalcRange(series,
+                            wind_start_normalized,
+                            wind_start_normalized + ruleTimebucket - 1,
+                            rule,
+                            NULL,
+                            &is_empty);
+
+            // if is_empty, it means that series is empty and we need to set startCurrentTimeBucket
+            // to -1
+            rule->startCurrentTimeBucket = is_empty ? -1LL : wind_start_normalized;
         }
 
         rule = rule->nextRule;
@@ -900,7 +974,7 @@ size_t SeriesDelRange(Series *series, timestamp_t start_ts, timestamp_t end_ts) 
 
     RedisModule_DictIteratorStop(iter);
 
-    CompactionDelRange(series, start_ts, end_ts);
+    timestamp_t last_ts_before_deletion = series->lastTimestamp;
 
     // Check if last timestamp deleted
     if (end_ts >= series->lastTimestamp && start_ts <= series->lastTimestamp) {
@@ -916,6 +990,9 @@ size_t SeriesDelRange(Series *series, timestamp_t start_ts, timestamp_t end_ts) 
         }
         RedisModule_DictIteratorStop(iter);
     }
+
+    CompactionDelRange(series, start_ts, end_ts, last_ts_before_deletion);
+
     return deletedSamples;
 }
 

--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -2,7 +2,7 @@ import os
 import sys
 from logging import exception
 from RLTest import Env as _rltestEnv
-
+from packaging import version
 
 try:
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../deps/readies"))
@@ -39,3 +39,16 @@ def decode_if_needed(data):
         return data.decode()
     else:
         return data
+
+def is_redis_version_smaller_than(con, _version, is_cluster=False):
+    res = con.execute_command('INFO')
+    ver = ""
+    if is_cluster:
+        try:
+            ver = ((list(res.values()))[0])['redis_version']
+        except:
+            ver = res['redis_version']
+        #print(((list(res.values()))[0]))
+    else:
+        ver = res['redis_version']
+    return (version.parse(ver) < version.parse(_version))

--- a/tests/flow/test_ts_delete.py
+++ b/tests/flow/test_ts_delete.py
@@ -396,13 +396,13 @@ def test_del_outside_retention_period(self):
             res = r.execute_command("ts.del", t1, 5, 25)
             assert False
         except Exception as e:
-            assert str(e) == "TSDB: Can't delete samples because raw samples expired and compacted data cannot be recalculated"
+            assert str(e) == "TSDB: When a series has compactions, deleting samples or compaction buckets beyond the series retention period is not possible"
 
         try:
             r.execute_command("ts.del", t1, 5, 25)
             assert False
         except Exception as e:
-            assert str(e) == "TSDB: Can't delete samples because raw samples expired and compacted data cannot be recalculated"
+            assert str(e) == "TSDB: When a series has compactions, deleting samples or compaction buckets beyond the series retention period is not possible"
 
 
         r.execute_command("ts.create", t3, 'RETENTION', 15)
@@ -417,7 +417,7 @@ def test_del_outside_retention_period(self):
             r.execute_command("ts.del", t3, 19, 25)
             assert False
         except Exception as e:
-            assert str(e) == "TSDB: Can't delete samples because raw samples expired and compacted data cannot be recalculated"
+            assert str(e) == "TSDB: When a series has compactions, deleting samples or compaction buckets beyond the series retention period is not possible"
 
         r.execute_command("ts.create", t5)
         r.execute_command("ts.create", t6)

--- a/tests/flow/test_ts_madd.py
+++ b/tests/flow/test_ts_madd.py
@@ -1,7 +1,6 @@
 import os
 import time
 import aof_parser
-from packaging import version
 
 from RLTest import Env, StandardEnv
 from includes import *
@@ -105,10 +104,6 @@ def test_extensive_ts_madd():
         for pos,datapoint in enumerate(returned_floats,start=1):
             assert pos == datapoint[0]
             assert float_lines[pos-1] == float(datapoint[1])
-
-def is_redis_version_smaller_than(con, _version):
-    res = con.execute_command('INFO')
-    return (version.parse(res['redis_version']) < version.parse(_version))
 
 def test_madd_some_failed_replicas():
     if not Env().useSlaves:


### PR DESCRIPTION
The issue:
https://github.com/RedisTimeSeries/RedisTimeSeries/issues/1421
The bug was fixed, by deleting the aggregation context and the last sample from the compaction key, and recreating the context from the older window.
All version where affected in some degree and from 1.8 it could cause a crash when trying to add new sample after the deletion when compaction is of type average.