### PR TITLE
MOD-14674 -  oss refresh list

### DIFF
--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -80,7 +80,7 @@ jobs:
     needs: [prepare-values]
     with:
       arch: x64
-      os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 azurelinux3 mariner2
+      os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       beta-version: ${{needs.prepare-values.outputs.beta-version}}
       quick: false
@@ -90,6 +90,7 @@ jobs:
     needs: [prepare-values]
     with:
       arch: arm64
+      os: bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       beta-version: ${{needs.prepare-values.outputs.beta-version}}
       quick: false

--- a/.github/workflows/event-tag.yml
+++ b/.github/workflows/event-tag.yml
@@ -33,7 +33,7 @@ jobs:
     needs: [prepare-values]
     with:
       arch: x64
-      os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 azurelinux3 mariner2 alpine
+      os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
     secrets: inherit
   build-linux-arm64:
@@ -41,7 +41,7 @@ jobs:
     needs: [prepare-values]
     with:
       arch: arm64
-      os: bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine
+      os: bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
     secrets: inherit
   macos:

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -17,7 +17,7 @@ on:
         required: true
         default: 'x64'
       os:
-        description: 'OS to build on (space-separated, e.g. "focal jammy rocky9")'
+        description: 'OS to build on (space-separated, e.g. "jammy noble resolute rocky10")'
         type: string
         required: false
         default: ''
@@ -49,7 +49,7 @@ on:
         type: string
         required: true
       os:
-        description: 'OS to build on (space-separated, e.g. "focal jammy rocky9")'
+        description: 'OS to build on (space-separated, e.g. "jammy noble resolute rocky10")'
         type: string
         required: false
         default: ''
@@ -105,9 +105,9 @@ jobs:
           OS="${{ inputs.os }}"
           if [ -z "${OS}" ]; then
             if [ "${{ inputs.arch }}" == "arm64" ]; then
-              OS="bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine"
+              OS="bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2"
             else
-              OS="bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine"
+              OS="bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie"
             fi
           fi
           # Convert space-separated list to JSON array

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           OS="${{ inputs.os }}"
           if [ -z "${OS}" ]; then
-            OS='["macos-14", "macos-15", "macos-26"]'
+            OS='["macos-14", "macos-15", "macos-26", "macos-14-large", "macos-15-intel", "macos-26-intel"]'
           else
             OS='["${OS}"]'
           fi
@@ -139,6 +139,13 @@ jobs:
           ref: ${{ needs.setup-environment.outputs.redis-ref }}
           path: 'redis'
           submodules: recursive
+      - name: Setup macOS 26 SDK
+        if: startsWith(matrix.os, 'macos-26')
+        run: |
+          _SDK="$(xcrun --sdk macosx --show-sdk-path)"
+          echo "SDKROOT=$_SDK" >> $GITHUB_ENV
+          echo "CC=/usr/bin/clang" >> $GITHUB_ENV
+          echo "CXX=/usr/bin/clang++" >> $GITHUB_ENV
       - name: Setup specific
         working-directory: .install
         run: ./install_script.sh

--- a/.github/workflows/flow-random-traffic.yml
+++ b/.github/workflows/flow-random-traffic.yml
@@ -43,7 +43,7 @@ jobs:
             echo "os=${INPUT_OS}" >> $GITHUB_OUTPUT
             echo "Using specified OS: ${INPUT_OS}"
           else
-            OS_LIST=(bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 azurelinux3 mariner2 alpine)
+            OS_LIST=(bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie)
             RANDOM_INDEX=$((RANDOM % ${#OS_LIST[@]}))
             SELECTED=${OS_LIST[$RANDOM_INDEX]}
             echo "os=${SELECTED}" >> $GITHUB_OUTPUT

--- a/Dockerfile.alma10
+++ b/Dockerfile.alma10
@@ -1,17 +1,13 @@
-FROM rockylinux:8
+# AlmaLinux 10.x
+FROM almalinux:10
 
 WORKDIR /workspace
 
-RUN dnf update -y
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dnf -y update
+RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync unzip clang jq \
+    autoconf automake libtool
 
-RUN dnf groupinstall "Development Tools" -yqq
-RUN dnf config-manager --set-enabled powertools
-RUN dnf install epel-release -yqq
-RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync clang curl python3.11-devel \
-    autoconf automake libtool jq
-
-RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 

--- a/Dockerfile.alma10
+++ b/Dockerfile.alma10
@@ -6,7 +6,7 @@ WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 RUN dnf -y update
 RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync unzip clang jq \
-    autoconf automake libtool
+    autoconf automake libtool python3-devel
 
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh

--- a/Dockerfile.alma8
+++ b/Dockerfile.alma8
@@ -9,10 +9,13 @@ RUN dnf groupinstall "Development Tools" -yqq
 RUN dnf config-manager --set-enabled powertools
 RUN dnf install epel-release -yqq
 RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync clang curl python3.11-devel \
+    bzip2-devel libffi-devel zlib-devel tar xz which rsync clang curl jq python3.11-devel \
     autoconf automake libtool
 
 RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
+ENV PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
+
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 

--- a/Dockerfile.alma8
+++ b/Dockerfile.alma8
@@ -1,4 +1,5 @@
-FROM rockylinux:8
+# AlmaLinux 8.x
+FROM almalinux:8
 
 WORKDIR /workspace
 
@@ -9,7 +10,7 @@ RUN dnf config-manager --set-enabled powertools
 RUN dnf install epel-release -yqq
 RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
     bzip2-devel libffi-devel zlib-devel tar xz which rsync clang curl python3.11-devel \
-    autoconf automake libtool jq
+    autoconf automake libtool
 
 RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
 COPY .install /workspace/.install

--- a/Dockerfile.alma9
+++ b/Dockerfile.alma9
@@ -1,17 +1,13 @@
-FROM rockylinux:8
+# AlmaLinux 9.x
+FROM almalinux:9
 
 WORKDIR /workspace
 
-RUN dnf update -y
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dnf -y update
+RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync unzip clang jq \
+    autoconf automake libtool
 
-RUN dnf groupinstall "Development Tools" -yqq
-RUN dnf config-manager --set-enabled powertools
-RUN dnf install epel-release -yqq
-RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync clang curl python3.11-devel \
-    autoconf automake libtool jq
-
-RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 

--- a/Dockerfile.alma9
+++ b/Dockerfile.alma9
@@ -5,8 +5,11 @@ WORKDIR /workspace
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN dnf -y update
-RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync unzip clang jq \
-    autoconf automake libtool
+RUN dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ gcc-toolset-13-libatomic-devel make wget git openssl openssl-devel which rsync unzip clang jq \
+    autoconf automake libtool python3-devel
+RUN cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh
+ENV PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH}"
 
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -1,17 +1,14 @@
-FROM rockylinux:8
+FROM debian:bookworm
 
 WORKDIR /workspace
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN dnf update -y
+RUN apt update -qq \
+    && apt upgrade -yqq \
+    && apt-get update \
+    && apt install -yqq git wget curl build-essential lcov openssl libssl-dev \
+    rsync unzip libclang-dev clang autoconf automake libtool
 
-RUN dnf groupinstall "Development Tools" -yqq
-RUN dnf config-manager --set-enabled powertools
-RUN dnf install epel-release -yqq
-RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync clang curl python3.11-devel \
-    autoconf automake libtool jq
-
-RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -7,7 +7,7 @@ RUN apt update -qq \
     && apt upgrade -yqq \
     && apt-get update \
     && apt install -yqq git wget curl build-essential lcov openssl libssl-dev \
-    rsync unzip libclang-dev clang autoconf automake libtool
+    rsync unzip libclang-dev clang autoconf automake libtool python3-dev
 
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh

--- a/Dockerfile.noble
+++ b/Dockerfile.noble
@@ -1,0 +1,39 @@
+# Ubuntu 24.04 LTS (Noble Numbat)
+FROM ubuntu:24.04
+
+WORKDIR /workspace
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    make \
+    gcc \
+    g++ \
+    gdb \
+    clang \
+    valgrind \
+    git \
+    jq \
+    libssl-dev \
+    autoconf \
+    automake \
+    libtool \
+    cmake \
+    curl \
+    wget \
+    libblocksruntime-dev \
+    unzip \
+    rsync
+
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requirements_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.noble
+++ b/Dockerfile.noble
@@ -23,7 +23,8 @@ RUN apt-get update && apt-get install -y \
     wget \
     libblocksruntime-dev \
     unzip \
-    rsync
+    rsync \
+    python3-dev
 
 ARG REDIS_REF=unstable
 ARG SANITIZER=

--- a/Dockerfile.resolute
+++ b/Dockerfile.resolute
@@ -1,0 +1,39 @@
+# Ubuntu 26.04 LTS (Resolute Raccoon)
+FROM ubuntu:26.04
+
+WORKDIR /workspace
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    make \
+    gcc \
+    g++ \
+    gdb \
+    clang \
+    valgrind \
+    git \
+    jq \
+    libssl-dev \
+    autoconf \
+    automake \
+    libtool \
+    cmake \
+    curl \
+    wget \
+    libblocksruntime-dev \
+    unzip \
+    rsync
+
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requirements_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.resolute
+++ b/Dockerfile.resolute
@@ -23,7 +23,8 @@ RUN apt-get update && apt-get install -y \
     wget \
     libblocksruntime-dev \
     unzip \
-    rsync
+    rsync \
+    python3-dev
 
 ARG REDIS_REF=unstable
 ARG SANITIZER=

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -6,7 +6,7 @@ WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 RUN dnf update -y
 RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync unzip clang jq \
-    autoconf automake libtool
+    autoconf automake libtool python3-devel
 
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -1,17 +1,13 @@
-FROM rockylinux:8
+# Rocky Linux 10.x
+FROM quay.io/rockylinux/rockylinux:10
 
 WORKDIR /workspace
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN dnf update -y
+RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync unzip clang jq \
+    autoconf automake libtool
 
-RUN dnf groupinstall "Development Tools" -yqq
-RUN dnf config-manager --set-enabled powertools
-RUN dnf install epel-release -yqq
-RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync clang curl python3.11-devel \
-    autoconf automake libtool jq
-
-RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -12,6 +12,9 @@ RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-liba
     autoconf automake libtool jq
 
 RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
+ENV PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
+
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 

--- a/Dockerfile.trixie
+++ b/Dockerfile.trixie
@@ -1,17 +1,14 @@
-FROM rockylinux:8
+FROM debian:trixie
 
 WORKDIR /workspace
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN dnf update -y
+RUN apt update -qq \
+    && apt upgrade -yqq \
+    && apt-get update \
+    && apt install -yqq git wget curl build-essential lcov openssl libssl-dev \
+    rsync unzip libclang-dev clang autoconf automake libtool
 
-RUN dnf groupinstall "Development Tools" -yqq
-RUN dnf config-manager --set-enabled powertools
-RUN dnf install epel-release -yqq
-RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync clang curl python3.11-devel \
-    autoconf automake libtool jq
-
-RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 

--- a/Dockerfile.trixie
+++ b/Dockerfile.trixie
@@ -7,7 +7,7 @@ RUN apt update -qq \
     && apt upgrade -yqq \
     && apt-get update \
     && apt install -yqq git wget curl build-essential lcov openssl libssl-dev \
-    rsync unzip libclang-dev clang autoconf automake libtool
+    rsync unzip libclang-dev clang autoconf automake libtool python3-dev
 
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -66,18 +66,27 @@ OS=$($READIES/bin/platform --os)
 [[ $OS == linux ]] && OS=Linux
 
 OSNICK=$($READIES/bin/platform --osnick)
+# platform reports centosN on Alma; use real ID from the image
+if [[ -r /etc/os-release ]]; then
+	# shellcheck disable=SC1091
+	. /etc/os-release
+	[[ ${ID:-} == almalinux ]] && OSNICK=alma${VERSION_ID%%.*}
+fi
 [[ $OSNICK == trusty ]]  && OSNICK=ubuntu14.04
 [[ $OSNICK == xenial ]]  && OSNICK=ubuntu16.04
 [[ $OSNICK == bionic ]]  && OSNICK=ubuntu18.04
 [[ $OSNICK == focal ]]   && OSNICK=ubuntu20.04
 [[ $OSNICK == jammy ]]   && OSNICK=ubuntu22.04
+[[ $OSNICK == noble ]]   && OSNICK=ubuntu24.04
+[[ $OSNICK == resolute ]] && OSNICK=ubuntu26.04
 [[ $OSNICK == centos7 ]] && OSNICK=rhel7
 [[ $OSNICK == centos8 ]] && OSNICK=rhel8
 [[ $OSNICK == centos9 ]] && OSNICK=rhel9
+[[ $OSNICK == centos10 ]] && OSNICK=rhel10
 [[ $OSNICK == ol8 ]]     && OSNICK=rhel8
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
 [[ $OSNICK == rocky9 ]]  && OSNICK=rhel9
-
+[[ $OSNICK == rocky10 ]] && OSNICK=rhel10
 
 PLATFORM="$OS-$OSNICK-$ARCH"
 

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -41,18 +41,26 @@ OS=$($READIES/bin/platform --os)
 [[ $OS == linux ]] && OS="Linux"
 
 [[ -z $OSNICK ]] && OSNICK=$($READIES/bin/platform --osnick)
+if [[ -r /etc/os-release ]]; then
+	# shellcheck disable=SC1091
+	. /etc/os-release
+	[[ ${ID:-} == almalinux ]] && OSNICK=alma${VERSION_ID%%.*}
+fi
 [[ $OSNICK == trusty ]]  && OSNICK=ubuntu14.04
 [[ $OSNICK == xenial ]]  && OSNICK=ubuntu16.04
 [[ $OSNICK == bionic ]]  && OSNICK=ubuntu18.04
 [[ $OSNICK == focal ]]   && OSNICK=ubuntu20.04
 [[ $OSNICK == jammy ]]   && OSNICK=ubuntu22.04
+[[ $OSNICK == noble ]]   && OSNICK=ubuntu24.04
+[[ $OSNICK == resolute ]] && OSNICK=ubuntu26.04
 [[ $OSNICK == centos7 ]] && OSNICK=rhel7
 [[ $OSNICK == centos8 ]] && OSNICK=rhel8
 [[ $OSNICK == centos9 ]] && OSNICK=rhel9
+[[ $OSNICK == centos10 ]] && OSNICK=rhel10
 [[ $OSNICK == ol8 ]]     && OSNICK=rhel8
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
 [[ $OSNICK == rocky9 ]]  && OSNICK=rhel9
-
+[[ $OSNICK == rocky10 ]] && OSNICK=rhel10
 
 PLATFORM="$OS-$OSNICK-$ARCH"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it expands the CI/build matrix and packaging OS detection across many new base images, which can introduce build failures and artifact naming inconsistencies.
> 
> **Overview**
> Extends the GitHub Actions build/test matrix to cover additional Linux distros (including Ubuntu `noble`/`resolute`, Rocky `10`, Alma `8/9/10`, Debian `bookworm`/`trixie`) and adds more macOS runners (including *large* and *intel* variants).
> 
> Introduces new Dockerfiles for the added Linux targets, refreshes the existing `Dockerfile.rocky8` (switch to `dnf`, updated toolchain/deps, Python `3.11`), and updates `sbin/pack.sh` and `sbin/upload-artifacts` to correctly map `OSNICK` for Alma/Rocky 10 and new Ubuntu codenames when naming/uploading artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb0127d2207da5e5627a61085cf35556501cc19b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->