### PR TITLE
MOD-8936 Fixed a crash upon TS.DEL for a series with rules when latest time-bucket is deleted (#1725)

### DIFF
--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -726,7 +726,7 @@ static bool delete_sample_before(RedisModuleCtx *ctx,
         goto _out;
     }
 
-    *deleted = Uncompressed_GetLastTimestamp(chunk);
+    *deleted = series->funcs->GetLastTimestamp(chunk);
     SeriesDelRange(series, *deleted, *deleted);
 
 _out:


### PR DESCRIPTION
The problem was an explicit call to `Uncompressed_GetLastTimestamp()` instead of using the `series->funcs` struct.

Added a test with a crashing scenario before the fix.

(cherry picked from commit 0032aa197e8533f09cb86a4e9a761aec24e96eb3)