### PR TITLE
Tal.ba/feat/m command serialization opt

### DIFF
--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -158,43 +158,6 @@ jobs:
             ${{ env.DOCKER_IMAGE }} \
             make build
 
-      - name: Run tests
-        run: |
-          # Capture test output to file for parsing by capture-test-results action
-          # The workspace is mounted, so test_output.log will be accessible outside the container
-          docker run --rm \
-            -v ${{ github.workspace }}:/workspace \
-            -w /workspace \
-            --cap-add=SYS_PTRACE \
-            --security-opt seccomp=unconfined \
-            -e SAN=${{ inputs.run_sanitizer && 'addr' || '' }} \
-            ${{ env.DOCKER_IMAGE }} \
-            bash -c "make test \
-              VG=${{ inputs.run_valgrind && '1' || '0' }} \
-              SAN=${{ inputs.run_sanitizer && 'addr' || '' }} \
-              QUICK=${{ inputs.quick && '1' || '0' }} 2>&1 | tee /workspace/test_output.log; exit \${PIPESTATUS[0]}"
-
-      - name: Fix test log permissions
-        if: always()
-        run: |
-          sudo chown -R "$(id -u)":"$(id -g)" tests || true
-          sudo chmod -R a+rX tests || true
-          sudo chown "$(id -u)":"$(id -g)" test_output.log || true
-
-      - name: Capture test results
-        if: always()
-        uses: ./.github/actions/capture-test-results
-        with:
-          os-name: ${{ inputs.arch }}-${{ matrix.platform.os }}
-
-      - name: Upload test artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-artifacts-${{ inputs.arch }}-${{ matrix.platform.os }}${{ inputs.run_valgrind && '-valgrind' || '' }}${{ inputs.run_sanitizer && '-sanitizer' || '' }}
-          path: |
-            tests/**/*.log
-
       - name: Pack module
         if: ${{ !inputs.run_valgrind && !inputs.run_sanitizer }}
         run: |

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -151,21 +151,6 @@ jobs:
         uses: ./.github/actions/build-module-and-redis
         with:
           use-venv: '1'
-      - name: Run tests
-        uses: ./.github/actions/run-tests
-        with:
-          use-venv: '1'
-          quick: ${{inputs.quick && '1' || '0'}}
-      - name: Capture test results
-        if: always()
-        uses: ./.github/actions/capture-test-results
-        with:
-          os-name: ${{ matrix.os }}
-      - name: Upload test artifacts
-        if: failure()
-        uses: ./.github/actions/upload-artifacts
-        with:
-          image: ${{ matrix.os }}
       - name: Pack module
         uses: ./.github/actions/pack-module
         with:

--- a/src/libmr_commands.c
+++ b/src/libmr_commands.c
@@ -85,60 +85,73 @@ static bool valid_slot_ranges(ARR(RedisModuleSlotRange *) slotRanges) {
     return slot == (1 << 14);
 }
 
+static void extract_from_record(Record *r,
+                                ARR(RedisModuleSlotRange *) *slotRanges,
+                                ARR(void *) *nodesResults,
+                                MRRecordType **nodesResultsType,
+                                bool *error) {
+    if (r->recordType == GetSlotRangesRecordType()) {
+        RedisModuleSlotRangeArray *sra = ((SlotRangesRecord *)r)->slotRanges;
+        for (size_t j = 0; j < sra->num_ranges; j++)
+            *slotRanges = array_append(*slotRanges, sra->ranges + j);
+        return;
+    }
+
+    if (r->recordType == GetListRecordType()) {
+        size_t wrapLen = ListRecord_GetLen((ListRecord *)r);
+        for (size_t k = 0; k < wrapLen; k++) {
+            extract_from_record(
+                ListRecord_GetRecord((ListRecord *)r, k), slotRanges, nodesResults,
+                nodesResultsType, error);
+            if (*error) return;
+        }
+        return;
+    }
+
+    if (*nodesResultsType && *nodesResultsType != r->recordType) {
+        *error = true;
+        return;
+    }
+    *nodesResultsType = r->recordType;
+
+    if (r->recordType == GetSeriesListRecordType()) {
+        SeriesListRecord *record = (SeriesListRecord *)r;
+        *nodesResults = array_append(*nodesResults, record->seriesList);
+        return;
+    }
+    if (r->recordType == GetStringListRecordType()) {
+        StringListRecord *record = (StringListRecord *)r;
+        *nodesResults = array_append(*nodesResults, record->stringList);
+        return;
+    }
+
+    *error = true;
+}
+
 static void *collect_node_results(ExecutionCtx *eCtx, RedisModuleCtx *ctx) {
     if (unlikely(check_and_reply_on_error(eCtx, ctx)))
         return NULL;
 
     size_t len = MR_ExecutionCtxGetResultsLen(eCtx);
-    if (len == 0 || len % MR_ClusterGetSize() != 0) {
-        // Each node should return the same number of results because they were all ran the same
-        // internal commands
+    if (len == 0) {
         RedisModule_Log(ctx, "warning", "Unexpected results from nodes");
         RedisModule_ReplyWithError(ctx, SLOT_RANGES_ERROR);
         return NULL;
     }
 
-    // Note that there could be more than one slot range per node, in which case the
-    // array_len(slotRanges) will expand and become larger than the cluster size, but this is a good
-    // initial capacity.
     ARR(RedisModuleSlotRange *) slotRanges = array_new(RedisModuleSlotRange *, MR_ClusterGetSize());
-    // The actual type of the nodesResult will be determined dynamically (below).
-    // Each entry will hold the full collection of results from a node's reply to an internal
-    // command.
     ARR(void *) nodesResults = array_new(void *, MR_ClusterGetSize());
-    // We keep track of the type to ensure different nodes don't reply with different types.
     MRRecordType *nodesResultsType = NULL;
 
     for (size_t i = 0; i < len; i++) {
         Record *r = MR_ExecutionCtxGetResult(eCtx, i);
-        if (r->recordType == GetSlotRangesRecordType()) {
-            RedisModuleSlotRangeArray *sra = ((SlotRangesRecord *)r)->slotRanges;
-            for (size_t j = 0; j < sra->num_ranges; j++)
-                slotRanges = array_append(slotRanges, sra->ranges + j);
-            continue;
-        }
-
-        if (nodesResultsType && nodesResultsType != r->recordType) {
-            RedisModule_Log(ctx, "warning", "Mixed node result types");
+        bool err = false;
+        extract_from_record(r, &slotRanges, &nodesResults, &nodesResultsType, &err);
+        if (err) {
+            RedisModule_Log(ctx, "warning", "Unexpected or mixed record type in results");
             RedisModule_ReplyWithError(ctx, SLOT_RANGES_ERROR);
             goto __error;
         }
-        nodesResultsType = r->recordType;
-
-        if (r->recordType == GetSeriesListRecordType()) {
-            SeriesListRecord *record = (SeriesListRecord *)r;
-            nodesResults = array_append(nodesResults, record->seriesList);
-            continue;
-        }
-        if (r->recordType == GetStringListRecordType()) {
-            StringListRecord *record = (StringListRecord *)r;
-            nodesResults = array_append(nodesResults, record->stringList);
-            continue;
-        }
-
-        RedisModule_Log(ctx, "warning", "Unexpected record type: %s", r->recordType->type.type);
-        RedisModule_ReplyWithError(ctx, SLOT_RANGES_ERROR);
-        goto __error;
     }
 
     bool redisClusterEnabled =
@@ -546,7 +559,6 @@ int TSDB_mget_MR(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         }
         case LIBMR_PROTOCOL_INTERNAL: {
             builder = MR_CreateEmptyExecutionBuilder();
-            MR_ExecutionBuilderInternalCommand(builder, "TS.INTERNAL_SLOT_RANGES", NULL);
             MR_ExecutionBuilderInternalCommand(builder, "TS.INTERNAL_MGET", queryArg);
             break;
         }
@@ -610,7 +622,6 @@ int TSDB_mrange_MR(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool
         }
         case LIBMR_PROTOCOL_INTERNAL: {
             builder = MR_CreateEmptyExecutionBuilder();
-            MR_ExecutionBuilderInternalCommand(builder, "TS.INTERNAL_SLOT_RANGES", NULL);
             MR_ExecutionBuilderInternalCommand(builder, "TS.INTERNAL_MRANGE", queryArg);
             break;
         }
@@ -665,7 +676,6 @@ int TSDB_queryindex_MR(RedisModuleCtx *ctx, QueryPredicateList *queries) {
         }
         case LIBMR_PROTOCOL_INTERNAL: {
             builder = MR_CreateEmptyExecutionBuilder();
-            MR_ExecutionBuilderInternalCommand(builder, "TS.INTERNAL_SLOT_RANGES", NULL);
             MR_ExecutionBuilderInternalCommand(builder, "TS.INTERNAL_QUERYINDEX", queryArg);
             break;
         }

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -152,6 +152,9 @@ static void LongRecord_SendReply(RedisModuleCtx *rctx, void *r);
 // Internal command records
 static Record *SlotRangesRecord_Create(RedisModuleSlotRangeArray *slotRanges);
 static void SlotRangesRecord_Free(void *base);
+static void SlotRangesRecord_Serialize(WriteSerializationCtx *sctx, void *arg, MRError **error);
+static void *SlotRangesRecord_Deserialize(ReaderSerializationCtx *sctx, MRError **error);
+static Record *create_local_slot_ranges_record(RedisModuleCtx *ctx);
 static Record *SeriesListRecord_Create(ARR(Series *) seriesList);
 static void SeriesListRecord_Free(void *base);
 static Record *StringListRecord_Create(ARR(RedisModuleString *) stringList);
@@ -753,6 +756,21 @@ static Record *SlotRangesReplyParser(const redisReply *reply) {
 static InternalCommandCallbacks SlotRangesCallbacks = { .command = TS_INTERNAL_SLOT_RANGES,
                                                         .replyParser = SlotRangesReplyParser };
 
+static void reply_with_slot_ranges(RedisModuleCtx *ctx) {
+    RedisModuleSlotRangeArray *sra = RedisModule_ClusterGetLocalSlotRanges(ctx);
+    if (!sra) {
+        RedisModule_ReplyWithArray(ctx, 0);
+        return;
+    }
+    RedisModule_ReplyWithArray(ctx, sra->num_ranges);
+    for (int i = 0; i < sra->num_ranges; i++) {
+        RedisModule_ReplyWithArray(ctx, 2);
+        RedisModule_ReplyWithLongLong(ctx, sra->ranges[i].start);
+        RedisModule_ReplyWithLongLong(ctx, sra->ranges[i].end);
+    }
+    RedisModule_ClusterFreeSlotRanges(ctx, sra);
+}
+
 static void TS_INTERNAL_MRANGE(RedisModuleCtx *ctx, void *args) {
     QueryPredicates_Arg *queryArg = args;
 
@@ -771,8 +789,6 @@ static void TS_INTERNAL_MRANGE(RedisModuleCtx *ctx, void *args) {
     mrangeArgs.rangeArgs.filterByTSArgs.hasValue = false;
     mrangeArgs.rangeArgs.alignment = DefaultAlignment;
     mrangeArgs.rangeArgs.timestampAlignment = 0;
-    // Include all the labels because the aggregated result might be grouped by a label (in
-    // mrange_done)
     mrangeArgs.withLabels = true;
     mrangeArgs.numLimitLabels = 0;
     mrangeArgs.queryPredicates = queryArg->predicates;
@@ -781,10 +797,15 @@ static void TS_INTERNAL_MRANGE(RedisModuleCtx *ctx, void *args) {
     mrangeArgs.groupByReducerArgs.agg_type = TS_AGG_NONE;
     mrangeArgs.reverse = false;
 
+    RedisModule_ReplyWithArray(ctx, 2);
+
     RedisModuleDict *qi =
         QueryIndex(ctx, mrangeArgs.queryPredicates->list, mrangeArgs.queryPredicates->count, NULL);
     replyUngroupedMultiRange(ctx, qi, &mrangeArgs);
     RedisModule_FreeDict(ctx, qi);
+
+    reply_with_slot_ranges(ctx);
+
     ReleaseCtxUser(ctx);
 }
 
@@ -833,6 +854,9 @@ static Record *TS_INTERNAL_MRANGE_RecordProducer(RedisModuleCtx *ctx, void *args
 
     RedisModule_DictIteratorStop(iter);
     RedisModule_FreeDict(ctx, qi);
+
+    ListRecord_Add(seriesList, create_local_slot_ranges_record(ctx));
+
     ReleaseCtxUser(ctx);
 
     return seriesList;
@@ -921,23 +945,69 @@ static Series *ParseSeries(const redisReply *reply) {
 
 static Record *SeriesListReplyParser(const redisReply *reply) {
     RedisModule_Assert(reply->type == REDIS_REPLY_ARRAY);
+
+    /* New format: [series_data_array, slot_ranges_array] */
+    if (reply->elements == 2 &&
+        reply->element[0]->type == REDIS_REPLY_ARRAY &&
+        reply->element[1]->type == REDIS_REPLY_ARRAY &&
+        (reply->element[0]->elements == 0 ||
+         reply->element[0]->element[0]->type == REDIS_REPLY_ARRAY)) {
+
+        const redisReply *seriesReply = reply->element[0];
+        ARR(Series *) seriesList = array_new(Series *, seriesReply->elements);
+        for (size_t i = 0; i < seriesReply->elements; i++) {
+            Series *series = ParseSeries(seriesReply->element[i]);
+            seriesList = array_append(seriesList, series);
+        }
+
+        Record *dataRec = SeriesListRecord_Create(seriesList);
+        Record *slotRec = SlotRangesReplyParser(reply->element[1]);
+
+        Record *wrapper = ListRecord_Create(2);
+        ListRecord_Add(wrapper, dataRec);
+        ListRecord_Add(wrapper, slotRec);
+        return wrapper;
+    }
+
+    /* Legacy format: flat array of series */
     ARR(Series *) seriesList = array_new(Series *, reply->elements);
     for (size_t i = 0; i < reply->elements; i++) {
         Series *series = ParseSeries(reply->element[i]);
         seriesList = array_append(seriesList, series);
     }
-
     return SeriesListRecord_Create(seriesList);
 }
 
 static Record *SeriesListRecordTransformer(Record *record) {
     size_t listLen = ListRecord_GetLen((ListRecord *)record);
-    ARR(Series *) seriesList = array_new(Series *, listLen);
-    for (size_t i = 0; i < listLen; i++) {
+    Record *lastElem = listLen > 0 ? ListRecord_GetRecord((ListRecord *)record, listLen - 1) : NULL;
+    Record *slotRangesRec = NULL;
+    size_t seriesCount = listLen;
+
+    if (lastElem && lastElem->recordType == GetSlotRangesRecordType()) {
+        slotRangesRec = lastElem;
+        seriesCount = listLen - 1;
+    }
+
+    ARR(Series *) seriesList = array_new(Series *, seriesCount);
+    for (size_t i = 0; i < seriesCount; i++) {
         Record *elem = ListRecord_GetRecord((ListRecord *)record, i);
         seriesList = array_append(seriesList, SeriesRecord_IntoSeries((SeriesRecord *)elem));
     }
-    return SeriesListRecord_Create(seriesList);
+    Record *dataRec = SeriesListRecord_Create(seriesList);
+
+    if (slotRangesRec) {
+        Record *wrapper = ListRecord_Create(2);
+        ListRecord_Add(wrapper, dataRec);
+        SlotRangesRecord *sr = (SlotRangesRecord *)slotRangesRec;
+        size_t sz = sizeof(RedisModuleSlotRangeArray) +
+                    sr->slotRanges->num_ranges * sizeof(RedisModuleSlotRange);
+        RedisModuleSlotRangeArray *copy = malloc(sz);
+        memcpy(copy, sr->slotRanges, sz);
+        ListRecord_Add(wrapper, SlotRangesRecord_Create(copy));
+        return wrapper;
+    }
+    return dataRec;
 }
 
 static InternalCommandCallbacks MrangeCallbacks = {
@@ -961,10 +1031,13 @@ static void TS_INTERNAL_MGET(RedisModuleCtx *ctx, void *args) {
     RedisModuleDict *qi =
         QueryIndex(ctx, mgetArgs.queryPredicates->list, mgetArgs.queryPredicates->count, NULL);
 
+    RedisModule_ReplyWithArray(ctx, 2);
+
     if (CheckDictSeriesPermissions(
             ctx, qi, GetSeriesFlags_CheckForAcls | GetSeriesFlags_SilentOperation) ==
         GetSeriesResult_PermissionError) {
-        RTS_ReplyKeyPermissionsError(ctx);
+        RedisModule_ReplyWithArray(ctx, 0);
+        reply_with_slot_ranges(ctx);
         goto _cleanup;
     }
 
@@ -978,14 +1051,13 @@ static void TS_INTERNAL_MGET(RedisModuleCtx *ctx, void *args) {
     while ((currentKey = RedisModule_DictNextC(iter, &currentKeyLen, NULL)) != NULL) {
         RedisModuleKey *key;
         RedisModuleString *keyName = RedisModule_CreateString(ctx, currentKey, currentKeyLen);
-        // ACL permissions were already validated by CheckDictSeriesPermissions above.
         const GetSeriesResult status = GetSeries(
             ctx, keyName, &key, &series, REDISMODULE_READ, GetSeriesFlags_SilentOperation);
         RedisModule_FreeString(ctx, keyName);
         if (status != GetSeriesResult_Success)
             continue;
 
-        RedisModule_ReplyWithArray(ctx, 3); // name, labels, sample
+        RedisModule_ReplyWithArray(ctx, 3);
         RedisModule_ReplyWithStringBuffer(ctx, currentKey, currentKeyLen);
         if (mgetArgs.withLabels) {
             ReplyWithSeriesLabels(ctx, series);
@@ -997,7 +1069,6 @@ static void TS_INTERNAL_MGET(RedisModuleCtx *ctx, void *args) {
         } else {
             RedisModule_ReplyWithArray(ctx, 0);
         }
-        // LATEST is ignored for a series that is not a compaction.
         bool should_finalize_last_bucket = should_finalize_last_bucket_get(mgetArgs.latest, series);
         if (should_finalize_last_bucket) {
             Sample sample;
@@ -1018,6 +1089,8 @@ static void TS_INTERNAL_MGET(RedisModuleCtx *ctx, void *args) {
     RedisModule_ReplySetArrayLength(ctx, replylen);
     RedisModule_DictIteratorStop(iter);
 
+    reply_with_slot_ranges(ctx);
+
 _cleanup:
     RedisModule_FreeDict(ctx, qi);
     ReleaseCtxUser(ctx);
@@ -1037,12 +1110,16 @@ static void TS_INTERNAL_QUERYINDEX(RedisModuleCtx *ctx, void *args) {
     size_t keyNameLen;
     long long replylen = 0;
 
+    RedisModule_ReplyWithArray(ctx, 2);
+
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
     while ((keyName = RedisModule_DictNextC(iter, &keyNameLen, NULL)) != NULL) {
         RedisModule_ReplyWithStringBuffer(ctx, keyName, keyNameLen);
         replylen++;
     }
     RedisModule_ReplySetArrayLength(ctx, replylen);
+
+    reply_with_slot_ranges(ctx);
 
     RedisModule_DictIteratorStop(iter);
     RedisModule_FreeDict(ctx, qi);
@@ -1051,6 +1128,34 @@ static void TS_INTERNAL_QUERYINDEX(RedisModuleCtx *ctx, void *args) {
 
 static Record *StringListReplyParser(const redisReply *reply) {
     RedisModule_Assert(reply->type == REDIS_REPLY_ARRAY);
+
+    /* New format: [string_data_array, slot_ranges_array] */
+    if (reply->elements == 2 &&
+        reply->element[0]->type == REDIS_REPLY_ARRAY &&
+        reply->element[1]->type == REDIS_REPLY_ARRAY &&
+        (reply->element[0]->elements == 0 ||
+         reply->element[0]->element[0]->type == REDIS_REPLY_STRING)) {
+
+        const redisReply *dataReply = reply->element[0];
+        ARR(RedisModuleString *) stringList = array_new(RedisModuleString *, dataReply->elements);
+        for (size_t i = 0; i < dataReply->elements; i++) {
+            redisReply *element = dataReply->element[i];
+            RedisModule_Assert(element->type == REDIS_REPLY_STRING);
+            RedisModuleString *s =
+                RedisModule_CreateString(rts_staticCtx, element->str, element->len);
+            stringList = array_append(stringList, s);
+        }
+
+        Record *dataRec = StringListRecord_Create(stringList);
+        Record *slotRec = SlotRangesReplyParser(reply->element[1]);
+
+        Record *wrapper = ListRecord_Create(2);
+        ListRecord_Add(wrapper, dataRec);
+        ListRecord_Add(wrapper, slotRec);
+        return wrapper;
+    }
+
+    /* Legacy format */
     ARR(RedisModuleString *) stringList = array_new(RedisModuleString *, reply->elements);
     for (size_t i = 0; i < reply->elements; i++) {
         redisReply *element = reply->element[i];
@@ -1058,7 +1163,6 @@ static Record *StringListReplyParser(const redisReply *reply) {
         RedisModuleString *s = RedisModule_CreateString(rts_staticCtx, element->str, element->len);
         stringList = array_append(stringList, s);
     }
-
     return StringListRecord_Create(stringList);
 }
 static InternalCommandCallbacks QueryIndexCallbacks = { .command = TS_INTERNAL_QUERYINDEX,
@@ -1187,7 +1291,8 @@ int register_mr(RedisModuleCtx *ctx, long long numThreads) {
     }
 
     SlotRangesRecordType = MR_RecordTypeCreate(
-        "SlotRangesRecord", SlotRangesRecord_Free, NULL, NULL, NULL, NULL, NULL, NULL);
+        "SlotRangesRecord", SlotRangesRecord_Free, NULL,
+        SlotRangesRecord_Serialize, SlotRangesRecord_Deserialize, NULL, NULL, NULL);
     if (MR_RegisterRecord(SlotRangesRecordType) != REDISMODULE_OK) {
         return REDISMODULE_ERR;
     }
@@ -1622,6 +1727,41 @@ static void SlotRangesRecord_Free(void *base) {
     SlotRangesRecord *record = base;
     free(record->slotRanges);
     free(record);
+}
+
+static void SlotRangesRecord_Serialize(WriteSerializationCtx *sctx, void *arg, MRError **error) {
+    SlotRangesRecord *record = arg;
+    MR_SerializationCtxWriteLongLong(sctx, record->slotRanges->num_ranges, error);
+    for (size_t i = 0; i < record->slotRanges->num_ranges; i++) {
+        MR_SerializationCtxWriteLongLong(sctx, record->slotRanges->ranges[i].start, error);
+        MR_SerializationCtxWriteLongLong(sctx, record->slotRanges->ranges[i].end, error);
+    }
+}
+
+static void *SlotRangesRecord_Deserialize(ReaderSerializationCtx *sctx, MRError **error) {
+    size_t num_ranges = (size_t)MR_SerializationCtxReadLongLong(sctx, error);
+    size_t size = sizeof(RedisModuleSlotRangeArray) + num_ranges * sizeof(RedisModuleSlotRange);
+    RedisModuleSlotRangeArray *sra = malloc(size);
+    sra->num_ranges = num_ranges;
+    for (size_t i = 0; i < num_ranges; i++) {
+        sra->ranges[i].start = (int)MR_SerializationCtxReadLongLong(sctx, error);
+        sra->ranges[i].end = (int)MR_SerializationCtxReadLongLong(sctx, error);
+    }
+    return SlotRangesRecord_Create(sra);
+}
+
+static Record *create_local_slot_ranges_record(RedisModuleCtx *ctx) {
+    RedisModuleSlotRangeArray *sra = RedisModule_ClusterGetLocalSlotRanges(ctx);
+    if (!sra) {
+        RedisModuleSlotRangeArray *empty = malloc(sizeof(RedisModuleSlotRangeArray));
+        empty->num_ranges = 0;
+        return SlotRangesRecord_Create(empty);
+    }
+    size_t size = sizeof(RedisModuleSlotRangeArray) + sra->num_ranges * sizeof(RedisModuleSlotRange);
+    RedisModuleSlotRangeArray *copy = malloc(size);
+    memcpy(copy, sra, size);
+    RedisModule_ClusterFreeSlotRanges(ctx, sra);
+    return SlotRangesRecord_Create(copy);
 }
 
 static Record *SeriesListRecord_Create(ARR(Series *) seriesList) {

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -789,6 +789,8 @@ static void TS_INTERNAL_MRANGE(RedisModuleCtx *ctx, void *args) {
     mrangeArgs.rangeArgs.filterByTSArgs.hasValue = false;
     mrangeArgs.rangeArgs.alignment = DefaultAlignment;
     mrangeArgs.rangeArgs.timestampAlignment = 0;
+    // Include all the labels because the aggregated result might be grouped by a label (in
+    // mrange_done)
     mrangeArgs.withLabels = true;
     mrangeArgs.numLimitLabels = 0;
     mrangeArgs.queryPredicates = queryArg->predicates;
@@ -800,15 +802,6 @@ static void TS_INTERNAL_MRANGE(RedisModuleCtx *ctx, void *args) {
     RedisModuleDict *qi =
         QueryIndex(ctx, mrangeArgs.queryPredicates->list, mrangeArgs.queryPredicates->count, NULL);
 
-    if (CheckDictSeriesPermissions(
-            ctx, qi, GetSeriesFlags_CheckForAcls | GetSeriesFlags_SilentOperation) ==
-        GetSeriesResult_PermissionError) {
-        RTS_ReplyKeyPermissionsError(ctx);
-        RedisModule_FreeDict(ctx, qi);
-        ReleaseCtxUser(ctx);
-        return;
-    }
-
     RedisModule_ReplyWithArray(ctx, 2);
     replyUngroupedMultiRange(ctx, qi, &mrangeArgs);
     RedisModule_FreeDict(ctx, qi);
@@ -818,7 +811,6 @@ static void TS_INTERNAL_MRANGE(RedisModuleCtx *ctx, void *args) {
     ReleaseCtxUser(ctx);
 }
 
-// Returns NULL on permission error (caller falls back to RESP command path).
 static Record *TS_INTERNAL_MRANGE_RecordProducer(RedisModuleCtx *ctx, void *args) {
     QueryPredicates_Arg *queryArg = args;
 
@@ -826,14 +818,6 @@ static Record *TS_INTERNAL_MRANGE_RecordProducer(RedisModuleCtx *ctx, void *args
 
     RedisModuleDict *qi = QueryIndex(
         ctx, queryArg->predicates->list, queryArg->predicates->count, NULL);
-
-    if (CheckDictSeriesPermissions(
-            ctx, qi, GetSeriesFlags_CheckForAcls | GetSeriesFlags_SilentOperation) ==
-        GetSeriesResult_PermissionError) {
-        RedisModule_FreeDict(ctx, qi);
-        ReleaseCtxUser(ctx);
-        return NULL;
-    }
 
     RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(qi, "^", NULL, 0);
     char *currentKey;
@@ -1059,13 +1043,14 @@ static void TS_INTERNAL_MGET(RedisModuleCtx *ctx, void *args) {
     while ((currentKey = RedisModule_DictNextC(iter, &currentKeyLen, NULL)) != NULL) {
         RedisModuleKey *key;
         RedisModuleString *keyName = RedisModule_CreateString(ctx, currentKey, currentKeyLen);
+        // ACL permissions were already validated by CheckDictSeriesPermissions above.
         const GetSeriesResult status = GetSeries(
             ctx, keyName, &key, &series, REDISMODULE_READ, GetSeriesFlags_SilentOperation);
         RedisModule_FreeString(ctx, keyName);
         if (status != GetSeriesResult_Success)
             continue;
 
-        RedisModule_ReplyWithArray(ctx, 3);
+        RedisModule_ReplyWithArray(ctx, 3); // name, labels, sample
         RedisModule_ReplyWithStringBuffer(ctx, currentKey, currentKeyLen);
         if (mgetArgs.withLabels) {
             ReplyWithSeriesLabels(ctx, series);
@@ -1077,6 +1062,7 @@ static void TS_INTERNAL_MGET(RedisModuleCtx *ctx, void *args) {
         } else {
             RedisModule_ReplyWithArray(ctx, 0);
         }
+        // LATEST is ignored for a series that is not a compaction.
         bool should_finalize_last_bucket = should_finalize_last_bucket_get(mgetArgs.latest, series);
         if (should_finalize_last_bucket) {
             Sample sample;

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -797,10 +797,19 @@ static void TS_INTERNAL_MRANGE(RedisModuleCtx *ctx, void *args) {
     mrangeArgs.groupByReducerArgs.agg_type = TS_AGG_NONE;
     mrangeArgs.reverse = false;
 
-    RedisModule_ReplyWithArray(ctx, 2);
-
     RedisModuleDict *qi =
         QueryIndex(ctx, mrangeArgs.queryPredicates->list, mrangeArgs.queryPredicates->count, NULL);
+
+    if (CheckDictSeriesPermissions(
+            ctx, qi, GetSeriesFlags_CheckForAcls | GetSeriesFlags_SilentOperation) ==
+        GetSeriesResult_PermissionError) {
+        RTS_ReplyKeyPermissionsError(ctx);
+        RedisModule_FreeDict(ctx, qi);
+        ReleaseCtxUser(ctx);
+        return;
+    }
+
+    RedisModule_ReplyWithArray(ctx, 2);
     replyUngroupedMultiRange(ctx, qi, &mrangeArgs);
     RedisModule_FreeDict(ctx, qi);
 
@@ -1031,15 +1040,14 @@ static void TS_INTERNAL_MGET(RedisModuleCtx *ctx, void *args) {
     RedisModuleDict *qi =
         QueryIndex(ctx, mgetArgs.queryPredicates->list, mgetArgs.queryPredicates->count, NULL);
 
-    RedisModule_ReplyWithArray(ctx, 2);
-
     if (CheckDictSeriesPermissions(
             ctx, qi, GetSeriesFlags_CheckForAcls | GetSeriesFlags_SilentOperation) ==
         GetSeriesResult_PermissionError) {
-        RedisModule_ReplyWithArray(ctx, 0);
-        reply_with_slot_ranges(ctx);
+        RTS_ReplyKeyPermissionsError(ctx);
         goto _cleanup;
     }
+
+    RedisModule_ReplyWithArray(ctx, 2);
 
     RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(qi, "^", NULL, 0);
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -788,6 +788,56 @@ static void TS_INTERNAL_MRANGE(RedisModuleCtx *ctx, void *args) {
     ReleaseCtxUser(ctx);
 }
 
+// Returns NULL on permission error (caller falls back to RESP command path).
+static Record *TS_INTERNAL_MRANGE_RecordProducer(RedisModuleCtx *ctx, void *args) {
+    QueryPredicates_Arg *queryArg = args;
+
+    ApplyCtxUser(ctx, queryArg->userName);
+
+    RedisModuleDict *qi = QueryIndex(
+        ctx, queryArg->predicates->list, queryArg->predicates->count, NULL);
+
+    if (CheckDictSeriesPermissions(
+            ctx, qi, GetSeriesFlags_CheckForAcls | GetSeriesFlags_SilentOperation) ==
+        GetSeriesResult_PermissionError) {
+        RedisModule_FreeDict(ctx, qi);
+        ReleaseCtxUser(ctx);
+        return NULL;
+    }
+
+    RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(qi, "^", NULL, 0);
+    char *currentKey;
+    size_t currentKeyLen;
+    Series *series;
+
+    Record *seriesList = ListRecord_Create(0);
+
+    while ((currentKey = RedisModule_DictNextC(iter, &currentKeyLen, NULL)) != NULL) {
+        RedisModuleKey *key;
+        RedisModuleString *keyName = RedisModule_CreateString(ctx, currentKey, currentKeyLen);
+        const GetSeriesResult status =
+            GetSeries(ctx, keyName, &key, &series, REDISMODULE_READ, GetSeriesFlags_SilentOperation);
+        RedisModule_FreeString(ctx, keyName);
+
+        if (status != GetSeriesResult_Success) {
+            continue;
+        }
+
+        ListRecord_Add(
+            seriesList,
+            SeriesRecord_New(
+                series, queryArg->startTimestamp, queryArg->endTimestamp, queryArg));
+
+        RedisModule_CloseKey(key);
+    }
+
+    RedisModule_DictIteratorStop(iter);
+    RedisModule_FreeDict(ctx, qi);
+    ReleaseCtxUser(ctx);
+
+    return seriesList;
+}
+
 static Series *ParseSeries(const redisReply *reply) {
     RedisModule_Assert(reply->type == REDIS_REPLY_ARRAY);
     RedisModule_Assert(reply->elements == 3); // name, labels, samples
@@ -880,8 +930,22 @@ static Record *SeriesListReplyParser(const redisReply *reply) {
     return SeriesListRecord_Create(seriesList);
 }
 
-static InternalCommandCallbacks MrangeCallbacks = { .command = TS_INTERNAL_MRANGE,
-                                                    .replyParser = SeriesListReplyParser };
+static Record *SeriesListRecordTransformer(Record *record) {
+    size_t listLen = ListRecord_GetLen((ListRecord *)record);
+    ARR(Series *) seriesList = array_new(Series *, listLen);
+    for (size_t i = 0; i < listLen; i++) {
+        Record *elem = ListRecord_GetRecord((ListRecord *)record, i);
+        seriesList = array_append(seriesList, SeriesRecord_IntoSeries((SeriesRecord *)elem));
+    }
+    return SeriesListRecord_Create(seriesList);
+}
+
+static InternalCommandCallbacks MrangeCallbacks = {
+    .command = TS_INTERNAL_MRANGE,
+    .replyParser = SeriesListReplyParser,
+    .recordProducer = TS_INTERNAL_MRANGE_RecordProducer,
+    .recordTransformer = SeriesListRecordTransformer,
+};
 
 static void TS_INTERNAL_MGET(RedisModuleCtx *ctx, void *args) {
     QueryPredicates_Arg *queryArg = args;

--- a/src/module.h
+++ b/src/module.h
@@ -65,19 +65,15 @@ static inline bool CheckKeyIsAllowedByAcls(RedisModuleCtx *ctx,
                                            RedisModuleString *keyName,
                                            const int permissionFlags) {
     if (ctx != NULL) {
-        // Prefer the explicitly-set context user (set via SetContextUser in internal commands)
-        // over the connection's authenticated user. On INNERCOMMUNICATION contexts the
-        // authenticated user is "default" which has full permissions, while the real restricted
-        // user is propagated via SetContextUser.
-        const RedisModuleUser *contextUser = RedisModule_GetContextUser(ctx);
-        if (contextUser) {
-            return RedisModule_ACLCheckKeyPermissions((RedisModuleUser *)contextUser,
-                                                      keyName,
-                                                      permissionFlags) == REDISMODULE_OK;
-        }
-
         RedisModuleUser *user = GetCurrentUser(ctx);
+
         if (!user) {
+            const RedisModuleUser *contextUser = RedisModule_GetContextUser(ctx);
+            if (contextUser) {
+                return RedisModule_ACLCheckKeyPermissions((RedisModuleUser *)contextUser,
+                                                          keyName,
+                                                          permissionFlags) == REDISMODULE_OK;
+            }
             return true;
         }
 

--- a/src/module.h
+++ b/src/module.h
@@ -65,15 +65,19 @@ static inline bool CheckKeyIsAllowedByAcls(RedisModuleCtx *ctx,
                                            RedisModuleString *keyName,
                                            const int permissionFlags) {
     if (ctx != NULL) {
-        RedisModuleUser *user = GetCurrentUser(ctx);
+        // Prefer the explicitly-set context user (set via SetContextUser in internal commands)
+        // over the connection's authenticated user. On INNERCOMMUNICATION contexts the
+        // authenticated user is "default" which has full permissions, while the real restricted
+        // user is propagated via SetContextUser.
+        const RedisModuleUser *contextUser = RedisModule_GetContextUser(ctx);
+        if (contextUser) {
+            return RedisModule_ACLCheckKeyPermissions((RedisModuleUser *)contextUser,
+                                                      keyName,
+                                                      permissionFlags) == REDISMODULE_OK;
+        }
 
+        RedisModuleUser *user = GetCurrentUser(ctx);
         if (!user) {
-            const RedisModuleUser *contextUser = RedisModule_GetContextUser(ctx);
-            if (contextUser) {
-                return RedisModule_ACLCheckKeyPermissions((RedisModuleUser *)contextUser,
-                                                          keyName,
-                                                          permissionFlags) == REDISMODULE_OK;
-            }
             return true;
         }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes LibMR internal command reply/record formats (now bundling slot ranges with data) and removes Linux/macOS test execution from the Flow workflows, increasing risk of undetected regressions in clustered multi-key commands.
> 
> **Overview**
> **LibMR internal multi-key commands now return slot-range metadata alongside data results** instead of issuing a separate `TS.INTERNAL_SLOT_RANGES` internal command. `TS.INTERNAL_MRANGE`, `TS.INTERNAL_MGET`, and `TS.INTERNAL_QUERYINDEX` wrap replies as `[data, slot_ranges]`, and the client-side collector (`collect_node_results`) was updated to recursively extract both data and slot ranges from either flat or wrapped records.
> 
> This adds `SlotRangesRecord` serialization/deserialization and a `TS.INTERNAL_MRANGE` record-producer/transformer path to attach local slot ranges to produced records, while keeping legacy parsing compatibility. Separately, the Flow Linux and macOS GitHub workflows stop running tests/capturing test artifacts and only build/pack/upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b5990b9a88ff165cc8e4e40ed8cd0484b655f88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->