### PR TITLE
Tweaks to RESP3 responses

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1098,7 +1098,7 @@ int TSDB_mget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         } else if (args.numLimitLabels > 0) {
             ReplyWithSeriesLabelsWithLimitC(ctx, series, limitLabelsStr, args.numLimitLabels);
         } else {
-            RedisModule_ReplyWithArray(ctx, 0);
+            RedisModule_ReplyWithMapOrArray(ctx, 0, false);
         }
         // LATEST is ignored for a series that is not a compaction.
         bool should_finalize_last_bucket = should_finalize_last_bucket_get(args.latest, series);

--- a/src/module.c
+++ b/src/module.c
@@ -137,34 +137,19 @@ int TSDB_info(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             if (!reply_map) {
                 RedisModule_ReplyWithArray(ctx, 5 * 2);
             } else {
-                RedisModule_ReplyWithArray(ctx, 5);
+                RedisModule_ReplyWithMap(ctx, 5);
             }
 
-            if (reply_map) {
-                RedisModule_ReplyWithMap(ctx, 1);
-            }
             RedisModule_ReplyWithSimpleString(ctx, "startTimestamp");
             RedisModule_ReplyWithLongLong(
                 ctx, numOfSamples == 0 ? -1 : series->funcs->GetFirstTimestamp(chunk));
-            if (reply_map) {
-                RedisModule_ReplyWithMap(ctx, 1);
-            }
             RedisModule_ReplyWithSimpleString(ctx, "endTimestamp");
             RedisModule_ReplyWithLongLong(
                 ctx, numOfSamples == 0 ? -1 : series->funcs->GetLastTimestamp(chunk));
-            if (reply_map) {
-                RedisModule_ReplyWithMap(ctx, 1);
-            }
             RedisModule_ReplyWithSimpleString(ctx, "samples");
             RedisModule_ReplyWithLongLong(ctx, numOfSamples);
-            if (reply_map) {
-                RedisModule_ReplyWithMap(ctx, 1);
-            }
             RedisModule_ReplyWithSimpleString(ctx, "size");
             RedisModule_ReplyWithLongLong(ctx, chunkSize);
-            if (reply_map) {
-                RedisModule_ReplyWithMap(ctx, 1);
-            }
             RedisModule_ReplyWithSimpleString(ctx, "bytesPerSample");
             RedisModule_ReplyWithDouble(
                 ctx, (numOfSamples == 0) ? (float)0 : (float)chunkSize / numOfSamples);

--- a/tests/flow/test_ts_resp3.py
+++ b/tests/flow/test_ts_resp3.py
@@ -23,8 +23,8 @@ def test_resp3(env):
         res = r.execute_command('ts.get', t1)
         assert res == [1000, 5.0]
         res = r.execute_command('ts.info', t1, 'DEBUG')
-        assert res == \
-            {b'totalSamples': 1000,
+        assert res == {
+            b'totalSamples': 1000,
             b'memoryUsage': 514, b'firstTimestamp': 1, b'lastTimestamp': 1000,
             b'retentionTime': 0, b'chunkCount': 2, b'chunkSize': 128,
             b'chunkType': b'compressed', b'duplicatePolicy': None,
@@ -33,10 +33,13 @@ def test_resp3(env):
             b'rules': {b't2{1}': [10, b'COUNT', 0]},
             b'keySelfName': b't1{1}',
             b'Chunks':
-            [[{b'startTimestamp': 1}, {b'endTimestamp': 510}, {b'samples': 510},
-            {b'size': 128}, {b'bytesPerSample': 0.250980406999588}],
-            [{b'startTimestamp': 511}, {b'endTimestamp': 1000}, {b'samples': 490},
-                {b'size': 128}, {b'bytesPerSample': 0.2612244784832001}]]}
+                [
+                    {b'startTimestamp': 1, b'endTimestamp': 510, b'samples': 510,
+                     b'size': 128, b'bytesPerSample': 0.250980406999588},
+                    {b'startTimestamp': 511, b'endTimestamp': 1000, b'samples': 490,
+                     b'size': 128, b'bytesPerSample': 0.2612244784832001}
+                ]
+        }
 
         res = r1.execute_command('ts.mget', 'WITHLABELS', 'FILTER', 'name=mush')
         assert res == {b't1{1}': [{b'name': b'mush'}, [1000, 5.0]],

--- a/tests/flow/test_ts_resp3.py
+++ b/tests/flow/test_ts_resp3.py
@@ -34,10 +34,20 @@ def test_resp3(env):
             b'keySelfName': b't1{1}',
             b'Chunks':
                 [
-                    {b'startTimestamp': 1, b'endTimestamp': 510, b'samples': 510,
-                     b'size': 128, b'bytesPerSample': 0.250980406999588},
-                    {b'startTimestamp': 511, b'endTimestamp': 1000, b'samples': 490,
-                     b'size': 128, b'bytesPerSample': 0.2612244784832001}
+                    {
+                        b'startTimestamp': 1,
+                        b'endTimestamp': 510,
+                        b'samples': 510,
+                        b'size': 128,
+                        b'bytesPerSample': 0.250980406999588
+                    },
+                    {
+                        b'startTimestamp': 511,
+                        b'endTimestamp': 1000,
+                        b'samples': 490,
+                        b'size': 128,
+                        b'bytesPerSample': 0.2612244784832001
+                    }
                 ]
         }
 

--- a/tests/flow/test_ts_resp3.py
+++ b/tests/flow/test_ts_resp3.py
@@ -50,6 +50,9 @@ def test_resp3(env):
                     }
                 ]
         }
+        res = r1.execute_command('ts.mget', 'FILTER', 'name=mush')
+        assert res == {b't1{1}': [{}, [1000, 5.0]],
+                       b't2{1}': [{}, [990, 10.0]]}
 
         res = r1.execute_command('ts.mget', 'WITHLABELS', 'FILTER', 'name=mush')
         assert res == {b't1{1}': [{b'name': b'mush'}, [1000, 5.0]],


### PR DESCRIPTION
# Description

Minor tweaks to the responses when the client is connected using `RESP3`.

- for `INFO` with `DEBUG` the `Chunks` section should be an array of maps where each map contains 5 k/v pairs. 
- When no labels are requested `MGET` should return an empty map instead of an empty array

## Related PRs
- #1454 