### PR TITLE
DOC-2283: replace RedisTimeSeries with Time Series

### DIFF
--- a/docs/docs/_index.md
+++ b/docs/docs/_index.md
@@ -1,5 +1,5 @@
 ---
-title: RedisTimeSeries
+title: Time Series
 linkTitle: Time Series
 description: Ingest and query time series data with Redis
 type: docs
@@ -8,7 +8,7 @@ type: docs
 [![Discord](https://img.shields.io/discord/697882427875393627?style=flat-square)](https://discord.gg/KExRgMb)
 [![Github](https://img.shields.io/static/v1?label=&message=repository&color=5961FF&logo=github)](https://github.com/RedisTimeSeries/RedisTimeSeries/)
 
-RedisTimeSeries is a Redis module that adds a time series data structure to Redis.
+Time Series is a Redis module that adds a time series data structure to Redis.
 
 ## Features
 * High volume inserts, low latency reads
@@ -26,10 +26,10 @@ See the [clients page](clients) for the full list.
 
 ## Using with other metrics tools
 
-In the [RedisTimeSeries](https://github.com/RedisTimeSeries) organization you can
-find projects that help you integrate RedisTimeSeries with other tools, including:
+In the [Time Series](https://github.com/RedisTimeSeries) organization you can
+find projects that help you integrate Time Series with other tools, including:
 
-1. [Prometheus](https://github.com/RedisTimeSeries/prometheus-redistimeseries-adapter), read/write adapter to use RedisTimeSeries as backend db.
+1. [Prometheus](https://github.com/RedisTimeSeries/prometheus-redistimeseries-adapter), read/write adapter to use Time Series as backend db.
 2. [Grafana 7.1+](https://github.com/RedisTimeSeries/grafana-redis-datasource), using the [Redis Data Source](https://redislabs.com/blog/introducing-the-redis-data-source-plug-in-for-grafana/).
 3. [Telegraf](https://github.com/influxdata/telegraf). Download the plugin from [InfluxData](https://portal.influxdata.com/downloads/). 
 4. StatsD, Graphite exports using graphite protocol.
@@ -40,7 +40,7 @@ A time series is a linked list of memory chunks. Each chunk has a predefined siz
 
 ## Forum
 
-Got questions? Feel free to ask at the [RedisTimeSeries mailing list](https://forum.redislabs.com/c/modules/redistimeseries).
+Got questions? Feel free to ask at the [Time Series mailing list](https://forum.redislabs.com/c/modules/redistimeseries).
 
 ## License
-RedisTimeSeries is licensed under the [Redis Source Available License 2.0 (RSALv2)](https://redis.com/legal/rsalv2-agreement) or the [Server Side Public License v1 (SSPLv1)](https://www.mongodb.com/licensing/server-side-public-license).
+Redis Time Series is licensed under the [Redis Source Available License 2.0 (RSALv2)](https://redis.com/legal/rsalv2-agreement) or the [Server Side Public License v1 (SSPLv1)](https://www.mongodb.com/licensing/server-side-public-license).

--- a/docs/docs/_index.md
+++ b/docs/docs/_index.md
@@ -8,7 +8,7 @@ type: docs
 [![Discord](https://img.shields.io/discord/697882427875393627?style=flat-square)](https://discord.gg/KExRgMb)
 [![Github](https://img.shields.io/static/v1?label=&message=repository&color=5961FF&logo=github)](https://github.com/RedisTimeSeries/RedisTimeSeries/)
 
-Time Series is a Redis module that adds a time series data structure to Redis.
+Time Series is a Redis feature that adds a time series data structure to Redis.
 
 ## Features
 * High volume inserts, low latency reads
@@ -26,7 +26,7 @@ See the [clients page](clients) for the full list.
 
 ## Using with other metrics tools
 
-In the [Time Series](https://github.com/RedisTimeSeries) organization you can
+In the [RedisTimeSeries](https://github.com/RedisTimeSeries) organization you can
 find projects that help you integrate Time Series with other tools, including:
 
 1. [Prometheus](https://github.com/RedisTimeSeries/prometheus-redistimeseries-adapter), read/write adapter to use Time Series as backend db.

--- a/docs/docs/clients.md
+++ b/docs/docs/clients.md
@@ -3,16 +3,16 @@ title: "Clients"
 linkTitle: "Clients"
 weight: 5
 description: >
-    RedisTimeSeries Client Libraries
+    Redis Time Series Client Libraries
 ---
 
-RedisTimeSeries has several client libraries, written by the module authors and community members - abstracting the API in different programming languages. 
+Time Series has several client libraries, written by the module authors and community members - abstracting the API in different programming languages. 
 
 While it is possible and simple to use the raw Redis commands API, in most cases it's more convenient to use a client library abstracting it. 
 
 ## Currently available Libraries
 
-Some languages have client libraries that provide support for RedisTimeSeries commands:
+Some languages have client libraries that provide support for Time Series commands:
 
 | Project | Language | License | Author | Stars |
 | ------- | -------- | ------- | ------ | --- |

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -6,7 +6,7 @@ description: >
     Commands Overview
 ---
 
-### RedisTimeSeries API
+### Time Series API
 
 Details on module's [commands](/commands/?group=timeseries) can be filtered for a specific module or command, e.g., `TS.CREATE`.
 The details also include the syntax for the commands, where:

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -3,7 +3,7 @@ title: "Configuration Parameters"
 linkTitle: "Configuration"
 weight: 3
 description: >
-    RedisTimeSeries supports multiple module configuration parameters. All of these parameters can only be set at load-time.
+    Time Series supports multiple module configuration parameters. All of these parameters can only be set at load-time.
 ---
 
 ## Setting configuration parameters on module load
@@ -28,19 +28,19 @@ From the command line:
 $ redis-server --loadmodule ./redistimeseries.so [OPT VAL]...
 ```
 
-## RedisTimeSeries configuration parameters
+## Time Series configuration parameters
 
 The following table summarizes which configuration parameters can be set at module load-time and run-time:
 
 | Configuration Parameter                                                    | Load-time          | Run-time             |
 | :-------                                                                   | :-----             | :-----------         |
-| [NUM_THREADS](#num_threads) (since RedisTimeSeries v1.6)                   | :white_check_mark: | :white_large_square: |
+| [NUM_THREADS](#num_threads) (since Time Series v1.6)                   | :white_check_mark: | :white_large_square: |
 | [COMPACTION_POLICY](#compaction_policy)                                    | :white_check_mark: | :white_large_square: |
 | [RETENTION_POLICY](#retention_policy)                                      | :white_check_mark: | :white_large_square: |
 | [DUPLICATE_POLICY](#duplicate_policy)                                      | :white_check_mark: | :white_large_square: |
-| [ENCODING](#encoding) (since RedisTimeSeries v1.6)                         | :white_check_mark: | :white_large_square: |
+| [ENCODING](#encoding) (since Time Series v1.6)                         | :white_check_mark: | :white_large_square: |
 | [CHUNK_SIZE_BYTES](#chunk_size_bytes)                                      | :white_check_mark: | :white_large_square: |
-| [OSS_GLOBAL_PASSWORD](#oss_global_password) (since RedisTimeSeries v1.8.4) | :white_check_mark: | :white_large_square: |
+| [OSS_GLOBAL_PASSWORD](#oss_global_password) (since Time Series v1.8.4) | :white_check_mark: | :white_large_square: |
 
 ### NUM_THREADS
 
@@ -79,7 +79,7 @@ Each rule is separated by a semicolon (`;`), the rule consists of multiple field
   | `std.s`    | sample standard deviation of the values                          |
   | `var.p`    | population variance of the values                                |
   | `var.s`    | sample variance of the values                                    |
-  | `twa`      | time-weighted average of all values (since RedisTimeSeries v1.8) |
+  | `twa`      | time-weighted average of all values (since Time Series v1.8) |
 
 * Duration of each time bucket - number and the time representation (Example for one minute: `1M`, `60s`, or `60000m`)
 
@@ -99,7 +99,7 @@ Each rule is separated by a semicolon (`;`), the rule consists of multiple field
     
   `0m`, `0s`, `0M`, `0h`, or `0d` means no expiration.
 
-* (since RedisTimeSeries v1.8):
+* (since Time Series v1.8):
 
   Optional: Time bucket alignment - number and the time representation (Example for one minute: `1M`, `60s`, or `60000m`)
 
@@ -113,11 +113,11 @@ Each rule is separated by a semicolon (`;`), the rule consists of multiple field
   
 When a compaction policy is defined, compaction rules will be created automatically for newly created time series, and their key would be set to:
   
-* Before RedisTimeSeries v1.8:
+* Before Time Series v1.8:
 
    _key_dur_agg_ where _key_ is the key of the source time series, _dur_ is the bucket duration, and _agg_ is the aggregator.
      
-* Since RedisTimeSeries v1.8:
+* Since Time Series v1.8:
 
    _key_dur_agg_aln_ where _key_ is the key of the source time series, _dur_ is the bucket duration, _agg_ is the aggregator, and _aln_ is the alignment timestamp.
 
@@ -195,7 +195,7 @@ Default chunk encoding for automatically created keys when [COMPACTION_POLICY](#
 
 Possible values: `COMPRESSED`, `UNCOMPRESSED`.
 
-Note: Before RedisTimeSeries 1.6 this configuration parameter was named `CHUNK_TYPE`.
+Note: Before Time Series 1.6 this configuration parameter was named `CHUNK_TYPE`.
 
 #### Default
 

--- a/docs/docs/development.md
+++ b/docs/docs/development.md
@@ -3,13 +3,13 @@ title: "Development"
 linkTitle: "Development"
 weight: 4
 description: >
-    Developing RedisTimeSeries
+    Developing Time Series
 ---
 
-Developing RedisTimeSeries involves setting up the development environment (which can be either Linux-based or macOS-based), building RedisTimeSeries, running tests and benchmarks, and debugging both the RedisTimeSeries module and its tests.
+Developing Time Series involves setting up the development environment (which can be either Linux-based or macOS-based), building Time Series, running tests and benchmarks, and debugging both the Time Series module and its tests.
 
 ## Cloning the git repository
-By invoking the following command, RedisTimeSeries module and its submodules are cloned:
+By invoking the following command, the Time Series module and its submodules are cloned:
 ```sh
 git clone --recursive https://github.com/RedisTimeSeries/RedisTimeSeries.git
 ```
@@ -33,7 +33,7 @@ docker exec -it $ts bash
 ```
 
 ## Installing prerequisites
-To build and test RedisTimeSeries one needs to install several packages, depending on the underlying OS. Currently, we support the Ubuntu/Debian, CentOS, Fedora, and macOS.
+To build and test Time Series one needs to install several packages, depending on the underlying OS. Currently, we support Ubuntu/Debian, CentOS, Fedora, and macOS.
 
 If you have `gnu make` installed, you can execute
 ```
@@ -66,14 +66,14 @@ Otherwise, you can invoke `./deps/readies/bin/getredis`.
 `make help` provides a quick summary of the development features.
 
 ## Building from source
-`make` will build RedisTimeSeries.
+`make` will build Time Series.
 
 Build artifacts are placed into `bin/linux-x64-release` (or similar, according to your platform and build options).
 
 Use `make clean` to remove built artifacts. `make clean ALL=1` will remove the entire binary artifacts directory.
 
-## Running Redis with RedisTimeSeries
-The following will run `redis` and load RedisTimeSeries module.
+## Running Redis with Time Series
+The following will run `redis` and load the Time Series module.
 ```
 make run
 ```
@@ -90,7 +90,7 @@ A single test can be run using the `TEST` parameter, e.g. `make flow_test TEST=f
 ## Debugging
 To build for debugging (enabling symbolic information and disabling optimization), run `make DEBUG=1`.
 One can the use `make run DEBUG=1` to invoke `gdb`.
-In addition to the usual way to set breakpoints in `gdb`, it is possible to use the `BB` macro to set a breakpoint inside RedisTimeSeries code. It will only have an effect when running under `gdb`.
+In addition to the usual way to set breakpoints in `gdb`, it is possible to use the `BB` macro to set a breakpoint inside the Time Series code. It will only have an effect when running under `gdb`.
 
 Similarly, Python tests in a single-test mode, one can set a breakpoint by using the `BB()` function inside a test. This will invoke `pudb`.
 

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -3,22 +3,22 @@ title: "Quickstart"
 linkTitle: "Quickstart"
 weight: 2
 description: >
-    Quick Start Guide to RedisTimeSeries
+    Quick Start Guide to Time Series
 ---
 
 ## Setup
 
-You can either get RedisTimeSeries setup in the cloud, in a Docker container or on your own machine.
+You can either get Time Series setup in the cloud, in a Docker container, or on your own machine.
 
 ### Redis Cloud
 
-RedisTimeSeries is available on all Redis Cloud managed services, including a completely free managed database up to 30MB.
+Time Series is available on all Redis Cloud managed services, including a completely free managed database up to 30MB.
 
 [Get started here](https://redislabs.com/try-free/)
 
 
 ### Docker
-To quickly try out RedisTimeSeries, launch an instance using docker:
+To quickly try out Time Series, launch an instance using docker:
 ```sh
 docker run -p 6379:6379 -it --rm redis/redis-stack-server
 ```
@@ -27,7 +27,7 @@ docker run -p 6379:6379 -it --rm redis/redis-stack-server
 
 First download the pre-compiled version from the [Redis download center](https://app.redislabs.com/#/rlec-downloads).
 
-Next, run Redis with RedisTimeSeries:
+Next, run Redis with Time Series:
 
 ```
 $ redis-server --loadmodule /path/to/module/redistimeseries.so
@@ -35,13 +35,13 @@ $ redis-server --loadmodule /path/to/module/redistimeseries.so
 
 ### Build and Run it yourself
 
-You can also build and run RedisTimeSeries on your own machine.
+You can also build and run Time Series on your own machine.
 
 Major Linux distributions as well as macOS are supported.
 
 #### Requirements
 
-First, clone the RedisTimeSeries repository from git:
+First, clone the Time Series repository from git:
 
 ```
 git clone --recursive https://github.com/RedisTimeSeries/RedisTimeSeries.git
@@ -86,7 +86,7 @@ For more information about modules, go to the [redis official documentation](htt
 
 ## Give it a try with `redis-cli`
 
-After you setup RedisTimeSeries, you can interact with it using redis-cli.
+After you setup Time Series, you can interact with it using redis-cli.
 
 ```sh
 $ redis-cli
@@ -164,7 +164,7 @@ TS.CREATE sensor1 LABELS region east
 
 
 ## Downsampling
-Another useful feature of RedisTimeSeries is compacting data by creating a rule for downsampling (`TS.CREATERULE`). For example, if you have collected more than one billion data points in a day, you could aggregate the data by every minute in order to downsample it, thereby reducing the dataset size to 24 * 60 = 1,440 data points. You can choose one of the many available aggregation types in order to aggregate multiple data points from a certain minute into a single one. The currently supported aggregation types are: `avg, sum, min, max, range, count, first, last, std.p, std.s, var.p, var.s and twa`.
+Another useful feature of Time Series is compacting data by creating a rule for downsampling (`TS.CREATERULE`). For example, if you have collected more than one billion data points in a day, you could aggregate the data by every minute in order to downsample it, thereby reducing the dataset size to 24 * 60 = 1,440 data points. You can choose one of the many available aggregation types in order to aggregate multiple data points from a certain minute into a single one. The currently supported aggregation types are: `avg, sum, min, max, range, count, first, last, std.p, std.s, var.p, var.s and twa`.
 
 It's important to point out that there is no data rewriting on the original timeseries; the compaction happens in a new series, while the original one stays the same. In order to prevent the original timeseries from growing indefinitely, you can use the retention option, which will trim it down to a certain period of time.
 
@@ -185,7 +185,7 @@ With this creation rule, datapoints added to the `sensor1` timeseries will be gr
 
 
 ## Filtering
-RedisTimeSeries allows to filter by value, timestamp and by labels:
+Time Series allows to filter by value, timestamp and by labels:
 
 ### Filtering by label
 You can retrieve datapoints from multiple timeseries in the same query, and the way to do this is by using label filters. For example:

--- a/docs/docs/reference/out-of-order_performance_considerations/_index.md
+++ b/docs/docs/reference/out-of-order_performance_considerations/_index.md
@@ -15,7 +15,7 @@ Ingest performance is critical for us, which pushed  us to assess and be transpa
 To do so, we created a Go benchmark client that enabled us to control key factors that dictate overall system performance, like the out-of-order ratio, the compression of the series, the number of concurrent clients used, and command pipelining. For the full benchmark-driver configuration details and parameters, please refer to this [GitHub link](https://github.com/RedisTimeSeries/redistimeseries-ooo-benchmark).
 
 
-Furthermore, all benchmark variations were run on Amazon Web Services instances, provisioned through our benchmark-testing infrastructure. Both the benchmarking client and database servers were running on separate c5.9xlarge instances. The tests were executed on a single-shard setup, with RedisTimeSeries version 1.4.
+Furthermore, all benchmark variations were run on Amazon Web Services instances, provisioned through our benchmark-testing infrastructure. Both the benchmarking client and database servers were running on separate c5.9xlarge instances. The tests were executed on a single-shard setup, with Redis Time Series version 1.4.
 
 
 Below you can see the correlation between achievable ops/sec and out-of-order ratio for both compressed and uncompressed chunks.


### PR DESCRIPTION
This commit is for the module de-branding effort.