### PR TITLE
Performance on CI prunning. Faster runs and profiler on demand.

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -3,9 +3,6 @@ name: Run a Benchmark Flow
 on:
   workflow_call:
     inputs:
-      container:
-        type: string
-        default: redisfab/rmbuilder:6.2.7-x64-bullseye
       module_path:
         type: string
         default: bin/linux-x64-release/redistimeseries.so
@@ -37,7 +34,6 @@ on:
 jobs:
   benchmark-steps:
     runs-on: ubuntu-latest
-    container: ${{ inputs.container }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -3,13 +3,13 @@ name: Run RedisTimeSeries Benchmarks
 on:
   workflow_dispatch:
     inputs:
-      extended:
+      profiler:
         type: boolean
-        description: 'Run extended benchmarks'
+        description: 'Run profiler on benchmarks'
         default: false
   workflow_call:
     inputs:
-      extended:
+      profiler:
         type: boolean
         default: false
 
@@ -17,7 +17,7 @@ jobs:
   benchmark-timeseries-oss-standalone:
     strategy:
       matrix:
-        member_id: [1, 2, 3]
+        member_id: [1, 2, 3, 4]
     uses: ./.github/workflows/benchmark-flow.yml
     secrets: inherit
     with:
@@ -25,6 +25,7 @@ jobs:
       benchmark_runner_group_total: ${{ strategy.job-total }}
 
   benchmark-timeseries-oss-standalone-profiler:
+    if: inputs.profiler
     strategy:
       matrix:
         member_id: [1, 2, 3]

--- a/.github/workflows/event-weekly.yml
+++ b/.github/workflows/event-weekly.yml
@@ -2,11 +2,11 @@ name: Weekly Flow
 
 on:
   schedule:
-    - cron: "0 0 * * 0"
+    - cron: "0 0 * * 1"
 
 jobs:
   run-benchmarks:
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit
     with:
-      extended: true
+      profiler: true


### PR DESCRIPTION
- Disabled profiling by default on PRs (dispatch can trigger it) and keep it on weekly. 
- Extended runner groups to make benchmarks faster