### PR TITLE
rename arm arch in zip filename

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -875,7 +875,7 @@ workflows:
             parameters:
               platform: [jammy, focal, bionic, amzn2, centos7, rocky8, rocky9, bullseye]
       - build-arm-platforms:
-          <<: *on-any-branch
+          <<: *on-integ-and-version-tags
           context: common
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -875,7 +875,7 @@ workflows:
             parameters:
               platform: [jammy, focal, bionic, amzn2, centos7, rocky8, rocky9, bullseye]
       - build-arm-platforms:
-          <<: *on-integ-and-version-tags
+          <<: *on-any-branch
           context: common
           matrix:
             parameters:

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -52,6 +52,7 @@ OP=""
 
 ARCH=$($READIES/bin/platform --arch)
 [[ $ARCH == x64 ]] && ARCH=x86_64
+[[ $ARCH == arm64v8 ]] && ARCH=aarch64
 
 OS=$($READIES/bin/platform --os)
 [[ $OS == linux ]] && OS=Linux


### PR DESCRIPTION
Use `aarch64` for the zip filename upon packing the module, to be aligned with the architecture name in module.json