### PR TITLE
Fix naming for macOS and arm artifacts

### DIFF
--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -50,8 +50,10 @@ OP=""
 
 # RLEC naming conventions
 
-ARCH=$($READIES/bin/platform --arch)
-[[ $ARCH == x64 ]] && ARCH=x86_64
+ARCH=$(uname -m)
+
+[[ $ARCH == x64 ]]     && ARCH=x86_64
+[[ $ARCH == arm64 ]]   && ARCH=aarch64
 [[ $ARCH == arm64v8 ]] && ARCH=aarch64
 
 OS=$($READIES/bin/platform --os)
@@ -70,7 +72,14 @@ OSNICK=$($READIES/bin/platform --osnick)
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
 [[ $OSNICK == rocky9 ]]  && OSNICK=rhel9
 
-[[ $OSNICK == bigsur ]]  && OSNICK=catalina
+if [[ $OS == macos ]]; then
+	# as we don't build on macOS for every platform, we converge to a least common denominator
+	if [[ $ARCH == x86_64 ]]; then
+		OSNICK=catalina  # to be aligned with the rest of the modules in redis stack
+	else
+		[[ $OSNICK == ventura ]] && OSNICK=monterey
+	fi
+fi
 
 PLATFORM="$OS-$OSNICK-$ARCH"
 


### PR DESCRIPTION
Follow up PR of https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1581

Fix naming for macOS and arm artifacts