### PR TITLE
Use Redis module configuration API

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -17,6 +17,211 @@
 
 TSConfig TSGlobalConfig;
 
+static const char *duplicate_policy_names[] = {
+    "block", "last", "first", "min", "max", "sum",
+};
+
+static const int duplicate_policy_flags[] = {
+    DP_BLOCK, DP_LAST, DP_FIRST, DP_MIN, DP_MAX, DP_SUM,
+};
+
+#define DUPLICATE_POLICY_FLAG_COUNT (sizeof(duplicate_policy_flags) / sizeof(int))
+
+static const char *encoding_names[] = {
+    "uncompressed",
+    "compressed",
+};
+
+static const int encoding_flags[] = { SERIES_OPT_UNCOMPRESSED, SERIES_OPT_COMPRESSED_GORILLA };
+
+#define ENCODING_FLAG_COUNT (sizeof(encoding_flags) / sizeof(int))
+
+static const char *conf_compaction_policy = "compaction_policy";
+static const char *conf_oss_global_password = "oss_global_password";
+static const char *conf_retention_policy = "retention_policy";
+static const char *conf_chunk_size_bytes = "chunk_size_bytes";
+static const char *conf_duplicate_policy = "duplicate_policy";
+static const char *conf_encoding = "encoding";
+static const char *conf_num_threads = "num_threads";
+static const char *conf_debug_force_rule_dump = "debug_force_rule_dump";
+static const char *conf_debug_dont_assert_on_failure = "debug_dont_assert_on_failure";
+
+static RedisModuleString *getString(const char *name, void *privdata) {
+    TSConfig *c = privdata;
+
+    if (strcasecmp(name, conf_compaction_policy) == 0) {
+        return c->compactionPolicyStr;
+    } else if (strcasecmp(name, conf_oss_global_password) == 0) {
+        return c->passwordStr;
+    }
+
+    return NULL;
+}
+
+static int setString(const char *name,
+                     RedisModuleString *val,
+                     void *privdata,
+                     RedisModuleString **err) {
+    size_t len;
+    const char *value = RedisModule_StringPtrLen(val, &len);
+
+    if (strcasecmp(name, conf_compaction_policy) == 0) {
+        SimpleCompactionRule *compactionRules = NULL;
+        uint64_t compactionRulesCount = 0;
+
+        if (len != 0) {
+            if (ParseCompactionPolicy(value, &compactionRules, &compactionRulesCount) != TRUE) {
+                *err = RedisModule_CreateStringPrintf(NULL,
+                                                      "Unable to parse compaction policy config");
+                return REDISMODULE_ERR;
+            }
+        }
+
+        SetCompactionRulesConfig(val, compactionRules, compactionRulesCount);
+    } else if (strcasecmp(name, conf_oss_global_password) == 0) {
+        SetOSSGlobalPasswordConfig(val);
+    } else {
+        return REDISMODULE_ERR;
+    }
+
+    return REDISMODULE_OK;
+}
+
+static int getEnum(const char *name, void *privdata) {
+    TSConfig *c = privdata;
+
+    if (strcasecmp(name, conf_duplicate_policy) == 0) {
+        return c->duplicatePolicy;
+    } else if (strcasecmp(name, conf_encoding) == 0) {
+        return c->options;
+    }
+
+    return REDISMODULE_ERR;
+}
+
+static int setEnum(const char *name, int val, void *privdata, RedisModuleString **err) {
+    TSConfig *c = privdata;
+
+    if (strcasecmp(name, conf_duplicate_policy) == 0) {
+        c->duplicatePolicy = val;
+    } else if (strcasecmp(name, conf_encoding) == 0) {
+        c->options = val;
+    } else {
+        return REDISMODULE_ERR;
+    }
+
+    return REDISMODULE_OK;
+}
+
+static int getBool(const char *name, void *privdata) {
+    TSConfig *c = privdata;
+
+    if (strcasecmp(name, conf_debug_force_rule_dump) == 0) {
+        return c->forceSaveCrossRef;
+    } else if (strcasecmp(name, conf_debug_dont_assert_on_failure) == 0) {
+        return c->dontAssertOnFailure;
+    }
+
+    return REDISMODULE_ERR;
+}
+
+static int setBool(const char *name, int val, void *privdata, RedisModuleString **err) {
+    TSConfig *c = privdata;
+
+    if (strcasecmp(name, conf_debug_force_rule_dump) == 0) {
+        c->forceSaveCrossRef = val;
+    } else if (strcasecmp(name, conf_debug_dont_assert_on_failure) == 0) {
+        c->dontAssertOnFailure = val;
+        _dontAssertOnFailiure = val;
+    } else {
+        return REDISMODULE_ERR;
+    }
+
+    return REDISMODULE_OK;
+}
+
+static long long getNumeric(const char *name, void *privdata) {
+    TSConfig *c = privdata;
+
+    if (strcasecmp(name, conf_retention_policy) == 0) {
+        return c->retentionPolicy;
+    } else if (strcasecmp(name, conf_chunk_size_bytes) == 0) {
+        return c->chunkSizeBytes;
+    } else if (strcasecmp(name, conf_num_threads) == 0) {
+        return c->numThreads;
+    }
+
+    return REDISMODULE_ERR;
+}
+
+static int setNumeric(const char *name, long long val, void *priv, RedisModuleString **err) {
+    TSConfig *c = priv;
+
+    if (strcasecmp(name, conf_retention_policy) == 0) {
+        c->retentionPolicy = val;
+    } else if (strcasecmp(name, conf_chunk_size_bytes) == 0) {
+        if (val % 8 != 0) {
+            // Currently the gorilla algorithm implementation can only handle chunks of size
+            // multiplication of 8
+            *err = RedisModule_CreateStringPrintf(
+                NULL,
+                "TSDB: CHUNK_SIZE value must be a multiple of 8 in the range [48 .. 1048576]");
+            return REDISMODULE_ERR;
+        }
+
+        c->chunkSizeBytes = val;
+    } else if (strcasecmp(name, conf_num_threads) == 0) {
+        c->numThreads = val;
+    } else {
+        return REDISMODULE_ERR;
+    }
+
+    return REDISMODULE_OK;
+}
+
+void FreeGlobalConfig(void) {
+    if (TSGlobalConfig.passwordStr) {
+        RedisModule_FreeString(NULL, TSGlobalConfig.passwordStr);
+    }
+    free(TSGlobalConfig.password);
+
+    if (TSGlobalConfig.compactionPolicyStr) {
+        RedisModule_FreeString(NULL, TSGlobalConfig.compactionPolicyStr);
+    }
+    free(TSGlobalConfig.compactionRules);
+}
+
+// Configuration via module config API
+int ModuleConfigInit(RedisModuleCtx *ctx) {
+    int ret = 0;
+    /* clang-format off */
+                                                 /* name */                         /* default-value */                 /* flags */                   /* min - max value */
+   ret |= RedisModule_RegisterNumericConfig(ctx, conf_retention_policy,             RETENTION_TIME_DEFAULT,         REDISMODULE_CONFIG_IMMUTABLE,       0,  LONG_MAX,            getNumeric, setNumeric, NULL, &TSGlobalConfig);
+   ret |= RedisModule_RegisterNumericConfig(ctx, conf_chunk_size_bytes,             Chunk_SIZE_BYTES_SECS,          REDISMODULE_CONFIG_IMMUTABLE,       48, 1048576,             getNumeric, setNumeric, NULL, &TSGlobalConfig);
+   ret |= RedisModule_RegisterNumericConfig(ctx, conf_num_threads,                  3,                              REDISMODULE_CONFIG_IMMUTABLE,       0,  LONG_MAX,            getNumeric, setNumeric, NULL, &TSGlobalConfig);
+
+                                                 /* name */                         /* default-value */                 /* flags */
+   ret |= RedisModule_RegisterBoolConfig(ctx,    conf_debug_force_rule_dump,        false,                          REDISMODULE_CONFIG_IMMUTABLE | REDISMODULE_CONFIG_HIDDEN,    getBool,    setBool,    NULL, &TSGlobalConfig);
+   ret |= RedisModule_RegisterBoolConfig(ctx,    conf_debug_dont_assert_on_failure, false,                          REDISMODULE_CONFIG_IMMUTABLE | REDISMODULE_CONFIG_HIDDEN,    getBool,    setBool,    NULL, &TSGlobalConfig);
+
+                                                 /* name */                         /* default-value */                 /* flags */
+   ret |= RedisModule_RegisterStringConfig(ctx,  conf_compaction_policy,            "",                             REDISMODULE_CONFIG_IMMUTABLE,                                getString,  setString,  NULL, &TSGlobalConfig);
+   ret |= RedisModule_RegisterStringConfig(ctx,  conf_oss_global_password,          "",                             REDISMODULE_CONFIG_IMMUTABLE,                                getString,  setString,  NULL, &TSGlobalConfig);
+
+                                                  /* name */                        /* default-value */                 /* flags */
+   ret |= RedisModule_RegisterEnumConfig(ctx,    conf_duplicate_policy,             DEFAULT_DUPLICATE_POLICY,       REDISMODULE_CONFIG_IMMUTABLE,                                duplicate_policy_names,   duplicate_policy_flags, DUPLICATE_POLICY_FLAG_COUNT, getEnum, setEnum, NULL, &TSGlobalConfig);
+   ret |= RedisModule_RegisterEnumConfig(ctx,    conf_encoding,                     SERIES_OPT_COMPRESSED_GORILLA,  REDISMODULE_CONFIG_IMMUTABLE | REDISMODULE_CONFIG_BITFLAGS,  encoding_names,           encoding_flags,         ENCODING_FLAG_COUNT,         getEnum, setEnum, NULL, &TSGlobalConfig);
+
+    /* clang-format on */
+
+    ret |= RedisModule_LoadConfigs(ctx);
+    if (ret != REDISMODULE_OK) {
+        return TSDB_ERROR;
+    }
+
+    return TSDB_OK;
+}
+
 int ParseDuplicatePolicy(RedisModuleCtx *ctx,
                          RedisModuleString **argv,
                          int argc,
@@ -33,16 +238,45 @@ const char *ChunkTypeToString(int options) {
     return "invalid";
 }
 
-int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-    TSGlobalConfig.hasGlobalConfig = FALSE;
-    TSGlobalConfig.options = 0;
-    // default serie encoding
-    TSGlobalConfig.options |= SERIES_OPT_DEFAULT_COMPRESSION;
+void SetCompactionRulesConfig(RedisModuleString *policyStr,
+                              SimpleCompactionRule *compactionRules,
+                              uint64_t compactionRulesCount) {
+    if (TSGlobalConfig.compactionPolicyStr) {
+        RedisModule_FreeString(NULL, TSGlobalConfig.compactionPolicyStr);
+    }
+    free(TSGlobalConfig.compactionRules);
 
+    TSGlobalConfig.compactionPolicyStr = RedisModule_CreateStringFromString(NULL, policyStr);
+    TSGlobalConfig.compactionRules = compactionRules;
+    TSGlobalConfig.compactionRulesCount = compactionRulesCount;
+}
+
+void SetOSSGlobalPasswordConfig(RedisModuleString *password) {
+    size_t len;
+    const char *ptr;
+
+    if (TSGlobalConfig.passwordStr) {
+        RedisModule_FreeString(NULL, TSGlobalConfig.passwordStr);
+    }
+    free(TSGlobalConfig.password);
+
+    TSGlobalConfig.passwordStr = RedisModule_CreateStringFromString(NULL, password);
+    ptr = RedisModule_StringPtrLen(TSGlobalConfig.passwordStr, &len);
+    if (len == 0) {
+        TSGlobalConfig.password = NULL;
+    } else {
+        TSGlobalConfig.password = rmalloc_strndup(ptr, len);
+    }
+}
+
+// Legacy configuration via module arguments
+int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc > 1 && RMUtil_ArgIndex("COMPACTION_POLICY", argv, argc) >= 0) {
         RedisModuleString *policy;
         const char *policy_cstr;
         size_t len;
+        SimpleCompactionRule *compactionRules;
+        uint64_t compactionRulesCount;
 
         if (RMUtil_ParseArgsAfter("COMPACTION_POLICY", argv, argc, "s", &policy) !=
             REDISMODULE_OK) {
@@ -50,31 +284,25 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             return TSDB_ERROR;
         }
         policy_cstr = RedisModule_StringPtrLen(policy, &len);
-        if (ParseCompactionPolicy(policy_cstr,
-                                  &TSGlobalConfig.compactionRules,
-                                  &TSGlobalConfig.compactionRulesCount) != TRUE) {
+        if (ParseCompactionPolicy(policy_cstr, &compactionRules, &compactionRulesCount) != TRUE) {
             RedisModule_Log(ctx, "warning", "Unable to parse argument after COMPACTION_POLICY");
             return TSDB_ERROR;
         }
 
+        SetCompactionRulesConfig(policy, compactionRules, compactionRulesCount);
         RedisModule_Log(ctx, "notice", "loaded default compaction policy: %s", policy_cstr);
-        TSGlobalConfig.hasGlobalConfig = TRUE;
     }
 
     if (argc > 1 && RMUtil_ArgIndex("OSS_GLOBAL_PASSWORD", argv, argc) >= 0) {
         RedisModuleString *password;
-        size_t len;
         if (RMUtil_ParseArgsAfter("OSS_GLOBAL_PASSWORD", argv, argc, "s", &password) !=
             REDISMODULE_OK) {
             RedisModule_Log(ctx, "warning", "Unable to parse argument after OSS_GLOBAL_PASSWORD");
             return TSDB_ERROR;
         }
 
-        TSGlobalConfig.password = (char *)RedisModule_StringPtrLen(password, &len);
+        SetOSSGlobalPasswordConfig(password);
         RedisModule_Log(ctx, "notice", "loaded tls password");
-        TSGlobalConfig.hasGlobalConfig = TRUE;
-    } else {
-        TSGlobalConfig.password = NULL;
     }
 
     if (argc > 1 && RMUtil_ArgIndex("RETENTION_POLICY", argv, argc) >= 0) {
@@ -87,15 +315,11 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
         RedisModule_Log(
             ctx, "notice", "loaded default retention policy: %lld", TSGlobalConfig.retentionPolicy);
-        TSGlobalConfig.hasGlobalConfig = TRUE;
-    } else {
-        TSGlobalConfig.retentionPolicy = RETENTION_TIME_DEFAULT;
     }
 
     if (!ValidateChunkSize(ctx, Chunk_SIZE_BYTES_SECS)) {
         return TSDB_ERROR;
     }
-    TSGlobalConfig.chunkSizeBytes = Chunk_SIZE_BYTES_SECS;
     if (ParseChunkSize(ctx, argv, argc, "CHUNK_SIZE_BYTES", &TSGlobalConfig.chunkSizeBytes) !=
         REDISMODULE_OK) {
         RedisModule_Log(ctx, "warning", "Unable to parse argument after CHUNK_SIZE_BYTES");
@@ -106,7 +330,6 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                     "loaded default CHUNK_SIZE_BYTES policy: %lld",
                     TSGlobalConfig.chunkSizeBytes);
 
-    TSGlobalConfig.duplicatePolicy = DEFAULT_DUPLICATE_POLICY;
     if (ParseDuplicatePolicy(
             ctx, argv, argc, DUPLICATE_POLICY_ARG, &TSGlobalConfig.duplicatePolicy) != TSDB_OK) {
         RedisModule_Log(ctx, "warning", "Unable to parse argument after DUPLICATE_POLICY");
@@ -159,48 +382,8 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             RedisModule_Log(ctx, "warning", "Unable to parse argument after COMPACTION_POLICY");
             return TSDB_ERROR;
         }
-    } else {
-        TSGlobalConfig.numThreads = 3;
     }
-    TSGlobalConfig.forceSaveCrossRef = false;
-    if (argc > 1 && RMUtil_ArgIndex("DEUBG_FORCE_RULE_DUMP", argv, argc) >= 0) {
-        RedisModuleString *forceSaveCrossRef;
-        if (RMUtil_ParseArgsAfter("DEUBG_FORCE_RULE_DUMP", argv, argc, "s", &forceSaveCrossRef) !=
-            REDISMODULE_OK) {
-            RedisModule_Log(ctx, "warning", "Unable to parse argument after DEUBG_FORCE_RULE_DUMP");
-            return TSDB_ERROR;
-        }
-        size_t forceSaveCrossRef_len;
-        const char *forceSaveCrossRef_cstr =
-            RedisModule_StringPtrLen(forceSaveCrossRef, &forceSaveCrossRef_len);
-        if (!strcasecmp(forceSaveCrossRef_cstr, "enable")) {
-            TSGlobalConfig.forceSaveCrossRef = true;
-        } else if (!strcasecmp(forceSaveCrossRef_cstr, "disable")) {
-            TSGlobalConfig.forceSaveCrossRef = false;
-        }
-    }
-    TSGlobalConfig.dontAssertOnFailiure = false;
-    if (argc > 1 && RMUtil_ArgIndex("DONT_ASSERT_ON_FAILIURE", argv, argc) >= 0) {
-        RedisModuleString *dontAssertOnFailiure;
-        if (RMUtil_ParseArgsAfter(
-                "DONT_ASSERT_ON_FAILIURE", argv, argc, "s", &dontAssertOnFailiure) !=
-            REDISMODULE_OK) {
-            RedisModule_Log(
-                ctx, "warning", "Unable to parse argument after DONT_ASSERT_ON_FAILIURE");
-            return TSDB_ERROR;
-        }
-        size_t dontAssertOnFailiure_len;
-        const char *dontAssertOnFailiure_cstr =
-            RedisModule_StringPtrLen(dontAssertOnFailiure, &dontAssertOnFailiure_len);
-        if (!strcasecmp(dontAssertOnFailiure_cstr, "enable")) {
-            TSGlobalConfig.dontAssertOnFailiure = true;
-        } else if (!strcasecmp(dontAssertOnFailiure_cstr, "disable")) {
-            TSGlobalConfig.dontAssertOnFailiure = false;
-        }
 
-        extern bool _dontAssertOnFailiure;
-        _dontAssertOnFailiure = TSGlobalConfig.dontAssertOnFailiure;
-    }
     RedisModule_Log(ctx,
                     "notice",
                     "Setting default series ENCODING to: %s",

--- a/src/config.h
+++ b/src/config.h
@@ -15,19 +15,26 @@ typedef struct
 {
     SimpleCompactionRule *compactionRules;
     uint64_t compactionRulesCount;
+    RedisModuleString *compactionPolicyStr;
     long long retentionPolicy;
     long long chunkSizeBytes;
-    short options;
-    int hasGlobalConfig;
+    int options;
     DuplicatePolicy duplicatePolicy;
-    long long numThreads;      // number of threads used by libMR
-    bool forceSaveCrossRef;    // Internal debug configuration param
-    char *password;            // tls password which used by libmr
-    bool dontAssertOnFailiure; // Internal debug configuration param
+    long long numThreads;   // number of threads used by libMR
+    bool forceSaveCrossRef; // Internal debug configuration param
+    char *password;         // tls password which used by libmr
+    RedisModuleString *passwordStr;
+    bool dontAssertOnFailure; // Internal debug configuration param
 } TSConfig;
 
 extern TSConfig TSGlobalConfig;
 
+void FreeGlobalConfig(void);
+void SetCompactionRulesConfig(RedisModuleString *policyStr,
+                              SimpleCompactionRule *compactionRules,
+                              uint64_t compactionRulesCount);
+void SetOSSGlobalPasswordConfig(RedisModuleString *password);
+int ModuleConfigInit(RedisModuleCtx *ctx);
 int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 const char *ChunkTypeToString(int options);
 typedef struct RTS_RedisVersion

--- a/tests/flow/test_lazy_del.py
+++ b/tests/flow/test_lazy_del.py
@@ -116,7 +116,7 @@ def test_dump_restore_dst_rule():
 def test_dump_restore_dst_rule_force_save_refs():
     Env().skipOnCluster()
     skip_on_rlec()
-    with Env(moduleArgs='DEUBG_FORCE_RULE_DUMP enable').getClusterConnectionIfNeeded() as r:
+    with Env(moduleArgs='--timeseries.DEBUG_FORCE_RULE_DUMP yes').getClusterConnectionIfNeeded() as r:
         key1 = 'ts1{a}'
         key2 = 'ts2{a}'
         key3 = 'ts3{a}'

--- a/tests/flow/test_ts_delete.py
+++ b/tests/flow/test_ts_delete.py
@@ -548,7 +548,7 @@ def test_del_with_rules_bug_4972_4(self):
         assert res == [[0, b'4']]
 
 def test_del_with_rules_bug_4972_5(self):
-    e = Env(moduleArgs='DONT_ASSERT_ON_FAILIURE enable')
+    e = Env(moduleArgs='--timeseries.DEBUG_DONT_ASSERT_ON_FAILURE yes')
     t1 = 't1{1}'
     t2 = 't2{1}'
     with e.getClusterConnectionIfNeeded() as r:
@@ -580,7 +580,7 @@ def test_del_with_rules_bug_4972_5(self):
         assert res == [[5, b'5'], [31, b'31']]
 
 def test_del_with_rules_bug_4972_6(self):
-    e = Env(moduleArgs='DONT_ASSERT_ON_FAILIURE enable')
+    e = Env(moduleArgs='--timeseries.DEBUG_DONT_ASSERT_ON_FAILURE yes')
     t1 = 't1{1}'
     t2 = 't2{1}'
     with e.getClusterConnectionIfNeeded() as r:


### PR DESCRIPTION
Use Redis module configuration API.

After this PR, Redis `config` command can be used for module configuration. 

Example usage:
- Command: 
  ```
  config set timeseries.retention_policy 1000
  config get timeseries.retention_policy
  ```
- CLI:  
   ```
  ./redis-server --port 5001 --loadmodule timeseries.so --timeseries.retention_policy 1000
  ```
- Config file: 
  ```
  loadmodule timeseries.so
  timeseries.retention_policy 1000
  ```

Notes:
- Configuration via module arguments is still allowed for backward compatibility. A warning is printed to the log in this case to tell this is legacy way to configure the module. 
- Configurations are immutable similar to module arguments. Currently, it can't be changed with `config set` command after loading the module. We may allow runtime reconfiguration in future.
- Currently, `CHUNK_TYPE` is a deprecated config in favor of `ENCODING`. So, I did not add `CHUNK_TYPE` to module configuration API. `timeseries.ENCODING` can be used instead in the new API. 

Implementation details:
- We had two debug configs: DEUBG_FORCE_RULE_DUMP and DONT_ASSERT_ON_FAILIURE. As backward compatibility is not a case here, I've moved these to new API and deleted from module arguments parsing. 

Additional fixes
- Fixed memory leaks that happens only if configuration is invalid and module load fails due to it. This is needed to test invalid configurations and verify things with the sanitizer run. 