### PR TITLE
Update commands.json

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -106,7 +106,7 @@
             },
             {
                 "name": "from_timestamp",
-                "type": "string"
+                "type": "integer"
             },
             {
                 "name": "to_timestamp",

--- a/commands.json
+++ b/commands.json
@@ -106,7 +106,7 @@
             },
             {
                 "name": "from_timestamp",
-                "type": "integer"
+                "type": "string"
             },
             {
                 "name": "to_timestamp",
@@ -205,7 +205,7 @@
             },
             {
                 "name": "timestamp",
-                "type": "integer"
+                "type": "string"
             },
             {
                 "name": "value",
@@ -314,7 +314,7 @@
                         "name": "key"
                     },
                     {
-                        "type": "integer",
+                        "type": "string",
                         "name": "timestamp"
                     },
                     {
@@ -341,7 +341,7 @@
             },
             {
                 "name": "timestamp",
-                "type": "integer",
+                "type": "string",
                 "token": "TIMESTAMP",
                 "optional": true
             },
@@ -398,7 +398,7 @@
             },
             {
                 "name": "timestamp",
-                "type": "integer",
+                "type": "string",
                 "token": "TIMESTAMP",
                 "optional": true
             },
@@ -566,11 +566,11 @@
             },
             {
                 "name": "fromTimestamp",
-                "type": "integer"
+                "type": "string"
             },
             {
                 "name": "toTimestamp",
-                "type": "integer"
+                "type": "string"
             },
             {
                 "name": "LATEST",
@@ -729,11 +729,11 @@
             },
             {
                 "name": "fromTimestamp",
-                "type": "integer"
+                "type": "string"
             },
             {
                 "name": "toTimestamp",
-                "type": "integer"
+                "type": "string"
             },
             {
                 "name": "LATEST",
@@ -888,11 +888,11 @@
         "arguments": [
             {
                 "name": "fromTimestamp",
-                "type": "integer"
+                "type": "string"
             },
             {
                 "name": "toTimestamp",
-                "type": "integer"
+                "type": "string"
             },
             {
                 "name": "LATEST",
@@ -1132,11 +1132,11 @@
         "arguments": [
             {
                 "name": "fromTimestamp",
-                "type": "integer"
+                "type": "string"
             },
             {
                 "name": "toTimestamp",
-                "type": "integer"
+                "type": "string"
             },
             {
                 "name": "LATEST",


### PR DESCRIPTION
timestamps can accept -, +, * hence - we change them from integer to string