### PR TITLE
MOD-14902 - existence check to prevent Timeseries crash when Redis is not aligned with new redis-core changes

### DIFF
--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -439,7 +439,9 @@ Record *ListWithSeriesLastDatapoint(const Series *series, bool latest, bool resp
 // Set the context user for ACL checks. Skips allocation if the context
 // already has the same user set, to avoid redundant alloc+free cycles.
 static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
-    if (!RedisModule_SetContextUser)
+    /* All module APIs used below must be non-NULL (Set+GetContextUser pair with ReleaseCtxUser). */
+    if (!RedisModule_SetContextUser || !RedisModule_GetContextUser ||
+        !RedisModule_GetModuleUserFromUserName || !RedisModule_GetUserUsername)
         return;
 
     size_t len = 0;
@@ -449,20 +451,18 @@ static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
     RedisModule_Assert(len > 0);
 
     // Check if the requested user is already set on the context
-    if (RedisModule_GetContextUser) {
-        const RedisModuleUser *currentUser = RedisModule_GetContextUser(ctx);
-        if (currentUser) {
-            RedisModuleString *currentName = RedisModule_GetUserUsername(currentUser);
-            if (currentName) {
-                int cmp = RedisModule_StringCompare(currentName, userName);
-                RedisModule_FreeString(ctx, currentName);
-                if (cmp == 0) {
-                    return; // Same user already set, nothing to do
-                }
+    const RedisModuleUser *currentUser = RedisModule_GetContextUser(ctx);
+    if (currentUser) {
+        RedisModuleString *currentName = RedisModule_GetUserUsername(currentUser);
+        if (currentName) {
+            int cmp = RedisModule_StringCompare(currentName, userName);
+            RedisModule_FreeString(ctx, currentName);
+            if (cmp == 0) {
+                return; // Same user already set, nothing to do
             }
-            RedisModule_FreeModuleUser((RedisModuleUser *)currentUser);
-            RedisModule_SetContextUser(ctx, NULL);
         }
+        RedisModule_FreeModuleUser((RedisModuleUser *)currentUser);
+        RedisModule_SetContextUser(ctx, NULL);
     }
 
     // Allocate and set the new user on the context

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -439,7 +439,8 @@ Record *ListWithSeriesLastDatapoint(const Series *series, bool latest, bool resp
 // Set the context user for ACL checks. Skips allocation if the context
 // already has the same user set, to avoid redundant alloc+free cycles.
 static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
-    if (!RedisModule_SetContextUser) return;
+    if (!RedisModule_SetContextUser)
+        return;
 
     size_t len = 0;
 
@@ -472,11 +473,13 @@ static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
 }
 
 static void ReleaseCtxUser(RedisModuleCtx *ctx) {
-    if (!RedisModule_GetContextUser) return;
+    if (!RedisModule_GetContextUser)
+        return;
     RedisModuleUser *user = (RedisModuleUser *)RedisModule_GetContextUser(ctx);
     if (user) {
         RedisModule_FreeModuleUser(user);
-        RedisModule_SetContextUser(ctx, NULL);
+        if (RedisModule_SetContextUser)
+            RedisModule_SetContextUser(ctx, NULL);
     }
 }
 

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -19,6 +19,12 @@
 
 #define SeriesRecordName "SeriesRecord"
 
+/* All four must be present: Apply sets user from name; Release reads and clears via the same API set. */
+#define API_USER_CONTEXT_SUPPORTED                                                                   \
+    (RedisModule_SetContextUser && RedisModule_GetContextUser &&                                     \
+     RedisModule_GetModuleUserFromUserName && RedisModule_GetUserUsername)
+
+
 static Record NullRecord;
 static MRRecordType *NullRecordType = NULL;
 static MRRecordType *StringRecordType = NULL;
@@ -439,9 +445,7 @@ Record *ListWithSeriesLastDatapoint(const Series *series, bool latest, bool resp
 // Set the context user for ACL checks. Skips allocation if the context
 // already has the same user set, to avoid redundant alloc+free cycles.
 static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
-    /* All module APIs used below must be non-NULL (Set+GetContextUser pair with ReleaseCtxUser). */
-    if (!RedisModule_SetContextUser || !RedisModule_GetContextUser ||
-        !RedisModule_GetModuleUserFromUserName || !RedisModule_GetUserUsername)
+    if (!API_USER_CONTEXT_SUPPORTED)
         return;
 
     size_t len = 0;
@@ -473,13 +477,12 @@ static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
 }
 
 static void ReleaseCtxUser(RedisModuleCtx *ctx) {
-    if (!RedisModule_GetContextUser)
+    if (!API_USER_CONTEXT_SUPPORTED)
         return;
     RedisModuleUser *user = (RedisModuleUser *)RedisModule_GetContextUser(ctx);
     if (user) {
         RedisModule_FreeModuleUser(user);
-        if (RedisModule_SetContextUser)
-            RedisModule_SetContextUser(ctx, NULL);
+        RedisModule_SetContextUser(ctx, NULL);
     }
 }
 

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -439,6 +439,8 @@ Record *ListWithSeriesLastDatapoint(const Series *series, bool latest, bool resp
 // Set the context user for ACL checks. Skips allocation if the context
 // already has the same user set, to avoid redundant alloc+free cycles.
 static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
+    if (!RedisModule_SetContextUser) return;
+
     size_t len = 0;
 
     RedisModule_Assert(userName != NULL);
@@ -446,18 +448,20 @@ static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
     RedisModule_Assert(len > 0);
 
     // Check if the requested user is already set on the context
-    const RedisModuleUser *currentUser = RedisModule_GetContextUser(ctx);
-    if (currentUser) {
-        RedisModuleString *currentName = RedisModule_GetUserUsername(currentUser);
-        if (currentName) {
-            int cmp = RedisModule_StringCompare(currentName, userName);
-            RedisModule_FreeString(ctx, currentName);
-            if (cmp == 0) {
-                return; // Same user already set, nothing to do
+    if (RedisModule_GetContextUser) {
+        const RedisModuleUser *currentUser = RedisModule_GetContextUser(ctx);
+        if (currentUser) {
+            RedisModuleString *currentName = RedisModule_GetUserUsername(currentUser);
+            if (currentName) {
+                int cmp = RedisModule_StringCompare(currentName, userName);
+                RedisModule_FreeString(ctx, currentName);
+                if (cmp == 0) {
+                    return; // Same user already set, nothing to do
+                }
             }
+            RedisModule_FreeModuleUser((RedisModuleUser *)currentUser);
+            RedisModule_SetContextUser(ctx, NULL);
         }
-        RedisModule_FreeModuleUser((RedisModuleUser *)currentUser);
-        RedisModule_SetContextUser(ctx, NULL);
     }
 
     // Allocate and set the new user on the context
@@ -468,6 +472,7 @@ static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
 }
 
 static void ReleaseCtxUser(RedisModuleCtx *ctx) {
+    if (!RedisModule_GetContextUser) return;
     RedisModuleUser *user = (RedisModuleUser *)RedisModule_GetContextUser(ctx);
     if (user) {
         RedisModule_FreeModuleUser(user);

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -19,11 +19,11 @@
 
 #define SeriesRecordName "SeriesRecord"
 
-/* All four must be present: Apply sets user from name; Release reads and clears via the same API set. */
-#define API_USER_CONTEXT_SUPPORTED                                                                   \
-    (RedisModule_SetContextUser && RedisModule_GetContextUser &&                                     \
+/* All four must be present: Apply sets user from name; Release reads and clears via the same API
+ * set. */
+#define API_USER_CONTEXT_SUPPORTED                                                                 \
+    (RedisModule_SetContextUser && RedisModule_GetContextUser &&                                   \
      RedisModule_GetModuleUserFromUserName && RedisModule_GetUserUsername)
-
 
 static Record NullRecord;
 static MRRecordType *NullRecordType = NULL;

--- a/src/module.h
+++ b/src/module.h
@@ -68,7 +68,8 @@ static inline bool CheckKeyIsAllowedByAcls(RedisModuleCtx *ctx,
         RedisModuleUser *user = GetCurrentUser(ctx);
 
         if (!user) {
-            const RedisModuleUser *contextUser = RedisModule_GetContextUser(ctx);
+            const RedisModuleUser *contextUser =
+                RedisModule_GetContextUser ? RedisModule_GetContextUser(ctx) : NULL;
             if (contextUser) {
                 return RedisModule_ACLCheckKeyPermissions((RedisModuleUser *)contextUser,
                                                           keyName,


### PR DESCRIPTION
This PR introduces a validation step to ensure the new API is available before we attempt to use it for retrieving the user context.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ACL enforcement paths by conditionally skipping context-user setup/lookup when Redis core lacks the required APIs, which could change permission-check behavior on older cores (though it primarily prevents crashes).
> 
> **Overview**
> Prevents crashes on Redis versions that don’t expose the newer context-user APIs by adding runtime feature detection and null-guards before calling `RedisModule_SetContextUser`/`RedisModule_GetContextUser` and related functions.
> 
> `ApplyCtxUser`/`ReleaseCtxUser` now no-op when the API set is unavailable, and `CheckKeyIsAllowedByAcls` safely handles missing `RedisModule_GetContextUser` instead of unconditionally calling it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c802e369b0788cf3ca437cfb4d4bd4f44b8b1b85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->