### PR TITLE
Suggestion - add a full path hint for redistimeseries.so

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -15,6 +15,7 @@ Setting configuration parameters at load-time is done by appending arguments aft
 In [redis.conf](/docs/manual/config/):
 
 ```sh
+# In a Redis Stack container image, the full path for the lib is /opt/redis-stack/lib/redistimeseries.so
 loadmodule ./redistimeseries.so [OPT VAL]...
 ```
 


### PR DESCRIPTION
I run Redis Stack in a StatefulSet, and I had to exec into the container to `find . -name redistimeseries.so` so I could prepare my configmap with something like:
```
    {{- if .Values.enableRedisTimeSeries }}
    loadmodule /opt/redis-stack/lib/redistimeseries.so
    {{- end }}   
```

So I decided to suggest a brief comment on top of the configuration, just to help the next person.