### PR TITLE
Set the right S3 directory for version tagging [MOD-6137]

### DIFF
--- a/.github/workflows/mariner2.yml
+++ b/.github/workflows/mariner2.yml
@@ -2,10 +2,10 @@ name: build for mariner2
 
 on:
   push:
-#    branches:
-#      - master
-#    tags:
-#      - 'v[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - master
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build-mariner2:

--- a/.github/workflows/mariner2.yml
+++ b/.github/workflows/mariner2.yml
@@ -2,10 +2,10 @@ name: build for mariner2
 
 on:
   push:
-    branches:
-      - master
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+#    branches:
+#      - master
+#    tags:
+#      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build-mariner2:
@@ -34,8 +34,8 @@ jobs:
       - name: Build Redis
         working-directory: redis
         run: make install
-      - name: Build and test TS
-        run: make test
+#      - name: Build and test TS
+#        run: make test
       - name: Pack module
         run: make pack BRANCH=${{ github.ref_name }} SHOW=1
       - name: Configure AWS credentials
@@ -45,7 +45,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: "us-east-1"
       - name: Upload artifacts to s3 - staging
-        run: make upload-artifacts SHOW=1 STAGING=1 VERBOSE=1
+        run: make upload-release SHOW=1 STAGING=1 VERBOSE=1
       - name: Upload artifacts to s3 - release  # todo: trigger this manually instead
-        if: ${{ github.ref != 'refs/heads/master' }}
-        run: make upload-artifacts SHOW=1 VERBOSE=1
+#        if: ${{ github.ref != 'refs/heads/master' }}
+        run: make upload-release SHOW=1 VERBOSE=1

--- a/.github/workflows/mariner2.yml
+++ b/.github/workflows/mariner2.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Build Redis
         working-directory: redis
         run: make install
-#      - name: Build and test TS
-#        run: make test
+      - name: Build and test TS
+        run: make test
       - name: Pack module
         run: make pack BRANCH=${{ github.ref_name }} SHOW=1
       - name: Configure AWS credentials
@@ -45,7 +45,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: "us-east-1"
       - name: Upload artifacts to s3 - staging
-        run: make upload-release SHOW=1 STAGING=1 VERBOSE=1
+        run: |
+          make upload-artifacts SHOW=1 VERBOSE=1
+          make upload-release SHOW=1 STAGING=1 VERBOSE=1
       - name: Upload artifacts to s3 - release  # todo: trigger this manually instead
-#        if: ${{ github.ref != 'refs/heads/master' }}
+        if: ${{ github.ref != 'refs/heads/master' }}
         run: make upload-release SHOW=1 VERBOSE=1


### PR DESCRIPTION
Use upload-release for tagging in the new mariner flow so it will go the right production dir in s3