### PR TITLE
MOD-9314 Some of the TS commands should use a random shard rather than first (#1736)

### DIFF
--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -33,3 +33,8 @@ exclude_commands:
     - timeseries.HELLO
     - timeseries.INNERCOMMUNICATION
     - timeseries.FORCESHARDSCONNECTION
+overide_command:
+    - { "command_name": "TS.MREVRANGE", "command_arity": -1, "flags": [ "readonly", "module" ], "first_key": 0, "last_key": 0, "step": -1 }
+    - { "command_name": "TS.MRANGE", "command_arity": -1, "flags": [ "readonly", "module" ], "first_key": 0, "last_key": 0, "step": -1 }
+    - { "command_name": "TS.MGET", "command_arity": -1, "flags": [ "readonly", "module" ], "first_key": 0, "last_key": 0, "step": -1 }
+    - { "command_name": "TS.QUERYINDEX", "command_arity": -1, "flags": [ "readonly", "module" ], "first_key": 0, "last_key": 0, "step": -1 }


### PR DESCRIPTION
The convention between the module and the proxy is to set those commands` `step` attribute to -1.

Note that the misspelled "overide_command" is because that's how it is spelled in the python's RAMP package (ramp-packer).

https://redislabs.atlassian.net/browse/MOD-9314
(cherry picked from commit 7d942a67167a0398def47049f166b317934fc260)