### PR TITLE
Backport #1770 + #1937 + #1954 to 1.8: nightly snapshot upload

### DIFF
--- a/.github/actions/pack-module/action.yml
+++ b/.github/actions/pack-module/action.yml
@@ -5,6 +5,9 @@ inputs:
     type: string
     description: "Specify whether to use the environment or not"
     default: '0'
+  beta-version:
+    description: 'Beta version for S3 uploads'
+    required: false
 
 runs:
   using: composite
@@ -21,4 +24,7 @@ runs:
         fi
         export PATH="$GITHUB_WORKSPACE/redis/src:$PATH"
         git config --global --add safe.directory $GITHUB_WORKSPACE
+        if [[ -n "${{ inputs.beta-version }}" ]]; then
+          export BETA_VERSION="${{ inputs.beta-version }}"
+        fi
         make pack BRANCH=$TAG_OR_BRANCH SHOW=1

--- a/.github/actions/upload-artifacts-to-s3-without-make/action.yml
+++ b/.github/actions/upload-artifacts-to-s3-without-make/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'OS Nickname'
     required: false
     default: ''
+  beta-version:
+    description: 'Beta version for S3 uploads'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -56,5 +60,19 @@ runs:
             if [[ $REF =~ $PATTERN ]]; then
               echo "This is a tagged build"
               RELEASE=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            fi
+          echo ::endgroup::
+          
+          echo ::group::upload to beta folder with version
+            # Use provided beta version if available
+            if [[ -n "${{ inputs.beta-version }}" ]]; then
+              BETA_VERSION="${{ inputs.beta-version }}"
+              echo "Using provided beta version: ${BETA_VERSION}"
+              
+              # Upload to beta folder
+              export BETA_VERSION="${BETA_VERSION}"
+              BETA=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            else
+              echo "No beta version provided, skipping beta upload"
             fi
           echo ::endgroup::

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -67,6 +67,23 @@ jobs:
           echo "### Nightly Build Info" >> $GITHUB_STEP_SUMMARY
           echo "- **Module Version:** ${{ steps.get-version.outputs.module-version }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Snapshot Template:** \`${{ steps.set-env.outputs.snapshot-template }}\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Create build metadata
+        run: |
+          echo '{}' | jq \
+            --arg snapshot_template "$SNAPSHOT_TEMPLATE" \
+            --arg module_version "$MODULE_VERSION" \
+            '{snapshot_template: $snapshot_template, module_version: $module_version}' \
+            > build-metadata.json
+        env:
+          SNAPSHOT_TEMPLATE: ${{ steps.set-env.outputs.snapshot-template }}
+          MODULE_VERSION: ${{ steps.get-version.outputs.module-version }}
+  
+      - name: Upload build metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-metadata
+          path: build-metadata.json
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -26,7 +26,12 @@ jobs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
       beta-timestamp: ${{ steps.set-env.outputs.beta-timestamp }}
       beta-version: ${{ steps.set-env.outputs.beta-version }}
+      module-version: ${{ steps.get-version.outputs.module-version }}
+      snapshot-template: ${{ steps.set-env.outputs.snapshot-template }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: set env
         id: set-env
         run: |
@@ -40,6 +45,28 @@ jobs:
           echo "beta-timestamp=${TIMESTAMP}" >> $GITHUB_OUTPUT
           echo "beta-version=${BETA_VERSION}" >> $GITHUB_OUTPUT
           echo "Generated beta version: ${BETA_VERSION}"
+
+          BRANCH_NAME="${{ github.ref_name }}"
+          BRANCH_NAME="${BRANCH_NAME//[^A-Za-z0-9._-]/_}"
+          SNAPSHOT_TEMPLATE="redistimeseries/snapshots/redistimeseries.@OS.${BRANCH_NAME}.${TIMESTAMP}.${WORKFLOW_NUM}.zip"
+          echo "snapshot-template=${SNAPSHOT_TEMPLATE}" >> $GITHUB_OUTPUT
+          echo "Snapshot template: ${SNAPSHOT_TEMPLATE}"
+
+      - name: Extract module version
+        id: get-version
+        run: |
+          MAJOR=$(grep '#define REDISTIMESERIES_VERSION_MAJOR' src/version.h | awk '{print $3}')
+          MINOR=$(grep '#define REDISTIMESERIES_VERSION_MINOR' src/version.h | awk '{print $3}')
+          PATCH=$(grep '#define REDISTIMESERIES_VERSION_PATCH' src/version.h | awk '{print $3}')
+          MODULE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "module-version=${MODULE_VERSION}" >> $GITHUB_OUTPUT
+          echo "Module version: ${MODULE_VERSION}"
+
+      - name: Summary
+        run: |
+          echo "### Nightly Build Info" >> $GITHUB_STEP_SUMMARY
+          echo "- **Module Version:** ${{ steps.get-version.outputs.module-version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Snapshot Template:** \`${{ steps.set-env.outputs.snapshot-template }}\`" >> $GITHUB_STEP_SUMMARY
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -24,11 +24,22 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
+      beta-timestamp: ${{ steps.set-env.outputs.beta-timestamp }}
+      beta-version: ${{ steps.set-env.outputs.beta-version }}
     steps:
       - name: set env
         id: set-env
         run: |
           echo "redis-ref=${{ inputs.redis-ref || '6.2' }}" >> $GITHUB_OUTPUT  # todo change per version/tag
+          
+          # Generate timestamp at workflow start for consistent beta versioning
+          TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")
+          WORKFLOW_NUM=${{ github.run_number }}
+          BETA_VERSION="99.99.99.${TIMESTAMP}.${WORKFLOW_NUM}"
+          
+          echo "beta-timestamp=${TIMESTAMP}" >> $GITHUB_OUTPUT
+          echo "beta-version=${BETA_VERSION}" >> $GITHUB_OUTPUT
+          echo "Generated beta version: ${BETA_VERSION}"
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit
@@ -38,6 +49,7 @@ jobs:
     with:
       os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 azurelinux3
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
       quick: true
     secrets: inherit
   mariner:
@@ -45,6 +57,7 @@ jobs:
     needs: [prepare-values]
     with:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
       quick: true
     secrets: inherit
   ubuntu-arm64:
@@ -52,6 +65,7 @@ jobs:
     needs: [prepare-values]
     with:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
       quick: true
     secrets: inherit
   macos:
@@ -59,6 +73,7 @@ jobs:
     needs: [prepare-values]
     with:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
       quick: true
     secrets: inherit
   alpine:
@@ -66,6 +81,7 @@ jobs:
     needs: [prepare-values]
     with:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
       quick: true
     secrets: inherit
   linux-valgrind:
@@ -74,6 +90,7 @@ jobs:
     with:
       os: jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
       run_valgrind: true
     secrets: inherit
   linux-sanitizer:
@@ -82,5 +99,6 @@ jobs:
     with:
       os: jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
       run_sanitizer: true
     secrets: inherit

--- a/.github/workflows/flow-alpine.yml
+++ b/.github/workflows/flow-alpine.yml
@@ -15,6 +15,11 @@ on:
         description: 'Run quick tests'
         type: boolean
         default: false
+      beta-version:
+        description: 'Beta version for S3 uploads'
+        type: string
+        required: false
+        default: ''
   workflow_call: # Allows to run this workflow from another workflow
     inputs:
       redis-ref:
@@ -25,6 +30,11 @@ on:
         description: 'Run quick tests'
         type: boolean
         default: false
+      beta-version:
+        description: 'Beta version for S3 uploads'
+        type: string
+        required: false
+        default: ''
 
 jobs:
   prepare-values:
@@ -104,9 +114,11 @@ jobs:
         uses: ./.github/actions/pack-module
         with:
           use-venv: '1'
+          beta-version: ${{ inputs.beta-version }}
       - name: Upload artifacts to S3
         uses: ./.github/actions/upload-artifacts-to-s3-without-make
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           github-ref: ${{ github.ref }}
+          beta-version: ${{ inputs.beta-version }}

--- a/.github/workflows/flow-linux-x86.yml
+++ b/.github/workflows/flow-linux-x86.yml
@@ -27,6 +27,11 @@ on:
         description: 'Run quick tests'
         type: boolean
         default: false
+      beta-version:
+        description: 'Beta version for S3 uploads'
+        type: string
+        required: false
+        default: ''
   workflow_call: # Allows to run this workflow from another workflow
     inputs:
       redis-ref:
@@ -49,7 +54,11 @@ on:
         description: 'Run quick tests'
         type: boolean
         default: false
-
+      beta-version:
+        description: 'Beta version for S3 uploads'
+        type: string
+        required: false
+        default: ''
 jobs:
   setup-environment:
     runs-on: ubuntu-latest
@@ -212,6 +221,7 @@ jobs:
         uses: ./.github/actions/pack-module
         with:
           use-venv: ${{matrix.docker_image.use-venv}}
+          beta-version: ${{ inputs.beta-version }}
       - name: Upload artifacts to S3
         if: ${{ !inputs.run_valgrind && !inputs.run_sanitizer }}
         uses: ./.github/actions/upload-artifacts-to-s3-without-make
@@ -219,3 +229,4 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           github-ref: ${{ github.ref }}
+          beta-version: ${{ inputs.beta-version }}

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -41,6 +41,11 @@ on:
         description: 'Run quick tests'
         type: boolean
         default: false
+      beta-version:
+        description: 'Beta version for S3 uploads'
+        type: string
+        required: false
+        default: ''
   workflow_call:
   # the defaults and options here are the same likes in "workflow_dispatch"
     inputs:
@@ -64,6 +69,11 @@ on:
         description: 'Run quick tests'
         type: boolean
         default: false
+      beta-version:
+        description: 'Beta version for S3 uploads'
+        type: string
+        required: false
+        default: ''
 
 
 jobs:
@@ -154,9 +164,11 @@ jobs:
         uses: ./.github/actions/pack-module
         with:
           use-venv: '1'
+          beta-version: ${{ inputs.beta-version }}
       - name: Upload artifacts to S3
         uses: ./.github/actions/upload-artifacts-to-s3-without-make
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           github-ref: ${{ github.ref }}
+          beta-version: ${{ inputs.beta-version }}

--- a/.github/workflows/flow-ubuntu-arm.yml
+++ b/.github/workflows/flow-ubuntu-arm.yml
@@ -15,6 +15,11 @@ on:
         description: 'Run quick tests'
         type: boolean
         default: false
+      beta-version:
+        description: 'Beta version for S3 uploads'
+        type: string
+        required: false
+        default: ''
   workflow_call: # Allows to run this workflow from another workflow
     inputs:
       redis-ref:
@@ -25,6 +30,11 @@ on:
         description: 'Run quick tests'
         type: boolean
         default: false
+      beta-version:
+        description: 'Beta version for S3 uploads'
+        type: string
+        required: false
+        default: ''
 
 
 jobs:
@@ -188,9 +198,11 @@ jobs:
         uses: ./.github/actions/pack-module
         with:
           use-venv: '1'
+          beta-version: ${{ inputs.beta-version }}
       - name: Upload artifacts to S3
         uses: ./.github/actions/upload-artifacts-to-s3-without-make
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           github-ref: ${{ github.ref }}
+          beta-version: ${{ inputs.beta-version }}

--- a/.github/workflows/mariner2.yml
+++ b/.github/workflows/mariner2.yml
@@ -11,6 +11,11 @@ on:
         description: 'Run quick tests'
         type: boolean
         default: false
+      beta-version:
+        description: 'Beta version for S3 uploads'
+        type: string
+        required: false
+        default: ''
 
 jobs:
   setup-environment:
@@ -69,9 +74,11 @@ jobs:
         uses: ./.github/actions/pack-module
         with:
           use-venv: '0'
+          beta-version: ${{ inputs.beta-version }}
       - name: Upload artifacts to S3
         uses: ./.github/actions/upload-artifacts-to-s3-without-make
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           github-ref: ${{ github.ref }}
+          beta-version: ${{ inputs.beta-version }}

--- a/.install/alpine.sh
+++ b/.install/alpine.sh
@@ -1,2 +1,2 @@
 apk add bash make libtool tar cmake python3 python3-dev py3-pip gcc git curl build-base autoconf automake py3-cryptography linux-headers musl-dev libffi-dev openssl-dev openssh py-virtualenv clang18-libclang gcompat libstdc++ libgcc g++ openblas-dev xsimd git xz bsd-compat-headers clang18 jq
-pip install -q --upgrade pip setuptools wheel
+pip install -q --upgrade pip "setuptools<81" wheel

--- a/.install/common_base_linux_mariner_2.0.sh
+++ b/.install/common_base_linux_mariner_2.0.sh
@@ -3,7 +3,7 @@
 tdnf install -y build-essential wget tar openssl-devel cmake python3 python3-pip which unzip jq
 git config --global --add safe.directory $PWD
 
-pip install --upgrade setuptools
+pip install --upgrade "setuptools<81"
 pip install -r tests/flow/requirements.txt
 
 pip install -r .install/build_package_requirements.txt  # required for packing the module (todo: move to pack.sh after refactor)

--- a/.install/common_installations.sh
+++ b/.install/common_installations.sh
@@ -4,7 +4,7 @@ OS_TYPE=$(uname -s)
 MODE=$1 # whether to install using sudo or not
 
 pip3 install --upgrade pip
-pip3 install -q --upgrade setuptools
+pip3 install -q --upgrade "setuptools<81"
 echo "pip version: $(pip3 --version)"
 echo "pip path: $(which pip3)"
 

--- a/.install/mariner2.sh
+++ b/.install/mariner2.sh
@@ -3,7 +3,7 @@
 tdnf install -y build-essential wget tar openssl-devel cmake python3 python3-pip which unzip jq
 git config --global --add safe.directory $PWD
 
-pip install --upgrade setuptools
+pip install --upgrade "setuptools<81"
 pip3 install -q -r tests/flow/requirements.txt
 pip3 install -q -r .install/build_package_requirements.txt
 

--- a/.install/microsoft_azure_linux_3.0.sh
+++ b/.install/microsoft_azure_linux_3.0.sh
@@ -40,7 +40,7 @@ wget https://www.python.org/ftp/python/3.9.9/Python-3.9.9.tgz && \
     ln -sf /usr/local/bin/python3.9 /usr/local/bin/python3 && \
     ln -sf /usr/local/bin/pip3.9 /usr/local/bin/pip3
 
-python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install --upgrade pip "setuptools<81" wheel
 pip install -r tests/flow/requirements.txt
 
 pip install -r .install/build_package_requirements.txt  # required for packing the module (todo: move to pack.sh after refactor)

--- a/Dockerfile.azurelinux3
+++ b/Dockerfile.azurelinux3
@@ -31,7 +31,7 @@ RUN wget https://www.python.org/ftp/python/3.9.9/Python-3.9.9.tgz && \
     ln -sf /usr/local/bin/python3.9 /usr/local/bin/python3 && \
     ln -sf /usr/local/bin/pip3.9 /usr/local/bin/pip3
 
-RUN python3 -m pip install --upgrade pip setuptools wheel
+RUN python3 -m pip install --upgrade pip "setuptools<81" wheel
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -306,6 +306,11 @@ if [[ $WITH_GITSHA == 1 ]]; then
 	BRANCH="${BRANCH}-${GIT_COMMIT}"
 fi
 
+if [[ -n $BETA_VERSION ]]; then
+	BETA_SUFFIX=$(echo "$BETA_VERSION" | cut -d'.' -f4,5,6)
+	BRANCH="${BRANCH}.${BETA_SUFFIX}"
+fi
+
 #----------------------------------------------------------------------------------------------
 
 RELEASE_ramp=${PACKAGE_NAME}.$OS-$OSNICK-$ARCH.$SEMVER${VARIANT}.zip

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -268,6 +268,12 @@ pack_deps() {
 NUMVER="$(NUMERIC=1 $SBIN/getver)"
 SEMVER="$($SBIN/getver)"
 
+# Override SEMVER with BETA_VERSION if provided (for nightly builds)
+if [[ -n $BETA_VERSION ]]; then
+	SEMVER="$BETA_VERSION"
+	echo "# Using beta version: $BETA_VERSION"
+fi
+
 if [[ -n $VARIANT ]]; then
 	_VARIANT="-${VARIANT}"
 fi

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -21,6 +21,7 @@ if [[ $1 == --help || $1 == help || $HELP == 1 ]]; then
 
 		RELEASE=1     Upload release artifacts
 		STAGING=1     Upload into staging area
+		BETA=1        Upload to beta folder with version
 
 		NOP=1         No operation
 		VERBOSE=1     Show artifacts details
@@ -128,4 +129,9 @@ s3_upload() {
 
 #----------------------------------------------------------------------------------------------
 
-PROD=redistimeseries PREFIX=redistimeseries s3_upload
+# Set S3 directory based on BETA flag
+if [[ $BETA == 1 && -n $BETA_VERSION ]]; then
+	PROD=redistimeseries/beta PREFIX=redistimeseries s3_upload
+else
+	PROD=redistimeseries PREFIX=redistimeseries s3_upload
+fi


### PR DESCRIPTION
Backports the nightly snapshot upload feature to `1.8`. Three commits cherry-picked in order:

1. `f12a5ec3` (PR #1770) — beta-version plumbing (cherry-pick `-m 1`). Required prerequisite for the next two commits.
2. `21387028` (PR #1937) — unique snapshot name + new output params for nightly event.
3. `690ab923` (PR #1954) — nightly build, upload snapshot artifact.

## Conflict resolution notes (#1770)

This branch retains the original split flow files (`flow-linux-x86.yml`, `flow-ubuntu-arm.yml`, `flow-alpine.yml`, `mariner2.yml`, `flow-macos.yml`), so the resolution differs from the 8.x backports.

- `event-nightly.yml`:
  - Kept the branch's `redis-ref` default of `'6.2'` (unchanged) and its `# todo change per version/tag` comment; added the `BETA_VERSION` block on top.
  - Preserved the branch's `quick: true` setting on every downstream job (the master version uses `quick: false`); only added `beta-version: ${{needs.prepare-values.outputs.beta-version}}` to each.
  - Preserved the branch-only `alpine` job and added `beta-version` to it.
- `flow-linux-x86.yml`: added the `beta-version` input block from PR #1770.
- `flow-alpine.yml`, `flow-macos.yml`, `flow-ubuntu-arm.yml`, `mariner2.yml`, `pack-module/action.yml`, `upload-artifacts-to-s3-without-make/action.yml`, `sbin/pack.sh`, `sbin/upload-artifacts` auto-merged.

## Conflict resolution notes (#1937, #1954)

Both auto-merged cleanly on top of #1770.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes packaging version/branch naming and S3 upload destinations used by CI, which could affect artifact naming, overwrites, or publication paths if misconfigured.
> 
> **Overview**
> Adds end-to-end **beta/nightly snapshot plumbing**: `event-nightly.yml` now generates a unique `beta-version` (timestamp + run number), publishes build metadata, and passes the version into all build workflows.
> 
> Updates pack/upload actions and scripts so a provided `BETA_VERSION` overrides `SEMVER`, appends a beta suffix to snapshot `BRANCH` names, and enables an optional `BETA=1` upload path that publishes artifacts under `redistimeseries/beta` in S3.
> 
> Pins Python tooling by upgrading to `setuptools<81` across install scripts and the Azure Linux Dockerfile to stabilize CI environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c11ffd23064ac6482bb706e7190cc3ba027849b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->