### PR TITLE
Backport #1770 + #1937 + #1954 to 1.10: nightly snapshot upload

### DIFF
--- a/.github/actions/pack-module/action.yml
+++ b/.github/actions/pack-module/action.yml
@@ -5,6 +5,9 @@ inputs:
     type: string
     description: "Specify whether to use the environment or not"
     default: '0'
+  beta-version:
+    description: 'Beta version for S3 uploads'
+    required: false
 
 runs:
   using: composite
@@ -21,4 +24,7 @@ runs:
         fi
         export PATH="$GITHUB_WORKSPACE/redis/src:$PATH"
         git config --global --add safe.directory $GITHUB_WORKSPACE
+        if [[ -n "${{ inputs.beta-version }}" ]]; then
+          export BETA_VERSION="${{ inputs.beta-version }}"
+        fi
         make pack BRANCH=$TAG_OR_BRANCH SHOW=1

--- a/.github/actions/upload-artifacts-to-s3-without-make/action.yml
+++ b/.github/actions/upload-artifacts-to-s3-without-make/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'OS Nickname'
     required: false
     default: ''
+  beta-version:
+    description: 'Beta version for S3 uploads'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -56,5 +60,19 @@ runs:
             if [[ $REF =~ $PATTERN ]]; then
               echo "This is a tagged build"
               RELEASE=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            fi
+          echo ::endgroup::
+          
+          echo ::group::upload to beta folder with version
+            # Use provided beta version if available
+            if [[ -n "${{ inputs.beta-version }}" ]]; then
+              BETA_VERSION="${{ inputs.beta-version }}"
+              echo "Using provided beta version: ${BETA_VERSION}"
+              
+              # Upload to beta folder
+              export BETA_VERSION="${BETA_VERSION}"
+              BETA=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            else
+              echo "No beta version provided, skipping beta upload"
             fi
           echo ::endgroup::

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -25,11 +25,22 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
+      beta-timestamp: ${{ steps.set-env.outputs.beta-timestamp }}
+      beta-version: ${{ steps.set-env.outputs.beta-version }}
     steps:
       - name: set env
         id: set-env
         run: |
           echo "redis-ref=${{ inputs.redis-ref || '7.2' }}" >> $GITHUB_OUTPUT  # todo change per version/tag
+          
+          # Generate timestamp at workflow start for consistent beta versioning
+          TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")
+          WORKFLOW_NUM=${{ github.run_number }}
+          BETA_VERSION="99.99.99.${TIMESTAMP}.${WORKFLOW_NUM}"
+          
+          echo "beta-timestamp=${TIMESTAMP}" >> $GITHUB_OUTPUT
+          echo "beta-version=${BETA_VERSION}" >> $GITHUB_OUTPUT
+          echo "Generated beta version: ${BETA_VERSION}"
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit
@@ -40,6 +51,7 @@ jobs:
       arch: x64
       os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
       quick: false
     secrets: inherit
   build-linux-arm64:
@@ -49,6 +61,7 @@ jobs:
       arch: arm64
       os: bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
       quick: false
     secrets: inherit
   macos:
@@ -56,6 +69,7 @@ jobs:
     needs: [prepare-values]
     with:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
       quick: false
     secrets: inherit
   linux-valgrind:
@@ -65,6 +79,7 @@ jobs:
       arch: x64
       os: jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
       run_valgrind: true
     secrets: inherit
   linux-sanitizer:
@@ -74,5 +89,6 @@ jobs:
       arch: x64
       os: jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
       run_sanitizer: true
     secrets: inherit

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -27,7 +27,12 @@ jobs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
       beta-timestamp: ${{ steps.set-env.outputs.beta-timestamp }}
       beta-version: ${{ steps.set-env.outputs.beta-version }}
+      module-version: ${{ steps.get-version.outputs.module-version }}
+      snapshot-template: ${{ steps.set-env.outputs.snapshot-template }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: set env
         id: set-env
         run: |
@@ -41,6 +46,28 @@ jobs:
           echo "beta-timestamp=${TIMESTAMP}" >> $GITHUB_OUTPUT
           echo "beta-version=${BETA_VERSION}" >> $GITHUB_OUTPUT
           echo "Generated beta version: ${BETA_VERSION}"
+
+          BRANCH_NAME="${{ github.ref_name }}"
+          BRANCH_NAME="${BRANCH_NAME//[^A-Za-z0-9._-]/_}"
+          SNAPSHOT_TEMPLATE="redistimeseries/snapshots/redistimeseries.@OS.${BRANCH_NAME}.${TIMESTAMP}.${WORKFLOW_NUM}.zip"
+          echo "snapshot-template=${SNAPSHOT_TEMPLATE}" >> $GITHUB_OUTPUT
+          echo "Snapshot template: ${SNAPSHOT_TEMPLATE}"
+
+      - name: Extract module version
+        id: get-version
+        run: |
+          MAJOR=$(grep '#define REDISTIMESERIES_VERSION_MAJOR' src/version.h | awk '{print $3}')
+          MINOR=$(grep '#define REDISTIMESERIES_VERSION_MINOR' src/version.h | awk '{print $3}')
+          PATCH=$(grep '#define REDISTIMESERIES_VERSION_PATCH' src/version.h | awk '{print $3}')
+          MODULE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "module-version=${MODULE_VERSION}" >> $GITHUB_OUTPUT
+          echo "Module version: ${MODULE_VERSION}"
+
+      - name: Summary
+        run: |
+          echo "### Nightly Build Info" >> $GITHUB_STEP_SUMMARY
+          echo "- **Module Version:** ${{ steps.get-version.outputs.module-version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Snapshot Template:** \`${{ steps.set-env.outputs.snapshot-template }}\`" >> $GITHUB_STEP_SUMMARY
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -68,6 +68,23 @@ jobs:
           echo "### Nightly Build Info" >> $GITHUB_STEP_SUMMARY
           echo "- **Module Version:** ${{ steps.get-version.outputs.module-version }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Snapshot Template:** \`${{ steps.set-env.outputs.snapshot-template }}\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Create build metadata
+        run: |
+          echo '{}' | jq \
+            --arg snapshot_template "$SNAPSHOT_TEMPLATE" \
+            --arg module_version "$MODULE_VERSION" \
+            '{snapshot_template: $snapshot_template, module_version: $module_version}' \
+            > build-metadata.json
+        env:
+          SNAPSHOT_TEMPLATE: ${{ steps.set-env.outputs.snapshot-template }}
+          MODULE_VERSION: ${{ steps.get-version.outputs.module-version }}
+  
+      - name: Upload build metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-metadata
+          path: build-metadata.json
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -41,6 +41,11 @@ on:
         description: 'Run quick tests'
         type: boolean
         default: false
+      beta-version:
+        description: 'Beta version for S3 uploads'
+        type: string
+        required: false
+        default: ''
   workflow_call:
   # the defaults and options here are the same likes in "workflow_dispatch"
     inputs:
@@ -64,6 +69,11 @@ on:
         description: 'Run quick tests'
         type: boolean
         default: false
+      beta-version:
+        description: 'Beta version for S3 uploads'
+        type: string
+        required: false
+        default: ''
 
 
 jobs:
@@ -162,9 +172,11 @@ jobs:
         uses: ./.github/actions/pack-module
         with:
           use-venv: '1'
+          beta-version: ${{ inputs.beta-version }}
       - name: Upload artifacts to S3
         uses: ./.github/actions/upload-artifacts-to-s3-without-make
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           github-ref: ${{ github.ref }}
+          beta-version: ${{ inputs.beta-version }}

--- a/.github/workflows/mariner2.yml
+++ b/.github/workflows/mariner2.yml
@@ -11,6 +11,11 @@ on:
         description: 'Run quick tests'
         type: boolean
         default: false
+      beta-version:
+        description: 'Beta version for S3 uploads'
+        type: string
+        required: false
+        default: ''
 
 jobs:
   setup-environment:
@@ -70,9 +75,11 @@ jobs:
         uses: ./.github/actions/pack-module
         with:
           use-venv: '0'
+          beta-version: ${{ inputs.beta-version }}
       - name: Upload artifacts to S3
         uses: ./.github/actions/upload-artifacts-to-s3-without-make
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           github-ref: ${{ github.ref }}
+          beta-version: ${{ inputs.beta-version }}

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -277,6 +277,12 @@ pack_deps() {
 NUMVER="$(NUMERIC=1 $SBIN/getver)"
 SEMVER="$($SBIN/getver)"
 
+# Override SEMVER with BETA_VERSION if provided (for nightly builds)
+if [[ -n $BETA_VERSION ]]; then
+	SEMVER="$BETA_VERSION"
+	echo "# Using beta version: $BETA_VERSION"
+fi
+
 if [[ -n $VARIANT ]]; then
 	_VARIANT="-${VARIANT}"
 fi

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -315,6 +315,11 @@ if [[ $WITH_GITSHA == 1 ]]; then
 	BRANCH="${BRANCH}-${GIT_COMMIT}"
 fi
 
+if [[ -n $BETA_VERSION ]]; then
+	BETA_SUFFIX=$(echo "$BETA_VERSION" | cut -d'.' -f4,5,6)
+	BRANCH="${BRANCH}.${BETA_SUFFIX}"
+fi
+
 #----------------------------------------------------------------------------------------------
 
 RELEASE_ramp=${PACKAGE_NAME}.$OS-$OSNICK-$ARCH.$SEMVER${VARIANT}.zip

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -21,6 +21,7 @@ if [[ $1 == --help || $1 == help || $HELP == 1 ]]; then
 
 		RELEASE=1     Upload release artifacts
 		STAGING=1     Upload into staging area
+		BETA=1        Upload to beta folder with version
 
 		NOP=1         No operation
 		VERBOSE=1     Show artifacts details
@@ -136,4 +137,9 @@ s3_upload() {
 
 #----------------------------------------------------------------------------------------------
 
-PROD=redistimeseries PREFIX=redistimeseries s3_upload
+# Set S3 directory based on BETA flag
+if [[ $BETA == 1 && -n $BETA_VERSION ]]; then
+	PROD=redistimeseries/beta PREFIX=redistimeseries s3_upload
+else
+	PROD=redistimeseries PREFIX=redistimeseries s3_upload
+fi


### PR DESCRIPTION
Backports the nightly snapshot upload feature to `1.10`. Three commits cherry-picked in order:

1. `f12a5ec3` (PR #1770) — beta-version plumbing (cherry-pick `-m 1`). Required prerequisite for the next two commits.
2. `21387028` (PR #1937) — unique snapshot name + new output params for nightly event.
3. `690ab923` (PR #1954) — nightly build, upload snapshot artifact.

## Conflict resolution notes (#1770)

- `event-nightly.yml`: kept the branch's `redis-ref` default of `'7.2'` (unchanged) and its `# todo change per version/tag` comment; added the `BETA_VERSION` block on top. Branch consolidates linux jobs into a single `flow-linux.yml`, so the `mariner` and `arm64` job blocks (and the `flow-alpine.yml`/`flow-linux-arm.yml`/`flow-linux-x86.yml` files) from PR #1770 were dropped. `beta-version:` was threaded into all existing downstream jobs (auto-merged for most; `build-linux-arm64` resolved manually).
- Removed `flow-alpine.yml`, `flow-linux-arm.yml`, `flow-linux-x86.yml` (they don't exist on this branch).
- `flow-linux.yml`, `flow-macos.yml`, `mariner2.yml` on this branch already accept `beta-version` input; PR #1770's `mariner2.yml` change auto-merged as a no-op.

## Conflict resolution notes (#1937, #1954)

Both auto-merged cleanly on top of #1770.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI packaging and S3 upload destinations for nightly builds, which can impact artifact naming and where binaries are published. Risk is limited to build/release automation but could break consumers if paths or versions are miscomputed.
> 
> **Overview**
> Adds **beta-version plumbing** across GitHub Actions so nightly builds can produce uniquely versioned artifacts and upload them separately from normal snapshots/releases.
> 
> `event-nightly.yml` now generates a timestamped `beta-version`, derives a unique `snapshot-template`, extracts the module version, and uploads build metadata; that `beta-version` is threaded into Linux/macOS/Mariner workflows. Packaging (`sbin/pack.sh`) can override `SEMVER` with `BETA_VERSION` and appends a beta suffix to snapshot `BRANCH` names.
> 
> S3 uploads gain an optional **beta channel**: the `upload-artifacts-to-s3-without-make` action conditionally runs a beta upload, and `sbin/upload-artifacts` routes `BETA=1` uploads to `redistimeseries/beta` when `BETA_VERSION` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4590e5fcdab148a84d2e57d8a43d917f2ccd118. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->