### PR TITLE
Enabled SPOT Instance deployments on RedisTimeSeries

### DIFF
--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -1,4 +1,10 @@
 version: 0.1
+
+remote:
+  - type: oss-standalone
+  - setup: redistimeseries-m5
+  - spot_instance: oss-redistimeseries-m5-spot-instances
+
 exporter:
   redistimeseries:
     timemetric: "$.StartTime"

--- a/tests/benchmarks/scaling-ts_mget_100K-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_mget_100K-series-tsbs-devops.yml
@@ -10,9 +10,7 @@ description: '
   sample query: "TS.MGET" "FILTER" "measurement=cpu" "fieldname=usage_nice"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_mget_10K-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_mget_10K-series-tsbs-devops.yml
@@ -10,9 +10,7 @@ description: '
   sample query: "TS.MGET" "FILTER" "measurement=cpu" "fieldname=usage_nice"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_mget_1K-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_mget_1K-series-tsbs-devops.yml
@@ -10,9 +10,7 @@ description: '
   sample query: "TS.MGET" "FILTER" "measurement=cpu" "fieldname=usage_nice"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_mget_1M-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_mget_1M-series-tsbs-devops.yml
@@ -10,9 +10,7 @@ description: '
   sample query: "TS.MGET" "FILTER" "measurement=cpu" "fieldname=usage_nice"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_mrange_100-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_mrange_100-series-tsbs-devops.yml
@@ -10,9 +10,7 @@ description: '
   sample query: "TS.MRANGE" - + FILTER "measurement=cpu" "hostname=host_9" fieldname=usage_nice
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_mrange_10K-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_mrange_10K-series-tsbs-devops.yml
@@ -10,9 +10,7 @@ description: '
   sample query: "TS.MRANGE" - + FILTER "measurement=cpu" "hostname=host_9" fieldname=usage_nice
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_mrange_1K-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_mrange_1K-series-tsbs-devops.yml
@@ -10,9 +10,7 @@ description: '
   sample query: "TS.MRANGE" - + FILTER "measurement=cpu" "hostname=host_9" fieldname=usage_nice
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_mrange_avg_100-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_mrange_avg_100-series-tsbs-devops.yml
@@ -12,9 +12,7 @@ description: '
   sample query: "TS.MRANGE" 1451606400000 1451610000000 AGGREGATION AVG 300000 FILTER "measurement=cpu" "hostname=host_9" fieldname=usage_nice
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_mrange_max_100-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_mrange_max_100-series-tsbs-devops.yml
@@ -12,9 +12,7 @@ description: '
   sample query: "TS.MRANGE" - + AGGREGATION MAX 3600000 FILTER "measurement=cpu" "hostname=host_9" fieldname=usage_nice
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_mrange_max_10K-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_mrange_max_10K-series-tsbs-devops.yml
@@ -12,9 +12,7 @@ description: '
   sample query: "TS.MRANGE" - + AGGREGATION MAX 3600000 FILTER "measurement=cpu" "hostname=host_9" fieldname=usage_nice
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_mrange_max_1K-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_mrange_max_1K-series-tsbs-devops.yml
@@ -12,9 +12,7 @@ description: '
   sample query: "TS.MRANGE" - + AGGREGATION MAX 3600000 FILTER "measurement=cpu" "hostname=host_9" fieldname=usage_nice
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_mrange_twa_100-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_mrange_twa_100-series-tsbs-devops.yml
@@ -12,9 +12,7 @@ description: '
   sample query: "TS.MRANGE" 1451606400000 1451610000000 AGGREGATION TWA 300000 10000 FILTER "measurement=cpu" "hostname=host_9" fieldname=usage_nice
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_mrevrange_as_mget_100K-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_mrevrange_as_mget_100K-series-tsbs-devops.yml
@@ -10,9 +10,7 @@ description: '
   sample query: "TS.MREVRANGE" - + COUNT 1 FILTER "measurement=cpu" "hostname=host_9" "fieldname=usage_nice"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_mrevrange_as_mget_10K-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_mrevrange_as_mget_10K-series-tsbs-devops.yml
@@ -10,9 +10,7 @@ description: '
   sample query: "TS.MREVRANGE" - + COUNT 1 FILTER "measurement=cpu" "hostname=host_9" "fieldname=usage_nice"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_mrevrange_as_mget_1K-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_mrevrange_as_mget_1K-series-tsbs-devops.yml
@@ -10,9 +10,7 @@ description: '
   sample query: "TS.MREVRANGE" - + COUNT 1 FILTER "measurement=cpu" "hostname=host_9" "fieldname=usage_nice"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_mrevrange_as_mget_1M-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_mrevrange_as_mget_1M-series-tsbs-devops.yml
@@ -10,9 +10,7 @@ description: '
   sample query: "TS.MREVRANGE" - + COUNT 1 FILTER "measurement=cpu" "hostname=host_9" "fieldname=usage_nice"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_queryindex_100K-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_queryindex_100K-series-tsbs-devops.yml
@@ -10,9 +10,7 @@ description: '
   sample query: "TS.QUERYINDEX" "measurement=cpu" "hostname=host_7"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_queryindex_10K-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_queryindex_10K-series-tsbs-devops.yml
@@ -10,9 +10,7 @@ description: '
   sample query: "TS.QUERYINDEX" "measurement=cpu" "hostname=host_7"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_queryindex_1K-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_queryindex_1K-series-tsbs-devops.yml
@@ -10,9 +10,7 @@ description: '
   sample query: "TS.QUERYINDEX" "measurement=cpu" "hostname=host_7"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/scaling-ts_queryindex_1M-series-tsbs-devops.yml
+++ b/tests/benchmarks/scaling-ts_queryindex_1M-series-tsbs-devops.yml
@@ -10,9 +10,7 @@ description: '
   sample query: "TS.QUERYINDEX" "measurement=cpu" "hostname=host_7"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/tsbs-devops-ingestion-scale100devices-10metrics-31days.yml
+++ b/tests/benchmarks/tsbs-devops-ingestion-scale100devices-10metrics-31days.yml
@@ -1,8 +1,6 @@
 name: "tsbs-devops-ingestion-scale100devices-10metrics-31days"
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-cluster-30-primaries

--- a/tests/benchmarks/tsbs-devops-ingestion-scale100devices-10metrics-4days-keyspace.yml
+++ b/tests/benchmarks/tsbs-devops-ingestion-scale100devices-10metrics-4days-keyspace.yml
@@ -1,8 +1,6 @@
 name: "tsbs-devops-ingestion-scale100-4days-keyspace"
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 dbconfig:
   - configuration-parameters:

--- a/tests/benchmarks/tsbs-devops-ingestion-scale100devices-10metrics-4days.yml
+++ b/tests/benchmarks/tsbs-devops-ingestion-scale100devices-10metrics-4days.yml
@@ -1,8 +1,6 @@
 name: "tsbs-devops-ingestion-scale100-4days"
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/tsbs-scale100-cpu-max-all-1.yml
+++ b/tests/benchmarks/tsbs-scale100-cpu-max-all-1.yml
@@ -7,9 +7,7 @@ description: '
   sample query: "TS.MRANGE" "1451695614264" "1451724414264" "WITHLABELS" "AGGREGATION" "MAX" "3600000" "FILTER" "measurement=cpu" "hostname=host_7"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/tsbs-scale100-cpu-max-all-1@4139rps.yml
+++ b/tests/benchmarks/tsbs-scale100-cpu-max-all-1@4139rps.yml
@@ -13,9 +13,7 @@ description: '
   sample query: "TS.MRANGE" "1451695614264" "1451724414264" "WITHLABELS" "AGGREGATION" "MAX" "3600000" "FILTER" "measurement=cpu" "hostname=host_7"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-cluster-15-primaries

--- a/tests/benchmarks/tsbs-scale100-cpu-max-all-8.yml
+++ b/tests/benchmarks/tsbs-scale100-cpu-max-all-8.yml
@@ -7,9 +7,7 @@ description: '
   sample query: "TS.MRANGE" "1451619133515" "1451647933515" "AGGREGATION" "MAX" "3600000" "FILTER" "measurement=cpu" "hostname=(host_99,host_84,host_23,host_20,host_30,host_47,host_43,host_4)" "GROUPBY" "fieldname" "REDUCE" "max"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/tsbs-scale100-cpu-max-all-8@588rps.yml
+++ b/tests/benchmarks/tsbs-scale100-cpu-max-all-8@588rps.yml
@@ -12,9 +12,7 @@ description: '
   sample query: "TS.MRANGE" "1451619133515" "1451647933515" "AGGREGATION" "MAX" "3600000" "FILTER" "measurement=cpu" "hostname=(host_99,host_84,host_23,host_20,host_30,host_47,host_43,host_4)" "GROUPBY" "fieldname" "REDUCE" "max"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-cluster-15-primaries

--- a/tests/benchmarks/tsbs-scale100-double-groupby-1.yml
+++ b/tests/benchmarks/tsbs-scale100-double-groupby-1.yml
@@ -7,9 +7,7 @@ description: '
   sample query: "TS.MRANGE" "1451736494155" "1451779694155" "AGGREGATION" "AVG" "3600000" "FILTER" "measurement=cpu" "fieldname=usage_user"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/tsbs-scale100-double-groupby-1@324rps.yml
+++ b/tests/benchmarks/tsbs-scale100-double-groupby-1@324rps.yml
@@ -12,9 +12,7 @@ description: '
   sample query: "TS.MRANGE" "1451736494155" "1451779694155" "AGGREGATION" "AVG" "3600000" "FILTER" "measurement=cpu" "fieldname=usage_user"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-cluster-15-primaries

--- a/tests/benchmarks/tsbs-scale100-double-groupby-5.yml
+++ b/tests/benchmarks/tsbs-scale100-double-groupby-5.yml
@@ -7,9 +7,7 @@ description: '
   sample query: "TS.MRANGE" "1451634696227" "1451677896227" "AGGREGATION" "AVG" "3600000" "FILTER" "measurement=cpu" "fieldname=(usage_user,usage_system,usage_idle,usage_nice,usage_iowait)" "GROUPBY" "hostname" "REDUCE" "max"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 setups:
   - oss-standalone
   - oss-cluster-02-primaries

--- a/tests/benchmarks/tsbs-scale100-double-groupby-5@70rps.yml
+++ b/tests/benchmarks/tsbs-scale100-double-groupby-5@70rps.yml
@@ -12,9 +12,7 @@ description: '
   sample query: "TS.MRANGE" "1451634696227" "1451677896227" "AGGREGATION" "AVG" "3600000" "FILTER" "measurement=cpu" "fieldname=(usage_user,usage_system,usage_idle,usage_nice,usage_iowait)" "GROUPBY" "hostname" "REDUCE" "max"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-cluster-15-primaries

--- a/tests/benchmarks/tsbs-scale100-double-groupby-all.yml
+++ b/tests/benchmarks/tsbs-scale100-double-groupby-all.yml
@@ -7,9 +7,7 @@ description: '
   sample query: TS.MRANGE" "1451786984066" "1451830184066" "AGGREGATION" "AVG" "3600000" "FILTER" "measurement=cpu" "GROUPBY" "hostname" "REDUCE" "max"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/tsbs-scale100-double-groupby-all@35rps.yml
+++ b/tests/benchmarks/tsbs-scale100-double-groupby-all@35rps.yml
@@ -12,9 +12,7 @@ description: '
   sample query: TS.MRANGE" "1451786984066" "1451830184066" "AGGREGATION" "AVG" "3600000" "FILTER" "measurement=cpu" "GROUPBY" "hostname" "REDUCE" "max"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-cluster-15-primaries

--- a/tests/benchmarks/tsbs-scale100-groupby-orderby-limit.yml
+++ b/tests/benchmarks/tsbs-scale100-groupby-orderby-limit.yml
@@ -7,9 +7,7 @@ description: '
   sample query: "TS.MREVRANGE" "-" "1451828519919" "COUNT" "5" "AGGREGATION" "MAX" "60000" "FILTER" "measurement=cpu" "fieldname=usage_user"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/tsbs-scale100-groupby-orderby-limit@28rps.yml
+++ b/tests/benchmarks/tsbs-scale100-groupby-orderby-limit@28rps.yml
@@ -12,9 +12,7 @@ description: '
   sample query: "TS.MREVRANGE" "-" "1451828519919" "COUNT" "5" "AGGREGATION" "MAX" "60000" "FILTER" "measurement=cpu" "fieldname=usage_user"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-cluster-15-primaries

--- a/tests/benchmarks/tsbs-scale100-high-cpu-1.yml
+++ b/tests/benchmarks/tsbs-scale100-high-cpu-1.yml
@@ -11,9 +11,7 @@ description: '
       "TS.MRANGE" "1451656883002" "1451700083002" "FILTER_BY_TS" "1451665600000" "1451665620000" "1451665630000" "1451665640000" (...)
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/tsbs-scale100-high-cpu-1@1816rps.yml
+++ b/tests/benchmarks/tsbs-scale100-high-cpu-1@1816rps.yml
@@ -16,9 +16,7 @@ description: '
       "TS.MRANGE" "1451656883002" "1451700083002" "FILTER_BY_TS" "1451665600000" "1451665620000" "1451665630000" "1451665640000" (...)
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-cluster-15-primaries

--- a/tests/benchmarks/tsbs-scale100-high-cpu-all.yml
+++ b/tests/benchmarks/tsbs-scale100-high-cpu-all.yml
@@ -12,9 +12,7 @@ description: '
       "TS.MRANGE" "1451631478487" "1451674678487" "FILTER_BY_TS" "1451631480000" "1451631490000" (...)
 '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/tsbs-scale100-high-cpu-all@18rps.yml
+++ b/tests/benchmarks/tsbs-scale100-high-cpu-all@18rps.yml
@@ -17,9 +17,7 @@ description: '
       "TS.MRANGE" "1451631478487" "1451674678487" "FILTER_BY_TS" "1451631480000" "1451631490000" (...)
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-cluster-15-primaries

--- a/tests/benchmarks/tsbs-scale100-lastpoint.yml
+++ b/tests/benchmarks/tsbs-scale100-lastpoint.yml
@@ -7,9 +7,7 @@ description: '
   sample query: "TS.MGET" "SELECTED_LABELS" "hostname" "fieldname" "FILTER" "measurement=cpu" "hostname!="
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/tsbs-scale100-lastpoint@488rps.yml
+++ b/tests/benchmarks/tsbs-scale100-lastpoint@488rps.yml
@@ -13,9 +13,7 @@ description: '
   '
 
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-cluster-15-primaries

--- a/tests/benchmarks/tsbs-scale100-single-groupby-1-1-1.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-1-1-1.yml
@@ -7,9 +7,7 @@ description: '
   sample query: "TS.MRANGE" "1451639198469" "1451642798469" "AGGREGATION" "MAX" "60000" "FILTER" "measurement=cpu" "fieldname=usage_user" "hostname=host_55"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/tsbs-scale100-single-groupby-1-1-12.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-1-1-12.yml
@@ -7,9 +7,7 @@ description: '
   sample query: "TS.MRANGE" "1451734900239" "1451778100239" "AGGREGATION" "MAX" "60000" "FILTER" "measurement=cpu" "fieldname=usage_user" "hostname=host_5"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/tsbs-scale100-single-groupby-1-1-12@2320rps.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-1-1-12@2320rps.yml
@@ -12,9 +12,7 @@ description: '
   sample query: "TS.MRANGE" "1451734900239" "1451778100239" "AGGREGATION" "MAX" "60000" "FILTER" "measurement=cpu" "fieldname=usage_user" "hostname=host_5"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-cluster-15-primaries

--- a/tests/benchmarks/tsbs-scale100-single-groupby-1-1-1@2320rps.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-1-1-1@2320rps.yml
@@ -12,9 +12,7 @@ description: '
   sample query: "TS.MRANGE" "1451639198469" "1451642798469" "AGGREGATION" "MAX" "60000" "FILTER" "measurement=cpu" "fieldname=usage_user" "hostname=host_55"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-cluster-15-primaries

--- a/tests/benchmarks/tsbs-scale100-single-groupby-1-8-1.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-1-8-1.yml
@@ -7,9 +7,7 @@ description: '
   sample query: "TS.MRANGE" "1451787921535" "1451791521535" "AGGREGATION" "MAX" "60000" "FILTER" "measurement=cpu" "fieldname=usage_user" "hostname=(host_53,host_24,host_50,host_65,host_54,host_32,host_99,host_20)" "GROUPBY" "hostname" "REDUCE" "max"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/tsbs-scale100-single-groupby-1-8-1@4458rps.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-1-8-1@4458rps.yml
@@ -12,9 +12,7 @@ description: '
   sample query: "TS.MRANGE" "1451787921535" "1451791521535" "AGGREGATION" "MAX" "60000" "FILTER" "measurement=cpu" "fieldname=usage_user" "hostname=(host_53,host_24,host_50,host_65,host_54,host_32,host_99,host_20)" "GROUPBY" "hostname" "REDUCE" "max"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-cluster-15-primaries

--- a/tests/benchmarks/tsbs-scale100-single-groupby-5-1-1.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-5-1-1.yml
@@ -7,9 +7,7 @@ description: '
   sample query: "TS.MRANGE" "1451736451709" "1451740051709" "AGGREGATION" "MAX" "60000" "FILTER" "measurement=cpu" "fieldname=(usage_user,usage_system,usage_idle,usage_nice,usage_iowait)" "hostname=host_83" "GROUPBY" "fieldname" "REDUCE" "max"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/tsbs-scale100-single-groupby-5-1-12.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-5-1-12.yml
@@ -7,9 +7,7 @@ description: '
   sample query: "TS.MRANGE" "1451721241054" "1451764441054" "AGGREGATION" "MAX" "60000" "FILTER" "measurement=cpu" "fieldname=(usage_user,usage_system,usage_idle,usage_nice,usage_iowait)" "hostname=host_34" "GROUPBY" "fieldname" "REDUCE" "max"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/tsbs-scale100-single-groupby-5-1-12@648rps.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-5-1-12@648rps.yml
@@ -12,9 +12,7 @@ description: '
   sample query: "TS.MRANGE" "1451721241054" "1451764441054" "AGGREGATION" "MAX" "60000" "FILTER" "measurement=cpu" "fieldname=(usage_user,usage_system,usage_idle,usage_nice,usage_iowait)" "hostname=host_34" "GROUPBY" "fieldname" "REDUCE" "max"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-cluster-15-primaries

--- a/tests/benchmarks/tsbs-scale100-single-groupby-5-1-1@648rps.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-5-1-1@648rps.yml
@@ -12,9 +12,7 @@ description: '
   sample query: "TS.MRANGE" "1451736451709" "1451740051709" "AGGREGATION" "MAX" "60000" "FILTER" "measurement=cpu" "fieldname=(usage_user,usage_system,usage_idle,usage_nice,usage_iowait)" "hostname=host_83" "GROUPBY" "fieldname" "REDUCE" "max"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-cluster-15-primaries

--- a/tests/benchmarks/tsbs-scale100-single-groupby-5-8-1.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-5-8-1.yml
@@ -7,9 +7,7 @@ description: '
   sample query: "TS.MRANGE" "1451613577327" "1451617177327" "AGGREGATION" "MAX" "60000" "FILTER" "measurement=cpu" "fieldname=(usage_user,usage_system,usage_idle,usage_nice,usage_iowait)" "hostname=(host_32,host_54,host_86,host_91,host_30,host_2,host_89,host_29)" "GROUPBY" "fieldname" "REDUCE" "max"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-standalone

--- a/tests/benchmarks/tsbs-scale100-single-groupby-5-8-1@1158rps.yml
+++ b/tests/benchmarks/tsbs-scale100-single-groupby-5-8-1@1158rps.yml
@@ -12,9 +12,7 @@ description: '
   sample query: "TS.MRANGE" "1451613577327" "1451617177327" "AGGREGATION" "MAX" "60000" "FILTER" "measurement=cpu" "fieldname=(usage_user,usage_system,usage_idle,usage_nice,usage_iowait)" "hostname=(host_32,host_54,host_86,host_91,host_30,host_2,host_89,host_29)" "GROUPBY" "fieldname" "REDUCE" "max"
   '
 
-remote:
-  - type: oss-standalone
-  - setup: redistimeseries-m5
+
 
 setups:
   - oss-cluster-15-primaries


### PR DESCRIPTION
This PR enables spot instance deployments as a 1st deployment option. If it fails it uses the default non spot deployment 