### PR TITLE
CVE fix to 1.8 (#6)

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -290,7 +290,8 @@ void GetPredicateKeysDicts(RedisModuleCtx *ctx,
 
     size_t to_allocate = 0;
 
-    if (__builtin_mul_overflow(predicate->valueListCount, sizeof(RedisModuleDict *), &to_allocate)) {
+    if (__builtin_mul_overflow(
+            predicate->valueListCount, sizeof(RedisModuleDict *), &to_allocate)) {
         return;
     }
 

--- a/src/utils/overflow.h
+++ b/src/utils/overflow.h
@@ -1,0 +1,14 @@
+#ifndef OVERFLOW_H
+#define OVERFLOW_H
+
+#include <stdbool.h>
+
+// Check if the addition of two numbers will overflow. Returns true if it will
+// overflow, false otherwise.
+inline bool check_mul_overflow(const size_t a, const size_t b) {
+    size_t result;
+    return __builtin_mul_overflow(a, b, &result);
+}
+
+
+#endif // OVERFLOW_H


### PR DESCRIPTION
* Disable the CodeQL CI workflow.

CodeQL is disabled for private repositories, so will never work.

* MOD-7548 Improve the code quality in the indexer.

* Track down the correct use of the types further

* Fix the garbage value read

* Fix the Apple clang compatibility issues.

Apple clang doesn't support the builtin_overflow_p (_p) family of functions. To make it compatible and buildable using both, the gcc and the clang family of compilers, this commit reverts back to using the non-_p family of functions.


(cherry picked from commit 8a903f604010dea3b45206c898fbf95865fd61d2)