### PR TITLE
Backport #1770 + #1937 + #1954 to 1.10: nightly snapshot upload (#1960)

### DIFF
--- a/.github/actions/pack-module/action.yml
+++ b/.github/actions/pack-module/action.yml
@@ -5,6 +5,9 @@ inputs:
     type: string
     description: "Specify whether to use the environment or not"
     default: '0'
+  beta-version:
+    description: 'Beta version for S3 uploads'
+    required: false
 
 runs:
   using: composite
@@ -21,4 +24,7 @@ runs:
         fi
         export PATH="$GITHUB_WORKSPACE/redis/src:$PATH"
         git config --global --add safe.directory $GITHUB_WORKSPACE
+        if [[ -n "${{ inputs.beta-version }}" ]]; then
+          export BETA_VERSION="${{ inputs.beta-version }}"
+        fi
         make pack BRANCH=$TAG_OR_BRANCH SHOW=1

--- a/.github/actions/upload-artifacts-to-s3-without-make/action.yml
+++ b/.github/actions/upload-artifacts-to-s3-without-make/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'OS Nickname'
     required: false
     default: ''
+  beta-version:
+    description: 'Beta version for S3 uploads'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -56,5 +60,19 @@ runs:
             if [[ $REF =~ $PATTERN ]]; then
               echo "This is a tagged build"
               RELEASE=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            fi
+          echo ::endgroup::
+          
+          echo ::group::upload to beta folder with version
+            # Use provided beta version if available
+            if [[ -n "${{ inputs.beta-version }}" ]]; then
+              BETA_VERSION="${{ inputs.beta-version }}"
+              echo "Using provided beta version: ${BETA_VERSION}"
+              
+              # Upload to beta folder
+              export BETA_VERSION="${BETA_VERSION}"
+              BETA=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            else
+              echo "No beta version provided, skipping beta upload"
             fi
           echo ::endgroup::

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -25,11 +25,66 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
+      beta-timestamp: ${{ steps.set-env.outputs.beta-timestamp }}
+      beta-version: ${{ steps.set-env.outputs.beta-version }}
+      module-version: ${{ steps.get-version.outputs.module-version }}
+      snapshot-template: ${{ steps.set-env.outputs.snapshot-template }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: set env
         id: set-env
         run: |
           echo "redis-ref=${{ inputs.redis-ref || '6.2' }}" >> $GITHUB_OUTPUT  # todo change per version/tag
+          
+          # Generate timestamp at workflow start for consistent beta versioning
+          TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")
+          WORKFLOW_NUM=${{ github.run_number }}
+          BETA_VERSION="99.99.99.${TIMESTAMP}.${WORKFLOW_NUM}"
+          
+          echo "beta-timestamp=${TIMESTAMP}" >> $GITHUB_OUTPUT
+          echo "beta-version=${BETA_VERSION}" >> $GITHUB_OUTPUT
+          echo "Generated beta version: ${BETA_VERSION}"
+
+          BRANCH_NAME="${{ github.ref_name }}"
+          BRANCH_NAME="${BRANCH_NAME//[^A-Za-z0-9._-]/_}"
+          SNAPSHOT_TEMPLATE="redistimeseries/snapshots/redistimeseries.@OS.${BRANCH_NAME}.${TIMESTAMP}.${WORKFLOW_NUM}.zip"
+          echo "snapshot-template=${SNAPSHOT_TEMPLATE}" >> $GITHUB_OUTPUT
+          echo "Snapshot template: ${SNAPSHOT_TEMPLATE}"
+
+      - name: Extract module version
+        id: get-version
+        run: |
+          MAJOR=$(grep '#define REDISTIMESERIES_VERSION_MAJOR' src/version.h | awk '{print $3}')
+          MINOR=$(grep '#define REDISTIMESERIES_VERSION_MINOR' src/version.h | awk '{print $3}')
+          PATCH=$(grep '#define REDISTIMESERIES_VERSION_PATCH' src/version.h | awk '{print $3}')
+          MODULE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "module-version=${MODULE_VERSION}" >> $GITHUB_OUTPUT
+          echo "Module version: ${MODULE_VERSION}"
+
+      - name: Summary
+        run: |
+          echo "### Nightly Build Info" >> $GITHUB_STEP_SUMMARY
+          echo "- **Module Version:** ${{ steps.get-version.outputs.module-version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Snapshot Template:** \`${{ steps.set-env.outputs.snapshot-template }}\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Create build metadata
+        run: |
+          echo '{}' | jq \
+            --arg snapshot_template "$SNAPSHOT_TEMPLATE" \
+            --arg module_version "$MODULE_VERSION" \
+            '{snapshot_template: $snapshot_template, module_version: $module_version}' \
+            > build-metadata.json
+        env:
+          SNAPSHOT_TEMPLATE: ${{ steps.set-env.outputs.snapshot-template }}
+          MODULE_VERSION: ${{ steps.get-version.outputs.module-version }}
+  
+      - name: Upload build metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-metadata
+          path: build-metadata.json
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit
@@ -40,7 +95,8 @@ jobs:
       arch: x64
       os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-      quick: true
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
+      quick: false
     secrets: inherit
   build-linux-arm64:
     uses: ./.github/workflows/flow-linux.yml
@@ -49,13 +105,15 @@ jobs:
       arch: arm64
       os: bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-      quick: false
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
+      quick: true
     secrets: inherit
   macos:
     uses: ./.github/workflows/flow-macos.yml
     needs: [prepare-values]
     with:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
       quick: true
     secrets: inherit
   linux-valgrind:
@@ -65,6 +123,7 @@ jobs:
       arch: x64
       os: jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
       run_valgrind: true
     secrets: inherit
   linux-sanitizer:
@@ -74,5 +133,6 @@ jobs:
       arch: x64
       os: jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
       run_sanitizer: true
     secrets: inherit

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -96,7 +96,7 @@ jobs:
       os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       beta-version: ${{needs.prepare-values.outputs.beta-version}}
-      quick: false
+      quick: true
     secrets: inherit
   build-linux-arm64:
     uses: ./.github/workflows/flow-linux.yml
@@ -106,7 +106,7 @@ jobs:
       os: bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       beta-version: ${{needs.prepare-values.outputs.beta-version}}
-      quick: true
+      quick: false
     secrets: inherit
   macos:
     uses: ./.github/workflows/flow-macos.yml

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -41,6 +41,11 @@ on:
         description: 'Run quick tests'
         type: boolean
         default: false
+      beta-version:
+        description: 'Beta version for S3 uploads'
+        type: string
+        required: false
+        default: ''
   workflow_call:
   # the defaults and options here are the same likes in "workflow_dispatch"
     inputs:
@@ -64,6 +69,11 @@ on:
         description: 'Run quick tests'
         type: boolean
         default: false
+      beta-version:
+        description: 'Beta version for S3 uploads'
+        type: string
+        required: false
+        default: ''
 
 
 jobs:
@@ -161,9 +171,11 @@ jobs:
         uses: ./.github/actions/pack-module
         with:
           use-venv: '1'
+          beta-version: ${{ inputs.beta-version }}
       - name: Upload artifacts to S3
         uses: ./.github/actions/upload-artifacts-to-s3-without-make
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           github-ref: ${{ github.ref }}
+          beta-version: ${{ inputs.beta-version }}

--- a/.github/workflows/mariner2.yml
+++ b/.github/workflows/mariner2.yml
@@ -11,6 +11,11 @@ on:
         description: 'Run quick tests'
         type: boolean
         default: false
+      beta-version:
+        description: 'Beta version for S3 uploads'
+        type: string
+        required: false
+        default: ''
 
 jobs:
   setup-environment:
@@ -69,9 +74,11 @@ jobs:
         uses: ./.github/actions/pack-module
         with:
           use-venv: '0'
+          beta-version: ${{ inputs.beta-version }}
       - name: Upload artifacts to S3
         uses: ./.github/actions/upload-artifacts-to-s3-without-make
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           github-ref: ${{ github.ref }}
+          beta-version: ${{ inputs.beta-version }}

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -277,6 +277,12 @@ pack_deps() {
 NUMVER="$(NUMERIC=1 $SBIN/getver)"
 SEMVER="$($SBIN/getver)"
 
+# Override SEMVER with BETA_VERSION if provided (for nightly builds)
+if [[ -n $BETA_VERSION ]]; then
+	SEMVER="$BETA_VERSION"
+	echo "# Using beta version: $BETA_VERSION"
+fi
+
 if [[ -n $VARIANT ]]; then
 	_VARIANT="-${VARIANT}"
 fi
@@ -307,6 +313,11 @@ if [[ $WITH_GITSHA == 1 ]]; then
 	git_config_add_ifnx safe.directory $ROOT
 	GIT_COMMIT=$(git rev-parse --short HEAD)
 	BRANCH="${BRANCH}-${GIT_COMMIT}"
+fi
+
+if [[ -n $BETA_VERSION ]]; then
+	BETA_SUFFIX=$(echo "$BETA_VERSION" | cut -d'.' -f4,5,6)
+	BRANCH="${BRANCH}.${BETA_SUFFIX}"
 fi
 
 #----------------------------------------------------------------------------------------------

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -21,6 +21,7 @@ if [[ $1 == --help || $1 == help || $HELP == 1 ]]; then
 
 		RELEASE=1     Upload release artifacts
 		STAGING=1     Upload into staging area
+		BETA=1        Upload to beta folder with version
 
 		NOP=1         No operation
 		VERBOSE=1     Show artifacts details
@@ -137,4 +138,9 @@ s3_upload() {
 
 #----------------------------------------------------------------------------------------------
 
-PROD=redistimeseries PREFIX=redistimeseries s3_upload
+# Set S3 directory based on BETA flag
+if [[ $BETA == 1 && -n $BETA_VERSION ]]; then
+	PROD=redistimeseries/beta PREFIX=redistimeseries s3_upload
+else
+	PROD=redistimeseries PREFIX=redistimeseries s3_upload
+fi


### PR DESCRIPTION
* Merge pull request #1770 from RedisTimeSeries/tomg-uplad-beta-version

MOD-11491 Adding generation and upload of the beta version to S3

* MOD-12726 unique snapshot name + new output params for nighly event (#1937)

* MOD-12726 unique snapshot name + new output params for nighly event

* remove tests(for testing hte change quick)

* add Summary

* bring back tests

* nightly build, upload snapshot artifact (#1954)

---------

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the build/release automation to alter artifact versioning and S3 upload destinations, which could break nightly packaging or publish artifacts to the wrong location if misconfigured. No runtime/module code changes, but impacts release pipeline behavior.
> 
> **Overview**
> Nightly workflow now generates a deterministic **beta version** (`99.99.99.<timestamp>.<run_number>`) and a unique snapshot naming template, surfaces these as job outputs, and publishes a small `build-metadata.json` artifact plus a step summary.
> 
> Packaging and uploads are extended end-to-end to accept/propagate `beta-version`: `pack.sh` can override `SEMVER` and append a beta suffix to snapshot `BRANCH` names, and `upload-artifacts` can optionally upload to `redistimeseries/beta` when `BETA=1` and `BETA_VERSION` are set. The composite GitHub Actions/workflows (`pack-module`, `upload-artifacts-to-s3-without-make`, and callers like `flow-macos`/`mariner2`/nightly jobs) now pass this input and perform an additional beta-folder upload when provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7df7c1349472236c0219c9bfb9a9b5179ed971ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->