### PR TITLE
Fix macos build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,31 +325,6 @@ jobs:
           platform: <<parameters.platform>>
           official: "0"
 
-  build-macos-m1:
-    macos:
-      xcode: 14.2.0
-    resource_class: macos.m1.large.gen1
-    parameters:
-      upload:
-        type: string
-        default: "yes"
-    steps:
-      - early-returns
-      - build-steps
-      - run:
-          name: Persist artifacts?
-          command: |
-            if [[ "<<parameters.upload>>" != "yes" ]]; then
-              circleci step halt
-            fi
-      - run:
-          name: Upload artifacts to S3
-          command: |
-            if [[ -n $CIRCLE_BRANCH && "<<parameters.upload>>" == "yes" ]]; then
-                make upload-artifacts SHOW=1 VERBOSE=1
-            fi
-      - persist-artifacts
-
   coverage:
     docker:
       - image: redisfab/rmbuilder:6.2.7-x64-bullseye
@@ -552,9 +527,6 @@ workflows:
           matrix:
             parameters:
               platform: [jammy, focal, bionic]
-      - build-macos-m1:
-          context: common
-          <<: *on-integ-and-version-tags
       - coverage:
           <<: *on-any-branch
       - sanitize:
@@ -571,7 +543,6 @@ workflows:
           requires:
             - build-platforms
             - build-arm-platforms
-            - build-macos-m1
       - upload-artifacts:
           name: upload-release-artifacts
           <<: *on-version-tags
@@ -579,7 +550,6 @@ workflows:
           requires:
             - build-platforms
             - build-arm-platforms
-            - build-macos-m1
       - release-qa-tests:
           <<: *on-version-tags
           context: common
@@ -605,6 +575,4 @@ workflows:
           cron: "20 17 * * 0,3"
           <<: *on-integ-branch-cron
     jobs:
-      - build-macos-m1:
-          upload: "no"
       - valgrind

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,31 +325,6 @@ jobs:
           platform: <<parameters.platform>>
           official: "0"
 
-  build-macos-x64:
-    macos:
-      xcode: 12.5.1
-    resource_class: macos.x86.medium.gen2
-    parameters:
-      upload:
-        type: string
-        default: "yes"
-    steps:
-      - early-returns
-      - build-steps
-      - run:
-          name: Persist artifacts?
-          command: |
-            if [[ "<<parameters.upload>>" != "yes" ]]; then
-              circleci step halt
-            fi
-      - run:
-          name: Upload artifacts to S3
-          command: |
-            if [[ -n $CIRCLE_BRANCH && "<<parameters.upload>>" == "yes" ]]; then
-                make upload-artifacts SHOW=1
-            fi
-      - persist-artifacts
-
   build-macos-m1:
     macos:
       xcode: 14.2.0
@@ -577,9 +552,6 @@ workflows:
           matrix:
             parameters:
               platform: [jammy, focal, bionic]
-      - build-macos-x64:
-          <<: *on-integ-and-version-tags
-          context: common
       - build-macos-m1:
           context: common
           <<: *on-integ-and-version-tags
@@ -599,7 +571,6 @@ workflows:
           requires:
             - build-platforms
             - build-arm-platforms
-            - build-macos-x64
             - build-macos-m1
       - upload-artifacts:
           name: upload-release-artifacts
@@ -608,7 +579,6 @@ workflows:
           requires:
             - build-platforms
             - build-arm-platforms
-            - build-macos-x64
             - build-macos-m1
       - release-qa-tests:
           <<: *on-version-tags
@@ -635,8 +605,6 @@ workflows:
           cron: "20 17 * * 0,3"
           <<: *on-integ-branch-cron
     jobs:
-      - build-macos-x64:
-          upload: "no"
       - build-macos-m1:
           upload: "no"
       - valgrind

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,152 @@
+name: CI Full suite
+# TODO: Currently, this suite only contains macOS builds. Rest of the builds
+# should be moved from CircleCI to here as well.
+#
+# This is a full workflow for the production branches and tags, which
+# includes building and testing on all supported platforms, and
+# uploading the artifacts to S3.
+
+# TODO:
+#
+# 1. Remove the use of "readies" completely.
+# 2. Remove the use of all the scripts for anything and do everything
+#    right here in the workflow.
+# 3. Use the corresponding actions for the end goal: aws s3 upload
+#    action. This also will remove the need for the installation of aws-cli.
+#
+# More info: jobs.steps.uses: docker://alpine:3.8 for docker images,
+# To use the AWS CLI: https://hub.docker.com/r/amazon/aws-cli
+
+on:
+  push:
+    paths-ignore:
+      - '.circleci/**'
+      - 'docs/**'
+      - '*.md'
+    branches:
+      - main
+      - master
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+'
+      - 'feature-*'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-m[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  setup-environment:
+    runs-on: ubuntu-latest
+    outputs:
+      STAGING: ${{ steps.set-staging.outputs.STAGING }}
+      TAG: ${{ steps.set-git-info.outputs.TAG }}
+      BRANCH: ${{ steps.set-git-info.outputs.BRANCH }}
+      TAG_OR_BRANCH: ${{ steps.set-git-info.outputs.TAG }}${{ steps.set-git-info.outputs.BRANCH }}
+    steps:
+      - name: Set the branch and tag outputs
+        id: set-git-info
+        run: |
+          export REF="${{ github.ref }}"
+          export BRANCH_PATTERN="^refs/heads/(.*)$"
+          export TAG_PATTERN="^refs/tags/(.*)$"
+
+          if [[ $REF =~ $BRANCH_PATTERN ]]; then
+            echo "BRANCH=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ $REF =~ $TAG_PATTERN ]]; then
+            echo "TAG=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+          fi
+      - name: Set the staging flag
+        id: set-staging
+        run: |
+          # If this is a version tag, then set to false, meaning this
+          # is not a production build.
+          export REF="${{ github.ref }}"
+          export PATTERN="refs/tags/v[0-9]+.*"
+          if [[ $REF =~ $PATTERN ]]; then
+            echo "This is a production build"
+            echo "STAGING=0" >> $GITHUB_OUTPUT
+          else
+            echo "This is a staging build"
+            echo "STAGING=1" >> $GITHUB_OUTPUT
+          fi
+
+  macos:
+    runs-on: ${{ matrix.os }}
+    env:
+      STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+      VERSION: ${{ needs.setup-environment.outputs.TAG }}
+      BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
+      TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH}}
+    strategy:
+      fail-fast: false
+      matrix:
+        redis-version: ["7.2.5", "unstable"]
+        # MacOS 13 - x86-64, MacOS 14 - ARM (Apple Chips).
+        os: ["macos-13", "macos-14"]
+    defaults:
+      run:
+        shell: bash -l -eo pipefail {0}
+    needs: setup-environment
+    steps:
+      - name: Install prerequisites
+        run: |
+          brew install make coreutils autoconf automake
+
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Install Python dependencies
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python3 -m pip install --upgrade pip setuptools wheel
+          python3 -m pip install -r tests/flow/requirements.txt
+          python3 -m pip install jinja2 ramp-packer
+          ./sbin/setup
+      - name: Checkout Redis
+        uses: actions/checkout@v3
+        with:
+          repository: 'redis/redis'
+          ref: ${{ matrix.redis-version }}
+          path: 'redis'
+      - name: Build Redis
+        run: |
+          cd redis && gmake -j `sysctl -n hw.logicalcpu`
+          echo "REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/redis/src" >> $GITHUB_PATH
+          export PATH="$GITHUB_WORKSPACE/redis/src:$PATH"
+          redis-server --version
+      - name: Build RedisTimeseries
+        run: |
+          source .venv/bin/activate
+          git submodule update --init --recursive
+          gmake build VERBOSE=1
+      - name: Run tests
+        run: |
+          source .venv/bin/activate
+          gmake test
+      - name: Pack module
+        run: |
+          source .venv/bin/activate
+          gmake pack BRANCH=$TAG_OR_BRANCH SHOW=1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "us-east-1"
+      - name: Upload artifacts to S3
+        run: |
+          source .venv/bin/activate
+          # Upload script needs GNU du 
+          export PATH="$(brew --prefix)/opt/coreutils/libexec/gnubin:$PATH"
+
+          mkdir -p bin
+          ln -s ~/workspace/artifacts bin/artifacts
+          if [[ $STAGING -eq 1 ]]; then
+            gmake upload-artifacts SHOW=1 VERBOSE=1
+          fi
+          gmake upload-release STAGING=$STAGING SHOW=1 VERBOSE=1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,7 +38,7 @@ jobs:
   setup-environment:
     runs-on: ubuntu-latest
     outputs:
-      STAGING: ${{ steps.set-staging.outputs.STAGING }}
+      TAGGED: ${{ steps.set-tagged.outputs.TAGGED }}
       TAG: ${{ steps.set-git-info.outputs.TAG }}
       BRANCH: ${{ steps.set-git-info.outputs.BRANCH }}
       TAG_OR_BRANCH: ${{ steps.set-git-info.outputs.TAG }}${{ steps.set-git-info.outputs.BRANCH }}
@@ -57,25 +57,25 @@ jobs:
           if [[ $REF =~ $TAG_PATTERN ]]; then
             echo "TAG=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
           fi
-      - name: Set the staging flag
-        id: set-staging
+      - name: Set the tagged flag
+        id: set-tagged
         run: |
           # If this is a version tag, then set to false, meaning this
           # is not a production build.
           export REF="${{ github.ref }}"
           export PATTERN="refs/tags/v[0-9]+.*"
           if [[ $REF =~ $PATTERN ]]; then
-            echo "This is a production build"
-            echo "STAGING=0" >> $GITHUB_OUTPUT
+            echo "This is a tagged build"
+            echo "TAGGED=1" >> $GITHUB_OUTPUT
           else
-            echo "This is a staging build"
-            echo "STAGING=1" >> $GITHUB_OUTPUT
+            echo "This is not a tagged build"
+            echo "TAGGED=1" >> $GITHUB_OUTPUT
           fi
 
   macos:
     runs-on: ${{ matrix.os }}
     env:
-      STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+      TAGGED: ${{ needs.setup-environment.outputs.TAGGED }}
       VERSION: ${{ needs.setup-environment.outputs.TAG }}
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
       TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH}}
@@ -146,7 +146,9 @@ jobs:
 
           mkdir -p bin
           ln -s ~/workspace/artifacts bin/artifacts
-          if [[ $STAGING -eq 1 ]]; then
+          if [[ TAGGED -eq 0 ]]; then
             gmake upload-artifacts SHOW=1 VERBOSE=1
+          else
+            gmake upload-release SHOW=1 VERBOSE=1
           fi
-          gmake upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
+          

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -69,7 +69,7 @@ jobs:
             echo "TAGGED=1" >> $GITHUB_OUTPUT
           else
             echo "This is not a tagged build"
-            echo "TAGGED=1" >> $GITHUB_OUTPUT
+            echo "TAGGED=0" >> $GITHUB_OUTPUT
           fi
 
   macos:
@@ -146,7 +146,7 @@ jobs:
 
           mkdir -p bin
           ln -s ~/workspace/artifacts bin/artifacts
-          if [[ TAGGED -eq 0 ]]; then
+          if [[ $TAGGED -eq 0 ]]; then
             gmake upload-artifacts SHOW=1 VERBOSE=1
           else
             gmake upload-release SHOW=1 VERBOSE=1


### PR DESCRIPTION
Move macOS builds from CircleCI to github actions

MacOS builds on CircleCI started to fail as Circle is dropping support of some instance types. 