### PR TITLE
MOD-12726 unique snapshot name + new output params for nighly event

### DIFF
--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -31,7 +31,12 @@ jobs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
       beta-timestamp: ${{ steps.set-env.outputs.beta-timestamp }}
       beta-version: ${{ steps.set-env.outputs.beta-version }}
+      module-version: ${{ steps.get-version.outputs.module-version }}
+      snapshot-template: ${{ steps.set-env.outputs.snapshot-template }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: set env
         id: set-env
         run: |
@@ -45,6 +50,22 @@ jobs:
           echo "beta-timestamp=${TIMESTAMP}" >> $GITHUB_OUTPUT
           echo "beta-version=${BETA_VERSION}" >> $GITHUB_OUTPUT
           echo "Generated beta version: ${BETA_VERSION}"
+
+          BRANCH_NAME="${{ github.ref_name }}"
+          BRANCH_NAME="${BRANCH_NAME//[^A-Za-z0-9._-]/_}"
+          SNAPSHOT_TEMPLATE="redistimeseries/snapshots/redistimeseries.@OS.${BRANCH_NAME}.${TIMESTAMP}.${WORKFLOW_NUM}.zip"
+          echo "snapshot-template=${SNAPSHOT_TEMPLATE}" >> $GITHUB_OUTPUT
+          echo "Snapshot template: ${SNAPSHOT_TEMPLATE}"
+
+      - name: Extract module version
+        id: get-version
+        run: |
+          MAJOR=$(grep '#define REDISTIMESERIES_VERSION_MAJOR' src/version.h | awk '{print $3}')
+          MINOR=$(grep '#define REDISTIMESERIES_VERSION_MINOR' src/version.h | awk '{print $3}')
+          PATCH=$(grep '#define REDISTIMESERIES_VERSION_PATCH' src/version.h | awk '{print $3}')
+          MODULE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "module-version=${MODULE_VERSION}" >> $GITHUB_OUTPUT
+          echo "Module version: ${MODULE_VERSION}"
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -66,6 +66,12 @@ jobs:
           MODULE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
           echo "module-version=${MODULE_VERSION}" >> $GITHUB_OUTPUT
           echo "Module version: ${MODULE_VERSION}"
+
+      - name: Summary
+        run: |
+          echo "### Nightly Build Info" >> $GITHUB_STEP_SUMMARY
+          echo "- **Module Version:** ${{ steps.get-version.outputs.module-version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Snapshot Template:** \`${{ steps.set-env.outputs.snapshot-template }}\`" >> $GITHUB_STEP_SUMMARY
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -158,42 +158,42 @@ jobs:
             ${{ env.DOCKER_IMAGE }} \
             make build
 
-      - name: Run tests
-        run: |
-          # Capture test output to file for parsing by capture-test-results action
-          # The workspace is mounted, so test_output.log will be accessible outside the container
-          docker run --rm \
-            -v ${{ github.workspace }}:/workspace \
-            -w /workspace \
-            --cap-add=SYS_PTRACE \
-            --security-opt seccomp=unconfined \
-            -e SAN=${{ inputs.run_sanitizer && 'addr' || '' }} \
-            ${{ env.DOCKER_IMAGE }} \
-            bash -c "make test \
-              VG=${{ inputs.run_valgrind && '1' || '0' }} \
-              SAN=${{ inputs.run_sanitizer && 'addr' || '' }} \
-              QUICK=${{ inputs.quick && '1' || '0' }} 2>&1 | tee /workspace/test_output.log; exit \${PIPESTATUS[0]}"
+      # - name: Run tests
+      #   run: |
+      #     # Capture test output to file for parsing by capture-test-results action
+      #     # The workspace is mounted, so test_output.log will be accessible outside the container
+      #     docker run --rm \
+      #       -v ${{ github.workspace }}:/workspace \
+      #       -w /workspace \
+      #       --cap-add=SYS_PTRACE \
+      #       --security-opt seccomp=unconfined \
+      #       -e SAN=${{ inputs.run_sanitizer && 'addr' || '' }} \
+      #       ${{ env.DOCKER_IMAGE }} \
+      #       bash -c "make test \
+      #         VG=${{ inputs.run_valgrind && '1' || '0' }} \
+      #         SAN=${{ inputs.run_sanitizer && 'addr' || '' }} \
+      #         QUICK=${{ inputs.quick && '1' || '0' }} 2>&1 | tee /workspace/test_output.log; exit \${PIPESTATUS[0]}"
 
-      - name: Fix test log permissions
-        if: always()
-        run: |
-          sudo chown -R "$(id -u)":"$(id -g)" tests || true
-          sudo chmod -R a+rX tests || true
-          sudo chown "$(id -u)":"$(id -g)" test_output.log || true
+      # - name: Fix test log permissions
+      #   if: always()
+      #   run: |
+      #     sudo chown -R "$(id -u)":"$(id -g)" tests || true
+      #     sudo chmod -R a+rX tests || true
+      #     sudo chown "$(id -u)":"$(id -g)" test_output.log || true
 
-      - name: Capture test results
-        if: always()
-        uses: ./.github/actions/capture-test-results
-        with:
-          os-name: ${{ inputs.arch }}-${{ matrix.platform.os }}
+      # - name: Capture test results
+      #   if: always()
+      #   uses: ./.github/actions/capture-test-results
+      #   with:
+      #     os-name: ${{ inputs.arch }}-${{ matrix.platform.os }}
 
-      - name: Upload test artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-artifacts-${{ inputs.arch }}-${{ matrix.platform.os }}${{ inputs.run_valgrind && '-valgrind' || '' }}${{ inputs.run_sanitizer && '-sanitizer' || '' }}
-          path: |
-            tests/**/*.log
+      # - name: Upload test artifacts
+      #   if: failure()
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: test-artifacts-${{ inputs.arch }}-${{ matrix.platform.os }}${{ inputs.run_valgrind && '-valgrind' || '' }}${{ inputs.run_sanitizer && '-sanitizer' || '' }}
+      #     path: |
+      #       tests/**/*.log
 
       - name: Pack module
         if: ${{ !inputs.run_valgrind && !inputs.run_sanitizer }}

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -158,42 +158,42 @@ jobs:
             ${{ env.DOCKER_IMAGE }} \
             make build
 
-      # - name: Run tests
-      #   run: |
-      #     # Capture test output to file for parsing by capture-test-results action
-      #     # The workspace is mounted, so test_output.log will be accessible outside the container
-      #     docker run --rm \
-      #       -v ${{ github.workspace }}:/workspace \
-      #       -w /workspace \
-      #       --cap-add=SYS_PTRACE \
-      #       --security-opt seccomp=unconfined \
-      #       -e SAN=${{ inputs.run_sanitizer && 'addr' || '' }} \
-      #       ${{ env.DOCKER_IMAGE }} \
-      #       bash -c "make test \
-      #         VG=${{ inputs.run_valgrind && '1' || '0' }} \
-      #         SAN=${{ inputs.run_sanitizer && 'addr' || '' }} \
-      #         QUICK=${{ inputs.quick && '1' || '0' }} 2>&1 | tee /workspace/test_output.log; exit \${PIPESTATUS[0]}"
+      - name: Run tests
+        run: |
+          # Capture test output to file for parsing by capture-test-results action
+          # The workspace is mounted, so test_output.log will be accessible outside the container
+          docker run --rm \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace \
+            --cap-add=SYS_PTRACE \
+            --security-opt seccomp=unconfined \
+            -e SAN=${{ inputs.run_sanitizer && 'addr' || '' }} \
+            ${{ env.DOCKER_IMAGE }} \
+            bash -c "make test \
+              VG=${{ inputs.run_valgrind && '1' || '0' }} \
+              SAN=${{ inputs.run_sanitizer && 'addr' || '' }} \
+              QUICK=${{ inputs.quick && '1' || '0' }} 2>&1 | tee /workspace/test_output.log; exit \${PIPESTATUS[0]}"
 
-      # - name: Fix test log permissions
-      #   if: always()
-      #   run: |
-      #     sudo chown -R "$(id -u)":"$(id -g)" tests || true
-      #     sudo chmod -R a+rX tests || true
-      #     sudo chown "$(id -u)":"$(id -g)" test_output.log || true
+      - name: Fix test log permissions
+        if: always()
+        run: |
+          sudo chown -R "$(id -u)":"$(id -g)" tests || true
+          sudo chmod -R a+rX tests || true
+          sudo chown "$(id -u)":"$(id -g)" test_output.log || true
 
-      # - name: Capture test results
-      #   if: always()
-      #   uses: ./.github/actions/capture-test-results
-      #   with:
-      #     os-name: ${{ inputs.arch }}-${{ matrix.platform.os }}
+      - name: Capture test results
+        if: always()
+        uses: ./.github/actions/capture-test-results
+        with:
+          os-name: ${{ inputs.arch }}-${{ matrix.platform.os }}
 
-      # - name: Upload test artifacts
-      #   if: failure()
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: test-artifacts-${{ inputs.arch }}-${{ matrix.platform.os }}${{ inputs.run_valgrind && '-valgrind' || '' }}${{ inputs.run_sanitizer && '-sanitizer' || '' }}
-      #     path: |
-      #       tests/**/*.log
+      - name: Upload test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifacts-${{ inputs.arch }}-${{ matrix.platform.os }}${{ inputs.run_valgrind && '-valgrind' || '' }}${{ inputs.run_sanitizer && '-sanitizer' || '' }}
+          path: |
+            tests/**/*.log
 
       - name: Pack module
         if: ${{ !inputs.run_valgrind && !inputs.run_sanitizer }}

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -308,6 +308,11 @@ if [[ $WITH_GITSHA == 1 ]]; then
 	BRANCH="${BRANCH}-${GIT_COMMIT}"
 fi
 
+if [[ -n $BETA_VERSION ]]; then
+	BETA_SUFFIX=$(echo "$BETA_VERSION" | cut -d'.' -f4,5,6)
+	BRANCH="${BRANCH}.${BETA_SUFFIX}"
+fi
+
 #----------------------------------------------------------------------------------------------
 
 RELEASE_ramp=${PACKAGE_NAME}.$OS-$OSNICK-$ARCH.$SEMVER${VARIANT}.zip


### PR DESCRIPTION
1. Make snapshot upload artifact name unique
2. Adding two output parameters to nightly event(snapshot name and version number)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI outputs and snapshot/package naming conventions, which can break downstream automation that expects previous artifact paths or filenames.
> 
> **Overview**
> Nightly GitHub Actions now generates and exports additional build metadata: `module-version` (parsed from `src/version.h`) and a unique `snapshot-template` based on branch, timestamp, and run number, and writes both into the run summary.
> 
> Packaging updates in `sbin/pack.sh` append a beta-derived suffix to the snapshot `BRANCH` when `BETA_VERSION` is set, making snapshot artifact names unique across nightly runs while preserving the existing release naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b5f7b2b50d7020ffc4358f8484f9f6e47940b7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->