### PR TITLE
Change CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -535,8 +535,8 @@ jobs:
           command: |
             mkdir -p bin
             ln -s ~/workspace/artifacts bin/artifacts
-            if [[ -n $CIRCLE_TAG && "<<parameters.staging-lab>>" != 1 ]]; then
-                make upload-release SHOW=1 VERSION=$CIRCLE_TAG
+            if [[ "<<parameters.staging-lab>>" != 1 ]]; then
+                make upload-release SHOW=1 VERSION=1.8.13
             else
                 make upload-release SHOW=1 STAGING=1
             fi
@@ -763,7 +763,7 @@ on-master: &on-master
 on-any-branch-except-version: &on-any-branch-except-version
   filters:
     branches:
-      only: /.*/
+      ignore: /^pre-rel-.*$/
     tags:
       ignore: /.*/
 
@@ -789,7 +789,7 @@ on-version-tags: &on-version-tags
   filters:
     branches:
       only:
-        ignore: /.*/
+        - /^pre-rel-.*$/
     tags:
       only: /^v[0-9].*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -536,7 +536,7 @@ jobs:
             mkdir -p bin
             ln -s ~/workspace/artifacts bin/artifacts
             if [[ -n $CIRCLE_TAG && "<<parameters.staging-lab>>" != 1 ]]; then
-                make upload-release SHOW=1
+                make upload-release SHOW=1 VERSION=$CIRCLE_TAG
             else
                 make upload-release SHOW=1 STAGING=1
             fi
@@ -760,6 +760,13 @@ on-master: &on-master
     tags:
       ignore: /.*/
 
+on-any-branch-except-version: &on-any-branch-except-version
+  filters:
+    branches:
+      only: /.*/
+    tags:
+      ignore: /.*/
+
 on-integ-branch: &on-integ-branch
   filters:
     branches:
@@ -778,20 +785,11 @@ on-integ-branch-cron: &on-integ-branch-cron
         - /^\d+\.\d+.*$/
         - /^feature-.*$/
 
-not-on-integ-branch: &not-on-integ-branch
-  filters:
-    branches:
-      ignore:
-        - master
-        - /^\d+\.\d+.*$/
-        - /^feature-.*$/
-    tags:
-      ignore: /.*/
-
 on-version-tags: &on-version-tags
   filters:
     branches:
-      ignore: /.*/
+      only:
+        ignore: /.*/
     tags:
       only: /^v[0-9].*/
 
@@ -814,9 +812,7 @@ workflows:
       << pipeline.parameters.run_default_flow >>
     jobs:
       - lint:
-          <<: *on-any-branch
-      - build:
-          <<: *not-on-integ-branch
+          <<: *on-any-branch-except-version
       - build:
           name: build-with-redis-<<matrix.redis_version>>
           <<: *on-integ-branch
@@ -825,53 +821,53 @@ workflows:
             parameters:
               redis_version: ["6.0", "6.2"]
       - test-rlec:
-          <<: *on-any-branch
+          <<: *on-any-branch-except-version
       - valgrind:
           <<: *never
       - build-platforms:
-          <<: *on-integ-and-version-tags
+          <<: *on-integ-branch
           context: common
           matrix:
             parameters:
               platform: [jammy, focal, bionic, xenial, amzn2, centos7, rocky8, bullseye]
       - build-arm-platforms:
-          <<: *on-integ-and-version-tags
+          <<: *on-integ-branch
           context: common
           matrix:
             parameters:
               platform: [jammy, focal, bionic]
       - build-macos-x64:
           context: common
-          <<: *on-integ-and-version-tags
+          <<: *on-integ-branch
       - build-macos-m1:
           context: common
-          <<: *on-integ-and-version-tags
+          <<: *on-integ-branch
       - coverage:
-          <<: *on-any-branch
+          <<: *on-any-branch-except-version
       - performance-ci-automation-oss-standalone:
           context: common
-          <<: *on-integ-and-version-tags
+          <<: *on-integ-branch
       - performance-ci-automation-oss-standalone-scaling:
           context: common
-          <<: *on-integ-and-version-tags
+          <<: *on-integ-branch
       - performance-ci-automation-oss-cluster-query:
           context: common
-          <<: *on-integ-and-version-tags
+          <<: *on-integ-branch
       - performance-ci-automation-oss-cluster-ingestion:
           context: common
-          <<: *on-integ-and-version-tags
+          <<: *on-integ-branch
       - performance-ci-automation-oss-standalone-scaling-profiler:
           context: common
-          <<: *on-integ-and-version-tags
+          <<: *on-integ-branch
       - performance-ci-automation-oss-standalone-tsbs-profiler:
           context: common
-          <<: *on-integ-and-version-tags
+          <<: *on-integ-branch
       - performance-ci-automation-oss-cluster-profiler-query:
           context: common
-          <<: *on-integ-and-version-tags
+          <<: *on-integ-branch
       - performance-ci-automation-oss-cluster-profiler-ingestion:
           context: common
-          <<: *on-integ-and-version-tags
+          <<: *on-integ-branch
       - upload-artifacts:
           name: upload-artifacts-to-staging-lab
           staging-lab: "1"
@@ -886,11 +882,6 @@ workflows:
           name: upload-release-artifacts
           context: common
           <<: *on-version-tags
-          requires:
-            - build-platforms
-            - build-arm-platforms
-            - build-macos-x64
-            - build-macos-m1
       - release-qa-tests:
           <<: *on-version-tags
           context: common

--- a/.github/workflows/mariner2.yml
+++ b/.github/workflows/mariner2.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - master
       - 1.8
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build-mariner2:
@@ -51,6 +49,3 @@ jobs:
         run: |
           make upload-artifacts SHOW=1 VERBOSE=1
           make upload-release SHOW=1 STAGING=1 VERBOSE=1
-      - name: Upload artifacts to s3 - release  # todo: trigger this manually instead
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        run: make upload-release SHOW=1 VERBOSE=1

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -77,7 +77,6 @@ else
 	MAYBE_SNAP=
 fi
 
-cd artifacts${MAYBE_SNAP}
 [[ $VERBOSE == 1 ]] && du -ah --apparent-size *
 
 #----------------------------------------------------------------------------------------------
@@ -116,6 +115,18 @@ s3_upload() {
 	return 0
 }
 
+s3_move_artifacts_to_release_branch() {
+  echo "Moving artifacts from snapshots to release directory for version=${VERSION}"
+  local snapshot_version_files="${S3_URL}/redistimeseries/snapshots/"
+  local release_dir="${S3_URL}/redistimeseries"
+  $OP aws --debug s3 cp --recursive ${snapshot_version_files} ${release_dir} --exclude "*" --include "*${VERSION}*"
+}
+
 #----------------------------------------------------------------------------------------------
 
-PROD=redistimeseries PREFIX=redistimeseries s3_upload
+if [ ${RELEASE} == 1 ]; then
+  s3_move_artifacts_to_release_branch
+else
+  cd artifacts${MAYBE_SNAP}
+  PROD=redistimeseries PREFIX=redistimeseries s3_upload
+fi


### PR DESCRIPTION
- revert -n $CIRCLE_TAG
- revert hack for on-version-tags

Now that we are doing all the tests before releasing, the release PR (tagging)
shold only move the tested artifacts from the snapshots to release directory