### PR TITLE
Fix naming of macos arm64 artifacts

### DIFF
--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -78,6 +78,7 @@ if [[ $OS == macos ]]; then
 		OSNICK=catalina  # to be aligned with the rest of the modules in redis stack
 	else
 		[[ $OSNICK == ventura ]] && OSNICK=monterey
+		[[ $OSNICK == sonoma ]] && OSNICK=monterey
 	fi
 fi
 

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -59,6 +59,7 @@ if [[ $OS == macos ]]; then
 		OSNICK=catalina  # to be aligned with the rest of the modules in redis stack
 	else
 		[[ $OSNICK == ventura ]] && OSNICK=monterey
+		[[ $OSNICK == sonoma ]] && OSNICK=monterey
 	fi
 fi
 


### PR DESCRIPTION
Use monterey name for macOS arm artifacts