### PR TITLE
MOD-7456 add new configuration options

### DIFF
--- a/.github/actions/install-python-deps/action.yml
+++ b/.github/actions/install-python-deps/action.yml
@@ -23,7 +23,6 @@ runs:
     - name: Install Python dependencies
       shell: bash
       run: |
-        pip list
         if command -v scl_source &> /dev/null
         then
             . scl_source enable devtoolset-11 || true
@@ -35,7 +34,6 @@ runs:
             . venv/bin/activate
           echo ::endgroup::
         fi
-        pip list
         echo ::group::Install python dependencies
           ./.install/common_installations.sh
           if [[ "${{inputs.extra-packages-to-install}}" != "" ]]; then
@@ -45,4 +43,3 @@ runs:
             ./sbin/setup
           fi
         echo ::endgroup::
-        pip list

--- a/.github/actions/install-python-deps/action.yml
+++ b/.github/actions/install-python-deps/action.yml
@@ -14,8 +14,8 @@ inputs:
     type: string
     default: ''
     require: false
-  
-  
+
+
 
 runs:
   using: composite
@@ -23,6 +23,7 @@ runs:
     - name: Install Python dependencies
       shell: bash
       run: |
+        pip list
         if command -v scl_source &> /dev/null
         then
             . scl_source enable devtoolset-11 || true
@@ -34,6 +35,7 @@ runs:
             . venv/bin/activate
           echo ::endgroup::
         fi
+        pip list
         echo ::group::Install python dependencies
           ./.install/common_installations.sh
           if [[ "${{inputs.extra-packages-to-install}}" != "" ]]; then
@@ -43,3 +45,4 @@ runs:
             ./sbin/setup
           fi
         echo ::endgroup::
+        pip list

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Run sanitizer on the tests'
     type: string
     default: ''
-  quick: 
+  quick:
     description: 'Run with quick flag'
     type: string
     default: ''
@@ -32,4 +32,4 @@ runs:
         if [[ "${{ inputs.use-venv }}" == "1" ]]; then
           . venv/bin/activate
         fi
-        make test VG=${{inputs.run_valgrind}} SAN=${{inputs.run_sanitizer}} QUICK=${{inputs.quick}} REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+        make test VG=${{inputs.run_valgrind}} SAN=${{inputs.run_sanitizer}} QUICK=${{inputs.quick}} REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server -- --verbose

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -32,4 +32,4 @@ runs:
         if [[ "${{ inputs.use-venv }}" == "1" ]]; then
           . venv/bin/activate
         fi
-        make test VG=${{inputs.run_valgrind}} SAN=${{inputs.run_sanitizer}} QUICK=${{inputs.quick}} REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server -- --verbose
+        make test VG=${{inputs.run_valgrind}} SAN=${{inputs.run_sanitizer}} QUICK=${{inputs.quick}} REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server

--- a/.github/workflows/flow-linux-x86.yml
+++ b/.github/workflows/flow-linux-x86.yml
@@ -1,14 +1,12 @@
 name: Flow Linux x86
-
 permissions:
   id-token: write
   contents: read
-
 on:
   workflow_dispatch:
     inputs:
       redis-ref:
-        description: 'Redis ref to checkout'  # todo change per version/tag
+        description: 'Redis ref to checkout' # todo change per version/tag
         type: string
         required: true
       os:
@@ -23,14 +21,14 @@ on:
         description: 'Run sanitizer on the tests'
         type: boolean
         default: false
-      quick: 
+      quick:
         description: 'Run quick tests'
         type: boolean
         default: false
   workflow_call: # Allows to run this workflow from another workflow
     inputs:
       redis-ref:
-        description: 'Redis ref to checkout'  # todo change per version/tag
+        description: 'Redis ref to checkout' # todo change per version/tag
         type: string
         required: true
       os:
@@ -45,11 +43,10 @@ on:
         description: 'Run sanitizer on the tests'
         type: boolean
         default: false
-      quick: 
+      quick:
         description: 'Run quick tests'
         type: boolean
         default: false
-
 jobs:
   setup-environment:
     runs-on: ubuntu-latest
@@ -112,14 +109,13 @@ jobs:
           MATRIX="${MATRIX%?}]"
           echo "${MATRIX}"
           echo "matrix=${MATRIX}" >> $GITHUB_OUTPUT
-  
   build-linux-matrix:
     name: ${{matrix.docker_image.image}}, ${{needs.setup-environment.outputs.redis-ref}}
     runs-on: ubuntu-latest
     needs: setup-environment
     strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         docker_image: ${{fromJson(needs.setup-environment.outputs.matrix)}}
     container:
       image: ${{ matrix.docker_image.image }}
@@ -173,16 +169,16 @@ jobs:
         working-directory: .install
         shell: bash
         run: |
-          ./install_script.sh 
-      - name: Setup Python for testing
-        if: ${{matrix.docker_image.image == 'ubuntu:jammy'}}
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.9'
-          architecture: 'x64'
+          ./install_script.sh
+      # - name: Setup Python for testing
+      #   if: ${{matrix.docker_image.image == 'ubuntu:jammy'}}
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.9'
+      #     architecture: 'x64'
       - name: Install python dependencies
         uses: ./.github/actions/install-python-deps
-        with: 
+        with:
           call-setup: ${{matrix.docker_image.call-setup}}
           use-venv: ${{matrix.docker_image.use-venv}}
       - name: build
@@ -192,7 +188,7 @@ jobs:
           use-venv: ${{matrix.docker_image.use-venv}}
       - name: Run tests
         uses: ./.github/actions/run-tests
-        with: 
+        with:
           use-venv: ${{matrix.docker_image.use-venv}}
           quick: ${{inputs.quick && '1' || '0'}}
           run_valgrind: ${{inputs.run_valgrind && '1' || '0'}}
@@ -200,7 +196,7 @@ jobs:
       - name: Upload test artifacts
         if: failure()
         uses: ./.github/actions/upload-artifacts
-        with: 
+        with:
           image: ${{ matrix.docker_image.image }}
       - name: Pack module
         if: ${{ !inputs.run_valgrind && !inputs.run_sanitizer }}

--- a/.github/workflows/flow-linux-x86.yml
+++ b/.github/workflows/flow-linux-x86.yml
@@ -170,12 +170,6 @@ jobs:
         shell: bash
         run: |
           ./install_script.sh
-      # - name: Setup Python for testing
-      #   if: ${{matrix.docker_image.image == 'ubuntu:jammy'}}
-      #   uses: actions/setup-python@v5
-      #   with:
-      #     python-version: '3.9'
-      #     architecture: 'x64'
       - name: Install python dependencies
         uses: ./.github/actions/install-python-deps
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ compile_commands.json
 
 .venv
 redis/
+temp-redis-config*

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MK_ALL_TARGETS=bindirs deps build pack
 
 include $(ROOT)/deps/readies/mk/main
 
-#----------------------------------------------------------------------------------------------  
+#----------------------------------------------------------------------------------------------
 
 export LIBMR_BINDIR=$(ROOT)/bin/$(FULL_VARIANT)/LibMR
 include $(ROOT)/build/LibMR/Makefile.defs
@@ -32,7 +32,7 @@ include $(ROOT)/build/rmutil/Makefile.defs
 export CPU_FEATURES_BINDIR=$(ROOT)/bin/$(FULL_VARIANT.release)/cpu_features
 include $(ROOT)/build/cpu_features/Makefile.defs
 
-#----------------------------------------------------------------------------------------------  
+#----------------------------------------------------------------------------------------------
 
 define HELPTEXT
 make build
@@ -85,7 +85,7 @@ make sanbox        # create container with CLang Sanitizer
 
 endef
 
-#----------------------------------------------------------------------------------------------  
+#----------------------------------------------------------------------------------------------
 
 MK_CUSTOM_CLEAN=1
 
@@ -298,11 +298,14 @@ clean:
 	@echo Cleaning ...
 	$(SHOW)rm -rf compile_commands.json
 ifeq ($(ALL),1)
+	@echo Cleaning ALL...
 	-$(SHOW)rm -rf $(BINROOT) $(LIBEVENT_BINDIR) $(DRAGONBOX_BINDIR) $(FAST_DOUBLE_PARSER_C_BINDIR) $(CPU_FEATURES_BINDIR)
 	$(SHOW)$(MAKE) -C $(ROOT)/build/libevent clean AUTOGEN=1
+	-$(SHOW)$(MAKE) --no-print-directory -C $(ROOT)/tests/unit DEBUG='' clean
 else
 	-$(SHOW)rm -rf $(BINDIR)
 ifeq ($(DEPS),1)
+	@echo Cleaning DEPS...
 	-$(SHOW)$(MAKE) --no-print-directory -C $(ROOT)/build/rmutil clean
 	-$(SHOW)$(MAKE) --no-print-directory -C $(ROOT)/build/hiredis clean
 	-$(SHOW)$(MAKE) --no-print-directory -C $(ROOT)/build/LibMR clean
@@ -310,7 +313,6 @@ ifeq ($(DEPS),1)
 	-$(SHOW)$(MAKE) --no-print-directory -C $(ROOT)/build/libevent DEBUG='' clean
 	-$(SHOW)$(MAKE) --no-print-directory -C $(ROOT)/build/dragonbox DEBUG='' clean
 	-$(SHOW)$(MAKE) --no-print-directory -C $(ROOT)/build/fast_double_parser_c DEBUG='' clean
-	-$(SHOW)$(MAKE) --no-print-directory -C $(ROOT)/tests/unit DEBUG='' clean
 endif
 endif
 
@@ -410,7 +412,7 @@ endif # RLEC
 BENCHMARK_ARGS = redisbench-admin run-local
 
 ifneq ($(REMOTE),)
-	BENCHMARK_ARGS = redisbench-admin run-remote 
+	BENCHMARK_ARGS = redisbench-admin run-remote
 endif
 
 BENCHMARK_ARGS += \

--- a/src/config.c
+++ b/src/config.c
@@ -254,6 +254,8 @@ static int setModernStringConfigValue(const char *name,
             return REDISMODULE_ERR;
         }
 
+        ClearCompactionRules();
+
         TSGlobalConfig.compactionRules = compactionRules;
         TSGlobalConfig.compactionRulesCount = compactionRulesCount;
 

--- a/src/config.c
+++ b/src/config.c
@@ -581,6 +581,7 @@ int ReadDeprecatedLoadTimeConfig(RedisModuleCtx *ctx,
         uint64_t compactionRulesCount = 0;
         if (ParseCompactionPolicy(policy_cstr, &compactionRules, &compactionRulesCount) != TRUE) {
             RedisModule_Log(ctx, "warning", "Unable to parse argument after COMPACTION_POLICY");
+            free(compactionRules);
             return TSDB_ERROR;
         }
 

--- a/src/config.c
+++ b/src/config.c
@@ -212,6 +212,11 @@ static int setModernStringConfigValue(const char *name,
 
         size_t len = 0;
         const char *str = RedisModule_StringPtrLen(value, &len);
+
+        if (!str || len == 0) {
+            return REDISMODULE_OK;
+        }
+
         TSGlobalConfig.password = strndup(str, len);
         return REDISMODULE_OK;
     } else if (!strcasecmp("global-user", name)) {
@@ -222,6 +227,11 @@ static int setModernStringConfigValue(const char *name,
 
         size_t len = 0;
         const char *str = RedisModule_StringPtrLen(value, &len);
+
+        if (!str || len == 0) {
+            return REDISMODULE_OK;
+        }
+
         TSGlobalConfig.username = strndup(str, len);
         return REDISMODULE_OK;
     } else if (!strcasecmp("ts-duplicate-policy", name)) {

--- a/src/config.c
+++ b/src/config.c
@@ -7,15 +7,55 @@
 
 #include "consts.h"
 #include "module.h"
+#include "parse_policies.h"
 #include "query_language.h"
 #include "RedisModulesSDK/redismodule.h"
 
 #include <assert.h>
 #include <string.h>
+#include <float.h>
 #include "rmutil/strings.h"
 #include "rmutil/util.h"
 
+/*
+ * Logs that a deprecated configuration option was used.
+ */
+#define LOG_DEPRECATED_OPTION(deprecatedName, modernName)                                          \
+    RedisModule_Log(rts_staticCtx,                                                                 \
+                    "warning",                                                                     \
+                    "%s is deprecated, please use the '%s' instead",                               \
+                    deprecatedName,                                                                \
+                    modernName);
+
 TSConfig TSGlobalConfig;
+
+void InitConfig() {
+    TSGlobalConfig.options = SERIES_OPT_DEFAULT_COMPRESSION;
+    TSGlobalConfig.password = "";
+    TSGlobalConfig.username = "";
+}
+
+RedisModuleString *GlobalConfigToString(RedisModuleCtx *ctx) {
+    return RedisModule_CreateStringPrintf(
+        ctx,
+        "COMPACTION_POLICY %s\n"
+        "RETENTION_POLICY %lld\n"
+        "CHUNK_SIZE % lld\n"
+        "ENCODING %s\n"
+        "DUPLICATE_POLICY %s\n"
+        "NUM_THREADS %lld\n"
+        "IGNORE_MAX_VAL_DIFF %lf\n"
+        "IGNORE_MAX_TIME_DIFF %lld\n",
+        CompactionRulesToString(TSGlobalConfig.compactionRules,
+                                TSGlobalConfig.compactionRulesCount),
+        TSGlobalConfig.retentionPolicy,
+        TSGlobalConfig.chunkSizeBytes,
+        ChunkTypeToString(TSGlobalConfig.options),
+        DuplicatePolicyToString(TSGlobalConfig.duplicatePolicy),
+        TSGlobalConfig.numThreads,
+        TSGlobalConfig.ignoreMaxValDiff,
+        TSGlobalConfig.ignoreMaxTimeDiff);
+}
 
 int ParseDuplicatePolicy(RedisModuleCtx *ctx,
                          RedisModuleString **argv,
@@ -33,12 +73,540 @@ const char *ChunkTypeToString(int options) {
     return "invalid";
 }
 
-int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-    TSGlobalConfig.hasGlobalConfig = FALSE;
-    TSGlobalConfig.options = SERIES_OPT_DEFAULT_COMPRESSION;
-    TSGlobalConfig.password = NULL;
+static RedisModuleString *getModernStringConfigValue(const char *name, void *privdata) {
+    if (!strcasecmp("ts-compaction-policy", name)) {
+        char *rulesAsString = CompactionRulesToString(TSGlobalConfig.compactionRules,
+                                                      TSGlobalConfig.compactionRulesCount);
+        RedisModuleString *out =
+            RedisModule_CreateString(rts_staticCtx, rulesAsString, strlen(rulesAsString));
+        free(rulesAsString);
+
+        return out;
+    } else if (!strcasecmp("global-password", name)) {
+        return RedisModule_CreateString(
+            rts_staticCtx, TSGlobalConfig.password, strlen(TSGlobalConfig.password));
+    } else if (!strcasecmp("global-user", name)) {
+        return RedisModule_CreateString(
+            rts_staticCtx, TSGlobalConfig.username, strlen(TSGlobalConfig.username));
+    } else if (!strcasecmp("ts-duplicate-policy", name)) {
+        const char *value = DuplicatePolicyToString(TSGlobalConfig.duplicatePolicy);
+        return RedisModule_CreateString(rts_staticCtx, value, strlen(value));
+    } else if (!strcasecmp("ts-encoding", name)) {
+        const char *value = ChunkTypeToString(TSGlobalConfig.options);
+        return RedisModule_CreateString(rts_staticCtx, value, strlen(value));
+    } else if (!strcasecmp("ts-ignore-max-val-diff", name)) {
+        return RedisModule_CreateStringPrintf(
+            rts_staticCtx, "%lf", TSGlobalConfig.ignoreMaxValDiff);
+    }
+
+    return NULL;
+}
+
+static RedisModuleString *getDeprecatedStringConfigValue(const char *deprecatedName,
+                                                         void *modernName) {
+    const char *modernNameStr = (const char *)modernName;
+
+    LOG_DEPRECATED_OPTION(deprecatedName, modernNameStr);
+
+    return getModernStringConfigValue(modernNameStr, NULL);
+}
+
+/*
+ * Parses a string value and validate it is a valid double in the range
+ * [min, max].
+ *
+ * If the value is invalid, set `err` to an error message.
+ * Otherwise, set `value` to the parsed value and return it without
+ * setting the error string.
+ *
+ * The success of the operation can be determined by checking if `err`
+ * is NULL.
+ */
+static double stringToDouble(const char *name,
+                             RedisModuleString *string,
+                             const double min,
+                             const double max,
+                             RedisModuleString **err) {
+    double value = 0.0;
+    long long longValue = 0;
+
+    if (RedisModule_StringToLongLong(string, &longValue) == REDISMODULE_OK) {
+        value = (double)longValue;
+    } else if (RedisModule_StringToDouble(string, &value) != REDISMODULE_OK) {
+        *err = RedisModule_CreateStringPrintf(rts_staticCtx, "Invalid value for `%s`", name);
+    }
+
+    if (value < min || value > max) {
+        *err = RedisModule_CreateStringPrintf(
+            rts_staticCtx,
+            "Invalid value for `%s`. Value must be in the range [%f .. %f]",
+            name,
+            min,
+            max);
+    }
+
+    return value;
+}
+
+static int setModernStringConfigValue(const char *name,
+                                      RedisModuleString *value,
+                                      void *data,
+                                      RedisModuleString **err) {
+    if (!strcasecmp("ts-compaction-policy", name)) {
+        // TODO: deallocate old compaction rules?
+        size_t len;
+        const char *policy_cstr = RedisModule_StringPtrLen(value, &len);
+
+        if (len == 0) {
+            TSGlobalConfig.compactionRules = NULL;
+            TSGlobalConfig.compactionRulesCount = 0;
+
+            return REDISMODULE_OK;
+        }
+
+        if (ParseCompactionPolicy(policy_cstr,
+                                  &TSGlobalConfig.compactionRules,
+                                  &TSGlobalConfig.compactionRulesCount) != TRUE) {
+            *err =
+                RedisModule_CreateStringPrintf(NULL, "Invalid compaction policy: %s", policy_cstr);
+            return REDISMODULE_ERR;
+        }
+
+        return REDISMODULE_OK;
+    } else if (!strcasecmp("ts-duplicate-policy", name)) {
+        const DuplicatePolicy newValue = RMStringLenDuplicationPolicyToEnum(value);
+
+        if (newValue == DP_INVALID) {
+            *err = RedisModule_CreateStringPrintf(
+                NULL, "Invalid duplicate policy: %s", RedisModule_StringPtrLen(value, NULL));
+            return REDISMODULE_ERR;
+        }
+
+        TSGlobalConfig.duplicatePolicy = newValue;
+        return REDISMODULE_OK;
+    } else if (!strcasecmp("ts-ignore-max-val-diff", name)) {
+        const double newValue = stringToDouble(
+            "ts-ignore-max-val-diff", value, IGNORE_MAX_VAL_DIFF_MIN, IGNORE_MAX_VAL_DIFF_MAX, err);
+
+        if (err && *err) {
+            return REDISMODULE_ERR;
+        }
+
+        TSGlobalConfig.ignoreMaxValDiff = newValue;
+        return REDISMODULE_OK;
+    } else if (!strcasecmp("global-password", name)) {
+        size_t len = 0;
+        const char *str = RedisModule_StringPtrLen(value, &len);
+        TSGlobalConfig.password = (char *)str;
+        // TSGlobalConfig.password = strndup(str, len);
+        return REDISMODULE_OK;
+    } else if (!strcasecmp("global-user", name)) {
+        size_t len = 0;
+        const char *str = RedisModule_StringPtrLen(value, &len);
+        // TSGlobalConfig.username = strndup(str, len);
+        TSGlobalConfig.username = (char *)str;
+        return REDISMODULE_OK;
+    } else if (!strcasecmp("ts-duplicate-policy", name)) {
+        const DuplicatePolicy newValue = RMStringLenDuplicationPolicyToEnum(value);
+
+        if (newValue == DP_INVALID) {
+            *err = RedisModule_CreateStringPrintf(
+                NULL, "Invalid duplicate policy: %s", RedisModule_StringPtrLen(value, NULL));
+            return REDISMODULE_ERR;
+        }
+
+        TSGlobalConfig.duplicatePolicy = newValue;
+        return REDISMODULE_OK;
+    } else if (!strcasecmp("ts-encoding", name)) {
+        size_t len;
+        const char *encoding = RedisModule_StringPtrLen(value, &len);
+        if (!strcasecmp(encoding, UNCOMPRESSED_ARG_STR)) {
+            TSGlobalConfig.options &= ~SERIES_OPT_DEFAULT_COMPRESSION;
+            TSGlobalConfig.options |= SERIES_OPT_UNCOMPRESSED;
+        } else if (!strcasecmp(encoding, COMPRESSED_GORILLA_ARG_STR)) {
+            TSGlobalConfig.options &= ~SERIES_OPT_DEFAULT_COMPRESSION;
+            TSGlobalConfig.options |= SERIES_OPT_COMPRESSED_GORILLA;
+        } else {
+            *err = RedisModule_CreateStringPrintf(NULL, "Invalid encoding: %s", encoding);
+            return REDISMODULE_ERR;
+        }
+
+        return REDISMODULE_OK;
+    }
+
+    return REDISMODULE_ERR;
+}
+
+static int setDeprecatedStringConfigValue(const char *deprecatedName,
+                                          RedisModuleString *value,
+                                          void *data,
+                                          RedisModuleString **err) {
+    const char *modernNameStr = (const char *)data;
+
+    LOG_DEPRECATED_OPTION(deprecatedName, modernNameStr);
+
+    return setModernStringConfigValue(modernNameStr, value, NULL, err);
+}
+
+static long long getModernIntegerConfigValue(const char *name, void *privdata) {
+    if (!strcasecmp("ts-num-threads", name)) {
+        return TSGlobalConfig.numThreads;
+    } else if (!strcasecmp("ts-retention-policy", name)) {
+        return TSGlobalConfig.retentionPolicy;
+    } else if (!strcasecmp("ts-chunk-size-bytes", name)) {
+        return TSGlobalConfig.chunkSizeBytes;
+    } else if (!strcasecmp("ts-ignore-max-time-diff", name)) {
+        return TSGlobalConfig.ignoreMaxTimeDiff;
+    }
+
+    return 0;
+}
+
+static long long getDeprecatedIntegerConfigValue(const char *deprecatedName, void *privdata) {
+    const char *modernNameStr = (const char *)privdata;
+
+    LOG_DEPRECATED_OPTION(deprecatedName, modernNameStr);
+
+    return getModernIntegerConfigValue(modernNameStr, NULL);
+}
+
+static int setModernIntegerConfigValue(const char *name,
+                                       long long value,
+                                       void *data,
+                                       RedisModuleString **err) {
+    if (!strcasecmp("ts-num-threads", name)) {
+        TSGlobalConfig.numThreads = value;
+
+        return REDISMODULE_OK;
+    } else if (!strcasecmp("ts-retention-policy", name)) {
+        TSGlobalConfig.retentionPolicy = value;
+
+        return REDISMODULE_OK;
+    } else if (!strcasecmp("ts-chunk-size-bytes", name)) {
+        if (!ValidateChunkSize(NULL, value, err)) {
+            return REDISMODULE_ERR;
+        }
+
+        TSGlobalConfig.chunkSizeBytes = value;
+
+        return REDISMODULE_OK;
+    } else if (!strcasecmp("ts-ignore-max-time-diff", name)) {
+        if (value < 0) {
+            *err = RedisModule_CreateStringPrintf(
+                NULL, "Invalid value for `ts-ignore-max-time-diff`. Value must be non-negative");
+            return REDISMODULE_ERR;
+        }
+
+        TSGlobalConfig.ignoreMaxTimeDiff = value;
+
+        return REDISMODULE_OK;
+    }
+
+    return REDISMODULE_ERR;
+}
+
+static int setDeprecatedIntegerConfigValue(const char *deprecatedName,
+                                           long long value,
+                                           void *data,
+                                           RedisModuleString **err) {
+    const char *modernNameStr = (const char *)data;
+
+    LOG_DEPRECATED_OPTION(deprecatedName, modernNameStr);
+
+    return setModernIntegerConfigValue(modernNameStr, value, NULL, err);
+}
+
+// Registers the options deprecated in 8.0.
+bool RegisterDeprecatedConfigurationOptions(RedisModuleCtx *ctx) {
+    if (RedisModule_RegisterStringConfig(ctx,
+                                         "OSS_GLOBAL_PASSWORD",
+                                         "",
+                                         REDISMODULE_CONFIG_IMMUTABLE |
+                                             REDISMODULE_CONFIG_SENSITIVE,
+                                         getDeprecatedStringConfigValue,
+                                         setDeprecatedStringConfigValue,
+                                         NULL,
+                                         "global-password")) {
+        return false;
+    }
+
+    if (RedisModule_RegisterStringConfig(ctx,
+                                         "COMPACTION_POLICY",
+                                         "",
+                                         REDISMODULE_CONFIG_DEFAULT,
+                                         getDeprecatedStringConfigValue,
+                                         setDeprecatedStringConfigValue,
+                                         NULL,
+                                         "ts-compaction-policy")) {
+        return false;
+    }
+
+    if (RedisModule_RegisterNumericConfig(ctx,
+                                          "NUM_THREADS",
+                                          DEFAULT_NUM_THREADS,
+                                          REDISMODULE_CONFIG_IMMUTABLE,
+                                          NUM_THREADS_MIN,
+                                          NUM_THREADS_MAX,
+                                          getDeprecatedIntegerConfigValue,
+                                          setDeprecatedIntegerConfigValue,
+                                          NULL,
+                                          "ts-num-threads")) {
+        return false;
+    }
+
+    if (RedisModule_RegisterNumericConfig(ctx,
+                                          "RETENTION_POLICY",
+                                          RETENTION_TIME_DEFAULT,
+                                          REDISMODULE_CONFIG_DEFAULT,
+                                          RETENTION_POLICY_MIN,
+                                          RETENTION_POLICY_MAX,
+                                          getDeprecatedIntegerConfigValue,
+                                          setDeprecatedIntegerConfigValue,
+                                          NULL,
+                                          "ts-retention-policy")) {
+        return false;
+    }
+
+    if (RedisModule_RegisterStringConfig(ctx,
+                                         "DUPLICATE_POLICY",
+                                         DEFAULT_DUPLICATE_POLICY_STRING,
+                                         REDISMODULE_CONFIG_DEFAULT,
+                                         getDeprecatedStringConfigValue,
+                                         setDeprecatedStringConfigValue,
+                                         NULL,
+                                         "ts-duplicate-policy")) {
+        return false;
+    }
+
+    if (RedisModule_RegisterNumericConfig(ctx,
+                                          "CHUNK_SIZE_BYTES",
+                                          Chunk_SIZE_BYTES_SECS,
+                                          REDISMODULE_CONFIG_DEFAULT,
+                                          CHUNK_SIZE_BYTES_MIN,
+                                          CHUNK_SIZE_BYTES_MAX,
+                                          getDeprecatedIntegerConfigValue,
+                                          setDeprecatedIntegerConfigValue,
+                                          NULL,
+                                          "ts-chunk-size-bytes")) {
+        return false;
+    }
+
+    if (RedisModule_RegisterStringConfig(ctx,
+                                         "ENCODING",
+                                         DEFAULT_ENCODING_STRING,
+                                         REDISMODULE_CONFIG_DEFAULT,
+                                         getDeprecatedStringConfigValue,
+                                         setDeprecatedStringConfigValue,
+                                         NULL,
+                                         "ts-encoding")) {
+        return false;
+    }
+
+    if (RedisModule_RegisterNumericConfig(ctx,
+                                          "IGNORE_MAX_TIME_DIFF",
+                                          IGNORE_MAX_TIME_DIFF_DEFAULT,
+                                          REDISMODULE_CONFIG_DEFAULT,
+                                          IGNORE_MAX_TIME_DIFF_MIN,
+                                          IGNORE_MAX_TIME_DIFF_MAX,
+                                          getDeprecatedIntegerConfigValue,
+                                          setDeprecatedIntegerConfigValue,
+                                          NULL,
+                                          "ts-ignore-max-time-diff")) {
+        return false;
+    }
+
+    if (RedisModule_RegisterStringConfig(ctx,
+                                         "IGNORE_MAX_VAL_DIFF",
+                                         "0.0",
+                                         REDISMODULE_CONFIG_DEFAULT,
+                                         getDeprecatedStringConfigValue,
+                                         setDeprecatedStringConfigValue,
+                                         NULL,
+                                         "ts-ignore-max-val-diff")) {
+        return false;
+    }
+
+    RedisModule_Log(ctx, "debug", "Registered deprecated configuration options");
+
+    return true;
+}
+
+bool RegisterModernConfigurationOptions(RedisModuleCtx *ctx) {
+    {
+        char *oldValue = CompactionRulesToString(TSGlobalConfig.compactionRules,
+                                                 TSGlobalConfig.compactionRulesCount);
+        bool wasNull = false;
+        if (!oldValue) {
+            oldValue = strdup("");
+            wasNull = true;
+        }
+
+        if (RedisModule_RegisterStringConfig(ctx,
+                                             "ts-compaction-policy",
+                                             oldValue,
+                                             REDISMODULE_CONFIG_DEFAULT,
+                                             getModernStringConfigValue,
+                                             setModernStringConfigValue,
+                                             NULL,
+                                             NULL)) {
+            if (!wasNull) {
+                free(oldValue);
+            }
+
+            return false;
+        }
+
+        if (!wasNull) {
+            free(oldValue);
+        }
+    }
+
+    {
+        char *oldValue = TSGlobalConfig.password;
+        if (!oldValue) {
+            oldValue = "";
+        }
+
+        if (RedisModule_RegisterStringConfig(ctx,
+                                             "global-password",
+                                             oldValue,
+                                             REDISMODULE_CONFIG_DEFAULT |
+                                                 REDISMODULE_CONFIG_SENSITIVE,
+                                             getModernStringConfigValue,
+                                             setModernStringConfigValue,
+                                             NULL,
+                                             NULL)) {
+            return false;
+        }
+    }
+
+    {
+        char *oldValue = TSGlobalConfig.username;
+        if (!oldValue) {
+            oldValue = "";
+        }
+
+        if (RedisModule_RegisterStringConfig(ctx,
+                                             "global-user",
+                                             oldValue,
+                                             REDISMODULE_CONFIG_DEFAULT |
+                                                 REDISMODULE_CONFIG_SENSITIVE,
+                                             getModernStringConfigValue,
+                                             setModernStringConfigValue,
+                                             NULL,
+                                             NULL)) {
+            return false;
+        }
+    }
+
+    if (RedisModule_RegisterNumericConfig(ctx,
+                                          "ts-num-threads",
+                                          TSGlobalConfig.numThreads,
+                                          REDISMODULE_CONFIG_IMMUTABLE,
+                                          NUM_THREADS_MIN,
+                                          NUM_THREADS_MAX,
+                                          getModernIntegerConfigValue,
+                                          setModernIntegerConfigValue,
+                                          NULL,
+                                          NULL)) {
+        return false;
+    }
+
+    if (RedisModule_RegisterNumericConfig(ctx,
+                                          "ts-retention-policy",
+                                          TSGlobalConfig.retentionPolicy,
+                                          REDISMODULE_CONFIG_DEFAULT,
+                                          RETENTION_POLICY_MIN,
+                                          RETENTION_POLICY_MAX,
+                                          getModernIntegerConfigValue,
+                                          setModernIntegerConfigValue,
+                                          NULL,
+                                          NULL)) {
+        return false;
+    }
+
+    if (RedisModule_RegisterStringConfig(ctx,
+                                         "ts-duplicate-policy",
+                                         DuplicatePolicyToString(TSGlobalConfig.duplicatePolicy),
+                                         REDISMODULE_CONFIG_DEFAULT,
+                                         getModernStringConfigValue,
+                                         setModernStringConfigValue,
+                                         NULL,
+                                         NULL)) {
+        return false;
+    }
+
+    if (RedisModule_RegisterNumericConfig(ctx,
+                                          "ts-chunk-size-bytes",
+                                          TSGlobalConfig.chunkSizeBytes,
+                                          REDISMODULE_CONFIG_DEFAULT,
+                                          CHUNK_SIZE_BYTES_MIN,
+                                          CHUNK_SIZE_BYTES_MAX,
+                                          getModernIntegerConfigValue,
+                                          setModernIntegerConfigValue,
+                                          NULL,
+                                          NULL)) {
+        return false;
+    }
+
+    if (RedisModule_RegisterStringConfig(ctx,
+                                         "ts-encoding",
+                                         ChunkTypeToString(TSGlobalConfig.options),
+                                         REDISMODULE_CONFIG_DEFAULT,
+                                         getModernStringConfigValue,
+                                         setModernStringConfigValue,
+                                         NULL,
+                                         NULL)) {
+        return false;
+    }
+
+    if (RedisModule_RegisterNumericConfig(ctx,
+                                          "ts-ignore-max-time-diff",
+                                          TSGlobalConfig.ignoreMaxTimeDiff,
+                                          REDISMODULE_CONFIG_DEFAULT,
+                                          IGNORE_MAX_TIME_DIFF_MIN,
+                                          IGNORE_MAX_TIME_DIFF_MAX,
+                                          getModernIntegerConfigValue,
+                                          setModernIntegerConfigValue,
+                                          NULL,
+                                          NULL)) {
+        return false;
+    }
+
+    {
+        char oldValue[32] = { 0 };
+        snprintf(oldValue, sizeof(oldValue), "%lf", TSGlobalConfig.ignoreMaxValDiff);
+
+        if (RedisModule_RegisterStringConfig(ctx,
+                                             "ts-ignore-max-val-diff",
+                                             oldValue,
+                                             REDISMODULE_CONFIG_DEFAULT,
+                                             getModernStringConfigValue,
+                                             setModernStringConfigValue,
+                                             NULL,
+                                             NULL)) {
+            return false;
+        }
+    }
+
+    RedisModule_Log(ctx, "debug", "Registered modern configuration options");
+
+    return true;
+}
+
+bool RegisterConfigurationOptions(RedisModuleCtx *ctx) {
+    // return RegisterDeprecatedConfigurationOptions(ctx) &&
+    // RegisterModernConfigurationOptions(ctx);
+    return RegisterModernConfigurationOptions(ctx);
+    // return RegisterDeprecatedConfigurationOptions(ctx);
+}
+
+int ReadDeprecatedLoadTimeConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    bool isDeprecated = false;
 
     if (argc > 1 && RMUtil_ArgIndex("COMPACTION_POLICY", argv, argc) >= 0) {
+        LOG_DEPRECATED_OPTION("COMPACTION_POLICY", "ts-compaction-policy");
+
         RedisModuleString *policy;
         const char *policy_cstr;
         size_t len;
@@ -57,10 +625,12 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         }
 
         RedisModule_Log(ctx, "notice", "loaded default compaction policy: %s", policy_cstr);
-        TSGlobalConfig.hasGlobalConfig = TRUE;
+        isDeprecated = true;
     }
 
     if (argc > 1 && RMUtil_ArgIndex("OSS_GLOBAL_PASSWORD", argv, argc) >= 0) {
+        LOG_DEPRECATED_OPTION("OSS_GLOBAL_PASSWORD", "global-password");
+
         RedisModuleString *password;
         size_t len;
         if (RMUtil_ParseArgsAfter("OSS_GLOBAL_PASSWORD", argv, argc, "s", &password) !=
@@ -71,11 +641,7 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
         TSGlobalConfig.password = (char *)RedisModule_StringPtrLen(password, &len);
         RedisModule_Log(ctx, "notice", "loaded tls password");
-        RedisModule_Log(ctx,
-                        "warning",
-                        "The 'OSS_GLOBAL_PASSWORD' configuration is deprecated. "
-                        "Please use 'global-password' instead.");
-        TSGlobalConfig.hasGlobalConfig = TRUE;
+        isDeprecated = true;
     }
 
     if (argc > 1 && RMUtil_ArgIndex("global-password", argv, argc) >= 0) {
@@ -89,7 +655,7 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
         TSGlobalConfig.password = (char *)RedisModule_StringPtrLen(password, &len);
         RedisModule_Log(ctx, "notice", "loaded global-password");
-        TSGlobalConfig.hasGlobalConfig = TRUE;
+        isDeprecated = true;
     }
 
     if (argc > 1 && RMUtil_ArgIndex("global-user", argv, argc) >= 0) {
@@ -102,12 +668,12 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
         TSGlobalConfig.username = (char *)RedisModule_StringPtrLen(username, &len);
         RedisModule_Log(ctx, "notice", "loaded global-user");
-        TSGlobalConfig.hasGlobalConfig = TRUE;
-    } else {
-        TSGlobalConfig.username = "default";
+        isDeprecated = true;
     }
 
     if (argc > 1 && RMUtil_ArgIndex("RETENTION_POLICY", argv, argc) >= 0) {
+        LOG_DEPRECATED_OPTION("RETENTION_POLICY", "ts-retention-policy");
+
         if (RMUtil_ParseArgsAfter(
                 "RETENTION_POLICY", argv, argc, "l", &TSGlobalConfig.retentionPolicy) !=
             REDISMODULE_OK) {
@@ -117,12 +683,10 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
         RedisModule_Log(
             ctx, "notice", "loaded default retention policy: %lld", TSGlobalConfig.retentionPolicy);
-        TSGlobalConfig.hasGlobalConfig = TRUE;
-    } else {
-        TSGlobalConfig.retentionPolicy = RETENTION_TIME_DEFAULT;
+        isDeprecated = true;
     }
 
-    if (!ValidateChunkSize(ctx, Chunk_SIZE_BYTES_SECS)) {
+    if (!ValidateChunkSize(ctx, Chunk_SIZE_BYTES_SECS, NULL)) {
         return TSDB_ERROR;
     }
     TSGlobalConfig.chunkSizeBytes = Chunk_SIZE_BYTES_SECS;
@@ -149,12 +713,14 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     if (argc > 1 && (RMUtil_ArgIndex("ENCODING", argv, argc) >= 0 ||
                      RMUtil_ArgIndex("CHUNK_TYPE", argv, argc) >= 0)) {
+        isDeprecated = true;
+
         if (RMUtil_ArgIndex("CHUNK_TYPE", argv, argc) >= 0) {
-            RedisModule_Log(
-                ctx,
-                "warning",
-                "CHUNK_TYPE configuration was deprecated and will be removed in future "
-                "versions of RedisTimeSeries. Please use ENCODING configuration instead.");
+            RedisModule_Log(ctx,
+                            "warning",
+                            "CHUNK_TYPE and ENCODING configuration options were deprecated "
+                            "and will be removed in future versions of RedisTimeSeries. "
+                            "Please use the 'ts-encoding' configuration instead.");
         }
         RedisModuleString *chunk_type;
         size_t len;
@@ -189,8 +755,10 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             RedisModule_Log(ctx, "warning", "Unable to parse argument after COMPACTION_POLICY");
             return TSDB_ERROR;
         }
+        LOG_DEPRECATED_OPTION("NUM_THREADS", "ts-num-threads");
+        isDeprecated = true;
     } else {
-        TSGlobalConfig.numThreads = 3;
+        TSGlobalConfig.numThreads = DEFAULT_NUM_THREADS;
     }
     TSGlobalConfig.forceSaveCrossRef = false;
     if (argc > 1 && RMUtil_ArgIndex("DEUBG_FORCE_RULE_DUMP", argv, argc) >= 0) {
@@ -208,8 +776,10 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         } else if (!strcasecmp(forceSaveCrossRef_cstr, "disable")) {
             TSGlobalConfig.forceSaveCrossRef = false;
         }
+
+        isDeprecated = true;
     }
-    TSGlobalConfig.dontAssertOnFailiure = false;
+    TSGlobalConfig.dontAssertOnFailure = false;
     if (argc > 1 && RMUtil_ArgIndex("DONT_ASSERT_ON_FAILIURE", argv, argc) >= 0) {
         RedisModuleString *dontAssertOnFailiure;
         if (RMUtil_ParseArgsAfter(
@@ -223,13 +793,15 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         const char *dontAssertOnFailiure_cstr =
             RedisModule_StringPtrLen(dontAssertOnFailiure, &dontAssertOnFailiure_len);
         if (!strcasecmp(dontAssertOnFailiure_cstr, "enable")) {
-            TSGlobalConfig.dontAssertOnFailiure = true;
+            TSGlobalConfig.dontAssertOnFailure = true;
         } else if (!strcasecmp(dontAssertOnFailiure_cstr, "disable")) {
-            TSGlobalConfig.dontAssertOnFailiure = false;
+            TSGlobalConfig.dontAssertOnFailure = false;
         }
 
         extern bool _dontAssertOnFailiure;
-        _dontAssertOnFailiure = TSGlobalConfig.dontAssertOnFailiure;
+        _dontAssertOnFailiure = TSGlobalConfig.dontAssertOnFailure;
+
+        isDeprecated = true;
     }
 
     TSGlobalConfig.ignoreMaxTimeDiff = 0;
@@ -245,6 +817,8 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             return TSDB_ERROR;
         }
         TSGlobalConfig.ignoreMaxTimeDiff = ignoreMaxTimeDiff;
+        LOG_DEPRECATED_OPTION("IGNORE_MAX_TIME_DIFF", "ts-ignore-max-time-diff");
+        isDeprecated = true;
     }
     RedisModule_Log(ctx,
                     "notice",
@@ -264,6 +838,9 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             return TSDB_ERROR;
         }
         TSGlobalConfig.ignoreMaxValDiff = ignoreMaxValDiff;
+
+        LOG_DEPRECATED_OPTION("IGNORE_MAX_VAL_DIFF", "ts-ignore-max-val-diff");
+        isDeprecated = true;
     }
     RedisModule_Log(
         ctx, "notice", "loaded default IGNORE_MAX_VAL_DIFF: %f", TSGlobalConfig.ignoreMaxValDiff);
@@ -272,6 +849,14 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                     "notice",
                     "Setting default series ENCODING to: %s",
                     ChunkTypeToString(TSGlobalConfig.options));
+
+    if (isDeprecated) {
+        RedisModule_Log(ctx,
+                        "warning",
+                        "Deprecated load-time configuration options were used. These will be "
+                        "removed in future versions of RedisTimeSeries.");
+    }
+
     return TSDB_OK;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -463,10 +463,10 @@ bool RegisterModernConfigurationOptions(RedisModuleCtx *ctx) {
     {
         char *oldValue = CompactionRulesToString(TSGlobalConfig.compactionRules,
                                                  TSGlobalConfig.compactionRulesCount);
-        bool wasNull = false;
+        bool shouldFree = false;
         if (!oldValue) {
             oldValue = strdup("");
-            wasNull = true;
+            shouldFree = true;
         }
 
         if (RedisModule_RegisterStringConfig(ctx,
@@ -477,14 +477,14 @@ bool RegisterModernConfigurationOptions(RedisModuleCtx *ctx) {
                                              setModernStringConfigValue,
                                              NULL,
                                              NULL)) {
-            if (!wasNull) {
+            if (shouldFree) {
                 free(oldValue);
             }
 
             return false;
         }
 
-        if (!wasNull) {
+        if (shouldFree) {
             free(oldValue);
         }
     }

--- a/src/config.c
+++ b/src/config.c
@@ -314,10 +314,8 @@ bool RegisterModernConfigurationOptions(RedisModuleCtx *ctx) {
     {
         char *oldValue = CompactionRulesToString(TSGlobalConfig.compactionRules,
                                                  TSGlobalConfig.compactionRulesCount);
-        bool shouldFree = false;
         if (!oldValue) {
             oldValue = strdup("");
-            shouldFree = true;
         }
 
         if (RedisModule_RegisterStringConfig(ctx,
@@ -328,16 +326,12 @@ bool RegisterModernConfigurationOptions(RedisModuleCtx *ctx) {
                                              setModernStringConfigValue,
                                              NULL,
                                              NULL)) {
-            if (shouldFree) {
-                free(oldValue);
-            }
+            free(oldValue);
 
             return false;
         }
 
-        if (shouldFree) {
-            free(oldValue);
-        }
+        free(oldValue);
     }
 
     {

--- a/src/config.c
+++ b/src/config.c
@@ -354,15 +354,9 @@ bool RegisterModernConfigurationOptions(RedisModuleCtx *ctx) {
             oldValue = "";
         }
 
-        RedisModule_Log(ctx,
-                        "warning",
-                        "Registering global password configuration option: \"%s\" - %s",
-                        oldValue,
-                        oldValue ? "is not null" : "is null");
-
         if (RedisModule_RegisterStringConfig(ctx,
                                              "ts-global-password",
-                                             "",
+                                             oldValue,
                                              REDISMODULE_CONFIG_DEFAULT |
                                                  REDISMODULE_CONFIG_SENSITIVE |
                                                  REDISMODULE_CONFIG_UNPREFIXED,

--- a/src/config.c
+++ b/src/config.c
@@ -39,6 +39,7 @@ void InitConfig(void) {
     TSGlobalConfig.password = NULL;
     TSGlobalConfig.username = NULL;
     TSGlobalConfig.compactionRulesStringToJustReturnInTheGetter = NULL;
+    TSGlobalConfig.ignoreMaxValDiffStringToJustReturnInTheGetter = NULL;
 }
 
 static inline void ClearCompactionRules() {
@@ -64,6 +65,12 @@ void FreeConfig(void) {
         RedisModule_FreeString(rts_staticCtx,
                                TSGlobalConfig.compactionRulesStringToJustReturnInTheGetter);
         TSGlobalConfig.compactionRulesStringToJustReturnInTheGetter = NULL;
+    }
+
+    if (TSGlobalConfig.ignoreMaxValDiffStringToJustReturnInTheGetter) {
+        RedisModule_FreeString(rts_staticCtx,
+                               TSGlobalConfig.ignoreMaxValDiffStringToJustReturnInTheGetter);
+        TSGlobalConfig.ignoreMaxValDiffStringToJustReturnInTheGetter = NULL;
     }
 
     ClearCompactionRules();
@@ -147,8 +154,15 @@ static RedisModuleString *getModernStringConfigValue(const char *name, void *pri
             return RedisModule_CreateString(rts_staticCtx, value, strlen(value));
         }
     } else if (!strcasecmp("ts-ignore-max-val-diff", name)) {
-        return RedisModule_CreateStringPrintf(
-            rts_staticCtx, "%lf", TSGlobalConfig.ignoreMaxValDiff);
+        if (TSGlobalConfig.ignoreMaxValDiffStringToJustReturnInTheGetter) {
+            RedisModule_FreeString(rts_staticCtx,
+                                   TSGlobalConfig.ignoreMaxValDiffStringToJustReturnInTheGetter);
+        }
+
+        TSGlobalConfig.ignoreMaxValDiffStringToJustReturnInTheGetter =
+            RedisModule_CreateStringPrintf(rts_staticCtx, "%lf", TSGlobalConfig.ignoreMaxValDiff);
+
+        return TSGlobalConfig.ignoreMaxValDiffStringToJustReturnInTheGetter;
     }
 
     return NULL;

--- a/src/config.h
+++ b/src/config.h
@@ -43,6 +43,7 @@ typedef struct
     bool dontAssertOnFailure;    // Internal debug configuration param
     long long ignoreMaxTimeDiff; // Insert filter max time diff with the last sample
     double ignoreMaxValDiff;     // Insert filter max value diff with the last sample
+    RedisModuleString *ignoreMaxValDiffStringToJustReturnInTheGetter;
 } TSConfig;
 
 extern TSConfig TSGlobalConfig;

--- a/src/config.h
+++ b/src/config.h
@@ -49,7 +49,10 @@ extern TSConfig TSGlobalConfig;
 void InitConfig();
 RedisModuleString *GlobalConfigToString(RedisModuleCtx *ctx);
 bool RegisterConfigurationOptions(RedisModuleCtx *ctx);
-int ReadDeprecatedLoadTimeConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+int ReadDeprecatedLoadTimeConfig(RedisModuleCtx *ctx,
+                                 RedisModuleString **argv,
+                                 int argc,
+                                 const bool showDeprecationWarning);
 const char *ChunkTypeToString(int options);
 typedef struct RTS_RedisVersion
 {
@@ -66,10 +69,21 @@ extern int RTS_RlecMinorVersion;
 extern int RTS_RlecPatchVersion;
 extern int RTS_RlecBuild;
 
-static inline int RTS_IsEnterprise() {
+static inline int RTS_IsEnterprise(void) {
     return RTS_RlecMajorVersion != -1;
 }
 
-int RTS_CheckSupportedVestion();
-void RTS_GetRedisVersion();
+/*
+ * Returns true if the current version of Redis supports the module
+ * configuration API.
+ */
+static inline bool RTS_RedisSupportsModuleConfigApi(void) {
+    return RTS_currVersion.redisMajorVersion >= 7 && RedisModule_RegisterEnumConfig &&
+           RedisModule_RegisterBoolConfig && RedisModule_RegisterStringConfig &&
+           RedisModule_RegisterNumericConfig && RedisModule_LoadConfigs;
+}
+
+int RTS_CheckSupportedVestion(void);
+void RTS_GetRedisVersion(void);
+
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -31,7 +31,6 @@ typedef struct
 {
     SimpleCompactionRule *compactionRules;
     uint64_t compactionRulesCount;
-    RedisModuleString *compactionRulesStringToJustReturnInTheGetter;
     long long retentionPolicy;
     long long chunkSizeBytes;
     short options;
@@ -43,7 +42,6 @@ typedef struct
     bool dontAssertOnFailure;    // Internal debug configuration param
     long long ignoreMaxTimeDiff; // Insert filter max time diff with the last sample
     double ignoreMaxValDiff;     // Insert filter max value diff with the last sample
-    RedisModuleString *ignoreMaxValDiffStringToJustReturnInTheGetter;
 } TSConfig;
 
 extern TSConfig TSGlobalConfig;

--- a/src/config.h
+++ b/src/config.h
@@ -11,6 +11,22 @@
 
 #include <stdbool.h>
 
+#define DEFAULT_NUM_THREADS 3
+#define NUM_THREADS_MIN 1
+#define NUM_THREADS_MAX 16
+#define RETENTION_POLICY_MIN 0
+#define RETENTION_POLICY_MAX LLONG_MAX
+#define CHUNK_SIZE_BYTES_MIN 48
+#define CHUNK_SIZE_BYTES_MAX 1048576
+#define IGNORE_MAX_TIME_DIFF_DEFAULT 0
+#define IGNORE_MAX_TIME_DIFF_MIN 0
+#define IGNORE_MAX_TIME_DIFF_MAX LLONG_MAX
+#define IGNORE_MAX_VAL_DIFF_DEFAULT 0.0
+#define IGNORE_MAX_VAL_DIFF_MIN 0.0
+#define IGNORE_MAX_VAL_DIFF_MAX DBL_MAX
+#define DEFAULT_ENCODING_STRING COMPRESSED_GORILLA_ARG_STR
+#define DEFAULT_DUPLICATE_POLICY_STRING "block"
+
 typedef struct
 {
     SimpleCompactionRule *compactionRules;
@@ -18,20 +34,22 @@ typedef struct
     long long retentionPolicy;
     long long chunkSizeBytes;
     short options;
-    int hasGlobalConfig;
     DuplicatePolicy duplicatePolicy;
     long long numThreads;        // number of threads used by libMR
     bool forceSaveCrossRef;      // Internal debug configuration param
     char *username;              // tls username which used by libmr
     char *password;              // tls password which used by libmr
-    bool dontAssertOnFailiure;   // Internal debug configuration param
+    bool dontAssertOnFailure;    // Internal debug configuration param
     long long ignoreMaxTimeDiff; // Insert filter max time diff with the last sample
     double ignoreMaxValDiff;     // Insert filter max value diff with the last sample
 } TSConfig;
 
 extern TSConfig TSGlobalConfig;
 
-int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+void InitConfig();
+RedisModuleString *GlobalConfigToString(RedisModuleCtx *ctx);
+bool RegisterConfigurationOptions(RedisModuleCtx *ctx);
+int ReadDeprecatedLoadTimeConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 const char *ChunkTypeToString(int options);
 typedef struct RTS_RedisVersion
 {

--- a/src/config.h
+++ b/src/config.h
@@ -31,6 +31,7 @@ typedef struct
 {
     SimpleCompactionRule *compactionRules;
     uint64_t compactionRulesCount;
+    RedisModuleString *compactionRulesStringToJustReturnInTheGetter;
     long long retentionPolicy;
     long long chunkSizeBytes;
     short options;
@@ -46,7 +47,8 @@ typedef struct
 
 extern TSConfig TSGlobalConfig;
 
-void InitConfig();
+void InitConfig(void);
+void FreeConfig(void);
 RedisModuleString *GlobalConfigToString(RedisModuleCtx *ctx);
 bool RegisterConfigurationOptions(RedisModuleCtx *ctx);
 int ReadDeprecatedLoadTimeConfig(RedisModuleCtx *ctx,

--- a/src/consts.h
+++ b/src/consts.h
@@ -82,6 +82,30 @@ typedef enum DuplicatePolicy
     DP_SUM = 6,
 } DuplicatePolicy;
 
+static inline __attribute__((always_inline)) const char *DuplicatePolicyToString(
+    const DuplicatePolicy policy) {
+    switch (policy) {
+        case DP_NONE:
+            return "none";
+        case DP_BLOCK:
+            return "block";
+        case DP_LAST:
+            return "last";
+        case DP_FIRST:
+            return "first";
+        case DP_MIN:
+            return "min";
+        case DP_MAX:
+            return "max";
+        case DP_SUM:
+            return "sum";
+        case DP_INVALID:
+            return "invalid";
+        default:
+            return "unknown";
+    }
+}
+
 /* Series struct options */
 #define SERIES_OPT_UNCOMPRESSED 0x1
 

--- a/src/generic_chunk.c
+++ b/src/generic_chunk.c
@@ -101,27 +101,6 @@ const ChunkFuncs *GetChunkClass(CHUNK_TYPES_T chunkType) {
     return NULL;
 }
 
-const char *DuplicatePolicyToString(DuplicatePolicy policy) {
-    switch (policy) {
-        case DP_NONE:
-            return "none";
-        case DP_BLOCK:
-            return "block";
-        case DP_LAST:
-            return "last";
-        case DP_FIRST:
-            return "first";
-        case DP_MAX:
-            return "max";
-        case DP_MIN:
-            return "min";
-        case DP_SUM:
-            return "sum";
-        default:
-            return "invalid";
-    }
-}
-
 int RMStringLenDuplicationPolicyToEnum(RedisModuleString *aggTypeStr) {
     size_t str_len;
     const char *aggTypeCStr = RedisModule_StringPtrLen(aggTypeStr, &str_len);

--- a/src/module.c
+++ b/src/module.c
@@ -456,6 +456,7 @@ int TSDB_generic_mrange(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
         ctx, args.queryPredicates->list, args.queryPredicates->count, &hasPermissionError);
 
     if (hasPermissionError) {
+        MRangeArgs_Free(&args);
         RTS_ReplyKeyPermissionsError(ctx);
         return REDISMODULE_ERR;
     }
@@ -1232,6 +1233,8 @@ int TSDB_mget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         ctx, args.queryPredicates->list, args.queryPredicates->count, &hasPermissionError);
 
     if (hasPermissionError) {
+        free(limitLabelsStr);
+        MGetArgs_Free(&args);
         RedisModule_FreeDict(ctx, result);
         RTS_ReplyKeyPermissionsError(ctx);
         return REDISMODULE_ERR;

--- a/src/module.c
+++ b/src/module.c
@@ -725,7 +725,8 @@ static inline int add(RedisModuleCtx *ctx,
         series = RedisModule_ModuleTypeGetValue(key);
         //  overwride key and database configuration for DUPLICATE_POLICY
         if (argv != NULL &&
-            ParseDuplicatePolicy(ctx, argv, argc, TS_ADD_DUPLICATE_POLICY_ARG, &dp) != TSDB_OK) {
+            ParseDuplicatePolicy(ctx, argv, argc, TS_ADD_DUPLICATE_POLICY_ARG, &dp, NULL) !=
+                TSDB_OK) {
             return REDISMODULE_ERR;
         }
     }

--- a/src/module.c
+++ b/src/module.c
@@ -1656,9 +1656,23 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         return REDISMODULE_ERR;
     }
 
-    if (ReadConfig(ctx, argv, argc) == TSDB_ERROR) {
+    InitConfig();
+    if (ReadDeprecatedLoadTimeConfig(ctx, argv, argc) == TSDB_ERROR) {
         RedisModule_Log(
-            ctx, "warning", "Failed to parse RedisTimeSeries configurations. aborting...");
+            ctx,
+            "warning",
+            "Failed to parse RedisTimeSeries configurations using the deprecated way, aborting...");
+        return REDISMODULE_ERR;
+    }
+
+    if (!RegisterConfigurationOptions(ctx)) {
+        RedisModule_Log(
+            ctx, "warning", "Failed to register the RedisTimeSeries configurations. aborting...");
+        return REDISMODULE_ERR;
+    }
+
+    if (RedisModule_LoadConfigs(ctx) != REDISMODULE_OK) {
+        RedisModule_Log(ctx, "warning", "Failed to load the RedisTimeSeries configurations.");
         return REDISMODULE_ERR;
     }
 

--- a/src/parse_policies.c
+++ b/src/parse_policies.c
@@ -14,6 +14,8 @@
 #include "rmutil/util.h"
 #include <rmutil/alloc.h>
 
+#define SINGLE_RULE_ITEM_STRING_LENGTH 32
+
 static const timestamp_t lookup_intervals[] = { ['m'] = 1,
                                                 ['s'] = 1000,
                                                 ['M'] = 1000 * 60,
@@ -169,18 +171,20 @@ char *CompactionRulesToString(const SimpleCompactionRule *compactionRules,
     result[0] = '\0'; // Initialize the string
 
     for (uint64_t i = 0; i < compactionRulesCount; ++i) {
-        static const size_t SINGLE_STRING_LENGTH = 32;
         const SimpleCompactionRule *rule = &compactionRules[i];
 
         // Convert bucket duration and retention size to strings
-        char bucket_duration[SINGLE_STRING_LENGTH];
-        char retention[SINGLE_STRING_LENGTH];
-        char alignment[SINGLE_STRING_LENGTH] = {};
+        char bucket_duration[SINGLE_RULE_ITEM_STRING_LENGTH] = { 0 };
+        char retention[SINGLE_RULE_ITEM_STRING_LENGTH] = { 0 };
+        char alignment[SINGLE_RULE_ITEM_STRING_LENGTH] = { 0 };
 
-        MillisecondsToTimeString(rule->bucketDuration, bucket_duration, SINGLE_STRING_LENGTH);
-        MillisecondsToTimeString(rule->retentionSizeMillisec, retention, SINGLE_STRING_LENGTH);
+        MillisecondsToTimeString(
+            rule->bucketDuration, bucket_duration, SINGLE_RULE_ITEM_STRING_LENGTH);
+        MillisecondsToTimeString(
+            rule->retentionSizeMillisec, retention, SINGLE_RULE_ITEM_STRING_LENGTH);
         if (rule->timestampAlignment > 0) {
-            MillisecondsToTimeString(rule->timestampAlignment, alignment, SINGLE_STRING_LENGTH);
+            MillisecondsToTimeString(
+                rule->timestampAlignment, alignment, SINGLE_RULE_ITEM_STRING_LENGTH);
         }
 
         // Get aggregation type as string

--- a/src/parse_policies.c
+++ b/src/parse_policies.c
@@ -138,3 +138,82 @@ int ParseCompactionPolicy(const char *policy_string,
     }
     return success;
 }
+
+// Helper function to convert milliseconds to a time string
+static inline void MillisecondsToTimeString(uint64_t millis, char *out, const size_t outLength) {
+    if (millis % (1000 * 60 * 60 * 24) == 0) {
+        snprintf(out, outLength, "%" PRIu64 "d", millis / (1000 * 60 * 60 * 24));
+    } else if (millis % (1000 * 60 * 60) == 0) {
+        snprintf(out, outLength, "%" PRIu64 "h", millis / (1000 * 60 * 60));
+    } else if (millis % (1000 * 60) == 0) {
+        snprintf(out, outLength, "%" PRIu64 "M", millis / (1000 * 60));
+    } else if (millis % 1000 == 0) {
+        snprintf(out, outLength, "%" PRIu64 "s", millis / 1000);
+    } else {
+        snprintf(out, outLength, "%" PRIu64 "m", millis);
+    }
+}
+
+char *CompactionRulesToString(const SimpleCompactionRule *compactionRules,
+                              const uint64_t compactionRulesCount) {
+    if (compactionRules == NULL || compactionRulesCount == 0) {
+        return NULL;
+    }
+
+    // Estimate a sufficiently large buffer size
+    size_t buffer_size = 256 * compactionRulesCount;
+    char *result = malloc(buffer_size);
+    if (!result) {
+        return NULL;
+    }
+    result[0] = '\0'; // Initialize the string
+
+    for (uint64_t i = 0; i < compactionRulesCount; ++i) {
+        static const size_t SINGLE_STRING_LENGTH = 32;
+        const SimpleCompactionRule *rule = &compactionRules[i];
+
+        // Convert bucket duration and retention size to strings
+        char bucket_duration[SINGLE_STRING_LENGTH];
+        char retention[SINGLE_STRING_LENGTH];
+        char alignment[SINGLE_STRING_LENGTH] = {};
+
+        MillisecondsToTimeString(rule->bucketDuration, bucket_duration, SINGLE_STRING_LENGTH);
+        MillisecondsToTimeString(rule->retentionSizeMillisec, retention, SINGLE_STRING_LENGTH);
+        if (rule->timestampAlignment > 0) {
+            MillisecondsToTimeString(rule->timestampAlignment, alignment, SINGLE_STRING_LENGTH);
+        }
+
+        // Get aggregation type as string
+        const char *aggTypeStr = AggTypeEnumToStringLowerCase(rule->aggType);
+        if (!aggTypeStr) {
+            free(result);
+            return NULL; // Invalid aggregation type
+        }
+
+        // Append the rule to the result string
+        if (rule->timestampAlignment > 0) {
+            snprintf(result + strlen(result),
+                     buffer_size - strlen(result),
+                     "%s:%s:%s:%s;",
+                     aggTypeStr,
+                     bucket_duration,
+                     retention,
+                     alignment);
+        } else {
+            snprintf(result + strlen(result),
+                     buffer_size - strlen(result),
+                     "%s:%s:%s;",
+                     aggTypeStr,
+                     bucket_duration,
+                     retention);
+        }
+    }
+
+    // Remove the trailing semicolon
+    size_t len = strlen(result);
+    if (len > 0 && result[len - 1] == ';') {
+        result[len - 1] = '\0';
+    }
+
+    return result;
+}

--- a/src/parse_policies.h
+++ b/src/parse_policies.h
@@ -21,4 +21,10 @@ typedef struct SimpleCompactionRule
 int ParseCompactionPolicy(const char *policy_string,
                           SimpleCompactionRule **parsed_rules,
                           uint64_t *count_rules);
+
+/* Converts the compaction rules back to a string. The returned string
+must be deallocated by the user using free(). Note that it might use the
+redis allocator. */
+char *CompactionRulesToString(const SimpleCompactionRule *compactionRules,
+                              uint64_t compactionRulesCount);
 #endif

--- a/src/query_language.c
+++ b/src/query_language.c
@@ -12,8 +12,8 @@
 #include "rmutil/util.h"
 #include "config.h"
 
-#define s(x) _s(x)
-#define _s(x) #x
+#define stringify(x) stringify2(x)
+#define stringify2(x) #x
 
 #define QUERY_TOKEN_SIZE 9
 static const char *QUERY_TOKENS[] = {
@@ -81,13 +81,14 @@ bool ValidateChunkSize(RedisModuleCtx *ctx, long long chunkSizeBytes, RedisModul
     }
 
     if (!err) {
-        RTS_ReplyGeneralError(ctx,
-                              "TSDB: CHUNK_SIZE value must be a multiple of 8 in the range [" s(
-                                  CHUNK_SIZE_BYTES_MIN) " .. " s(CHUNK_SIZE_BYTES_MAX) "]");
+        RTS_ReplyGeneralError(
+            ctx,
+            "TSDB: CHUNK_SIZE value must be a multiple of 8 in the range [" stringify(
+                CHUNK_SIZE_BYTES_MIN) " .. " stringify(CHUNK_SIZE_BYTES_MAX) "]");
     } else {
         const char *errorMessage =
-            "TSDB: CHUNK_SIZE value must be a multiple of 8 in the range [" s(
-                CHUNK_SIZE_BYTES_MIN) " .. " s(CHUNK_SIZE_BYTES_MAX) "]";
+            "TSDB: CHUNK_SIZE value must be a multiple of 8 in the range [" stringify(
+                CHUNK_SIZE_BYTES_MIN) " .. " stringify(CHUNK_SIZE_BYTES_MAX) "]";
         *err = RedisModule_CreateString(NULL, errorMessage, strlen(errorMessage));
     }
 

--- a/src/query_language.c
+++ b/src/query_language.c
@@ -98,8 +98,13 @@ int ParseChunkSize(RedisModuleCtx *ctx,
                    RedisModuleString **argv,
                    int argc,
                    const char *arg_prefix,
-                   long long *chunkSizeBytes) {
+                   long long *chunkSizeBytes,
+                   bool *found) {
     if (RMUtil_ArgIndex(arg_prefix, argv, argc) >= 0) {
+        if (found) {
+            *found = true;
+        }
+
         if (RMUtil_ParseArgsAfter(arg_prefix, argv, argc, "l", chunkSizeBytes) != REDISMODULE_OK) {
             RTS_ReplyGeneralError(ctx, "TSDB: Couldn't parse CHUNK_SIZE");
             return TSDB_ERROR;
@@ -117,9 +122,14 @@ int ParseDuplicatePolicy(RedisModuleCtx *ctx,
                          RedisModuleString **argv,
                          int argc,
                          const char *arg_prefix,
-                         DuplicatePolicy *policy) {
+                         DuplicatePolicy *policy,
+                         bool *found) {
     RedisModuleString *duplicationPolicyInput = NULL;
     if (RMUtil_ArgIndex(arg_prefix, argv, argc) != -1) {
+        if (found) {
+            *found = true;
+        }
+
         if (RMUtil_ParseArgsAfter(arg_prefix, argv, argc, "s", &duplicationPolicyInput) !=
             REDISMODULE_OK) {
             RTS_ReplyGeneralError(ctx, "TSDB: Couldn't parse DUPLICATE_POLICY");
@@ -188,7 +198,7 @@ int parseCreateArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, Cre
         goto err_exit;
     }
 
-    if (ParseChunkSize(ctx, argv, argc, "CHUNK_SIZE", &cCtx->chunkSizeBytes) != TSDB_OK) {
+    if (ParseChunkSize(ctx, argv, argc, "CHUNK_SIZE", &cCtx->chunkSizeBytes, NULL) != TSDB_OK) {
         goto err_exit;
     }
 
@@ -197,7 +207,7 @@ int parseCreateArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, Cre
     }
 
     cCtx->duplicatePolicy = DP_NONE;
-    if (ParseDuplicatePolicy(ctx, argv, argc, DUPLICATE_POLICY_ARG, &cCtx->duplicatePolicy) !=
+    if (ParseDuplicatePolicy(ctx, argv, argc, DUPLICATE_POLICY_ARG, &cCtx->duplicatePolicy, NULL) !=
         TSDB_OK) {
         goto err_exit;
     }

--- a/src/query_language.h
+++ b/src/query_language.h
@@ -117,13 +117,15 @@ int ParseChunkSize(RedisModuleCtx *ctx,
                    RedisModuleString **argv,
                    int argc,
                    const char *arg_prefix,
-                   long long *chunkSizeBytes);
+                   long long *chunkSizeBytes,
+                   bool *found);
 
 int ParseDuplicatePolicy(RedisModuleCtx *ctx,
                          RedisModuleString **argv,
                          int argc,
                          const char *arg_prefix,
-                         DuplicatePolicy *policy);
+                         DuplicatePolicy *policy,
+                         bool *found);
 
 int parseEncodingArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int *options);
 

--- a/src/query_language.h
+++ b/src/query_language.h
@@ -167,7 +167,8 @@ void MRangeArgs_Free(MRangeArgs *args);
 
 int parseMGetCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, MGetArgs *out);
 void MGetArgs_Free(MGetArgs *args);
-bool ValidateChunkSize(RedisModuleCtx *ctx, long long chunkSizeBytes);
+bool ValidateChunkSize(RedisModuleCtx *ctx, long long chunkSizeBytes, RedisModuleString **err);
+bool ValidateChunkSizeSimple(long long chunkSizeBytes);
 int parseLatestArg(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool *latest);
 
 #endif // REDISTIMESERIES_QUERY_LANGUAGE_H

--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -182,6 +182,8 @@ def is_line_in_server_log(env, line):
 # Creates a temporary file with the content provided.
 # Returns the filepath of the created file.
 def create_config_file(content) -> str:
-    with tempfile.NamedTemporaryFile(prefix='temp-redis-config', delete=False, dir=f"{os.getcwd()}/logs/") as f:
+    dir = f"{os.getcwd()}/logs/"
+    os.makedirs(dir, exist_ok=True)
+    with tempfile.NamedTemporaryFile(prefix='temp-redis-config', delete=False, dir=dir) as f:
         f.write(content.encode())
         return f.name

--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -169,6 +169,8 @@ def skip(always=False, on_cluster=False, on_macos=False, asan=False, onVersionLo
 
 def get_server_log_path(env):
     path = env.getConnection().execute_command('CONFIG', 'GET', 'logfile')[1].decode()
+    if os.path.isabs(path):
+        return path
     return os.path.abspath(f"{env.logDir}/{path}")
 
 def is_line_in_server_log(env, line):

--- a/tests/flow/requirements.txt
+++ b/tests/flow/requirements.txt
@@ -1,6 +1,4 @@
-# This commit points to a non-versioned branch "eranhd-pin-poetry-to-use-version-lt-2".
-# This is a temporary solution until the issue with poetry is resolved.
-RLTest @ git+https://github.com/RedisLabsModules/RLTest@bdc620e28d3e17c395d03166aebc06dbd0459f7c
+RLTest @ git+https://github.com/RedisLabsModules/RLTest@b6277948f262562a486d7c5efca032d69bba7f75
 statistics
 # hiredis==2.0.0  # disabled until RESP3-related problem is resolved
 #gevent~=22.10.1

--- a/tests/flow/requirements.txt
+++ b/tests/flow/requirements.txt
@@ -1,4 +1,6 @@
-RLTest @ git+https://github.com/RedisLabsModules/RLTest@32f298311a4594c5ac439b2c4f9ece214e7929a1 # should be chagne in the next RLTest version 
+# This commit points to a non-versioned branch "eranhd-pin-poetry-to-use-version-lt-2".
+# This is a temporary solution until the issue with poetry is resolved.
+RLTest @ git+https://github.com/RedisLabsModules/RLTest@bdc620e28d3e17c395d03166aebc06dbd0459f7c
 statistics
 # hiredis==2.0.0  # disabled until RESP3-related problem is resolved
 #gevent~=22.10.1

--- a/tests/flow/test_acls.py
+++ b/tests/flow/test_acls.py
@@ -148,6 +148,13 @@ def test_non_local_data_when_the_user_has_access(env):
 
         env.assertEqual(len(r1.execute_command('TS.MRANGE - + FILTER metric=cpu')), 2)
 
+def test_libmr_adds_acl_category(env):
+    if not env.isCluster() or SANITIZER == 'address' or is_redis_version_smaller_than(env, '7.4.0', env.isCluster()):
+        env.skip()
+
+    acl_category = '_timeseries_libmr_internal'
+    env.expect('acl', 'cat').contains(acl_category.encode())
+
 def do_test_libmr(env):
     if not env.isCluster() or SANITIZER == 'address' or is_redis_version_smaller_than(env, '7.4.0', env.isCluster()):
         env.skip()

--- a/tests/flow/test_acls.py
+++ b/tests/flow/test_acls.py
@@ -189,13 +189,12 @@ def do_test_libmr(env):
         env.assertEqual(len(r1.execute_command('TS.MRANGE - + FILTER metric=cpu')), 2)
 
 def test_acl_libmr_username_with_password_in_config():
-    redisConfigFile = '/tmp/redis.conf'
-    if os.path.isfile(redisConfigFile):
-        os.unlink(redisConfigFile)
-    with open(redisConfigFile, 'w') as f:
-        f.write('user tslibmr on >tslibmrpassword -@all +@_timeseries_libmr_internal\n')
-
-    env = Env(redisConfigFile=redisConfigFile, moduleArgs='global-user tslibmr; global-password tslibmrpassword')
+    configFileContent = """
+    user tslibmr on >tslibmrpassword -@all +@_timeseries_libmr_internal
+    ts-global-user tslibmr
+    ts-global-password tslibmrpassword
+    """
+    env = Env(redisConfigFileContent=configFileContent)
 
     do_test_libmr(env)
 
@@ -203,13 +202,13 @@ def test_acl_libmr_username_with_password_in_config_set_incorrectly(env):
     if not env.isCluster() or SANITIZER == 'address' or is_redis_version_lower_than(env, '7.4.0', env.isCluster()):
         env.skip()
 
-    redisConfigFile = '/tmp/redis2.conf'
-    if os.path.isfile(redisConfigFile):
-        os.unlink(redisConfigFile)
-    with open(redisConfigFile, 'w') as f:
-        f.write('user tslibmr2 on >tslibmrpassword +@all -@_timeseries_libmr_internal\nuser default on >password +@all -@_timeseries_libmr_internal +timeseries.FORCESHARDSCONNECTION +timeseries.INFOCLUSTER\n')
-
-    env = Env(password='password', redisConfigFile=redisConfigFile, moduleArgs='global-user nonexistinguseeeer; global-password nonexistinguserpasswd')
+    configFileContent = """
+    user tslibmr2 on >tslibmrpassword +@all -@_timeseries_libmr_internal
+    user default on >password +@all -@_timeseries_libmr_internal +timeseries.FORCESHARDSCONNECTION +timeseries.INFOCLUSTER
+    ts-global-user nonexistinguseeeer
+    ts-global-password nonexistinguserpasswd
+    """
+    env = Env(password='password', redisConfigFileContent=configFileContent)
 
     # Should raise a timeout error, as we can't connect to the nodes
     # due to the user having no permissions to invoke the corresponding
@@ -218,13 +217,12 @@ def test_acl_libmr_username_with_password_in_config_set_incorrectly(env):
         do_test_libmr(env)
 
 def test_acl_libmr_username_with_password_in_config_set_to_disallow():
-    redisConfigFile = '/tmp/redis3.conf'
-    if os.path.isfile(redisConfigFile):
-        os.unlink(redisConfigFile)
-    with open(redisConfigFile, 'w') as f:
-        f.write('user tslibmr3 on >tslibmrpassword +@all -@_timeseries_libmr_internal\n')
-
-    env = Env(redisConfigFile=redisConfigFile, moduleArgs='global-user tslibmr3; global-password tslibmrpassword')
+    configFileContent = """
+    user tslibmr3 on >tslibmrpassword +@all -@_timeseries_libmr_internal
+    ts-global-user tslibmr3
+    ts-global-password tslibmrpassword
+    """
+    env = Env(redisConfigFileContent=configFileContent)
 
     # Should raise a timeout error, as we can't connect to the nodes
     # due to the user having no permissions to invoke the corresponding

--- a/tests/flow/test_acls.py
+++ b/tests/flow/test_acls.py
@@ -149,14 +149,14 @@ def test_non_local_data_when_the_user_has_access(env):
         env.assertEqual(len(r1.execute_command('TS.MRANGE - + FILTER metric=cpu')), 2)
 
 def test_libmr_adds_acl_category(env):
-    if not env.isCluster() or SANITIZER == 'address' or is_redis_version_smaller_than(env, '7.4.0', env.isCluster()):
+    if not env.isCluster() or SANITIZER == 'address' or is_redis_version_lower_than(env, '7.4.0', env.isCluster()):
         env.skip()
 
     acl_category = '_timeseries_libmr_internal'
     env.expect('acl', 'cat').contains(acl_category.encode())
 
 def do_test_libmr(env):
-    if not env.isCluster() or SANITIZER == 'address' or is_redis_version_smaller_than(env, '7.4.0', env.isCluster()):
+    if not env.isCluster() or SANITIZER == 'address' or is_redis_version_lower_than(env, '7.4.0', env.isCluster()):
         env.skip()
 
     for shard in range(0, env.shardsCount):
@@ -200,7 +200,7 @@ def test_acl_libmr_username_with_password_in_config():
     do_test_libmr(env)
 
 def test_acl_libmr_username_with_password_in_config_set_incorrectly(env):
-    if not env.isCluster() or SANITIZER == 'address' or is_redis_version_smaller_than(env, '7.4.0', env.isCluster()):
+    if not env.isCluster() or SANITIZER == 'address' or is_redis_version_lower_than(env, '7.4.0', env.isCluster()):
         env.skip()
 
     redisConfigFile = '/tmp/redis2.conf'

--- a/tests/flow/test_globalconfigs.py
+++ b/tests/flow/test_globalconfigs.py
@@ -256,9 +256,11 @@ def test_module_config_api_is_unused_on_old_versions(env):
     skip_on_rlec()
 
     with env.getConnection() as conn:
-        # with pytest.raises() as excinfo:
-        conn.execute_command('CONFIG', 'GET', 'global-user')
-        assert is_line_in_server_log(env, 'deprecated')
+        # It should return an empty array as the option is not supported.
+        # The command should not raise an exception and no deprecation
+        # warnings should be emitted.
+        conn.execute_command('CONFIG', 'GET', 'ts-global-user')
+        assert not is_line_in_server_log(env, 'ts-global-user is deprecated, please use ')
 
 @skip(onVersionLowerThan='7.0', on_cluster=True)
 def test_module_config_api_is_used_on_recent_redis_versions(env):
@@ -272,41 +274,41 @@ def test_module_config_api_is_used_on_recent_redis_versions(env):
     # check that no exception is raised, no crashes observed and so on.
     with env.getConnection() as conn:
         # String or floating-point value options:
-        conn.execute_command('CONFIG', 'GET', 'timeseries.ts-compaction-policy')
-        conn.execute_command('CONFIG', 'SET', 'timeseries.ts-compaction-policy', 'max:1m:1d;min:10s:1h;avg:2h:10d;avg:3d:100d')
+        conn.execute_command('CONFIG', 'GET', 'ts-compaction-policy')
+        conn.execute_command('CONFIG', 'SET', 'ts-compaction-policy', 'max:1m:1d;min:10s:1h;avg:2h:10d;avg:3d:100d')
 
-        conn.execute_command('CONFIG', 'GET', 'timeseries.global-user')
-        conn.execute_command('CONFIG', 'SET', 'timeseries.global-user', 'test')
+        conn.execute_command('CONFIG', 'GET', 'ts-global-user')
+        conn.execute_command('CONFIG', 'SET', 'ts-global-user', 'test')
 
-        conn.execute_command('CONFIG', 'GET', 'timeseries.global-password')
-        conn.execute_command('CONFIG', 'SET', 'timeseries.global-password', 'test')
+        conn.execute_command('CONFIG', 'GET', 'ts-global-password')
+        conn.execute_command('CONFIG', 'SET', 'ts-global-password', 'test')
 
-        conn.execute_command('CONFIG', 'GET', 'timeseries.ts-duplicate-policy')
-        conn.execute_command('CONFIG', 'SET', 'timeseries.ts-duplicate-policy', 'last')
-        conn.execute_command('CONFIG', 'SET', 'timeseries.ts-duplicate-policy', 'LAST')
+        conn.execute_command('CONFIG', 'GET', 'ts-duplicate-policy')
+        conn.execute_command('CONFIG', 'SET', 'ts-duplicate-policy', 'last')
+        conn.execute_command('CONFIG', 'SET', 'ts-duplicate-policy', 'LAST')
 
-        conn.execute_command('CONFIG', 'GET', 'timeseries.ts-encoding')
-        conn.execute_command('CONFIG', 'SET', 'timeseries.ts-encoding', 'compressed')
+        conn.execute_command('CONFIG', 'GET', 'ts-encoding')
+        conn.execute_command('CONFIG', 'SET', 'ts-encoding', 'compressed')
 
-        conn.execute_command('CONFIG', 'GET', 'timeseries.ts-ignore-max-val-diff')
-        conn.execute_command('CONFIG', 'SET', 'timeseries.ts-ignore-max-val-diff', '10')
-        conn.execute_command('CONFIG', 'SET', 'timeseries.ts-ignore-max-val-diff', '10.0')
+        conn.execute_command('CONFIG', 'GET', 'ts-ignore-max-val-diff')
+        conn.execute_command('CONFIG', 'SET', 'ts-ignore-max-val-diff', '10')
+        conn.execute_command('CONFIG', 'SET', 'ts-ignore-max-val-diff', '10.0')
 
         # Integer value options:
-        conn.execute_command('CONFIG', 'GET', 'timeseries.ts-num-threads')
+        conn.execute_command('CONFIG', 'GET', 'ts-num-threads')
 
         # Can't set an immutable config value.
         with pytest.raises(redis.exceptions.ResponseError):
-            conn.execute_command('CONFIG', 'SET', 'timeseries.ts-num-threads', '2')
+            conn.execute_command('CONFIG', 'SET', 'ts-num-threads', '2')
 
-        conn.execute_command('CONFIG', 'GET', 'timeseries.ts-retention-policy')
-        conn.execute_command('CONFIG', 'SET', 'timeseries.ts-retention-policy', '1')
+        conn.execute_command('CONFIG', 'GET', 'ts-retention-policy')
+        conn.execute_command('CONFIG', 'SET', 'ts-retention-policy', '1')
 
-        conn.execute_command('CONFIG', 'GET', 'timeseries.ts-chunk-size-bytes')
-        conn.execute_command('CONFIG', 'SET', 'timeseries.ts-chunk-size-bytes', '2048')
+        conn.execute_command('CONFIG', 'GET', 'ts-chunk-size-bytes')
+        conn.execute_command('CONFIG', 'SET', 'ts-chunk-size-bytes', '2048')
 
-        conn.execute_command('CONFIG', 'GET', 'timeseries.ts-ignore-max-time-diff')
-        conn.execute_command('CONFIG', 'SET', 'timeseries.ts-ignore-max-time-diff', '5')
+        conn.execute_command('CONFIG', 'GET', 'ts-ignore-max-time-diff')
+        conn.execute_command('CONFIG', 'SET', 'ts-ignore-max-time-diff', '5')
 
         assert not is_line_in_server_log(env, 'is deprecated, please use')
 
@@ -362,13 +364,13 @@ def test_module_config_takes_precedence_over_module_arguments(env):
     ]
 
     configFileContent = """
-    timeseries.ts-ignore-max-time-diff 20
-    timeseries.ts-chunk-size-bytes 4096
-    timeseries.ts-retention-policy 40
-    timeseries.ts-duplicate-policy last
-    timeseries.ts-compaction-policy max:1m:1d
-    timeseries.ts-encoding uncompressed
-    timeseries.global-password test2
+    ts-ignore-max-time-diff 20
+    ts-chunk-size-bytes 4096
+    ts-retention-policy 40
+    ts-duplicate-policy last
+    ts-compaction-policy max:1m:1d
+    ts-encoding uncompressed
+    ts-global-password test2
     """
 
     env = Env(moduleArgs=args, redisConfigFileContent=configFileContent)
@@ -376,10 +378,10 @@ def test_module_config_takes_precedence_over_module_arguments(env):
     assert is_line_in_server_log(env, 'Deprecated load-time configuration options were used')
 
     with env.getConnection() as conn:
-        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'timeseries.ts-ignore-max-time-diff')[1], b'20')
-        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'timeseries.ts-chunk-size-bytes')[1], b'4096')
-        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'timeseries.ts-retention-policy')[1], b'40')
-        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'timeseries.ts-duplicate-policy')[1], b'last')
-        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'timeseries.ts-compaction-policy')[1], b'max:1m:1d')
-        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'timeseries.ts-encoding')[1], b'uncompressed')
-        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'timeseries.global-password')[1], b'test2')
+        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-ignore-max-time-diff')[1], b'20')
+        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-chunk-size-bytes')[1], b'4096')
+        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-retention-policy')[1], b'40')
+        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-duplicate-policy')[1], b'last')
+        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-compaction-policy')[1], b'max:1m:1d')
+        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-encoding')[1], b'uncompressed')
+        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-global-password')[1], b'test2')

--- a/tests/flow/test_globalconfigs.py
+++ b/tests/flow/test_globalconfigs.py
@@ -259,8 +259,10 @@ def test_module_config_api_is_unused_on_old_versions(env):
         # It should return an empty array as the option is not supported.
         # The command should not raise an exception and no deprecation
         # warnings should be emitted.
-        conn.execute_command('CONFIG', 'GET', 'ts-global-user')
-        assert not is_line_in_server_log(env, 'ts-global-user is deprecated, please use ')
+        env.expectEqual(len(conn.execute_command('CONFIG', 'GET', 'ts-global-user')), 0)
+
+    assert is_line_in_server_log(env, f"{arg[0]} is deprecated, please use")
+    assert is_line_in_server_log(env, 'Deprecated load-time configuration options were used')
 
 @skip(onVersionLowerThan='7.0', on_cluster=True)
 def test_module_config_api_is_used_on_recent_redis_versions(env):

--- a/tests/flow/test_globalconfigs.py
+++ b/tests/flow/test_globalconfigs.py
@@ -283,10 +283,8 @@ def test_module_config_api_is_used_on_recent_redis_versions():
         conn.execute_command('CONFIG', 'SET', 'ts-compaction-policy', 'max:1m:1d;min:10s:1h;avg:2h:10d;avg:3d:100d')
 
         conn.execute_command('CONFIG', 'GET', 'ts-global-user')
-        conn.execute_command('CONFIG', 'SET', 'ts-global-user', 'test')
 
         conn.execute_command('CONFIG', 'GET', 'ts-global-password')
-        conn.execute_command('CONFIG', 'SET', 'ts-global-password', 'test')
 
         conn.execute_command('CONFIG', 'GET', 'ts-duplicate-policy')
         conn.execute_command('CONFIG', 'SET', 'ts-duplicate-policy', 'last')

--- a/tests/flow/test_globalconfigs.py
+++ b/tests/flow/test_globalconfigs.py
@@ -248,6 +248,7 @@ def test_negative_configuration():
 
 @skip(onVersionLowerThan='6.2', onVersionHigherThan='7.0', on_cluster=True)
 def test_module_config_api_is_unused_on_old_versions(env):
+    env = Env(noLog=False)
     '''
     Tests that the module configuration API is not attempted to be used
     on Redis versions older than 7.0 and no deprecation warnings are
@@ -264,12 +265,14 @@ def test_module_config_api_is_unused_on_old_versions(env):
     assert is_line_in_server_log(env, f"{arg[0]} is deprecated, please use")
     assert is_line_in_server_log(env, 'Deprecated load-time configuration options were used')
 
-@skip(onVersionLowerThan='7.0', on_cluster=True)
-def test_module_config_api_is_used_on_recent_redis_versions(env):
+def test_module_config_api_is_used_on_recent_redis_versions():
     '''
     Tests that the module configuration API is used on Redis versions
     starting 7.0 and the deprecation warnings are emitted.
     '''
+    env = Env(noLog=False)
+    if is_redis_version_lower_than(env, '7.0') or env.isCluster():
+        env.skip()
     skip_on_rlec()
 
     # All these options are expected to return a valid value, so just
@@ -314,13 +317,15 @@ def test_module_config_api_is_used_on_recent_redis_versions(env):
 
         assert not is_line_in_server_log(env, 'is deprecated, please use')
 
-@skip(onVersionLowerThan='7.0', on_cluster=True)
-def test_module_config_from_module_arguments_raises_deprecation_messages(env):
+def test_module_config_from_module_arguments_raises_deprecation_messages():
     '''
     Tests that using the deprecated module configuration options
     (module arguments) while the module configuration API is used at the
     same time, leads to the deprecation messages.
     '''
+    env = Env(noLog=False)
+    if is_redis_version_lower_than(env, '7.0') or env.isCluster():
+        env.skip()
     skip_on_rlec()
 
     # All these options are expected to return a valid value, so just
@@ -338,17 +343,19 @@ def test_module_config_from_module_arguments_raises_deprecation_messages(env):
     ]
 
     for arg in args:
-        env = Env(moduleArgs=f"{arg[0]} {arg[1]}")
+        env = Env(moduleArgs=f"{arg[0]} {arg[1]}", noLog=False)
         assert is_line_in_server_log(env, f"{arg[0]} is deprecated, please use")
         assert is_line_in_server_log(env, 'Deprecated load-time configuration options were used')
 
-@skip(onVersionLowerThan='7.0', on_cluster=True)
-def test_module_config_takes_precedence_over_module_arguments(env):
+def test_module_config_takes_precedence_over_module_arguments():
     '''
     Tests that using the deprecated module configuration options
     (module arguments) while also using the the module configuration API
     leads to the latter taking precedence.
     '''
+    env = Env(noLog=False)
+    if is_redis_version_lower_than(env, '7.0') or env.isCluster():
+        env.skip()
     skip_on_rlec()
 
     # All these options are expected to return a valid value, so just
@@ -375,7 +382,7 @@ def test_module_config_takes_precedence_over_module_arguments(env):
     ts-global-password test2
     """
 
-    env = Env(moduleArgs=args, redisConfigFileContent=configFileContent)
+    env = Env(moduleArgs=args, redisConfigFileContent=configFileContent, noLog=False)
     assert is_line_in_server_log(env, " is deprecated, please use")
     assert is_line_in_server_log(env, 'Deprecated load-time configuration options were used')
 

--- a/tests/flow/test_ts_delete.py
+++ b/tests/flow/test_ts_delete.py
@@ -552,7 +552,7 @@ def test_del_with_rules_bug_4972_5(self):
     t1 = 't1{1}'
     t2 = 't2{1}'
     with e.getClusterConnectionIfNeeded() as r:
-        is_less_than_ver7_0_5 = is_redis_version_smaller_than(r, "7.0.5", e.is_cluster())
+        is_less_than_ver7_0_5 = is_redis_version_lower_than(r, "7.0.5", e.is_cluster())
         if is_less_than_ver7_0_5:
             return
         # data was taken from test_dump_restore_dst_rule on version TS_OVERFLOW_RDB_VER
@@ -584,7 +584,7 @@ def test_del_with_rules_bug_4972_6(self):
     t1 = 't1{1}'
     t2 = 't2{1}'
     with e.getClusterConnectionIfNeeded() as r:
-        is_less_than_ver7_0_5 = is_redis_version_smaller_than(r, "7.0.5", e.is_cluster())
+        is_less_than_ver7_0_5 = is_redis_version_lower_than(r, "7.0.5", e.is_cluster())
         if is_less_than_ver7_0_5:
             return
         # data was taken from test_dump_restore_dst_rule on version TS_OVERFLOW_RDB_VER

--- a/tests/flow/test_ts_madd.py
+++ b/tests/flow/test_ts_madd.py
@@ -115,7 +115,7 @@ def test_madd_some_failed_replicas():
     env.cmd('CONFIG', 'SET', 'appendfsync', 'always')
 
     with env.getClusterConnectionIfNeeded() as r:
-        is_less_than_ver7 = is_redis_version_smaller_than(r, "7.0.0")
+        is_less_than_ver7 = is_redis_version_lower_than(r, "7.0.0")
 
         r.execute_command("ts.create", "test_key1", 'RETENTION', 100, 'ENCODING', 'UNCOMPRESSED', 'CHUNK_SIZE', 128, "DUPLICATE_POLICY", "block", 'LABELS', 'name', 'Or', 'color', 'pink')
         r.execute_command("set", "test_key3", "danni")

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -62,7 +62,7 @@ help() {
 		COV=1                 Run with coverage analysis
 		VG=1                  Run with Valgrind
 		VG_LEAKS=0            Do not detect leaks
-		SAN=type              Use LLVM sanitizer (type=address|memory|leak|thread) 
+		SAN=type              Use LLVM sanitizer (type=address|memory|leak|thread)
 		BB=1                  Enable Python debugger (break using BB() in tests)
 		GDB=1                 Enable interactive gdb debugging (in single-test mode)
 
@@ -91,7 +91,7 @@ help() {
 	END
 }
 
-#---------------------------------------------------------------------------------------------- 
+#----------------------------------------------------------------------------------------------
 
 traps() {
 	local func="$1"
@@ -124,7 +124,7 @@ stop() {
 
 traps 'stop' SIGINT
 
-#---------------------------------------------------------------------------------------------- 
+#----------------------------------------------------------------------------------------------
 
 setup_rltest() {
 	if [[ $RLTEST == view ]]; then
@@ -147,7 +147,7 @@ setup_rltest() {
 			echo "PYTHONPATH=$PYTHONPATH"
 		fi
 	fi
-	
+
 	if [[ $RLTEST_VERBOSE == 1 ]]; then
 		RLTEST_ARGS+=" -v"
 	fi
@@ -317,7 +317,7 @@ run_tests() {
 	fi
 
 	[[ $RLEC == 1 ]] && export RLEC_CLUSTER=1
-	
+
 	local E=0
 	if [[ $NOP != 1 ]]; then
 		{ $OP python3 -m RLTest @$rltest_config; (( E |= $? )); } || true

--- a/tests/unit/unittests_parse_policies.c
+++ b/tests/unit/unittests_parse_policies.c
@@ -91,6 +91,7 @@ static inline void PolicyStringCompare(const char *s, const char *expectedOverri
         mu_assert_string_eq(s, actual);
     }
     free(actual);
+    free(parsedRules);
 }
 
 MU_TEST(test_PolicyToString) {

--- a/tests/unit/unittests_parse_policies.c
+++ b/tests/unit/unittests_parse_policies.c
@@ -17,8 +17,10 @@
 MU_TEST(test_valid_policy) {
     SimpleCompactionRule *parsedRules;
     uint64_t rulesCount;
-    int result = ParseCompactionPolicy(
-        "max:1m:1h:1m;min:10s:10d:0m;last:5M:10m;avg:2h:10d:1d;avg:3d:100d", &parsedRules, &rulesCount);
+    int result =
+        ParseCompactionPolicy("max:1m:1h:1m;min:10s:10d:0m;last:5M:10m;avg:2h:10d:1d;avg:3d:100d",
+                              &parsedRules,
+                              &rulesCount);
     mu_check(result == TRUE);
     mu_check(rulesCount == 5);
 
@@ -72,9 +74,33 @@ MU_TEST(test_invalid_policy) {
     result = ParseCompactionPolicy("max:abcdfeffas", &parsedRules, &rulesCount);
     mu_check(result == FALSE);
     mu_check(rulesCount == 0);
-    if(parsedRules) {
+    if (parsedRules) {
         free(parsedRules);
     }
+}
+
+static inline void PolicyStringCompare(const char *s, const char *expectedOverride) {
+    SimpleCompactionRule *parsedRules = NULL;
+    uint64_t rulesCount = 0;
+    const int result = ParseCompactionPolicy(s, &parsedRules, &rulesCount);
+    mu_check(result == TRUE);
+    char *actual = CompactionRulesToString(parsedRules, rulesCount);
+    if (expectedOverride) {
+        mu_assert_string_eq(expectedOverride, actual);
+    } else {
+        mu_assert_string_eq(s, actual);
+    }
+    free(actual);
+}
+
+MU_TEST(test_PolicyToString) {
+    PolicyStringCompare("max:1m:1h:1m;min:10s:10d:0m;last:5M:10m;avg:2h:10d:1d;avg:3d:100d",
+                        "max:1m:1h:1m;min:10s:10d;last:5M:10m;avg:2h:10d:1d;avg:3d:100d");
+    PolicyStringCompare("max:1m:1h:1m", NULL);
+    PolicyStringCompare("min:10s:10d:0m", "min:10s:10d");
+    PolicyStringCompare("last:5M:10m", NULL);
+    PolicyStringCompare("avg:2h:10d:1d", NULL);
+    PolicyStringCompare("avg:3d:100d", NULL);
 }
 
 MU_TEST(test_StringLenAggTypeToEnum) {
@@ -93,4 +119,5 @@ MU_TEST_SUITE(parse_policies_test_suite) {
     MU_RUN_TEST(test_valid_policy);
     MU_RUN_TEST(test_invalid_policy);
     MU_RUN_TEST(test_StringLenAggTypeToEnum);
+    MU_RUN_TEST(test_PolicyToString);
 }


### PR DESCRIPTION
This PR introduces the usage of the new config API, which appeared in Redis at the start of version 7. 

The relevant changes made are:

1. Deprecates the old way of using the load-time module arguments as the way to configure the module.
2. Adds the new options with the new naming convention, which are utilised with the new config API.
3. Fixes some UB in the old code.
4. Performs a little refactoring on the code to make it simpler, better testable and allow to actually retrieve the configuration option values back at any time.

The new configuration API will always override the configuration options used 'the old way' through the module arguments. This allows the user to start the migration to the new API, even though everything still works as expected.

There are no changes done to make sure the module runs well on the versions lower than Redis 7, this is TBD.

What's left:

- [x] ~Check if we can raise the minimum redis version requirement to Redis 7 or we need to provide a fully backwards-compatible code with Redis servers of versions lower than 7.~
- [x] Make the code backwards-compatible with the older Redis versions lower than 7.
- [x] Add the flow tests which specifically test the new config API and the deprecation behaviour and option precedence.