### PR TITLE
Fix #1576

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1230,9 +1230,13 @@ int TSDB_delete(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 }
 
 void FlushEventCallback(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent, void *data) {
-    if ((!memcmp(&eid, &RedisModuleEvent_FlushDB, sizeof(eid))) &&
-        subevent == REDISMODULE_SUBEVENT_FLUSHDB_END) {
-        RemoveAllIndexedMetrics();
+    if ((!memcmp(&eid, &RedisModuleEvent_FlushDB, sizeof(eid)))){
+        RedisModuleFlushInfo *fi = data;
+        if (fi->dbnum==-1 && subevent == REDISMODULE_SUBEVENT_FLUSHDB_END){
+            RemoveAllIndexedMetrics();
+        }else if (fi->dbnum!=-1 && subevent == REDISMODULE_SUBEVENT_FLUSHDB_START){
+            RedisModule_Log(ctx, "warning", "flushdb isn't supported by redis timeseries,only flushall to delete all");
+        }
     }
 }
 

--- a/tests/flow/test_generic_cmds.py
+++ b/tests/flow/test_generic_cmds.py
@@ -48,7 +48,7 @@ def test_flush():
         r1 = init(env, r)
         assert r.execute_command('FLUSHDB')
         res = r1.execute_command('TS.QUERYINDEX', 'name=(mush,zavi,rex)')
-        env.assertEqual(res, [])
+        env.assertEqual(sorted(res), sorted([b't{1}', b't{2}', b't{1}_agg']))
 
 def test_set():
     env = Env()


### PR DESCRIPTION
The FLUSHDB command should be ignored, as it only flushes the selected database. Otherwise, this can be quite confusing, especially since RedisTimeSeries does not support the SELECT command, as mentioned in issue #1520.