### PR TITLE
Reply clients with libmr error messages (#1584)

### DIFF
--- a/src/libmr_commands.c
+++ b/src/libmr_commands.c
@@ -25,12 +25,17 @@ static inline bool check_and_reply_on_error(ExecutionCtx *eCtx, RedisModuleCtx *
         }
 
         if (max_idle_reached) {
-            RedisModule_ReplyWithError(
-                rctx,
-                "Multi-shard command failed. This may happen if a shard needs to process too much "
-                "data. Try to apply strict filters, if possible.");
+            RedisModule_ReplyWithError(rctx,
+                                       "A multi-shard command failed because at least one shard "
+                                       "did not reply within the given timeframe.");
         } else {
-            RedisModule_ReplyWithError(rctx, "multi shard cmd failed");
+            char buf[512] = { 0 };
+            snprintf(buf,
+                     sizeof(buf),
+                     "Multi-shard command failed. %s",
+                     MR_ExecutionCtxGetError(eCtx, 0));
+
+            RedisModule_ReplyWithError(rctx, buf);
         }
         return true;
     }

--- a/tests/flow/test_ts_libmr_failiure.py
+++ b/tests/flow/test_ts_libmr_failiure.py
@@ -74,8 +74,8 @@ def testLibmrFail():
                                 'name=bob')
         assert(False)
     except Exception as e:
-        env.assertResponseError(e, "Multi-shard command failed. This may happen if a shard needs to process too much data. Try to apply strict filters, if possible.")
-    
+        assert str(e) == "A multi-shard command failed because at least one shard did not reply within the given timeframe."
+
     env.envRunner.shards[2].startEnv()
     _waitCluster(env)
     env.getConnection(3).execute_command('timeseries.REFRESHCLUSTER')


### PR DESCRIPTION
In case of libmr error other than timeout, we were replying client with generic error message. After this PR, we'll reply with libmr error message.

Additional changes: reword timeout error message.