### PR TITLE
Use fixed version of RLTest v0.7.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -394,13 +394,12 @@ flow_tests: #$(TARGET)
 	GEN=$(GEN) AOF=$(AOF) SLAVES=$(SLAVES) AOF_SLAVES=$(AOF_SLAVES) OSS_CLUSTER=$(OSS_CLUSTER) \
 	VALGRIND=$(VALGRIND) \
 	TEST=$(TEST) \
-	RLTEST_ARGS='--no-progress' \
 	$(ROOT)/tests/flow/tests.sh
 
 else # RLEC
 
 flow_tests: #$(TARGET)
-	$(SHOW)RLEC=1 RLTEST_ARGS='--no-progress' $(ROOT)/tests/flow/tests.sh
+	$(SHOW)RLEC=1 $(ROOT)/tests/flow/tests.sh
 
 endif # RLEC
 

--- a/Makefile
+++ b/Makefile
@@ -394,12 +394,13 @@ flow_tests: #$(TARGET)
 	GEN=$(GEN) AOF=$(AOF) SLAVES=$(SLAVES) AOF_SLAVES=$(AOF_SLAVES) OSS_CLUSTER=$(OSS_CLUSTER) \
 	VALGRIND=$(VALGRIND) \
 	TEST=$(TEST) \
+	RLTEST_ARGS='--no-progress' \
 	$(ROOT)/tests/flow/tests.sh
 
 else # RLEC
 
 flow_tests: #$(TARGET)
-	$(SHOW)RLEC=1 $(ROOT)/tests/flow/tests.sh
+	$(SHOW)RLEC=1 RLTEST_ARGS='--no-progress' $(ROOT)/tests/flow/tests.sh
 
 endif # RLEC
 

--- a/tests/flow/requirements.txt
+++ b/tests/flow/requirements.txt
@@ -1,4 +1,4 @@
-RLTest~=0.7.2
+RLTest~=0.7.7
 statistics
 # hiredis==2.0.0  # disabled until RESP3-related problem is resolved
 gevent~=22.10.1

--- a/tests/flow/requirements.txt
+++ b/tests/flow/requirements.txt
@@ -1,4 +1,4 @@
-RLTest~=0.7.7
+RLTest==0.7.5
 statistics
 # hiredis==2.0.0  # disabled until RESP3-related problem is resolved
 gevent~=22.10.1


### PR DESCRIPTION
Currenly we get 

```
Running general tests:
OSError: [Errno 9] Bad file descriptor
Error in sys.excepthook:
Traceback (most recent call last):
  File "/root/.local/lib/python3.9/site-packages/progressbar/utils.py", line 350, in flush
    self.stdout._flush()
  File "/root/.local/lib/python3.9/site-packages/progressbar/utils.py", line 224, in _flush
    self.target.write(value)
OSError: [Errno 9] Bad file descriptor
```

Looks like a PR was merged to RLTest: https://github.com/RedisLabsModules/RLTest/pull/211

We can use a workaround to skip progressbar feature which throws above exception but some sanitizer tests are also failing with the latest RLTest (v0.7.7).
 
Probably, it is better to stick with a version of RLTest (v0.7.5) that works for us now. Later, we may try to integrate the latest version.


