### PR TITLE
fix: pass osnick to upload action so all OS artifacts are uploaded

### DIFF
--- a/.github/actions/upload-artifacts-to-s3-without-make/action.yml
+++ b/.github/actions/upload-artifacts-to-s3-without-make/action.yml
@@ -47,6 +47,10 @@ runs:
           aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
           aws configure set region "$AWS_REGION"
 
+          if [[ -n "${{ inputs.osnick }}" ]]; then
+            export OSNICK="${{ inputs.osnick }}"
+          fi
+
           echo ::group::upload artifacts
             SNAPSHOT=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
           echo ::endgroup::

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -201,3 +201,4 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           github-ref: ${{ github.ref }}
           beta-version: ${{ inputs.beta-version }}
+          osnick: ${{ matrix.platform.os }}


### PR DESCRIPTION
## Summary

- Fix artifact uploads being silently skipped for all OS variants except the one matching the host runner's OS
- Affects both x64 and arm64 builds — \`flow-linux.yml\` is shared by both architectures
- The \`upload-artifacts-to-s3-without-make\` action has an \`osnick\` input, but it was never passed from the workflow and never forwarded to the upload script

## Root Cause

\`sbin/upload-artifacts\` auto-detects the host runner's OS to build \`PLATFORM="\$OS-\$OSNICK-\$ARCH"\`, then globs for artifacts matching that platform. Since all jobs for a given architecture share the same runner, only artifacts named after the runner's OS are ever found:

| Architecture | Runner OS | Only this variant uploads | Everything else |
|---|---|---|---|
| **arm64** | ubuntu24.04 | \`noble\` | jammy, bionic, focal, rocky8/9, etc. — silently skipped |
| **x64** | ubuntu22.04 | \`jammy\` | bionic, focal, noble, rocky8/9, amazonlinux2, etc. — silently skipped |

The failure is silent because the glob uses \`2>/dev/null\` and the loop simply runs zero iterations, the script exits 0, and the only missing sign in the logs is the absent \`upload:\` line.

## Fix

Two changes are required together:

1. **\`flow-linux.yml\`** — pass the matrix OS nickname to the action:
   \`\`\`yaml
   osnick: \${{ matrix.platform.os }}
   \`\`\`

2. **\`action.yml\`** — forward it as \`OSNICK\` env var before invoking the script:
   \`\`\`bash
   if [[ -n "\${{ inputs.osnick }}" ]]; then
     export OSNICK="\${{ inputs.osnick }}"
   fi
   \`\`\`

The upload script already maps OS nicknames to version strings (jammy→ubuntu22.04, noble→ubuntu24.04, rocky8→rhel8, etc.), so passing the matrix OS name is sufficient.

This fix is identical to what is already on \`master\`.