### PR TITLE
Add nightly event to macOS 15

### DIFF
--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
     inputs:
       os:
-        description: "OS version to run the tests on. MacOS 12 and 13 - x86-64, MacOS 14 - ARM (Apple Chips)."
+        description: "OS version to run the tests on. MacOS 13 - x86-64, MacOS 14 and 15 - ARM (Apple Chips)."
         required: true
         type: string
         default: "macos-12"
@@ -50,7 +50,7 @@ on:
   # the defaults and options here are the same likes in "workflow_dispatch"
     inputs:
       os:
-        description: "OS version to run the tests on. MacOS 13 - x86-64, MacOS 14 - ARM (Apple Chips)."
+        description: "OS version to run the tests on. MacOS 13 - x86-64, MacOS 14 and 15 - ARM (Apple Chips)."
         required: false
         type: string
       run_valgrind:
@@ -101,7 +101,7 @@ jobs:
         run: |
           OS="${{ inputs.os }}"
           if [ -z "${OS}" ]; then
-            OS='["macos-13", "macos-14"]'
+            OS='["macos-13", "macos-14", "macos-15"]'
           else
             OS='["${OS}"]'
           fi


### PR DESCRIPTION
Add macOS 15 to the reusable macOS workflow's default matrix so the nightly event runs on it, and update workflow input descriptions to reflect this new coverage.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd04f55c-01f4-4e55-a614-625be40e749d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bd04f55c-01f4-4e55-a614-625be40e749d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds macOS 15 to the default macOS matrix and updates workflow input descriptions to reflect supported OS versions.
> 
> - **CI/Workflows** (`.github/workflows/flow-macos.yml`):
>   - Add `"macos-15"` to default OS matrix when no input is provided.
>   - Update OS input descriptions to include `macOS 15` (ARM) alongside `macOS 13` (x86-64) and `macOS 14` (ARM) in both `workflow_dispatch` and `workflow_call`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc0fc82db41ca6700386f9e4854afbf147d45d73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->