### PR TITLE
Cherry-pick: MOD-13142 Allow changing number of threads, while pool hasn't started (#1928)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -9,6 +9,7 @@
 #include "config.h"
 
 #include "consts.h"
+#include "libmr_integration.h"
 #include "module.h"
 #include "parse_policies.h"
 #include "query_language.h"
@@ -374,6 +375,14 @@ static int setModernIntegerConfigValue(const char *name,
                                        void *data,
                                        RedisModuleString **err) {
     if (!strcasecmp("ts-num-threads", name)) {
+        if (LibMR_IsInitialized()) {
+            if (LibMR_ResizeExecutionThreadPoolIfUnstarted(value) != REDISMODULE_OK) {
+                *err = RedisModule_CreateStringPrintf(
+                    NULL, "Cannot set ts-num-threads after the LibMR worker pool has started");
+                return REDISMODULE_ERR;
+            }
+        }
+
         TSGlobalConfig.numThreads = value;
 
         return REDISMODULE_OK;
@@ -434,8 +443,7 @@ bool RegisterModernConfigurationOptions(RedisModuleCtx *ctx) {
     if (RedisModule_RegisterNumericConfig(ctx,
                                           "ts-num-threads",
                                           TSGlobalConfig.numThreads,
-                                          REDISMODULE_CONFIG_IMMUTABLE |
-                                              REDISMODULE_CONFIG_UNPREFIXED,
+                                          REDISMODULE_CONFIG_UNPREFIXED,
                                           NUM_THREADS_MIN,
                                           NUM_THREADS_MAX,
                                           getModernIntegerConfigValue,
@@ -597,6 +605,29 @@ bool RegisterConfigurationOptions(RedisModuleCtx *ctx) {
     return RegisterModernConfigurationOptions(ctx);
 }
 
+static int ParseNumThreadsArg(RedisModuleCtx *ctx,
+                              const char *argName,
+                              RedisModuleString **argv,
+                              int argc,
+                              long long *out) {
+    long long parsed = 0;
+    if (RMUtil_ParseArgsAfter(argName, argv, argc, "l", &parsed) != REDISMODULE_OK) {
+        RedisModule_Log(ctx, "error", "Unable to parse argument after %s", argName);
+        return TSDB_ERROR;
+    }
+    if (parsed < NUM_THREADS_MIN || parsed > NUM_THREADS_MAX) {
+        RedisModule_Log(ctx,
+                        "error",
+                        "Invalid value for %s. Must be between %d and %d",
+                        argName,
+                        NUM_THREADS_MIN,
+                        NUM_THREADS_MAX);
+        return TSDB_ERROR;
+    }
+    *out = parsed;
+    return TSDB_OK;
+}
+
 int ReadDeprecatedLoadTimeConfig(RedisModuleCtx *ctx,
                                  RedisModuleString **argv,
                                  int argc,
@@ -755,16 +786,39 @@ int ReadDeprecatedLoadTimeConfig(RedisModuleCtx *ctx,
             return TSDB_ERROR;
         }
     }
-    if (argc > 1 && RMUtil_ArgIndex("NUM_THREADS", argv, argc) >= 0) {
-        if (RMUtil_ParseArgsAfter("NUM_THREADS", argv, argc, "l", &TSGlobalConfig.numThreads) !=
-            REDISMODULE_OK) {
-            RedisModule_Log(ctx, "warning", "Unable to parse argument after NUM_THREADS");
+    // Default, can be overridden either by legacy module arguments (deprecated) or by modern ones.
+    // Note: Modern module configs are loaded later via RedisModule_LoadConfigs(), but supporting
+    // the modern name here as a module argument helps users migrate from the legacy NUM_THREADS
+    // arg.
+    TSGlobalConfig.numThreads = DEFAULT_NUM_THREADS;
+    bool modernNumThreadsFound = false;
+
+    if (argc > 1 && RMUtil_ArgIndex("ts-num-threads", argv, argc) >= 0) {
+        long long parsed;
+        if (ParseNumThreadsArg(ctx, "ts-num-threads", argv, argc, &parsed) != TSDB_OK) {
             return TSDB_ERROR;
         }
+        TSGlobalConfig.numThreads = parsed;
+        modernNumThreadsFound = true;
+    }
+
+    if (argc > 1 && RMUtil_ArgIndex("NUM_THREADS", argv, argc) >= 0) {
+        long long parsed;
+        if (ParseNumThreadsArg(ctx, "NUM_THREADS", argv, argc, &parsed) != TSDB_OK) {
+            return TSDB_ERROR;
+        }
+
+        if (modernNumThreadsFound) {
+            RedisModule_Log(
+                ctx,
+                "warning",
+                "Both ts-num-threads and NUM_THREADS were provided. Using ts-num-threads.");
+        } else {
+            TSGlobalConfig.numThreads = parsed;
+        }
+
         LOG_DEPRECATED_OPTION("NUM_THREADS", "ts-num-threads", showDeprecationWarning);
         isDeprecated = true;
-    } else {
-        TSGlobalConfig.numThreads = DEFAULT_NUM_THREADS;
     }
 
     if (argc > 1 && RMUtil_ArgIndex("LIBMR_PROTOCOL", argv, argc) >= 0) {

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -918,6 +918,16 @@ static Record *StringListReplyParser(const redisReply *reply) {
 static InternalCommandCallbacks QueryIndexCallbacks = { .command = TS_INTERNAL_QUERYINDEX,
                                                         .replyParser = StringListReplyParser };
 
+static bool mr_initialized = false;
+
+bool LibMR_IsInitialized() {
+    return mr_initialized;
+}
+
+int LibMR_ResizeExecutionThreadPoolIfUnstarted(long long numThreads) {
+    return MR_ResizeExecutionThreadPoolIfUnstarted(numThreads);
+}
+
 int register_mr(RedisModuleCtx *ctx, long long numThreads) {
     if (MR_Init(ctx, numThreads, TSGlobalConfig.password) != REDISMODULE_OK) {
         RedisModule_Log(ctx, "warning", "Failed to init LibMR. aborting...");
@@ -1058,6 +1068,7 @@ int register_mr(RedisModuleCtx *ctx, long long numThreads) {
     MR_RegisterReader("ShardMgetMapper", ShardMgetMapper, QueryPredicatesType);
 
     MR_RegisterReader("ShardQueryindexMapper", ShardQueryindexMapper, QueryPredicatesType);
+    mr_initialized = true;
 
     return REDISMODULE_OK;
 }

--- a/src/libmr_integration.h
+++ b/src/libmr_integration.h
@@ -116,6 +116,8 @@ void SeriesRecord_SendReply(RedisModuleCtx *rctx, void *record);
 Series *SeriesRecord_IntoSeries(SeriesRecord *record);
 
 int register_mr(RedisModuleCtx *ctx, long long numThreads);
+int LibMR_ResizeExecutionThreadPoolIfUnstarted(long long numThreads);
+bool LibMR_IsInitialized();
 bool IsMRCluster();
 
 #endif // REDIS_TIMESERIES_CLEAN_MR_INTEGRATION_H

--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -1,4 +1,7 @@
 import os
+import re
+import shutil
+import subprocess
 import sys
 from logging import exception
 from RLTest import Env as rltestEnv, Defaults
@@ -207,6 +210,65 @@ def is_line_in_server_log(env, line):
             if line in file_line:
                 return True
     return False
+
+
+def _get_worker_thread_names_linux(pid, prefix):
+    task_dir = f"/proc/{pid}/task"
+    if not os.path.isdir(task_dir):
+        return None
+
+    names = []
+    for tid in os.listdir(task_dir):
+        comm_path = os.path.join(task_dir, tid, "comm")
+        try:
+            with open(comm_path) as f:
+                name = f.read().strip()
+        except OSError:
+            continue
+        if re.fullmatch(re.escape(prefix) + r"\d+", name):
+            names.append(name)
+    return names
+
+def _get_worker_thread_names_darwin_sample(pid, prefix):
+    """Use /usr/bin/sample (1s) to read pthread names; returns None if sampling fails."""
+    sample_bin = shutil.which("sample")
+    if not sample_bin:
+        return None
+    r = subprocess.run(
+        [sample_bin, str(pid), "1"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if r.returncode != 0:
+        return None
+    text = r.stdout or ""
+    # e.g. "    873 Thread_4791505: timeseries-5"
+    pat = re.compile(r"Thread_\d+:\s*(" + re.escape(prefix) + r"\d+)")
+    found = pat.findall(text)
+    return list(dict.fromkeys(found))
+
+
+def get_worker_thread_names(conn, prefix="timeseries-"):
+    """Return the list of LibMR worker thread names for a Redis server process.
+
+    *conn* is an open Redis connection to the instance to inspect.
+    On Linux, reads /proc/<pid>/task/*/comm. On macOS, runs ``sample`` for one
+    second and parses its stdout (requires ``/usr/bin/sample``).
+    Only includes numbered pool threads (*prefix* + digits), not e.g.
+    *prefix* + ``el``. Returns None if thread names cannot be read.
+    """
+    info = conn.info("server")
+    pid = info["process_id"]
+
+    if sys.platform == "linux":
+        return _get_worker_thread_names_linux(pid, prefix)
+
+    if sys.platform == "darwin":
+        return _get_worker_thread_names_darwin_sample(pid, prefix)
+
+    return None
+
 
 # Creates a temporary file with the content provided.
 # Returns the filepath of the created file.

--- a/tests/flow/test_globalconfigs.py
+++ b/tests/flow/test_globalconfigs.py
@@ -294,10 +294,8 @@ def test_module_config_api_is_used_on_recent_redis_versions():
 
         # Integer value options:
         conn.execute_command('CONFIG', 'GET', 'ts-num-threads')
-
-        # Can't set an immutable config value.
-        with pytest.raises(redis.exceptions.ResponseError):
-            conn.execute_command('CONFIG', 'SET', 'ts-num-threads', '2')
+        conn.execute_command('CONFIG', 'SET', 'ts-num-threads', '2')
+        env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-num-threads')[1], b'2')
 
         conn.execute_command('CONFIG', 'GET', 'ts-retention-policy')
         conn.execute_command('CONFIG', 'SET', 'ts-retention-policy', '1')
@@ -385,3 +383,41 @@ def test_module_config_takes_precedence_over_module_arguments():
         env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-duplicate-policy')[1], b'last')
         env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-compaction-policy')[1], b'max:1m:1d')
         env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-encoding')[1], b'uncompressed')
+
+def test_ts_num_threads_module_arg():
+    '''
+    Tests that ts-num-threads is accepted as a module-load argument,
+    can be updated via CONFIG SET before LibMR runs, no deprecation
+    warning is emitted, and the configured number of LibMR worker
+    threads is actually spawned.
+
+    Requires cluster mode (worker threads are created lazily on the
+    first libmr execution, which only happens in cluster mode) and
+    Redis >= 7.0 (module config API).
+
+    Thread names are read from /proc on Linux or via ``sample`` on macOS.
+    '''
+    env = Env(moduleArgs="ts-num-threads 5", noLog=False)
+    if not env.isCluster():
+        env.skip()
+    if is_redis_version_lower_than(env, '7.0'):
+        env.skip()
+
+    conn = env.getConnection(1)
+    env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-num-threads')[1], b'5')
+    conn.execute_command('CONFIG', 'SET', 'ts-num-threads', '6')
+    env.assertEqual(conn.execute_command('CONFIG', 'GET', 'ts-num-threads')[1], b'6')
+
+    # TS.MRANGE triggers libmr, which forces the lazy thread pool to start.
+    conn.execute_command('TS.MRANGE', '-', '+', 'FILTER', 'name=ts')
+
+    names = get_worker_thread_names(conn)
+    if names is None:
+        assert False, "Failed to get worker thread names"
+    # Worker threads are named timeseries-0 … timeseries-[n-1];
+    env.assertEqual(len(names), 6,
+                        message="Expected 6 LibMR worker threads")
+
+    # Try set after pool already started.
+    with pytest.raises(Exception):
+        conn.execute_command('CONFIG', 'SET', 'ts-num-threads', '8')


### PR DESCRIPTION
MOD-13142 Allow changing number of threads, while pool hasn't started (#1928)

* config: accept ts-num-threads as load-time arg

Also allow PYTHON override for flow tests, and add a regression test for ts-num-threads module args.

* config: log load-time parse failures as error

* tests: refine ts-num-threads module-arg coverage

Skip RLEC explicitly without redundant skip_on_rlec(), and assert CONFIG SET is rejected since ts-num-threads is immutable.

* format: clang-format config.c

* tests: address review feedback on ts-num-threads test

Remove redundant is_rlec() check (env.isCluster() already covers RLEC)
and verify CONFIG GET returns unchanged value after rejected CONFIG SET.

Made-with: Cursor

* tests: fix indentation in else branch of tests.sh

Made-with: Cursor

* config: deduplicate num-threads parsing; verify threads in test

Extract ParseNumThreadsArg() to eliminate duplicated parsing and
validation between ts-num-threads and NUM_THREADS load-time args.

Add get_worker_thread_names() utility that reads /proc/<pid>/task/
to discover LibMR worker threads by name, and use it to assert the
configured thread count actually took effect.

Made-with: Cursor

* tests: verify ts-num-threads in cluster mode

Consolidate into a single cluster-mode test that verifies the
config value is accepted, CONFIG SET is rejected (immutable),
and the configured number of LibMR worker threads is actually
spawned after triggering TS.MRANGE.

Worker threads are created lazily (on first mr_thpool_add_work),
which only happens in cluster mode, so standalone is skipped.

Made-with: Cursor

* .

* .

* MOD-13142 Allow changing number of threads, while pool hasn't started yet

* guard call for LibMR_ResizeExecutionThreadPoolIfUnstarted

* fix linux thread names regex

* test

---------

Co-authored-by: Tom Gabsow <gabsow.tom@gmail.com>

Cherry-pick of 29fc839f40f8aea54b7baeea9427cf6208a7691f onto 8.8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime thread-pool sizing behavior and removes immutability from `ts-num-threads`, which could affect stability/performance if misused or if LibMR initialization state is misdetected.
> 
> **Overview**
> Allows `ts-num-threads` to be changed via `CONFIG SET` *until* the LibMR worker pool has started, by removing the config’s immutability and attempting a pre-start resize via LibMR (otherwise returning an error once the pool is running).
> 
> Also accepts `ts-num-threads` as a module-load argument (in addition to deprecated `NUM_THREADS`), centralizes/validates parsing with clearer error logging, and adds LibMR initialization tracking/wrappers (`LibMR_IsInitialized`, `LibMR_ResizeExecutionThreadPoolIfUnstarted`).
> 
> Flow tests are updated to reflect mutability, add a cluster-only regression test that verifies the configured worker thread count actually spawns, and introduce a helper to discover LibMR worker threads on Linux/macOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43e43c47491743944d3d88a5bd8f13a08274c08d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->