### PR TITLE
CVE fix to 1.12 (#8)

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -6,9 +6,11 @@
 #include "indexer.h"
 
 #include "consts.h"
+#include "utils/overflow.h"
 
 #include <assert.h>
 #include <limits.h>
+#include <stdint.h>
 #include <string.h>
 #include <rmutil/alloc.h>
 
@@ -43,10 +45,12 @@ void FreeLabels(void *value, size_t labelsCount) {
 
 static int parseValueList(char *token, size_t *count, RedisModuleString ***values) {
     char *iter_ptr;
+
     if (token == NULL) {
         return TSDB_ERROR;
     }
-    size_t token_len = strlen(token);
+
+    const size_t token_len = strnlen(token, PTRDIFF_MAX);
 
     if (token[token_len - 1] == ')') {
         token[token_len - 1] = '\0'; // remove closing parentheses
@@ -54,20 +58,30 @@ static int parseValueList(char *token, size_t *count, RedisModuleString ***value
         return TSDB_ERROR;
     }
 
-    int filterCount = 0;
-    for (int i = 0; token[i] != '\0'; i++) {
+    size_t filterCount = 0;
+
+    for (size_t i = 0; token[i] != '\0' && i < token_len; ++i) {
         if (token[i] == ',') {
             filterCount++;
         }
     }
+
     if (token_len <= 1) {
         // when the token is <=1 it means that we have an empty list
         *count = 0;
         *values = NULL;
         return TSDB_OK;
+    } else if (filterCount == SIZE_MAX) {
+        // Returning before the overflow.
+        return TSDB_ERROR;
     } else {
         *count = filterCount + 1;
     }
+
+    if (check_mul_overflow(*count, sizeof(RedisModuleString *))) {
+        return TSDB_ERROR;
+    }
+
     *values = calloc(*count, sizeof(RedisModuleString *));
 
     char *subToken = strtok_r(token, ",", &iter_ptr);
@@ -270,17 +284,27 @@ void GetPredicateKeysDicts(RedisModuleCtx *ctx,
             ctx, K_PREFIX, RedisModule_StringPtrLen(predicate->key, &_s));
         (*dicts)[0] = RedisModule_DictGet(labelsIndex, index_key, NULL);
         RedisModule_FreeString(ctx, index_key);
-    } else { // one or more entries
-        *dicts = (RedisModuleDict **)malloc(sizeof(RedisModuleDict *) * predicate->valueListCount);
-        *dicts_size = predicate->valueListCount;
-        for (int i = 0; i < predicate->valueListCount; i++) {
-            value = RedisModule_StringPtrLen(predicate->valuesList[i], &_s);
-            index_key = RedisModule_CreateStringPrintf(ctx, KV_PREFIX, key, value);
-            (*dicts)[i] = RedisModule_DictGet(labelsIndex, index_key, NULL);
-            RedisModule_FreeString(ctx, index_key);
-        }
+
+        return;
     }
-    return;
+
+    size_t to_allocate = 0;
+
+    if (__builtin_mul_overflow(
+            predicate->valueListCount, sizeof(RedisModuleDict *), &to_allocate)) {
+        return;
+    }
+
+    // one or more entries
+    *dicts = (RedisModuleDict **)malloc(to_allocate);
+    *dicts_size = predicate->valueListCount;
+
+    for (size_t i = 0; i < predicate->valueListCount; ++i) {
+        value = RedisModule_StringPtrLen(predicate->valuesList[i], &_s);
+        index_key = RedisModule_CreateStringPrintf(ctx, KV_PREFIX, key, value);
+        (*dicts)[i] = RedisModule_DictGet(labelsIndex, index_key, NULL);
+        RedisModule_FreeString(ctx, index_key);
+    }
 }
 
 void PromoteSmallestPredicateToFront(RedisModuleCtx *ctx,
@@ -301,12 +325,13 @@ void PromoteSmallestPredicateToFront(RedisModuleCtx *ctx,
     uint64_t currentDictSize;
     RedisModuleDict **dicts = NULL;
     size_t dicts_size;
-    for (int i = 0; i < predicate_count; i++) {
+    for (size_t i = 0; i < predicate_count; ++i) {
         if (!IS_INCLUSION(index_predicate[i].type)) {
             // There is at least 1 inclusion predicate
             continue;
         }
 
+        dicts_size = 0;
         GetPredicateKeysDicts(ctx, &index_predicate[i], &dicts, &dicts_size);
         uint64_t curSize = _calc_dicts_total_size(dicts, dicts_size);
         free(dicts);
@@ -329,7 +354,7 @@ static bool _isKeySatisfyAllPredicates(RedisModuleCtx *ctx,
                                        size_t predicate_count) {
     RedisModuleDict **dicts = NULL;
     size_t dicts_size;
-    for (size_t i = 1; i < predicate_count; i++) {
+    for (size_t i = 1; i < min(predicate_count, SIZE_MAX - 1); ++i) {
         bool inclusion = IS_INCLUSION(index_predicate[i].type);
         GetPredicateKeysDicts(ctx, &index_predicate[i], &dicts, &dicts_size);
         bool found = false;
@@ -368,7 +393,7 @@ RedisModuleDict *QueryIndex(RedisModuleCtx *ctx,
     }
 
     RedisModuleDict **dicts = NULL;
-    size_t dicts_size;
+    size_t dicts_size = 0;
     GetPredicateKeysDicts(ctx, &index_predicate[0], &dicts, &dicts_size);
 
     for (size_t i = 0; i < dicts_size; i++) {
@@ -411,10 +436,10 @@ RedisModuleDict *QueryIndex(RedisModuleCtx *ctx,
 }
 
 void QueryPredicate_Free(QueryPredicate *predicate_list, size_t count) {
-    for (int predicate_index = 0; predicate_index < count; predicate_index++) {
+    for (size_t predicate_index = 0; predicate_index < count; predicate_index++) {
         QueryPredicate *predicate = &predicate_list[predicate_index];
         if (predicate->valuesList != NULL) {
-            for (int i = 0; i < predicate->valueListCount; i++) {
+            for (size_t i = 0; i < predicate->valueListCount; i++) {
                 if (predicate->valuesList[i] != NULL) {
                     RedisModule_FreeString(NULL, predicate->valuesList[i]);
                 }
@@ -427,14 +452,16 @@ void QueryPredicate_Free(QueryPredicate *predicate_list, size_t count) {
 
 void QueryPredicateList_Free(QueryPredicateList *list) {
     if (list->ref > 1) {
-        list->ref--;
+        --list->ref;
         return;
     }
+
     assert(list->ref == 1);
 
-    for (int i = 0; i < list->count; i++) {
+    for (size_t i = 0; i < list->count; i++) {
         QueryPredicate_Free(&list->list[i], 1);
     }
+
     free(list->list);
     free(list);
 }

--- a/src/utils/overflow.h
+++ b/src/utils/overflow.h
@@ -1,0 +1,14 @@
+#ifndef OVERFLOW_H
+#define OVERFLOW_H
+
+#include <stdbool.h>
+
+// Check if the addition of two numbers will overflow. Returns true if it will
+// overflow, false otherwise.
+inline bool check_mul_overflow(const size_t a, const size_t b) {
+    size_t result;
+    return __builtin_mul_overflow(a, b, &result);
+}
+
+
+#endif // OVERFLOW_H


### PR DESCRIPTION
* Disable the CodeQL CI workflow.

CodeQL is disabled for private repositories, so will never work.

* MOD-7548 Improve the code quality in the indexer.

* Track down the correct use of the types further

* Fix the garbage value read

* Fix the Apple clang compatibility issues.

Apple clang doesn't support the builtin_overflow_p (_p) family of functions. To make it compatible and buildable using both, the gcc and the clang family of compilers, this commit reverts back to using the non-_p family of functions.

* Bump version to 1.12.3

(cherry picked from commit 19d43005edf719d7a95674f88586ffb71b610dee)