### PR TITLE
MOD-5413 Prevent non-positive values for COUNT argument in TS.RANGE

### DIFF
--- a/src/query_language.c
+++ b/src/query_language.c
@@ -443,6 +443,11 @@ static int parseCountArgument(RedisModuleCtx *ctx,
             RTS_ReplyGeneralError(ctx, "TSDB: Couldn't parse COUNT");
             return TSDB_ERROR;
         }
+
+        if (*count < 1) {
+            RTS_ReplyGeneralError(ctx, "TSDB: Invalid COUNT value");
+            return TSDB_ERROR;
+        }
     }
     return TSDB_OK;
 }

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -1561,7 +1561,8 @@ def test_ts_range_count_validation():
     Validate COUNT argument is non-positive for TS.RANGE family commands
     """
     env = Env(decodeResponses=True)
-    key = 't1{1}'
+    env.skipOnCluster()
+    key = 'x'
     with env.getClusterConnectionIfNeeded() as r:
         for i in range(10):
             r.execute_command('TS.ADD', key, i, i)

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -1561,18 +1561,19 @@ def test_ts_range_count_validation():
     Validate COUNT argument is non-positive for TS.RANGE family commands
     """
     env = Env(decodeResponses=True)
+    key = 't1{1}'
     with env.getClusterConnectionIfNeeded() as r:
         for i in range(10):
-            r.execute_command('TS.ADD', 'key', i, i)
+            r.execute_command('TS.ADD', key, i, i)
 
-    env.expect('TS.RANGE', 'key', '-', '+', 'COUNT', '0').error().contains('TSDB: Invalid COUNT value')
-    env.expect('TS.RANGE', 'key', '-', '+', 'COUNT', '-1').error().contains('TSDB: Invalid COUNT value')
-    env.expect('TS.RANGE', 'key', '-', '+', 'COUNT', '-2').error().contains('TSDB: Invalid COUNT value')
-    env.expect('TS.REVRANGE', 'key', '-', '+', 'COUNT', '-1000').error().contains('TSDB: Invalid COUNT value')
+    env.expect('TS.RANGE', key, '-', '+', 'COUNT', '0').error().contains('TSDB: Invalid COUNT value')
+    env.expect('TS.RANGE', key, '-', '+', 'COUNT', '-1').error().contains('TSDB: Invalid COUNT value')
+    env.expect('TS.RANGE', key, '-', '+', 'COUNT', '-2').error().contains('TSDB: Invalid COUNT value')
+    env.expect('TS.REVRANGE', key, '-', '+', 'COUNT', '-1000').error().contains('TSDB: Invalid COUNT value')
     env.expect('TS.MRANGE', '-', '+', 'COUNT', '-2', 'FILTER', 'a=x').error().contains('TSDB: Invalid COUNT value')
     env.expect('TS.MREVRANGE', '-', '+', 'COUNT', '0', 'FILTER', 'a=x').error().contains('TSDB: Invalid COUNT value')
 
-    assert r.execute_command('TS.RANGE', 'key', '-', '+', 'COUNT', 2) == [[0, '0'], [1, '1']]
-    assert r.execute_command('TS.RANGE', 'key', '-', '+', 'COUNT', 2, 'AGGREGATION', 'sum', 5) == [[0, '10'], [5, '35']]
+    assert r.execute_command('TS.RANGE', key, '-', '+', 'COUNT', 2) == [[0, '0'], [1, '1']]
+    assert r.execute_command('TS.RANGE', key, '-', '+', 'COUNT', 2, 'AGGREGATION', 'sum', 5) == [[0, '10'], [5, '35']]
 
 


### PR DESCRIPTION
Currently, user can specify non-positive value for COUNT argument in TS.RANGE family commands.

If it's -1, command is executed as if like COUNT argument is not given at all.
If it is 0 or any other negative value, empty array will be returned. 

Added validation to reject any non-positive value for COUNT argument.