### PR TITLE
MOD-7456 add new configuration options (#1661)

### DIFF
--- a/.github/actions/install-python-deps/action.yml
+++ b/.github/actions/install-python-deps/action.yml
@@ -14,8 +14,8 @@ inputs:
     type: string
     default: ''
     require: false
-  
-  
+
+
 
 runs:
   using: composite

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Run sanitizer on the tests'
     type: string
     default: ''
-  quick: 
+  quick:
     description: 'Run with quick flag'
     type: string
     default: ''
@@ -32,4 +32,4 @@ runs:
         if [[ "${{ inputs.use-venv }}" == "1" ]]; then
           . venv/bin/activate
         fi
-        make test VG=${{inputs.run_valgrind}} SAN=${{inputs.run_sanitizer}} QUICK=${{inputs.quick}} REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+        make test VG=${{inputs.run_valgrind}} SAN=${{inputs.run_sanitizer}} QUICK=${{inputs.quick}} VERBOSE=1 SHOW=1 REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server

--- a/.github/workflows/flow-linux-x86.yml
+++ b/.github/workflows/flow-linux-x86.yml
@@ -1,14 +1,12 @@
 name: Flow Linux x86
-
 permissions:
   id-token: write
   contents: read
-
 on:
   workflow_dispatch:
     inputs:
       redis-ref:
-        description: 'Redis ref to checkout'  # todo change per version/tag
+        description: 'Redis ref to checkout' # todo change per version/tag
         type: string
         required: true
       os:
@@ -23,14 +21,14 @@ on:
         description: 'Run sanitizer on the tests'
         type: boolean
         default: false
-      quick: 
+      quick:
         description: 'Run quick tests'
         type: boolean
         default: false
   workflow_call: # Allows to run this workflow from another workflow
     inputs:
       redis-ref:
-        description: 'Redis ref to checkout'  # todo change per version/tag
+        description: 'Redis ref to checkout' # todo change per version/tag
         type: string
         required: true
       os:
@@ -45,11 +43,10 @@ on:
         description: 'Run sanitizer on the tests'
         type: boolean
         default: false
-      quick: 
+      quick:
         description: 'Run quick tests'
         type: boolean
         default: false
-
 jobs:
   setup-environment:
     runs-on: ubuntu-latest
@@ -112,14 +109,13 @@ jobs:
           MATRIX="${MATRIX%?}]"
           echo "${MATRIX}"
           echo "matrix=${MATRIX}" >> $GITHUB_OUTPUT
-  
   build-linux-matrix:
     name: ${{matrix.docker_image.image}}, ${{needs.setup-environment.outputs.redis-ref}}
     runs-on: ubuntu-latest
     needs: setup-environment
     strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         docker_image: ${{fromJson(needs.setup-environment.outputs.matrix)}}
     container:
       image: ${{ matrix.docker_image.image }}
@@ -173,16 +169,10 @@ jobs:
         working-directory: .install
         shell: bash
         run: |
-          ./install_script.sh 
-      - name: Setup Python for testing
-        if: ${{matrix.docker_image.image == 'ubuntu:jammy'}}
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.9'
-          architecture: 'x64'
+          ./install_script.sh
       - name: Install python dependencies
         uses: ./.github/actions/install-python-deps
-        with: 
+        with:
           call-setup: ${{matrix.docker_image.call-setup}}
           use-venv: ${{matrix.docker_image.use-venv}}
       - name: build
@@ -192,7 +182,7 @@ jobs:
           use-venv: ${{matrix.docker_image.use-venv}}
       - name: Run tests
         uses: ./.github/actions/run-tests
-        with: 
+        with:
           use-venv: ${{matrix.docker_image.use-venv}}
           quick: ${{inputs.quick && '1' || '0'}}
           run_valgrind: ${{inputs.run_valgrind && '1' || '0'}}
@@ -200,7 +190,7 @@ jobs:
       - name: Upload test artifacts
         if: failure()
         uses: ./.github/actions/upload-artifacts
-        with: 
+        with:
           image: ${{ matrix.docker_image.image }}
       - name: Pack module
         if: ${{ !inputs.run_valgrind && !inputs.run_sanitizer }}

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ compile_commands.json
 
 .venv
 redis/
+temp-redis-config*

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MK_ALL_TARGETS=bindirs deps build pack
 
 include $(ROOT)/deps/readies/mk/main
 
-#----------------------------------------------------------------------------------------------  
+#----------------------------------------------------------------------------------------------
 
 export LIBMR_BINDIR=$(ROOT)/bin/$(FULL_VARIANT)/LibMR
 include $(ROOT)/build/LibMR/Makefile.defs
@@ -32,7 +32,7 @@ include $(ROOT)/build/rmutil/Makefile.defs
 export CPU_FEATURES_BINDIR=$(ROOT)/bin/$(FULL_VARIANT.release)/cpu_features
 include $(ROOT)/build/cpu_features/Makefile.defs
 
-#----------------------------------------------------------------------------------------------  
+#----------------------------------------------------------------------------------------------
 
 define HELPTEXT
 make build
@@ -85,7 +85,7 @@ make sanbox        # create container with CLang Sanitizer
 
 endef
 
-#----------------------------------------------------------------------------------------------  
+#----------------------------------------------------------------------------------------------
 
 MK_CUSTOM_CLEAN=1
 
@@ -298,11 +298,14 @@ clean:
 	@echo Cleaning ...
 	$(SHOW)rm -rf compile_commands.json
 ifeq ($(ALL),1)
+	@echo Cleaning ALL...
 	-$(SHOW)rm -rf $(BINROOT) $(LIBEVENT_BINDIR) $(DRAGONBOX_BINDIR) $(FAST_DOUBLE_PARSER_C_BINDIR) $(CPU_FEATURES_BINDIR)
 	$(SHOW)$(MAKE) -C $(ROOT)/build/libevent clean AUTOGEN=1
+	-$(SHOW)$(MAKE) --no-print-directory -C $(ROOT)/tests/unit DEBUG='' clean
 else
 	-$(SHOW)rm -rf $(BINDIR)
 ifeq ($(DEPS),1)
+	@echo Cleaning DEPS...
 	-$(SHOW)$(MAKE) --no-print-directory -C $(ROOT)/build/rmutil clean
 	-$(SHOW)$(MAKE) --no-print-directory -C $(ROOT)/build/hiredis clean
 	-$(SHOW)$(MAKE) --no-print-directory -C $(ROOT)/build/LibMR clean
@@ -310,7 +313,6 @@ ifeq ($(DEPS),1)
 	-$(SHOW)$(MAKE) --no-print-directory -C $(ROOT)/build/libevent DEBUG='' clean
 	-$(SHOW)$(MAKE) --no-print-directory -C $(ROOT)/build/dragonbox DEBUG='' clean
 	-$(SHOW)$(MAKE) --no-print-directory -C $(ROOT)/build/fast_double_parser_c DEBUG='' clean
-	-$(SHOW)$(MAKE) --no-print-directory -C $(ROOT)/tests/unit DEBUG='' clean
 endif
 endif
 
@@ -410,7 +412,7 @@ endif # RLEC
 BENCHMARK_ARGS = redisbench-admin run-local
 
 ifneq ($(REMOTE),)
-	BENCHMARK_ARGS = redisbench-admin run-remote 
+	BENCHMARK_ARGS = redisbench-admin run-remote
 endif
 
 BENCHMARK_ARGS += \

--- a/src/config.c
+++ b/src/config.c
@@ -7,21 +7,101 @@
 
 #include "consts.h"
 #include "module.h"
+#include "parse_policies.h"
 #include "query_language.h"
 #include "RedisModulesSDK/redismodule.h"
 
 #include <assert.h>
 #include <string.h>
+#include <float.h>
 #include "rmutil/strings.h"
 #include "rmutil/util.h"
 
+/*
+ * Logs that a deprecated configuration option was used.
+ */
+#define LOG_DEPRECATED_OPTION(deprecatedName, modernName, show)                                    \
+    if (show) {                                                                                    \
+        RedisModule_Log(rts_staticCtx,                                                             \
+                        "warning",                                                                 \
+                        "%s is deprecated, please use the '%s' instead",                           \
+                        deprecatedName,                                                            \
+                        modernName);                                                               \
+    }
+
+#define LOG_DEPRECATED_OPTION_ALWAYS(deprecatedName, modernName)                                   \
+    LOG_DEPRECATED_OPTION(deprecatedName, modernName, true)
+
 TSConfig TSGlobalConfig;
+
+static RedisModuleString *getConfigStringCache = NULL;
+
+void InitConfig(void) {
+    TSGlobalConfig.options = SERIES_OPT_DEFAULT_COMPRESSION;
+    TSGlobalConfig.password = NULL;
+    TSGlobalConfig.username = NULL;
+
+    if (getConfigStringCache) {
+        RedisModule_FreeString(rts_staticCtx, getConfigStringCache);
+        getConfigStringCache = NULL;
+    }
+}
+
+static inline void ClearCompactionRules(void) {
+    if (TSGlobalConfig.compactionRules) {
+        free(TSGlobalConfig.compactionRules);
+        TSGlobalConfig.compactionRules = NULL;
+        TSGlobalConfig.compactionRulesCount = 0;
+    }
+}
+
+void FreeConfig(void) {
+    if (TSGlobalConfig.password) {
+        free(TSGlobalConfig.password);
+        TSGlobalConfig.password = NULL;
+    }
+
+    if (TSGlobalConfig.username) {
+        free(TSGlobalConfig.username);
+        TSGlobalConfig.username = NULL;
+    }
+
+    if (getConfigStringCache) {
+        RedisModule_FreeString(rts_staticCtx, getConfigStringCache);
+        getConfigStringCache = NULL;
+    }
+
+    ClearCompactionRules();
+}
+
+RedisModuleString *GlobalConfigToString(RedisModuleCtx *ctx) {
+    return RedisModule_CreateStringPrintf(
+        ctx,
+        "COMPACTION_POLICY %s\n"
+        "RETENTION_POLICY %lld\n"
+        "CHUNK_SIZE % lld\n"
+        "ENCODING %s\n"
+        "DUPLICATE_POLICY %s\n"
+        "NUM_THREADS %lld\n"
+        "IGNORE_MAX_VAL_DIFF %lf\n"
+        "IGNORE_MAX_TIME_DIFF %lld\n",
+        CompactionRulesToString(TSGlobalConfig.compactionRules,
+                                TSGlobalConfig.compactionRulesCount),
+        TSGlobalConfig.retentionPolicy,
+        TSGlobalConfig.chunkSizeBytes,
+        ChunkTypeToString(TSGlobalConfig.options),
+        DuplicatePolicyToString(TSGlobalConfig.duplicatePolicy),
+        TSGlobalConfig.numThreads,
+        TSGlobalConfig.ignoreMaxValDiff,
+        TSGlobalConfig.ignoreMaxTimeDiff);
+}
 
 int ParseDuplicatePolicy(RedisModuleCtx *ctx,
                          RedisModuleString **argv,
                          int argc,
                          const char *arg_prefix,
-                         DuplicatePolicy *policy);
+                         DuplicatePolicy *policy,
+                         bool *found);
 
 const char *ChunkTypeToString(int options) {
     if (options & SERIES_OPT_UNCOMPRESSED) {
@@ -33,12 +113,473 @@ const char *ChunkTypeToString(int options) {
     return "invalid";
 }
 
-int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-    TSGlobalConfig.hasGlobalConfig = FALSE;
-    TSGlobalConfig.options = SERIES_OPT_DEFAULT_COMPRESSION;
-    TSGlobalConfig.password = NULL;
+static RedisModuleString *getModernStringConfigValue(const char *name, void *privdata) {
+    if (!strcasecmp("ts-compaction-policy", name)) {
+        char *rulesAsString = CompactionRulesToString(TSGlobalConfig.compactionRules,
+                                                      TSGlobalConfig.compactionRulesCount);
+
+        if (!rulesAsString) {
+            return NULL;
+        }
+
+        if (getConfigStringCache) {
+            RedisModule_FreeString(rts_staticCtx, getConfigStringCache);
+        }
+
+        getConfigStringCache =
+            RedisModule_CreateString(rts_staticCtx, rulesAsString, strlen(rulesAsString));
+
+        free(rulesAsString);
+
+        return getConfigStringCache;
+    } else if (!strcasecmp("ts-global-password", name) && TSGlobalConfig.password) {
+        if (getConfigStringCache) {
+            RedisModule_FreeString(rts_staticCtx, getConfigStringCache);
+        }
+
+        getConfigStringCache = RedisModule_CreateString(
+            rts_staticCtx, TSGlobalConfig.password, strlen(TSGlobalConfig.password));
+
+        return getConfigStringCache;
+    } else if (!strcasecmp("ts-global-user", name) && TSGlobalConfig.username) {
+        if (getConfigStringCache) {
+            RedisModule_FreeString(rts_staticCtx, getConfigStringCache);
+        }
+
+        getConfigStringCache = RedisModule_CreateString(
+            rts_staticCtx, TSGlobalConfig.username, strlen(TSGlobalConfig.username));
+
+        return getConfigStringCache;
+    } else if (!strcasecmp("ts-duplicate-policy", name)) {
+        const char *value = DuplicatePolicyToString(TSGlobalConfig.duplicatePolicy);
+
+        if (!value) {
+            return NULL;
+        }
+
+        if (getConfigStringCache) {
+            RedisModule_FreeString(rts_staticCtx, getConfigStringCache);
+        }
+
+        getConfigStringCache = RedisModule_CreateString(rts_staticCtx, value, strlen(value));
+
+        return getConfigStringCache;
+    } else if (!strcasecmp("ts-encoding", name)) {
+        const char *value = ChunkTypeToString(TSGlobalConfig.options);
+
+        if (!value) {
+            return NULL;
+        }
+
+        if (getConfigStringCache) {
+            RedisModule_FreeString(rts_staticCtx, getConfigStringCache);
+        }
+
+        getConfigStringCache = RedisModule_CreateString(rts_staticCtx, value, strlen(value));
+
+        return getConfigStringCache;
+    } else if (!strcasecmp("ts-ignore-max-val-diff", name)) {
+        if (getConfigStringCache) {
+            RedisModule_FreeString(rts_staticCtx, getConfigStringCache);
+        }
+
+        getConfigStringCache =
+            RedisModule_CreateStringPrintf(rts_staticCtx, "%lf", TSGlobalConfig.ignoreMaxValDiff);
+
+        return getConfigStringCache;
+    }
+
+    return NULL;
+}
+
+/*
+ * Parses a string value and validate it is a valid double in the range
+ * [min, max].
+ *
+ * If the value is invalid, set `err` to an error message.
+ * Otherwise, set `value` to the parsed value and return it without
+ * setting the error string.
+ *
+ * The success of the operation can be determined by checking if `err`
+ * is NULL.
+ */
+static double stringToDouble(const char *name,
+                             RedisModuleString *string,
+                             const double min,
+                             const double max,
+                             RedisModuleString **err) {
+    double value = 0.0;
+    long long longValue = 0;
+
+    if (RedisModule_StringToLongLong(string, &longValue) == REDISMODULE_OK) {
+        value = (double)longValue;
+    } else if (RedisModule_StringToDouble(string, &value) != REDISMODULE_OK) {
+        *err = RedisModule_CreateStringPrintf(rts_staticCtx, "Invalid value for `%s`", name);
+    }
+
+    if (value < min || value > max) {
+        *err = RedisModule_CreateStringPrintf(
+            rts_staticCtx,
+            "Invalid value for `%s`. Value must be in the range [%f .. %f]",
+            name,
+            min,
+            max);
+    }
+
+    return value;
+}
+
+static bool Config_SetCompactionPolicyFromCStr(const char *policyString, RedisModuleString **err) {
+    if (!policyString || strlen(policyString) == 0) {
+        ClearCompactionRules();
+
+        return true;
+    }
+
+    SimpleCompactionRule *compactionRules = NULL;
+    uint64_t compactionRulesCount = 0;
+
+    if (ParseCompactionPolicy(policyString, &compactionRules, &compactionRulesCount) != TRUE) {
+        *err = RedisModule_CreateStringPrintf(NULL, "Invalid compaction policy: %s", policyString);
+        return false;
+    }
+
+    ClearCompactionRules();
+
+    TSGlobalConfig.compactionRules = compactionRules;
+    TSGlobalConfig.compactionRulesCount = compactionRulesCount;
+
+    return true;
+}
+
+static bool Config_SetDuplicationPolicyFromRedisString(RedisModuleString *value,
+                                                       RedisModuleString **err) {
+    const DuplicatePolicy newValue = RMStringLenDuplicationPolicyToEnum(value);
+
+    if (newValue == DP_INVALID) {
+        *err = RedisModule_CreateStringPrintf(
+            NULL, "Invalid duplicate policy: %s", RedisModule_StringPtrLen(value, NULL));
+        return false;
+    }
+
+    TSGlobalConfig.duplicatePolicy = newValue;
+    return true;
+}
+
+static bool Config_SetIgnoreMaxValDiffFromRedisString(RedisModuleString *value,
+                                                      RedisModuleString **err) {
+    const double newValue = stringToDouble(
+        "ts-ignore-max-val-diff", value, IGNORE_MAX_VAL_DIFF_MIN, IGNORE_MAX_VAL_DIFF_MAX, err);
+
+    if (err && *err) {
+        return false;
+    }
+
+    TSGlobalConfig.ignoreMaxValDiff = newValue;
+    return true;
+}
+
+static bool Config_SetGlobalPasswordFromRedisString(RedisModuleString *value) {
+    if (TSGlobalConfig.password) {
+        free(TSGlobalConfig.password);
+        TSGlobalConfig.password = NULL;
+    }
+
+    size_t len = 0;
+    const char *str = RedisModule_StringPtrLen(value, &len);
+
+    if (!str || len == 0) {
+        return true;
+    }
+
+    TSGlobalConfig.password = strndup(str, len);
+    return true;
+}
+
+static bool Config_SetGlobalUserFromRedisString(RedisModuleString *value) {
+    if (TSGlobalConfig.username) {
+        free(TSGlobalConfig.username);
+        TSGlobalConfig.username = NULL;
+    }
+
+    size_t len = 0;
+    const char *str = RedisModule_StringPtrLen(value, &len);
+
+    if (!str || len == 0) {
+        return true;
+    }
+
+    TSGlobalConfig.username = strndup(str, len);
+    return true;
+}
+
+static bool Config_SetEncodingFromRedisString(RedisModuleString *value, RedisModuleString **err) {
+    size_t len = 0;
+    const char *encoding = RedisModule_StringPtrLen(value, &len);
+
+    if (!strcasecmp(encoding, UNCOMPRESSED_ARG_STR)) {
+        TSGlobalConfig.options &= ~SERIES_OPT_DEFAULT_COMPRESSION;
+        TSGlobalConfig.options |= SERIES_OPT_UNCOMPRESSED;
+    } else if (!strcasecmp(encoding, COMPRESSED_GORILLA_ARG_STR)) {
+        TSGlobalConfig.options &= ~SERIES_OPT_DEFAULT_COMPRESSION;
+        TSGlobalConfig.options |= SERIES_OPT_COMPRESSED_GORILLA;
+    } else {
+        *err = RedisModule_CreateStringPrintf(NULL, "Invalid encoding: %s", encoding);
+        return false;
+    }
+
+    return true;
+}
+
+static int setModernStringConfigValue(const char *name,
+                                      RedisModuleString *value,
+                                      void *data,
+                                      RedisModuleString **err) {
+    if (!strcasecmp("ts-compaction-policy", name)) {
+        size_t len = 0;
+        const char *policyString = RedisModule_StringPtrLen(value, &len);
+
+        return Config_SetCompactionPolicyFromCStr(policyString, err) ? REDISMODULE_OK
+                                                                     : REDISMODULE_ERR;
+    } else if (!strcasecmp("ts-duplicate-policy", name)) {
+        return Config_SetDuplicationPolicyFromRedisString(value, err) ? REDISMODULE_OK
+                                                                      : REDISMODULE_ERR;
+    } else if (!strcasecmp("ts-ignore-max-val-diff", name)) {
+        return Config_SetIgnoreMaxValDiffFromRedisString(value, err) ? REDISMODULE_OK
+                                                                     : REDISMODULE_ERR;
+    } else if (!strcasecmp("ts-global-password", name)) {
+        return Config_SetGlobalPasswordFromRedisString(value) ? REDISMODULE_OK : REDISMODULE_ERR;
+    } else if (!strcasecmp("ts-global-user", name)) {
+        return Config_SetGlobalUserFromRedisString(value) ? REDISMODULE_OK : REDISMODULE_ERR;
+    } else if (!strcasecmp("ts-encoding", name)) {
+        return Config_SetEncodingFromRedisString(value, err) ? REDISMODULE_OK : REDISMODULE_ERR;
+    }
+
+    return REDISMODULE_ERR;
+}
+
+static long long getModernIntegerConfigValue(const char *name, void *privdata) {
+    if (!strcasecmp("ts-num-threads", name)) {
+        return TSGlobalConfig.numThreads;
+    } else if (!strcasecmp("ts-retention-policy", name)) {
+        return TSGlobalConfig.retentionPolicy;
+    } else if (!strcasecmp("ts-chunk-size-bytes", name)) {
+        return TSGlobalConfig.chunkSizeBytes;
+    } else if (!strcasecmp("ts-ignore-max-time-diff", name)) {
+        return TSGlobalConfig.ignoreMaxTimeDiff;
+    }
+
+    return 0;
+}
+
+static int setModernIntegerConfigValue(const char *name,
+                                       long long value,
+                                       void *data,
+                                       RedisModuleString **err) {
+    if (!strcasecmp("ts-num-threads", name)) {
+        TSGlobalConfig.numThreads = value;
+
+        return REDISMODULE_OK;
+    } else if (!strcasecmp("ts-retention-policy", name)) {
+        TSGlobalConfig.retentionPolicy = value;
+
+        return REDISMODULE_OK;
+    } else if (!strcasecmp("ts-chunk-size-bytes", name)) {
+        if (!ValidateChunkSize(NULL, value, err)) {
+            return REDISMODULE_ERR;
+        }
+
+        TSGlobalConfig.chunkSizeBytes = value;
+
+        return REDISMODULE_OK;
+    } else if (!strcasecmp("ts-ignore-max-time-diff", name)) {
+        if (value < 0) {
+            *err = RedisModule_CreateStringPrintf(
+                NULL, "Invalid value for `ts-ignore-max-time-diff`. Value must be non-negative");
+            return REDISMODULE_ERR;
+        }
+
+        TSGlobalConfig.ignoreMaxTimeDiff = value;
+
+        return REDISMODULE_OK;
+    }
+
+    return REDISMODULE_ERR;
+}
+
+bool RegisterModernConfigurationOptions(RedisModuleCtx *ctx) {
+    {
+        char *oldValue = CompactionRulesToString(TSGlobalConfig.compactionRules,
+                                                 TSGlobalConfig.compactionRulesCount);
+        if (!oldValue) {
+            oldValue = strdup("");
+        }
+
+        if (RedisModule_RegisterStringConfig(ctx,
+                                             "ts-compaction-policy",
+                                             oldValue,
+                                             REDISMODULE_CONFIG_UNPREFIXED,
+                                             getModernStringConfigValue,
+                                             setModernStringConfigValue,
+                                             NULL,
+                                             NULL)) {
+            free(oldValue);
+
+            return false;
+        }
+
+        free(oldValue);
+    }
+
+    {
+        char *oldValue = TSGlobalConfig.password;
+        if (!oldValue) {
+            oldValue = "";
+        }
+
+        if (RedisModule_RegisterStringConfig(ctx,
+                                             "ts-global-password",
+                                             oldValue,
+                                             REDISMODULE_CONFIG_IMMUTABLE |
+                                                 REDISMODULE_CONFIG_SENSITIVE |
+                                                 REDISMODULE_CONFIG_UNPREFIXED,
+                                             getModernStringConfigValue,
+                                             setModernStringConfigValue,
+                                             NULL,
+                                             NULL)) {
+            return false;
+        }
+    }
+
+    {
+        char *oldValue = TSGlobalConfig.username;
+        if (!oldValue) {
+            oldValue = "";
+        }
+
+        if (RedisModule_RegisterStringConfig(ctx,
+                                             "ts-global-user",
+                                             oldValue,
+                                             REDISMODULE_CONFIG_IMMUTABLE |
+                                                 REDISMODULE_CONFIG_SENSITIVE |
+                                                 REDISMODULE_CONFIG_UNPREFIXED,
+                                             getModernStringConfigValue,
+                                             setModernStringConfigValue,
+                                             NULL,
+                                             NULL)) {
+            return false;
+        }
+    }
+
+    if (RedisModule_RegisterNumericConfig(ctx,
+                                          "ts-num-threads",
+                                          TSGlobalConfig.numThreads,
+                                          REDISMODULE_CONFIG_IMMUTABLE |
+                                              REDISMODULE_CONFIG_UNPREFIXED,
+                                          NUM_THREADS_MIN,
+                                          NUM_THREADS_MAX,
+                                          getModernIntegerConfigValue,
+                                          setModernIntegerConfigValue,
+                                          NULL,
+                                          NULL)) {
+        return false;
+    }
+
+    if (RedisModule_RegisterNumericConfig(ctx,
+                                          "ts-retention-policy",
+                                          TSGlobalConfig.retentionPolicy,
+                                          REDISMODULE_CONFIG_UNPREFIXED,
+                                          RETENTION_POLICY_MIN,
+                                          RETENTION_POLICY_MAX,
+                                          getModernIntegerConfigValue,
+                                          setModernIntegerConfigValue,
+                                          NULL,
+                                          NULL)) {
+        return false;
+    }
+
+    if (RedisModule_RegisterStringConfig(ctx,
+                                         "ts-duplicate-policy",
+                                         DuplicatePolicyToString(TSGlobalConfig.duplicatePolicy),
+                                         REDISMODULE_CONFIG_UNPREFIXED,
+                                         getModernStringConfigValue,
+                                         setModernStringConfigValue,
+                                         NULL,
+                                         NULL)) {
+        return false;
+    }
+
+    if (RedisModule_RegisterNumericConfig(ctx,
+                                          "ts-chunk-size-bytes",
+                                          TSGlobalConfig.chunkSizeBytes,
+                                          REDISMODULE_CONFIG_UNPREFIXED,
+                                          CHUNK_SIZE_BYTES_MIN,
+                                          CHUNK_SIZE_BYTES_MAX,
+                                          getModernIntegerConfigValue,
+                                          setModernIntegerConfigValue,
+                                          NULL,
+                                          NULL)) {
+        return false;
+    }
+
+    if (RedisModule_RegisterStringConfig(ctx,
+                                         "ts-encoding",
+                                         ChunkTypeToString(TSGlobalConfig.options),
+                                         REDISMODULE_CONFIG_UNPREFIXED,
+                                         getModernStringConfigValue,
+                                         setModernStringConfigValue,
+                                         NULL,
+                                         NULL)) {
+        return false;
+    }
+
+    if (RedisModule_RegisterNumericConfig(ctx,
+                                          "ts-ignore-max-time-diff",
+                                          TSGlobalConfig.ignoreMaxTimeDiff,
+                                          REDISMODULE_CONFIG_UNPREFIXED,
+                                          IGNORE_MAX_TIME_DIFF_MIN,
+                                          IGNORE_MAX_TIME_DIFF_MAX,
+                                          getModernIntegerConfigValue,
+                                          setModernIntegerConfigValue,
+                                          NULL,
+                                          NULL)) {
+        return false;
+    }
+
+    {
+        char oldValue[32] = { 0 };
+        snprintf(oldValue, sizeof(oldValue), "%lf", TSGlobalConfig.ignoreMaxValDiff);
+
+        if (RedisModule_RegisterStringConfig(ctx,
+                                             "ts-ignore-max-val-diff",
+                                             oldValue,
+                                             REDISMODULE_CONFIG_UNPREFIXED,
+                                             getModernStringConfigValue,
+                                             setModernStringConfigValue,
+                                             NULL,
+                                             NULL)) {
+            return false;
+        }
+    }
+
+    RedisModule_Log(ctx, "debug", "Registered modern configuration options");
+
+    return true;
+}
+
+bool RegisterConfigurationOptions(RedisModuleCtx *ctx) {
+    return RegisterModernConfigurationOptions(ctx);
+}
+
+int ReadDeprecatedLoadTimeConfig(RedisModuleCtx *ctx,
+                                 RedisModuleString **argv,
+                                 int argc,
+                                 const bool showDeprecationWarning) {
+    bool isDeprecated = false;
 
     if (argc > 1 && RMUtil_ArgIndex("COMPACTION_POLICY", argv, argc) >= 0) {
+        LOG_DEPRECATED_OPTION("COMPACTION_POLICY", "ts-compaction-policy", showDeprecationWarning);
+
         RedisModuleString *policy;
         const char *policy_cstr;
         size_t len;
@@ -49,18 +590,28 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             return TSDB_ERROR;
         }
         policy_cstr = RedisModule_StringPtrLen(policy, &len);
-        if (ParseCompactionPolicy(policy_cstr,
-                                  &TSGlobalConfig.compactionRules,
-                                  &TSGlobalConfig.compactionRulesCount) != TRUE) {
+        SimpleCompactionRule *compactionRules = NULL;
+        uint64_t compactionRulesCount = 0;
+        if (ParseCompactionPolicy(policy_cstr, &compactionRules, &compactionRulesCount) != TRUE) {
             RedisModule_Log(ctx, "warning", "Unable to parse argument after COMPACTION_POLICY");
+            free(compactionRules);
             return TSDB_ERROR;
         }
 
         RedisModule_Log(ctx, "notice", "loaded default compaction policy: %s", policy_cstr);
-        TSGlobalConfig.hasGlobalConfig = TRUE;
+
+        if (TSGlobalConfig.compactionRules) {
+            free(TSGlobalConfig.compactionRules);
+        }
+
+        TSGlobalConfig.compactionRules = compactionRules;
+        TSGlobalConfig.compactionRulesCount = compactionRulesCount;
+        isDeprecated = true;
     }
 
     if (argc > 1 && RMUtil_ArgIndex("OSS_GLOBAL_PASSWORD", argv, argc) >= 0) {
+        LOG_DEPRECATED_OPTION("OSS_GLOBAL_PASSWORD", "global-password", showDeprecationWarning);
+
         RedisModuleString *password;
         size_t len;
         if (RMUtil_ParseArgsAfter("OSS_GLOBAL_PASSWORD", argv, argc, "s", &password) !=
@@ -69,16 +620,14 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             return TSDB_ERROR;
         }
 
-        TSGlobalConfig.password = (char *)RedisModule_StringPtrLen(password, &len);
+        const char *temp = (char *)RedisModule_StringPtrLen(password, &len);
+        TSGlobalConfig.password = strndup(temp, len);
         RedisModule_Log(ctx, "notice", "loaded tls password");
-        RedisModule_Log(ctx,
-                        "warning",
-                        "The 'OSS_GLOBAL_PASSWORD' configuration is deprecated. "
-                        "Please use 'global-password' instead.");
-        TSGlobalConfig.hasGlobalConfig = TRUE;
+        isDeprecated = true;
     }
 
     if (argc > 1 && RMUtil_ArgIndex("global-password", argv, argc) >= 0) {
+        LOG_DEPRECATED_OPTION("global-password", "ts-global-password", showDeprecationWarning);
         RedisModuleString *password;
         size_t len;
         if (RMUtil_ParseArgsAfter("global-password", argv, argc, "s", &password) !=
@@ -87,12 +636,14 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             return TSDB_ERROR;
         }
 
-        TSGlobalConfig.password = (char *)RedisModule_StringPtrLen(password, &len);
+        const char *temp = (char *)RedisModule_StringPtrLen(password, &len);
+        TSGlobalConfig.password = strndup(temp, len);
         RedisModule_Log(ctx, "notice", "loaded global-password");
-        TSGlobalConfig.hasGlobalConfig = TRUE;
+        isDeprecated = true;
     }
 
     if (argc > 1 && RMUtil_ArgIndex("global-user", argv, argc) >= 0) {
+        LOG_DEPRECATED_OPTION("global-user", "ts-global-user", showDeprecationWarning);
         RedisModuleString *username;
         size_t len;
         if (RMUtil_ParseArgsAfter("global-user", argv, argc, "s", &username) != REDISMODULE_OK) {
@@ -100,14 +651,15 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             return TSDB_ERROR;
         }
 
-        TSGlobalConfig.username = (char *)RedisModule_StringPtrLen(username, &len);
+        const char *temp = (char *)RedisModule_StringPtrLen(username, &len);
+        TSGlobalConfig.username = strndup(temp, len);
         RedisModule_Log(ctx, "notice", "loaded global-user");
-        TSGlobalConfig.hasGlobalConfig = TRUE;
-    } else {
-        TSGlobalConfig.username = "default";
+        isDeprecated = true;
     }
 
     if (argc > 1 && RMUtil_ArgIndex("RETENTION_POLICY", argv, argc) >= 0) {
+        LOG_DEPRECATED_OPTION("RETENTION_POLICY", "ts-retention-policy", showDeprecationWarning);
+
         if (RMUtil_ParseArgsAfter(
                 "RETENTION_POLICY", argv, argc, "l", &TSGlobalConfig.retentionPolicy) !=
             REDISMODULE_OK) {
@@ -117,31 +669,51 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
         RedisModule_Log(
             ctx, "notice", "loaded default retention policy: %lld", TSGlobalConfig.retentionPolicy);
-        TSGlobalConfig.hasGlobalConfig = TRUE;
-    } else {
-        TSGlobalConfig.retentionPolicy = RETENTION_TIME_DEFAULT;
+        isDeprecated = true;
     }
 
-    if (!ValidateChunkSize(ctx, Chunk_SIZE_BYTES_SECS)) {
+    if (!ValidateChunkSize(ctx, Chunk_SIZE_BYTES_SECS, NULL)) {
         return TSDB_ERROR;
     }
     TSGlobalConfig.chunkSizeBytes = Chunk_SIZE_BYTES_SECS;
-    if (ParseChunkSize(ctx, argv, argc, "CHUNK_SIZE_BYTES", &TSGlobalConfig.chunkSizeBytes) !=
-        REDISMODULE_OK) {
+    bool chunkSizeBytesFound = false;
+    if (ParseChunkSize(ctx,
+                       argv,
+                       argc,
+                       "CHUNK_SIZE_BYTES",
+                       &TSGlobalConfig.chunkSizeBytes,
+                       &chunkSizeBytesFound) != REDISMODULE_OK) {
         RedisModule_Log(ctx, "warning", "Unable to parse argument after CHUNK_SIZE_BYTES");
         return TSDB_ERROR;
     }
+
     RedisModule_Log(ctx,
                     "notice",
                     "loaded default CHUNK_SIZE_BYTES policy: %lld",
                     TSGlobalConfig.chunkSizeBytes);
 
+    LOG_DEPRECATED_OPTION(
+        "CHUNK_SIZE_BYTES", "ts-chunk-size-bytes", chunkSizeBytesFound && showDeprecationWarning);
+
+    isDeprecated = isDeprecated || chunkSizeBytesFound;
+
     TSGlobalConfig.duplicatePolicy = DEFAULT_DUPLICATE_POLICY;
-    if (ParseDuplicatePolicy(
-            ctx, argv, argc, DUPLICATE_POLICY_ARG, &TSGlobalConfig.duplicatePolicy) != TSDB_OK) {
+    bool duplicatePolicyFound = false;
+    if (ParseDuplicatePolicy(ctx,
+                             argv,
+                             argc,
+                             DUPLICATE_POLICY_ARG,
+                             &TSGlobalConfig.duplicatePolicy,
+                             &duplicatePolicyFound) != TSDB_OK) {
         RedisModule_Log(ctx, "warning", "Unable to parse argument after DUPLICATE_POLICY");
         return TSDB_ERROR;
     }
+
+    isDeprecated = isDeprecated || duplicatePolicyFound;
+
+    LOG_DEPRECATED_OPTION(
+        "DUPLICATE_POLICY", "ts-duplicate-policy", duplicatePolicyFound && showDeprecationWarning);
+
     RedisModule_Log(ctx,
                     "notice",
                     "loaded server DUPLICATE_POLICY: %s",
@@ -149,13 +721,16 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     if (argc > 1 && (RMUtil_ArgIndex("ENCODING", argv, argc) >= 0 ||
                      RMUtil_ArgIndex("CHUNK_TYPE", argv, argc) >= 0)) {
-        if (RMUtil_ArgIndex("CHUNK_TYPE", argv, argc) >= 0) {
-            RedisModule_Log(
-                ctx,
-                "warning",
-                "CHUNK_TYPE configuration was deprecated and will be removed in future "
-                "versions of RedisTimeSeries. Please use ENCODING configuration instead.");
+        isDeprecated = true;
+
+        if (RMUtil_ArgIndex("ENCODING", argv, argc) >= 0) {
+            LOG_DEPRECATED_OPTION("ENCODING", "ts-encoding", showDeprecationWarning);
         }
+
+        if (RMUtil_ArgIndex("CHUNK_TYPE", argv, argc) >= 0) {
+            LOG_DEPRECATED_OPTION("CHUNK_TYPE", "ts-encoding", showDeprecationWarning);
+        }
+
         RedisModuleString *chunk_type;
         size_t len;
         const char *chunk_type_cstr;
@@ -186,11 +761,13 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc > 1 && RMUtil_ArgIndex("NUM_THREADS", argv, argc) >= 0) {
         if (RMUtil_ParseArgsAfter("NUM_THREADS", argv, argc, "l", &TSGlobalConfig.numThreads) !=
             REDISMODULE_OK) {
-            RedisModule_Log(ctx, "warning", "Unable to parse argument after COMPACTION_POLICY");
+            RedisModule_Log(ctx, "warning", "Unable to parse argument after NUM_THREADS");
             return TSDB_ERROR;
         }
+        LOG_DEPRECATED_OPTION("NUM_THREADS", "ts-num-threads", showDeprecationWarning);
+        isDeprecated = true;
     } else {
-        TSGlobalConfig.numThreads = 3;
+        TSGlobalConfig.numThreads = DEFAULT_NUM_THREADS;
     }
     TSGlobalConfig.forceSaveCrossRef = false;
     if (argc > 1 && RMUtil_ArgIndex("DEUBG_FORCE_RULE_DUMP", argv, argc) >= 0) {
@@ -208,8 +785,10 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         } else if (!strcasecmp(forceSaveCrossRef_cstr, "disable")) {
             TSGlobalConfig.forceSaveCrossRef = false;
         }
+
+        isDeprecated = true;
     }
-    TSGlobalConfig.dontAssertOnFailiure = false;
+    TSGlobalConfig.dontAssertOnFailure = false;
     if (argc > 1 && RMUtil_ArgIndex("DONT_ASSERT_ON_FAILIURE", argv, argc) >= 0) {
         RedisModuleString *dontAssertOnFailiure;
         if (RMUtil_ParseArgsAfter(
@@ -223,13 +802,15 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         const char *dontAssertOnFailiure_cstr =
             RedisModule_StringPtrLen(dontAssertOnFailiure, &dontAssertOnFailiure_len);
         if (!strcasecmp(dontAssertOnFailiure_cstr, "enable")) {
-            TSGlobalConfig.dontAssertOnFailiure = true;
+            TSGlobalConfig.dontAssertOnFailure = true;
         } else if (!strcasecmp(dontAssertOnFailiure_cstr, "disable")) {
-            TSGlobalConfig.dontAssertOnFailiure = false;
+            TSGlobalConfig.dontAssertOnFailure = false;
         }
 
         extern bool _dontAssertOnFailiure;
-        _dontAssertOnFailiure = TSGlobalConfig.dontAssertOnFailiure;
+        _dontAssertOnFailiure = TSGlobalConfig.dontAssertOnFailure;
+
+        isDeprecated = true;
     }
 
     TSGlobalConfig.ignoreMaxTimeDiff = 0;
@@ -245,6 +826,9 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             return TSDB_ERROR;
         }
         TSGlobalConfig.ignoreMaxTimeDiff = ignoreMaxTimeDiff;
+        LOG_DEPRECATED_OPTION(
+            "IGNORE_MAX_TIME_DIFF", "ts-ignore-max-time-diff", showDeprecationWarning);
+        isDeprecated = true;
     }
     RedisModule_Log(ctx,
                     "notice",
@@ -264,6 +848,10 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             return TSDB_ERROR;
         }
         TSGlobalConfig.ignoreMaxValDiff = ignoreMaxValDiff;
+
+        LOG_DEPRECATED_OPTION(
+            "IGNORE_MAX_VAL_DIFF", "ts-ignore-max-val-diff", showDeprecationWarning);
+        isDeprecated = true;
     }
     RedisModule_Log(
         ctx, "notice", "loaded default IGNORE_MAX_VAL_DIFF: %f", TSGlobalConfig.ignoreMaxValDiff);
@@ -272,6 +860,14 @@ int ReadConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                     "notice",
                     "Setting default series ENCODING to: %s",
                     ChunkTypeToString(TSGlobalConfig.options));
+
+    if (isDeprecated && showDeprecationWarning) {
+        RedisModule_Log(ctx,
+                        "warning",
+                        "Deprecated load-time configuration options were used. These will be "
+                        "removed in future versions of RedisTimeSeries.");
+    }
+
     return TSDB_OK;
 }
 
@@ -288,7 +884,7 @@ int RTS_RlecMinorVersion;
 int RTS_RlecPatchVersion;
 int RTS_RlecBuild;
 
-int RTS_CheckSupportedVestion() {
+int RTS_CheckSupportedVestion(void) {
     if (RTS_currVersion.redisMajorVersion < RTS_minSupportedVersion.redisMajorVersion) {
         return REDISMODULE_ERR;
     }
@@ -308,7 +904,7 @@ int RTS_CheckSupportedVestion() {
     return REDISMODULE_OK;
 }
 
-void RTS_GetRedisVersion() {
+void RTS_GetRedisVersion(void) {
     RedisModuleCallReply *reply = RedisModule_Call(rts_staticCtx, "info", "c", "server");
     assert(RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_STRING);
     size_t len;

--- a/src/consts.h
+++ b/src/consts.h
@@ -82,6 +82,30 @@ typedef enum DuplicatePolicy
     DP_SUM = 6,
 } DuplicatePolicy;
 
+static inline __attribute__((always_inline)) const char *DuplicatePolicyToString(
+    const DuplicatePolicy policy) {
+    switch (policy) {
+        case DP_NONE:
+            return "none";
+        case DP_BLOCK:
+            return "block";
+        case DP_LAST:
+            return "last";
+        case DP_FIRST:
+            return "first";
+        case DP_MIN:
+            return "min";
+        case DP_MAX:
+            return "max";
+        case DP_SUM:
+            return "sum";
+        case DP_INVALID:
+            return "invalid";
+        default:
+            return "unknown";
+    }
+}
+
 /* Series struct options */
 #define SERIES_OPT_UNCOMPRESSED 0x1
 

--- a/src/generic_chunk.c
+++ b/src/generic_chunk.c
@@ -101,27 +101,6 @@ const ChunkFuncs *GetChunkClass(CHUNK_TYPES_T chunkType) {
     return NULL;
 }
 
-const char *DuplicatePolicyToString(DuplicatePolicy policy) {
-    switch (policy) {
-        case DP_NONE:
-            return "none";
-        case DP_BLOCK:
-            return "block";
-        case DP_LAST:
-            return "last";
-        case DP_FIRST:
-            return "first";
-        case DP_MAX:
-            return "max";
-        case DP_MIN:
-            return "min";
-        case DP_SUM:
-            return "sum";
-        default:
-            return "invalid";
-    }
-}
-
 int RMStringLenDuplicationPolicyToEnum(RedisModuleString *aggTypeStr) {
     size_t str_len;
     const char *aggTypeCStr = RedisModule_StringPtrLen(aggTypeStr, &str_len);

--- a/src/parse_policies.h
+++ b/src/parse_policies.h
@@ -21,4 +21,10 @@ typedef struct SimpleCompactionRule
 int ParseCompactionPolicy(const char *policy_string,
                           SimpleCompactionRule **parsed_rules,
                           uint64_t *count_rules);
+
+/* Converts the compaction rules back to a string. The returned string
+must be deallocated by the user using free(). Note that it might use the
+redis allocator. */
+char *CompactionRulesToString(const SimpleCompactionRule *compactionRules,
+                              uint64_t compactionRulesCount);
 #endif

--- a/src/query_language.h
+++ b/src/query_language.h
@@ -117,13 +117,15 @@ int ParseChunkSize(RedisModuleCtx *ctx,
                    RedisModuleString **argv,
                    int argc,
                    const char *arg_prefix,
-                   long long *chunkSizeBytes);
+                   long long *chunkSizeBytes,
+                   bool *found);
 
 int ParseDuplicatePolicy(RedisModuleCtx *ctx,
                          RedisModuleString **argv,
                          int argc,
                          const char *arg_prefix,
-                         DuplicatePolicy *policy);
+                         DuplicatePolicy *policy,
+                         bool *found);
 
 int parseEncodingArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int *options);
 
@@ -167,7 +169,8 @@ void MRangeArgs_Free(MRangeArgs *args);
 
 int parseMGetCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, MGetArgs *out);
 void MGetArgs_Free(MGetArgs *args);
-bool ValidateChunkSize(RedisModuleCtx *ctx, long long chunkSizeBytes);
+bool ValidateChunkSize(RedisModuleCtx *ctx, long long chunkSizeBytes, RedisModuleString **err);
+bool ValidateChunkSizeSimple(long long chunkSizeBytes);
 int parseLatestArg(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool *latest);
 
 #endif // REDISTIMESERIES_QUERY_LANGUAGE_H

--- a/tests/flow/requirements.txt
+++ b/tests/flow/requirements.txt
@@ -1,4 +1,4 @@
-RLTest @ git+https://github.com/RedisLabsModules/RLTest@32f298311a4594c5ac439b2c4f9ece214e7929a1 # should be chagne in the next RLTest version 
+RLTest @ git+https://github.com/RedisLabsModules/RLTest@b6277948f262562a486d7c5efca032d69bba7f75
 statistics
 # hiredis==2.0.0  # disabled until RESP3-related problem is resolved
 #gevent~=22.10.1

--- a/tests/flow/test_acls.py
+++ b/tests/flow/test_acls.py
@@ -148,8 +148,15 @@ def test_non_local_data_when_the_user_has_access(env):
 
         env.assertEqual(len(r1.execute_command('TS.MRANGE - + FILTER metric=cpu')), 2)
 
+def test_libmr_adds_acl_category(env):
+    if not env.isCluster() or SANITIZER == 'address' or is_redis_version_lower_than(env, '7.4.0', env.isCluster()):
+        env.skip()
+
+    acl_category = '_timeseries_libmr_internal'
+    env.expect('acl', 'cat').contains(acl_category.encode())
+
 def do_test_libmr(env):
-    if not env.isCluster() or SANITIZER == 'address' or is_redis_version_smaller_than(env, '7.4.0', env.isCluster()):
+    if not env.isCluster() or SANITIZER == 'address' or is_redis_version_lower_than(env, '7.4.0', env.isCluster()):
         env.skip()
 
     for shard in range(0, env.shardsCount):
@@ -182,27 +189,26 @@ def do_test_libmr(env):
         env.assertEqual(len(r1.execute_command('TS.MRANGE - + FILTER metric=cpu')), 2)
 
 def test_acl_libmr_username_with_password_in_config():
-    redisConfigFile = '/tmp/redis.conf'
-    if os.path.isfile(redisConfigFile):
-        os.unlink(redisConfigFile)
-    with open(redisConfigFile, 'w') as f:
-        f.write('user tslibmr on >tslibmrpassword -@all +@_timeseries_libmr_internal\n')
-
-    env = Env(redisConfigFile=redisConfigFile, moduleArgs='global-user tslibmr; global-password tslibmrpassword')
+    configFileContent = """
+    user tslibmr on >tslibmrpassword -@all +@_timeseries_libmr_internal
+    ts-global-user tslibmr
+    ts-global-password tslibmrpassword
+    """
+    env = Env(redisConfigFileContent=configFileContent)
 
     do_test_libmr(env)
 
 def test_acl_libmr_username_with_password_in_config_set_incorrectly(env):
-    if not env.isCluster() or SANITIZER == 'address' or is_redis_version_smaller_than(env, '7.4.0', env.isCluster()):
+    if not env.isCluster() or SANITIZER == 'address' or is_redis_version_lower_than(env, '7.4.0', env.isCluster()):
         env.skip()
 
-    redisConfigFile = '/tmp/redis2.conf'
-    if os.path.isfile(redisConfigFile):
-        os.unlink(redisConfigFile)
-    with open(redisConfigFile, 'w') as f:
-        f.write('user tslibmr2 on >tslibmrpassword +@all -@_timeseries_libmr_internal\nuser default on >password +@all -@_timeseries_libmr_internal +timeseries.FORCESHARDSCONNECTION +timeseries.INFOCLUSTER\n')
-
-    env = Env(password='password', redisConfigFile=redisConfigFile, moduleArgs='global-user nonexistinguseeeer; global-password nonexistinguserpasswd')
+    configFileContent = """
+    user tslibmr2 on >tslibmrpassword +@all -@_timeseries_libmr_internal
+    user default on >password +@all -@_timeseries_libmr_internal +timeseries.FORCESHARDSCONNECTION +timeseries.INFOCLUSTER
+    ts-global-user nonexistinguseeeer
+    ts-global-password nonexistinguserpasswd
+    """
+    env = Env(password='password', redisConfigFileContent=configFileContent)
 
     # Should raise a timeout error, as we can't connect to the nodes
     # due to the user having no permissions to invoke the corresponding
@@ -211,13 +217,12 @@ def test_acl_libmr_username_with_password_in_config_set_incorrectly(env):
         do_test_libmr(env)
 
 def test_acl_libmr_username_with_password_in_config_set_to_disallow():
-    redisConfigFile = '/tmp/redis3.conf'
-    if os.path.isfile(redisConfigFile):
-        os.unlink(redisConfigFile)
-    with open(redisConfigFile, 'w') as f:
-        f.write('user tslibmr3 on >tslibmrpassword +@all -@_timeseries_libmr_internal\n')
-
-    env = Env(redisConfigFile=redisConfigFile, moduleArgs='global-user tslibmr3; global-password tslibmrpassword')
+    configFileContent = """
+    user tslibmr3 on >tslibmrpassword +@all -@_timeseries_libmr_internal
+    ts-global-user tslibmr3
+    ts-global-password tslibmrpassword
+    """
+    env = Env(redisConfigFileContent=configFileContent)
 
     # Should raise a timeout error, as we can't connect to the nodes
     # due to the user having no permissions to invoke the corresponding

--- a/tests/flow/test_globalconfigs.py
+++ b/tests/flow/test_globalconfigs.py
@@ -245,3 +245,150 @@ def test_negative_configuration():
 
     with pytest.raises(Exception) as excinfo:
         env = Env(moduleArgs='CHUNK_TYPE compressed; global-user')
+
+@skip(onVersionLowerThan='6.2', onVersionHigherThan='7.0', on_cluster=True)
+def test_module_config_api_is_unused_on_old_versions(env):
+    env = Env(noLog=False)
+    '''
+    Tests that the module configuration API is not attempted to be used
+    on Redis versions older than 7.0 and no deprecation warnings are
+    emitted.
+    '''
+    skip_on_rlec()
+
+    with env.getConnection() as conn:
+        # It should return an empty array as the option is not supported.
+        # The command should not raise an exception and no deprecation
+        # warnings should be emitted.
+        env.expectEqual(len(conn.execute_command('CONFIG', 'GET', 'ts-global-user')), 0)
+
+    assert is_line_in_server_log(env, f"{arg[0]} is deprecated, please use")
+    assert is_line_in_server_log(env, 'Deprecated load-time configuration options were used')
+
+def test_module_config_api_is_used_on_recent_redis_versions():
+    '''
+    Tests that the module configuration API is used on Redis versions
+    starting 7.0 and the deprecation warnings are emitted.
+    '''
+    env = Env(noLog=False)
+    if is_redis_version_lower_than(env, '7.0') or env.isCluster():
+        env.skip()
+    skip_on_rlec()
+
+    # All these options are expected to return a valid value, so just
+    # check that no exception is raised, no crashes observed and so on.
+    with env.getConnection() as conn:
+        # String or floating-point value options:
+        conn.execute_command('CONFIG', 'GET', 'ts-compaction-policy')
+        conn.execute_command('CONFIG', 'SET', 'ts-compaction-policy', 'max:1m:1d;min:10s:1h;avg:2h:10d;avg:3d:100d')
+
+        conn.execute_command('CONFIG', 'GET', 'ts-global-user')
+
+        conn.execute_command('CONFIG', 'GET', 'ts-global-password')
+
+        conn.execute_command('CONFIG', 'GET', 'ts-duplicate-policy')
+        conn.execute_command('CONFIG', 'SET', 'ts-duplicate-policy', 'last')
+        conn.execute_command('CONFIG', 'SET', 'ts-duplicate-policy', 'LAST')
+
+        conn.execute_command('CONFIG', 'GET', 'ts-encoding')
+        conn.execute_command('CONFIG', 'SET', 'ts-encoding', 'compressed')
+
+        conn.execute_command('CONFIG', 'GET', 'ts-ignore-max-val-diff')
+        conn.execute_command('CONFIG', 'SET', 'ts-ignore-max-val-diff', '10')
+        conn.execute_command('CONFIG', 'SET', 'ts-ignore-max-val-diff', '10.0')
+
+        # Integer value options:
+        conn.execute_command('CONFIG', 'GET', 'ts-num-threads')
+
+        # Can't set an immutable config value.
+        with pytest.raises(redis.exceptions.ResponseError):
+            conn.execute_command('CONFIG', 'SET', 'ts-num-threads', '2')
+
+        conn.execute_command('CONFIG', 'GET', 'ts-retention-policy')
+        conn.execute_command('CONFIG', 'SET', 'ts-retention-policy', '1')
+
+        conn.execute_command('CONFIG', 'GET', 'ts-chunk-size-bytes')
+        conn.execute_command('CONFIG', 'SET', 'ts-chunk-size-bytes', '2048')
+
+        conn.execute_command('CONFIG', 'GET', 'ts-ignore-max-time-diff')
+        conn.execute_command('CONFIG', 'SET', 'ts-ignore-max-time-diff', '5')
+
+        assert not is_line_in_server_log(env, 'is deprecated, please use')
+
+def test_module_config_from_module_arguments_raises_deprecation_messages():
+    '''
+    Tests that using the deprecated module configuration options
+    (module arguments) while the module configuration API is used at the
+    same time, leads to the deprecation messages.
+    '''
+    env = Env(noLog=False)
+    if is_redis_version_lower_than(env, '7.0') or env.isCluster():
+        env.skip()
+    skip_on_rlec()
+
+    # All these options are expected to return a valid value, so just
+    # check that no exception is raised, no crashes observed and so on.
+    args = [
+        ['CHUNK_TYPE', 'compressed'],
+        ['ENCODING', 'compressed'],
+        ['COMPACTION_POLICY', 'max:1m:1d\\;min:10s:1h\\;avg:2h:10d\\;avg:3d:100d'],
+        ['DUPLICATE_POLICY', 'MAX'],
+        ['IGNORE_MAX_TIME_DIFF', '10'],
+        ['IGNORE_MAX_VAL_DIFF', '10'],
+        ['RETENTION_POLICY', '30'],
+        ['CHUNK_SIZE_BYTES', '2048'],
+        ['OSS_GLOBAL_PASSWORD', 'test'],
+    ]
+
+    for arg in args:
+        env = Env(moduleArgs=f"{arg[0]} {arg[1]}", noLog=False)
+        assert is_line_in_server_log(env, f"{arg[0]} is deprecated, please use")
+        assert is_line_in_server_log(env, 'Deprecated load-time configuration options were used')
+
+def test_module_config_takes_precedence_over_module_arguments():
+    '''
+    Tests that using the deprecated module configuration options
+    (module arguments) while also using the the module configuration API
+    leads to the latter taking precedence.
+    '''
+    env = Env(noLog=False)
+    if is_redis_version_lower_than(env, '7.0') or env.isCluster():
+        env.skip()
+    skip_on_rlec()
+
+    # All these options are expected to return a valid value, so just
+    # check that no exception is raised, no crashes observed and so on.
+    args = [
+        'CHUNK_TYPE', 'compressed',
+        'ENCODING', 'compressed',
+        'COMPACTION_POLICY', 'max:1m:1d\\;min:10s:1h\\;avg:2h:10d\\;avg:3d:100d',
+        'DUPLICATE_POLICY', 'MAX',
+        'IGNORE_MAX_TIME_DIFF', '10',
+        'IGNORE_MAX_VAL_DIFF', '10',
+        'RETENTION_POLICY', '30',
+        'CHUNK_SIZE_BYTES', '2048',
+        'OSS_GLOBAL_PASSWORD', 'test',
+    ]
+
+    configFileContent = """
+    ts-ignore-max-time-diff 20
+    ts-chunk-size-bytes 4096
+    ts-retention-policy 40
+    ts-duplicate-policy last
+    ts-compaction-policy max:1m:1d
+    ts-encoding uncompressed
+    ts-global-password test2
+    """
+
+    env = Env(moduleArgs=args, redisConfigFileContent=configFileContent, noLog=False)
+    assert is_line_in_server_log(env, " is deprecated, please use")
+    assert is_line_in_server_log(env, 'Deprecated load-time configuration options were used')
+
+    with env.getConnection() as conn:
+        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-ignore-max-time-diff')[1], b'20')
+        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-chunk-size-bytes')[1], b'4096')
+        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-retention-policy')[1], b'40')
+        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-duplicate-policy')[1], b'last')
+        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-compaction-policy')[1], b'max:1m:1d')
+        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-encoding')[1], b'uncompressed')
+        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-global-password')[1], b'test2')

--- a/tests/flow/test_ts_delete.py
+++ b/tests/flow/test_ts_delete.py
@@ -552,7 +552,7 @@ def test_del_with_rules_bug_4972_5(self):
     t1 = 't1{1}'
     t2 = 't2{1}'
     with e.getClusterConnectionIfNeeded() as r:
-        is_less_than_ver7_0_5 = is_redis_version_smaller_than(r, "7.0.5", e.is_cluster())
+        is_less_than_ver7_0_5 = is_redis_version_lower_than(r, "7.0.5", e.is_cluster())
         if is_less_than_ver7_0_5:
             return
         # data was taken from test_dump_restore_dst_rule on version TS_OVERFLOW_RDB_VER
@@ -584,7 +584,7 @@ def test_del_with_rules_bug_4972_6(self):
     t1 = 't1{1}'
     t2 = 't2{1}'
     with e.getClusterConnectionIfNeeded() as r:
-        is_less_than_ver7_0_5 = is_redis_version_smaller_than(r, "7.0.5", e.is_cluster())
+        is_less_than_ver7_0_5 = is_redis_version_lower_than(r, "7.0.5", e.is_cluster())
         if is_less_than_ver7_0_5:
             return
         # data was taken from test_dump_restore_dst_rule on version TS_OVERFLOW_RDB_VER

--- a/tests/flow/test_ts_madd.py
+++ b/tests/flow/test_ts_madd.py
@@ -115,7 +115,7 @@ def test_madd_some_failed_replicas():
     env.cmd('CONFIG', 'SET', 'appendfsync', 'always')
 
     with env.getClusterConnectionIfNeeded() as r:
-        is_less_than_ver7 = is_redis_version_smaller_than(r, "7.0.0")
+        is_less_than_ver7 = is_redis_version_lower_than(r, "7.0.0")
 
         r.execute_command("ts.create", "test_key1", 'RETENTION', 100, 'ENCODING', 'UNCOMPRESSED', 'CHUNK_SIZE', 128, "DUPLICATE_POLICY", "block", 'LABELS', 'name', 'Or', 'color', 'pink')
         r.execute_command("set", "test_key3", "danni")

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -62,7 +62,7 @@ help() {
 		COV=1                 Run with coverage analysis
 		VG=1                  Run with Valgrind
 		VG_LEAKS=0            Do not detect leaks
-		SAN=type              Use LLVM sanitizer (type=address|memory|leak|thread) 
+		SAN=type              Use LLVM sanitizer (type=address|memory|leak|thread)
 		BB=1                  Enable Python debugger (break using BB() in tests)
 		GDB=1                 Enable interactive gdb debugging (in single-test mode)
 
@@ -91,7 +91,7 @@ help() {
 	END
 }
 
-#---------------------------------------------------------------------------------------------- 
+#----------------------------------------------------------------------------------------------
 
 traps() {
 	local func="$1"
@@ -124,7 +124,7 @@ stop() {
 
 traps 'stop' SIGINT
 
-#---------------------------------------------------------------------------------------------- 
+#----------------------------------------------------------------------------------------------
 
 setup_rltest() {
 	if [[ $RLTEST == view ]]; then
@@ -147,7 +147,7 @@ setup_rltest() {
 			echo "PYTHONPATH=$PYTHONPATH"
 		fi
 	fi
-	
+
 	if [[ $RLTEST_VERBOSE == 1 ]]; then
 		RLTEST_ARGS+=" -v"
 	fi
@@ -317,7 +317,7 @@ run_tests() {
 	fi
 
 	[[ $RLEC == 1 ]] && export RLEC_CLUSTER=1
-	
+
 	local E=0
 	if [[ $NOP != 1 ]]; then
 		{ $OP python3 -m RLTest @$rltest_config; (( E |= $? )); } || true


### PR DESCRIPTION
* Compatibility fixes

* Fix the UB in the original code

* Revert to using NULL as username and password

* Fix some compilation issue

* Fix the memory leak in the unittests

* Inverse the logic to free the memory properly

* Provide with a better backward-compatibility code.

Also removes the unused code.

* Deallocate the compaction rules string

* Add the new config behaviour tests

* Test the config API precedence

* Remove the configuration options prefix

* Bump the sdk submodule

* Fix the test

* Use the new config API in the ACL tests

* Try fix the test

* See more GHA output

* Fix the test

* Remove the CI changes used to debug the issue

* Fix the leak

* Fix the other leaks

* Fix another leak

* Use just one temporary string object

* Try fix the last leak

* Fix the leaks

* Update RLTest

* Try fixing the ubuntu jammy python issue

* Do not install old python 3.9 on ubuntu

* Refactor the configuration loading

* Address the review comments\

This is a backport of https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1661