### PR TITLE
improve tests speed

### DIFF
--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -31,12 +31,15 @@ SANITIZER = os.getenv('SANITIZER', '')
 VALGRIND = (os.getenv('VALGRIND', '0') == '1') or (os.getenv('VG', '0') == '1')
 CODE_COVERAGE = os.getenv('CODE_COVERAGE', '0') == '1'
 
-# Use generous terminate patience for all configurations. RLTest polls and
-# returns as soon as the process exits, so a high retry count costs nothing
-# when shutdown is fast, but prevents force-kills under Valgrind/sanitizer
-# where shutdown is much slower.
-Defaults.terminate_retries = 20
-Defaults.terminate_retries_secs = 1
+# Under Valgrind/sanitizer Redis shuts down much more slowly, so we need
+# generous retry patience to avoid force-kills. The retry loop sleeps
+# terminateRetrySecs between each attempt, so keeping this large under normal
+# operation would add ~1s of forced sleep per shutdown even when Redis exits
+# quickly. Use the default (None) path in normal operation, which polls
+# every 100ms and returns as soon as the process exits.
+if VALGRIND or SANITIZER:
+    Defaults.terminate_retries = 20
+    Defaults.terminate_retry_secs = 1
 
 
 class ShardConnectionTimeoutException(Exception):
@@ -101,8 +104,9 @@ def Env(*args, **kwargs):
 
     env = rltestEnv(*args,
                     terminateRetries=Defaults.terminate_retries,
-                    terminateRetrySecs=Defaults.terminate_retries_secs,
+                    terminateRetrySecs=Defaults.terminate_retry_secs,
                     **kwargs)
+
     Defaults.no_log = temp_no_log
     Defaults.no_capture_output = no_capture_output
 

--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -31,15 +31,20 @@ SANITIZER = os.getenv('SANITIZER', '')
 VALGRIND = (os.getenv('VALGRIND', '0') == '1') or (os.getenv('VG', '0') == '1')
 CODE_COVERAGE = os.getenv('CODE_COVERAGE', '0') == '1'
 
-# Under Valgrind/sanitizer Redis shuts down much more slowly, so we need
-# generous retry patience to avoid force-kills. The retry loop sleeps
-# terminateRetrySecs between each attempt, so keeping this large under normal
-# operation would add ~1s of forced sleep per shutdown even when Redis exits
-# quickly. Use the default (None) path in normal operation, which polls
-# every 100ms and returns as soon as the process exits.
+# RLTest's terminateRetries path: sends SIGTERM, sleeps terminate_retry_secs,
+# checks, repeats up to terminateRetries times, then force-kills (SIGKILL).
+# The terminateRetries=None path polls every 100ms but NEVER force-kills —
+# it can hang indefinitely if Redis doesn't exit (calls communicate() at 30s
+# which itself blocks forever). We always use the retry path to keep the
+# force-kill safety valve, but use a short sleep so we don't waste time.
+#   Normal: 30 retries x 0.1s = force-kill after ~3s if Redis hangs
+#   VG/SAN: 120 retries x 1s = force-kill after ~2min (Redis is much slower)
 if VALGRIND or SANITIZER:
     Defaults.terminate_retries = 20
     Defaults.terminate_retry_secs = 1
+else:
+    Defaults.terminate_retries = 30
+    Defaults.terminate_retry_secs = 0.1
 
 
 class ShardConnectionTimeoutException(Exception):

--- a/tests/flow/test_globalconfigs.py
+++ b/tests/flow/test_globalconfigs.py
@@ -14,8 +14,9 @@ class testModuleLoadTimeArguments(object):
                                 ]
 
     def test(self):
-        Env().skipOnCluster()
         skip_on_rlec()
+        env = Env()
+        env.skipOnCluster()
         for variation in self.test_variations:
             should_ok = variation[0]
             if should_ok:
@@ -29,9 +30,9 @@ class testModuleLoadTimeArguments(object):
 
 
 def test_ignore():
-    Env().skipOnCluster()
     skip_on_rlec()
     env = Env(moduleArgs='IGNORE_MAX_TIME_DIFF 10; IGNORE_MAX_VAL_DIFF 20')
+    env.skipOnCluster()
     with env.getConnection() as r:
         # Verify module args work as the default config
         r.execute_command('TS.ADD', 'key1', '1000', '100', 'DUPLICATE_POLICY', 'LAST')
@@ -59,9 +60,9 @@ def test_ignore_invalid_module_args(env):
 
 
 def test_encoding_uncompressed():
-    Env().skipOnCluster()
     skip_on_rlec()
     env = Env(moduleArgs='ENCODING UNCOMPRESSED; COMPACTION_POLICY max:1s:1m')
+    env.skipOnCluster()
     with env.getConnection() as r:
         r.execute_command('FLUSHALL')
         r.execute_command('TS.ADD', 't1', '1', 1.0)
@@ -69,18 +70,18 @@ def test_encoding_uncompressed():
 
 
 def test_encoding_compressed():
-    Env().skipOnCluster()
     skip_on_rlec()
     env = Env(moduleArgs='ENCODING compressed; COMPACTION_POLICY max:1s:1m')
+    env.skipOnCluster()
     with env.getConnection() as r:
         r.execute_command('FLUSHALL')
         r.execute_command('TS.ADD', 't1', '1', 1.0)
         assert TSInfo(r.execute_command('TS.INFO', 't1_MAX_1000')).chunk_type == b'compressed'
 
 def test_uncompressed():
-    Env().skipOnCluster()
     skip_on_rlec()
     env = Env(moduleArgs='CHUNK_TYPE UNCOMPRESSED; COMPACTION_POLICY max:1s:1m')
+    env.skipOnCluster()
     with env.getConnection() as r:
         r.execute_command('FLUSHALL')
         r.execute_command('TS.ADD', 't1', '1', 1.0)
@@ -88,18 +89,17 @@ def test_uncompressed():
 
 
 def test_compressed():
-    Env().skipOnCluster()
     skip_on_rlec()
     env = Env(moduleArgs='CHUNK_TYPE compressed; COMPACTION_POLICY max:1s:1m')
+    env.skipOnCluster()
     with env.getConnection() as r:
         r.execute_command('FLUSHALL')
         r.execute_command('TS.ADD', 't1', '1', 1.0)
         assert TSInfo(r.execute_command('TS.INFO', 't1_MAX_1000')).chunk_type == b'compressed'
 
 def test_compressed_debug():
-    Env().skipOnCluster()
-
     env = Env(moduleArgs='CHUNK_TYPE compressed COMPACTION_POLICY max:1s:1m')
+    env.skipOnCluster()
     skip_on_rlec()
     with env.getConnection() as r:
         r.execute_command('FLUSHALL')
@@ -110,9 +110,9 @@ def test_compressed_debug():
         assert TSInfo(r.execute_command('TS.INFO', 't1_MAX_1000', 'DEBUG')).chunks == [[b'startTimestamp', 0, b'endTimestamp', 3000, b'samples', 2, b'size', 4096, b'bytesPerSample', b'2048']]
 
 def test_timestamp_alignment():
-    Env().skipOnCluster()
     skip_on_rlec()
     env = Env(moduleArgs='CHUNK_TYPE UNCOMPRESSED; COMPACTION_POLICY max:1s:0:500m')
+    env.skipOnCluster()
     with env.getConnection() as r:
         r.execute_command('FLUSHALL')
         r.execute_command('TS.ADD', 't1', '1', 1.0)
@@ -134,9 +134,9 @@ def test_timestamp_alignment():
 class testGlobalConfigTests():
 
     def __init__(self):
-        Env().skipOnCluster()
         skip_on_rlec()
         self.env = Env(moduleArgs='COMPACTION_POLICY max:1m:1d\\;min:10s:1h\\;avg:2h:10d\\;avg:3d:100d')
+        self.env.skipOnCluster()
 
     def test_autocreate(self):
         with self.env.getConnection() as r:
@@ -196,7 +196,8 @@ class testGlobalConfigTests():
 
 
 def test_negative_configuration():
-    Env().skipOnCluster()
+    check_env = Env()
+    check_env.skipOnCluster()
     skip_on_rlec()
     with pytest.raises(Exception) as excinfo:
         env = Env(moduleArgs='CHUNK_SIZE_BYTES 80; DUPLICATE_POLICY abc')

--- a/tests/flow/test_lazy_del.py
+++ b/tests/flow/test_lazy_del.py
@@ -5,118 +5,186 @@ from test_helper_classes import TSInfo, ALLOWED_ERROR, _insert_data, _get_ts_inf
     _insert_agg_data
 from includes import *
 
-def test_lazy_del_src():
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", 'src{test}')
-        r.execute_command("ts.create", 'dst{test}')
-        r.execute_command("ts.createrule", 'src{test}', 'dst{test}', 'AGGREGATION', 'avg', 60000)
-        
-        assert _get_ts_info(r, 'dst{test}').sourceKey.decode() == 'src{test}'
-        assert len(_get_ts_info(r, 'src{test}').rules) == 1
-        assert _get_ts_info(r, 'src{test}').rules[0][0].decode() == 'dst{test}'
-        r.execute_command('DEL', 'src{test}')
 
-        assert _get_ts_info(r, 'dst{test}').sourceKey is None
-        assert len(_get_ts_info(r, 'dst{test}').rules) == 0
+class testLazyDel:
+    def __init__(self):
+        self.env = Env()
 
-def test_lazy_del_dst():
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", 'src{test}')
-        r.execute_command("ts.create", 'dst{test}')
-        r.execute_command('TS.CREATERULE', 'src{test}', 'dst{test}', 'AGGREGATION', 'avg', 60000)
-        
-        assert _get_ts_info(r, 'dst{test}').sourceKey.decode() == 'src{test}'
-        assert len(_get_ts_info(r, 'src{test}').rules) == 1
-        assert _get_ts_info(r, 'src{test}').rules[0][0].decode() == 'dst{test}'
-        r.execute_command('DEL', 'dst{test}')
+    def test_lazy_del_src(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", 'src{test}')
+            r.execute_command("ts.create", 'dst{test}')
+            r.execute_command("ts.createrule", 'src{test}', 'dst{test}', 'AGGREGATION', 'avg', 60000)
 
-        assert _get_ts_info(r, 'src{test}').sourceKey is None
-        assert len(_get_ts_info(r, 'src{test}').rules) == 0
+            assert _get_ts_info(r, 'dst{test}').sourceKey.decode() == 'src{test}'
+            assert len(_get_ts_info(r, 'src{test}').rules) == 1
+            assert _get_ts_info(r, 'src{test}').rules[0][0].decode() == 'dst{test}'
+            r.execute_command('DEL', 'src{test}')
 
-#def test_533_dump_rules() implementing test_dump_restore_src_rule
-def test_dump_restore_dst_rule():
-    with Env().getClusterConnectionIfNeeded() as r:
-        key1 = 'ts1{a}'
-        key2 = 'ts2{a}'
-        key3 = 'ts3{a}'
-        key4 = 'ts4{a}'
-        key5 = 'ts5{a}'
-        key6 = 'ts6{a}'
-        n_dst_keys = 5
-        r.execute_command('TS.CREATE', key1)
-        r.execute_command('TS.CREATE', key2)
-        r.execute_command('TS.CREATE', key3)
-        r.execute_command('TS.CREATE', key4)
-        r.execute_command('TS.CREATE', key5)
-        r.execute_command('TS.CREATE', key6)
-        r.execute_command('TS.CREATERULE', key1, key2, 'AGGREGATION', 'avg', 60000)
-        r.execute_command('TS.CREATERULE', key1, key3, 'AGGREGATION', 'twa', 10)
-        r.execute_command('TS.CREATERULE', key1, key4, 'AGGREGATION', 'last', 10)
-        r.execute_command('TS.CREATERULE', key1, key5, 'AGGREGATION', 'count', 10)
-        r.execute_command('TS.CREATERULE', key1, key6, 'AGGREGATION', 'first', 10)
+            assert _get_ts_info(r, 'dst{test}').sourceKey is None
+            assert len(_get_ts_info(r, 'dst{test}').rules) == 0
 
-        assert _get_ts_info(r, key2).sourceKey.decode() == key1
-        assert len(_get_ts_info(r, key1).rules) == n_dst_keys
+    def test_lazy_del_dst(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", 'src{test}')
+            r.execute_command("ts.create", 'dst{test}')
+            r.execute_command('TS.CREATERULE', 'src{test}', 'dst{test}', 'AGGREGATION', 'avg', 60000)
 
-        data = r.execute_command('DUMP', key2)
-        r.execute_command('DEL', key2)
-        r.execute_command('restore', key2, 0, data)
+            assert _get_ts_info(r, 'dst{test}').sourceKey.decode() == 'src{test}'
+            assert len(_get_ts_info(r, 'src{test}').rules) == 1
+            assert _get_ts_info(r, 'src{test}').rules[0][0].decode() == 'dst{test}'
+            r.execute_command('DEL', 'dst{test}')
 
-        assert _get_ts_info(r, key1).sourceKey is None
-        assert len(_get_ts_info(r, key1).rules) == n_dst_keys - 1
-        assert _get_ts_info(r, key2).sourceKey is None
-        assert len(_get_ts_info(r, key2).rules) == 0
-    
-        data = r.execute_command('DUMP', key3)
-        r.execute_command('DEL', key3)
-        r.execute_command('restore', key3, 0, data)
-        assert _get_ts_info(r, key1).sourceKey is None
-        assert len(_get_ts_info(r, key1).rules) == n_dst_keys - 2
-        assert _get_ts_info(r, key3).sourceKey is None
-        assert len(_get_ts_info(r, key3).rules) == 0
+            assert _get_ts_info(r, 'src{test}').sourceKey is None
+            assert len(_get_ts_info(r, 'src{test}').rules) == 0
 
-        data = r.execute_command('DUMP', key4)
-        r.execute_command('DEL', key4)
-        r.execute_command('restore', key4, 0, data)
-        assert _get_ts_info(r, key1).sourceKey is None
-        assert len(_get_ts_info(r, key1).rules) ==  n_dst_keys - 3
-        assert _get_ts_info(r, key4).sourceKey is None
-        assert len(_get_ts_info(r, key4).rules) == 0
+    def test_dump_restore_dst_rule(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            key1 = 'ts1{a}'
+            key2 = 'ts2{a}'
+            key3 = 'ts3{a}'
+            key4 = 'ts4{a}'
+            key5 = 'ts5{a}'
+            key6 = 'ts6{a}'
+            n_dst_keys = 5
+            r.execute_command('TS.CREATE', key1)
+            r.execute_command('TS.CREATE', key2)
+            r.execute_command('TS.CREATE', key3)
+            r.execute_command('TS.CREATE', key4)
+            r.execute_command('TS.CREATE', key5)
+            r.execute_command('TS.CREATE', key6)
+            r.execute_command('TS.CREATERULE', key1, key2, 'AGGREGATION', 'avg', 60000)
+            r.execute_command('TS.CREATERULE', key1, key3, 'AGGREGATION', 'twa', 10)
+            r.execute_command('TS.CREATERULE', key1, key4, 'AGGREGATION', 'last', 10)
+            r.execute_command('TS.CREATERULE', key1, key5, 'AGGREGATION', 'count', 10)
+            r.execute_command('TS.CREATERULE', key1, key6, 'AGGREGATION', 'first', 10)
 
-        data = r.execute_command('DUMP', key5)
-        r.execute_command('DEL', key5)
-        r.execute_command('restore', key5, 0, data)
-        assert _get_ts_info(r, key1).sourceKey is None
-        assert len(_get_ts_info(r, key1).rules) ==  n_dst_keys - 4
-        assert _get_ts_info(r, key5).sourceKey is None
-        assert len(_get_ts_info(r, key5).rules) == 0
+            assert _get_ts_info(r, key2).sourceKey.decode() == key1
+            assert len(_get_ts_info(r, key1).rules) == n_dst_keys
 
-        data = r.execute_command('DUMP', key6)
-        r.execute_command('DEL', key6)
-        r.execute_command('restore', key6, 0, data)
-        assert _get_ts_info(r, key1).sourceKey is None
-        assert len(_get_ts_info(r, key1).rules) ==  n_dst_keys - 5
-        assert _get_ts_info(r, key6).sourceKey is None
-        assert len(_get_ts_info(r, key6).rules) == 0
+            data = r.execute_command('DUMP', key2)
+            r.execute_command('DEL', key2)
+            r.execute_command('restore', key2, 0, data)
 
-        r.execute_command('TS.CREATERULE', key1, key2, 'AGGREGATION', 'avg', 60000)
-        assert _get_ts_info(r, key2).sourceKey.decode() == key1
-        assert len(_get_ts_info(r, key1).rules) == 1
+            assert _get_ts_info(r, key1).sourceKey is None
+            assert len(_get_ts_info(r, key1).rules) == n_dst_keys - 1
+            assert _get_ts_info(r, key2).sourceKey is None
+            assert len(_get_ts_info(r, key2).rules) == 0
 
-        data = r.execute_command('DUMP', key1)
-        r.execute_command('DEL', key1)
-        r.execute_command('restore', key1, 0, data)
+            data = r.execute_command('DUMP', key3)
+            r.execute_command('DEL', key3)
+            r.execute_command('restore', key3, 0, data)
+            assert _get_ts_info(r, key1).sourceKey is None
+            assert len(_get_ts_info(r, key1).rules) == n_dst_keys - 2
+            assert _get_ts_info(r, key3).sourceKey is None
+            assert len(_get_ts_info(r, key3).rules) == 0
 
-        assert _get_ts_info(r, key1).sourceKey is None
-        assert len(_get_ts_info(r, key1).rules) == 0
-        assert _get_ts_info(r, key2).sourceKey is None
-        assert len(_get_ts_info(r, key2).rules) == 0
+            data = r.execute_command('DUMP', key4)
+            r.execute_command('DEL', key4)
+            r.execute_command('restore', key4, 0, data)
+            assert _get_ts_info(r, key1).sourceKey is None
+            assert len(_get_ts_info(r, key1).rules) == n_dst_keys - 3
+            assert _get_ts_info(r, key4).sourceKey is None
+            assert len(_get_ts_info(r, key4).rules) == 0
+
+            data = r.execute_command('DUMP', key5)
+            r.execute_command('DEL', key5)
+            r.execute_command('restore', key5, 0, data)
+            assert _get_ts_info(r, key1).sourceKey is None
+            assert len(_get_ts_info(r, key1).rules) == n_dst_keys - 4
+            assert _get_ts_info(r, key5).sourceKey is None
+            assert len(_get_ts_info(r, key5).rules) == 0
+
+            data = r.execute_command('DUMP', key6)
+            r.execute_command('DEL', key6)
+            r.execute_command('restore', key6, 0, data)
+            assert _get_ts_info(r, key1).sourceKey is None
+            assert len(_get_ts_info(r, key1).rules) == n_dst_keys - 5
+            assert _get_ts_info(r, key6).sourceKey is None
+            assert len(_get_ts_info(r, key6).rules) == 0
+
+            r.execute_command('TS.CREATERULE', key1, key2, 'AGGREGATION', 'avg', 60000)
+            assert _get_ts_info(r, key2).sourceKey.decode() == key1
+            assert len(_get_ts_info(r, key1).rules) == 1
+
+            data = r.execute_command('DUMP', key1)
+            r.execute_command('DEL', key1)
+            r.execute_command('restore', key1, 0, data)
+
+            assert _get_ts_info(r, key1).sourceKey is None
+            assert len(_get_ts_info(r, key1).rules) == 0
+            assert _get_ts_info(r, key2).sourceKey is None
+            assert len(_get_ts_info(r, key2).rules) == 0
+
+    def test_dump_restore_dst_rule_old_version(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            key1 = 'ts1{a}'
+            key2 = 'ts2{a}'
+            r.execute_command('TS.CREATE', key1)
+
+            # data was taken from test_dump_restore_dst_rule on version TS_OVERFLOW_RDB_VER
+            data = b'\a\x81M \xc1\xf96\x0f\x10\x04\x05\x06ts2{a}\x02\x00\x02P\x00\x02\x02\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x02\x00\x02\x01\x05\x06ts1{a}\x02\x00\x02\x00\x02\x01\x02P\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02 \x02 \x05\xc36P\x00\x01\x00\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0{\x00\x01\x00\x00\x00\t\x00\xb7J\aG\x17\xe4\xec\xcc'
+            r.execute_command('restore', key2, 0, data)
+
+            assert _get_ts_info(r, key1).sourceKey is None
+            assert len(_get_ts_info(r, key1).rules) == 0
+            assert _get_ts_info(r, key2).sourceKey is None
+            assert len(_get_ts_info(r, key2).rules) == 0
+
+            r.execute_command('DEL', key1)
+
+            # data was taken from test_dump_restore_dst_rule on version TS_OVERFLOW_RDB_VER
+            data = b'\a\x81M \xc1\xf96\x0f\x10\x04\x05\x06ts1{a}\x02\x00\x02P\x00\x02\x02\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x01\x05\x06ts2{a}\x02\x80\x00\x00\xea`\x02\x04\x02\x81\xff\xff\xff\xff\xff\xff\xff\xff\x04\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x02\x01\x02P\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02 \x02 \x05\xc36P\x00\x01\x00\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0{\x00\x01\x00\x00\x00\t\x00j\x85\xe4Z\xb6\xb9\xc38'
+            r.execute_command('restore', key1, 0, data)
+
+            assert _get_ts_info(r, key1).sourceKey is None
+            assert len(_get_ts_info(r, key1).rules) == 0
+            assert _get_ts_info(r, key2).sourceKey is None
+            assert len(_get_ts_info(r, key2).rules) == 0
+
+    def test_info_doesnt_delete_acl_restricted(self):
+        env = self.env
+        env.flush()
+        env.skipOnCluster()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'a')
+            r.execute_command('TS.CREATE', 'b')
+
+            r.execute_command('TS.CREATERULE', 'a', 'b', 'AGGREGATION', 'avg', 60000)
+            assert _get_ts_info(r, 'b').sourceKey.decode() == 'a'
+            assert len(_get_ts_info(r, 'a').rules) == 1
+            assert _get_ts_info(r, 'a').rules[0][0].decode() == 'b'
+
+            r.execute_command('ACL SETUSER usr on >p ~a* +@all')
+            r.execute_command('AUTH usr p')
+            assert len(_get_ts_info(r, 'a').rules) == 1
+            assert _get_ts_info(r, 'a').rules[0][0].decode() == 'b'
+            try:
+                _get_ts_info(r, 'b')
+                assert False
+            except redis.exceptions.NoPermissionError:
+                pass
+
+            r.execute_command('AUTH default ""')
+            assert len(_get_ts_info(r, 'a').rules) == 1
+            assert _get_ts_info(r, 'a').rules[0][0].decode() == 'b'
+            assert _get_ts_info(r, 'b').sourceKey.decode() == 'a'
+
 
 # test for version problems in dump restore
 def test_dump_restore_dst_rule_force_save_refs():
-    Env().skipOnCluster()
     skip_on_rlec()
-    with Env(moduleArgs='DEUBG_FORCE_RULE_DUMP enable').getClusterConnectionIfNeeded() as r:
+    env = Env(moduleArgs='DEUBG_FORCE_RULE_DUMP enable')
+    env.skipOnCluster()
+    with env.getClusterConnectionIfNeeded() as r:
         key1 = 'ts1{a}'
         key2 = 'ts2{a}'
         key3 = 'ts3{a}'
@@ -137,55 +205,3 @@ def test_dump_restore_dst_rule_force_save_refs():
         assert len(_get_ts_info(r, key1).rules) != 0
         assert _get_ts_info(r, key2).sourceKey != None
         assert len(_get_ts_info(r, key2).rules) == 0
-
-def test_dump_restore_dst_rule_old_version():
-    with Env().getClusterConnectionIfNeeded() as r:
-        key1 = 'ts1{a}'
-        key2 = 'ts2{a}'
-        r.execute_command('TS.CREATE', key1)
-
-        # data was taken from test_dump_restore_dst_rule on version TS_OVERFLOW_RDB_VER
-        data = b'\a\x81M \xc1\xf96\x0f\x10\x04\x05\x06ts2{a}\x02\x00\x02P\x00\x02\x02\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x02\x00\x02\x01\x05\x06ts1{a}\x02\x00\x02\x00\x02\x01\x02P\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02 \x02 \x05\xc36P\x00\x01\x00\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0{\x00\x01\x00\x00\x00\t\x00\xb7J\aG\x17\xe4\xec\xcc'
-        r.execute_command('restore', key2, 0, data)
-
-        assert _get_ts_info(r, key1).sourceKey is None
-        assert len(_get_ts_info(r, key1).rules) == 0
-        assert _get_ts_info(r, key2).sourceKey is None
-        assert len(_get_ts_info(r, key2).rules) == 0
-
-        r.execute_command('DEL', key1)
-
-        # data was taken from test_dump_restore_dst_rule on version TS_OVERFLOW_RDB_VER
-        data = b'\a\x81M \xc1\xf96\x0f\x10\x04\x05\x06ts1{a}\x02\x00\x02P\x00\x02\x02\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x01\x05\x06ts2{a}\x02\x80\x00\x00\xea`\x02\x04\x02\x81\xff\xff\xff\xff\xff\xff\xff\xff\x04\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x02\x01\x02P\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02 \x02 \x05\xc36P\x00\x01\x00\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0{\x00\x01\x00\x00\x00\t\x00j\x85\xe4Z\xb6\xb9\xc38'
-        r.execute_command('restore', key1, 0, data)
-
-        assert _get_ts_info(r, key1).sourceKey is None
-        assert len(_get_ts_info(r, key1).rules) == 0
-        assert _get_ts_info(r, key2).sourceKey is None
-        assert len(_get_ts_info(r, key2).rules) == 0
-
-def test_info_doesnt_delete_acl_restricted():
-    Env().skipOnCluster()
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'a')
-        r.execute_command('TS.CREATE', 'b')
-
-        r.execute_command('TS.CREATERULE', 'a', 'b', 'AGGREGATION', 'avg', 60000)
-        assert _get_ts_info(r, 'b').sourceKey.decode() == 'a'
-        assert len(_get_ts_info(r, 'a').rules) == 1
-        assert _get_ts_info(r, 'a').rules[0][0].decode() == 'b'
-
-        r.execute_command('ACL SETUSER usr on >p ~a* +@all')
-        r.execute_command('AUTH usr p')
-        assert len(_get_ts_info(r, 'a').rules) == 1
-        assert _get_ts_info(r, 'a').rules[0][0].decode() == 'b'
-        try:
-            _get_ts_info(r, 'b')
-            assert False
-        except redis.exceptions.NoPermissionError:
-            pass
-        
-        r.execute_command('AUTH default ""')
-        assert len(_get_ts_info(r, 'a').rules) == 1
-        assert _get_ts_info(r, 'a').rules[0][0].decode() == 'b'
-        assert _get_ts_info(r, 'b').sourceKey.decode() == 'a'

--- a/tests/flow/test_ts_add.py
+++ b/tests/flow/test_ts_add.py
@@ -5,293 +5,362 @@ import redis
 from RLTest import Env
 from test_helper_classes import _get_ts_info, TSInfo
 from includes import *
-import random 
+import random
 import struct
 
-def test_add_different_slot_range():
-    env = Env(decodeResponses=True)
-    if not env.isCluster():
-        env.skip()
-    with env.getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('config','set', 'ts-compaction-policy', 'sum:1M:1h') == 'OK', 'Failed to set compaction policy'
-        assert r.execute_command('ts.add', 'b', '1', '1') == 1, 'Failed to add data'
-        assert r.execute_command('type', 'b') == 'TSDB-TYPE', 'type is not TSDB-TYPE, result: ' + str(r.execute_command('type', 'a'))
-        assert r.execute_command('type', 'b_SUM_60000') != 'TSDB-TYPE', 'type is TSDB-TYPE, result: ' + str(r.execute_command('type', 'a_SUM_60000'))
-        assert r.execute_command('ts.add', '{b}', '1', '1') == 1, 'Failed to add data'
-        assert r.execute_command('type', '{b}') == 'TSDB-TYPE', 'type is not TSDB-TYPE, result: ' + str(r.execute_command('type', '{b}'))
-        assert r.execute_command('type', '{b}_SUM_60000') == 'TSDB-TYPE', 'type is not TSDB-TYPE, result: ' + str(r.execute_command('type', '{b}_SUM_60000'))
-        assert 'b_SUM_60000' not in r.execute_command('KEYS', '*'), 'Keys are not as expected: ' + str(r.execute_command('KEYS', '*'))
 
-def test_issue_504():
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('ts.create', 'tester')
-        for i in range(100, 3000):
-            assert r.execute_command('ts.add', 'tester', i, i * 1.1) == i
-        assert r.execute_command('ts.add', 'tester', 99, 1) == 99
-        assert r.execute_command('ts.add', 'tester', 98, 1) == 98
+class testTsAdd:
+    def __init__(self):
+        self.env = Env()
 
+    def test_issue_504(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('ts.create', 'tester')
+            for i in range(100, 3000):
+                assert r.execute_command('ts.add', 'tester', i, i * 1.1) == i
+            assert r.execute_command('ts.add', 'tester', 99, 1) == 99
+            assert r.execute_command('ts.add', 'tester', 98, 1) == 98
 
-def test_issue_588():
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('ts.create', 'test1', "DUPLICATE_POLICY", "min")
-        r.execute_command('ts.add', 'test1', 1, -0.05)
-        assert float(r.execute_command('TS.RANGE', 'test1', "-", "+")[0][1]) == -0.05
-        r.execute_command('ts.add', 'test1', 1, -0.06)
-        assert float(r.execute_command('TS.RANGE', 'test1', "-", "+")[0][1]) == -0.06
+    def test_issue_588(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('ts.create', 'test1', "DUPLICATE_POLICY", "min")
+            r.execute_command('ts.add', 'test1', 1, -0.05)
+            assert float(r.execute_command('TS.RANGE', 'test1', "-", "+")[0][1]) == -0.05
+            r.execute_command('ts.add', 'test1', 1, -0.06)
+            assert float(r.execute_command('TS.RANGE', 'test1', "-", "+")[0][1]) == -0.06
 
-        r.execute_command('ts.create', 'test2', "DUPLICATE_POLICY", "max")
-        r.execute_command('ts.add', 'test2', 1, -0.06)
-        assert float(r.execute_command('TS.RANGE', 'test2', "-", "+")[0][1]) == -0.06
-        r.execute_command('ts.add', 'test2', 1, -0.05)
-        assert float(r.execute_command('TS.RANGE', 'test2', "-", "+")[0][1]) == -0.05
+            r.execute_command('ts.create', 'test2', "DUPLICATE_POLICY", "max")
+            r.execute_command('ts.add', 'test2', 1, -0.06)
+            assert float(r.execute_command('TS.RANGE', 'test2', "-", "+")[0][1]) == -0.06
+            r.execute_command('ts.add', 'test2', 1, -0.05)
+            assert float(r.execute_command('TS.RANGE', 'test2', "-", "+")[0][1]) == -0.05
 
+    def test_automatic_timestamp(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', 'tester')
+            response_timestamp = r.execute_command('TS.ADD', 'tester', '*', 1)
+            curr_time = int(time.time() * 1000)
+            result = r.execute_command('TS.RANGE', 'tester', 0, curr_time)
+            # test time difference is not more than 5 milliseconds
+            assert result[0][0] - curr_time <= 5
+            assert response_timestamp - curr_time <= 5
 
-def test_automatic_timestamp():
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', 'tester')
-        response_timestamp = r.execute_command('TS.ADD', 'tester', '*', 1)
-        curr_time = int(time.time() * 1000)
-        result = r.execute_command('TS.RANGE', 'tester', 0, curr_time)
-        # test time difference is not more than 5 milliseconds
-        assert result[0][0] - curr_time <= 5
-        assert response_timestamp - curr_time <= 5
+    def test_add_create_key(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            ts = time.time()
+            assert r.execute_command('TS.ADD', 'tester1', str(int(ts)), str(ts), 'RETENTION', '666', 'LABELS', 'name',
+                                     'blabla') == int(ts)
+            info = _get_ts_info(r, 'tester1')
+            assert info.total_samples == 1
+            assert info.retention_msecs == 666
+            assert info.labels == {b'name': b'blabla'}
 
+            assert r.execute_command('TS.ADD', 'tester2', str(int(ts)), str(ts), 'LABELS', 'name', 'blabla2', 'location',
+                                     'earth')
+            info = _get_ts_info(r, 'tester2')
+            assert info.total_samples == 1
+            assert info.labels == {b'location': b'earth', b'name': b'blabla2'}
 
-def test_add_create_key():
-    with Env().getClusterConnectionIfNeeded() as r:
-        ts = time.time()
-        assert r.execute_command('TS.ADD', 'tester1', str(int(ts)), str(ts), 'RETENTION', '666', 'LABELS', 'name',
-                                 'blabla') == int(ts)
-        info = _get_ts_info(r, 'tester1')
-        assert info.total_samples == 1
-        assert info.retention_msecs == 666
-        assert info.labels == {b'name': b'blabla'}
+    def test_ts_add_encoding(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            for ENCODING in ['compressed', 'uncompressed']:
+                r.execute_command('FLUSHALL')
+                r.execute_command('ts.add', 't1', '*', '5.0', 'ENCODING', ENCODING)
+                env.assertEqual(TSInfo(r.execute_command('TS.INFO', 't1')).chunk_type, ENCODING.encode())
+                # backwards compatible check
+                r.execute_command('ts.add', 't1_bc', '*', '5.0', ENCODING)
+                env.assertEqual(TSInfo(r.execute_command('TS.INFO', 't1_bc')).chunk_type, ENCODING.encode())
 
-        assert r.execute_command('TS.ADD', 'tester2', str(int(ts)), str(ts), 'LABELS', 'name', 'blabla2', 'location',
-                                 'earth')
-        info = _get_ts_info(r, 'tester2')
-        assert info.total_samples == 1
-        assert info.labels == {b'location': b'earth', b'name': b'blabla2'}
+    def test_different_chunk_size(self):
+        env = self.env
+        env.flush()
+        env.skipOnCluster()
+        with env.getConnection() as r:
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command('TS.add', 'tester', "1636545188", "123", 'LABELS', 'id', 'abc1231232', 'CHUNK_SIZE', '0')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command('TS.add', 'tester', "1636545188", "123", 'LABELS', 'id', 'abc1231232', 'CHUNK_SIZE', '-1000')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command('TS.add', 'tester', "1636545188", "123", 'LABELS', 'id', 'abc1231232', 'CHUNK_SIZE', '100')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command('TS.add', 'tester', "1636545188", "123", 'LABELS', 'id', 'abc1231232', 'CHUNK_SIZE', '127')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command('TS.add', 'tester', "1636545188", "123", 'LABELS', 'id', 'abc1231232', 'CHUNK_SIZE', '40000000')
 
-def test_ts_add_encoding():
-    for ENCODING in ['compressed','uncompressed']:
-        e = Env()
-        e.flush()
-        with e.getClusterConnectionIfNeeded() as r:
-            r.execute_command('ts.add', 't1', '*', '5.0', 'ENCODING', ENCODING)
-            e.assertEqual(TSInfo(r.execute_command('TS.INFO', 't1')).chunk_type, ENCODING.encode())
-            # backwards compatible check
-            r.execute_command('ts.add', 't1_bc', '*', '5.0', ENCODING)
-            e.assertEqual(TSInfo(r.execute_command('TS.INFO', 't1_bc')).chunk_type, ENCODING.encode())
+            r.execute_command('TS.add', 'tester3', "1636545188", "123", 'LABELS', 'id', 'abc1231232', 'CHUNK_SIZE', '128')
+            r.execute_command('TS.add', 'tester2', "1636545188", "123", 'LABELS', 'id', 'abc1231232', 'CHUNK_SIZE', '40000')
 
+    def test_valid_labels(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command('TS.CREATE', 'tester', 'LABELS', 'name', '')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command('TS.ADD', 'tester2', '*', 1, 'LABELS', 'name', 'myName', 'location', '')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command('TS.ADD', 'tester2', '*', 1, 'LABELS', 'name', 'myName', 'location', 'list)')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command('TS.ADD', 'tester2', '*', 1, 'LABELS', 'name', 'myName', 'location', 'li(st')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command('TS.ADD', 'tester2', '*', 1, 'LABELS', 'name', 'myName', 'location', 'lis,t')
 
-def test_different_chunk_size():
-    Env().skipOnCluster()
-    with Env().getConnection() as r:
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command('TS.add', 'tester', "1636545188", "123", 'LABELS', 'id', 'abc1231232', 'CHUNK_SIZE', '0')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command('TS.add', 'tester', "1636545188", "123", 'LABELS', 'id', 'abc1231232', 'CHUNK_SIZE', '-1000')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command('TS.add', 'tester', "1636545188", "123", 'LABELS', 'id', 'abc1231232', 'CHUNK_SIZE', '100')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command('TS.add', 'tester', "1636545188", "123", 'LABELS', 'id', 'abc1231232', 'CHUNK_SIZE', '127')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command('TS.add', 'tester', "1636545188", "123", 'LABELS', 'id', 'abc1231232', 'CHUNK_SIZE', '40000000')
+    def test_valid_timestamp(self):
+        env = self.env
+        env.flush()
+        with env.getConnection() as r:
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command('TS.ADD', 'timestamp', '12434fd', '34')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command('TS.ADD', 'timestamp', '-34', '22')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command('TS.ADD', 'timestamp', '*235', '45')
 
-        r.execute_command('TS.add', 'tester3', "1636545188", "123", 'LABELS', 'id', 'abc1231232', 'CHUNK_SIZE', '128')
+    def test_gorilla(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('ts.create', 'monkey')
+            r.execute_command('ts.add', 'monkey', '0', '1')
+            r.execute_command('ts.add', 'monkey', '1', '1')
+            r.execute_command('ts.add', 'monkey', '2', '1')
+            r.execute_command('ts.add', 'monkey', '50', '1')
+            r.execute_command('ts.add', 'monkey', '51', '1')
+            r.execute_command('ts.add', 'monkey', '500', '1')
+            r.execute_command('ts.add', 'monkey', '501', '1')
+            r.execute_command('ts.add', 'monkey', '3000', '1')
+            r.execute_command('ts.add', 'monkey', '3001', '1')
+            r.execute_command('ts.add', 'monkey', '10000', '1')
+            r.execute_command('ts.add', 'monkey', '10001', '1')
+            r.execute_command('ts.add', 'monkey', '100000', '1')
+            r.execute_command('ts.add', 'monkey', '100001', '1')
+            r.execute_command('ts.add', 'monkey', '100002', '1')
+            r.execute_command('ts.add', 'monkey', '100004', '1')
+            r.execute_command('ts.add', 'monkey', '1000000', '1')
+            r.execute_command('ts.add', 'monkey', '1000001', '1')
+            r.execute_command('ts.add', 'monkey', '10000011000001', '1')
+            r.execute_command('ts.add', 'monkey', '10000011000002', '1')
+            expected_result = [[0, b'1'], [1, b'1'], [2, b'1'], [50, b'1'], [51, b'1'],
+                               [500, b'1'], [501, b'1'], [3000, b'1'], [3001, b'1'],
+                               [10000, b'1'], [10001, b'1'], [100000, b'1'], [100001, b'1'],
+                               [100002, b'1'], [100004, b'1'], [1000000, b'1'], [1000001, b'1'],
+                               [10000011000001, b'1'], [10000011000002, b'1']]
+            assert expected_result == r.execute_command('TS.range', 'monkey', 0, '+')
 
-        r.execute_command('TS.add', 'tester2', "1636545188", "123", 'LABELS', 'id', 'abc1231232', 'CHUNK_SIZE', '40000')
+    def test_ts_add_negative(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command('TS.CREATE', 'tester', 'ENCODING')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command('TS.CREATE', 'tester', 'ENCODING', 'bad-encoding')
 
+    def test_ts_upsert(self):
+        env = self.env
+        env.flush()
+        if VALGRIND == 1:
+            env.skip()
+        random.seed(5)
+        with env.getClusterConnectionIfNeeded() as r:
+            DOUBLE_MAX = 1.7976931348623158E+308     # 64 bit floating point max value
+            MAX_INT64 = pow(2, 63) - 1
+            key = 't1{1}'
+            key2 = 't2{1}'
+            r.execute_command('ts.create', key, 'CHUNK_SIZE', 128, 'DUPLICATE_POLICY', 'LAST')
+            r.execute_command('ts.create', key2, 'CHUNK_SIZE', 128)
+            j = 1
+            while True:
+                info = TSInfo(r.execute_command("ts.info", key, 'DEBUG'))
+                if len(info.chunks) > 1:
+                    break
+                for i in range(1, 10):
+                    r.execute_command('ts.add', key, MAX_INT64 - j, DOUBLE_MAX - j)
+                    r.execute_command('ts.add', key2, MAX_INT64 - j, DOUBLE_MAX - j)
+                    j += 1
 
-def test_valid_labels():
-    with Env().getClusterConnectionIfNeeded() as r:
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command('TS.CREATE', 'tester', 'LABELS', 'name', '')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command('TS.ADD', 'tester2', '*', 1, 'LABELS', 'name', 'myName', 'location', '')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command('TS.ADD', 'tester2', '*', 1, 'LABELS', 'name', 'myName', 'location', 'list)')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command('TS.ADD', 'tester2', '*', 1, 'LABELS', 'name', 'myName', 'location', 'li(st')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command('TS.ADD', 'tester2', '*', 1, 'LABELS', 'name', 'myName', 'location', 'lis,t')
-
-def test_valid_timestamp():
-    with Env().getConnection() as r:
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command('TS.ADD', 'timestamp', '12434fd', '34')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command('TS.ADD', 'timestamp', '-34', '22')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command('TS.ADD', 'timestamp', '*235', '45')
-
-def test_gorilla():
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('ts.create', 'monkey')
-        r.execute_command('ts.add', 'monkey', '0', '1')
-        r.execute_command('ts.add', 'monkey', '1', '1')
-        r.execute_command('ts.add', 'monkey', '2', '1')
-        r.execute_command('ts.add', 'monkey', '50', '1')
-        r.execute_command('ts.add', 'monkey', '51', '1')
-        r.execute_command('ts.add', 'monkey', '500', '1')
-        r.execute_command('ts.add', 'monkey', '501', '1')
-        r.execute_command('ts.add', 'monkey', '3000', '1')
-        r.execute_command('ts.add', 'monkey', '3001', '1')
-        r.execute_command('ts.add', 'monkey', '10000', '1')
-        r.execute_command('ts.add', 'monkey', '10001', '1')
-        r.execute_command('ts.add', 'monkey', '100000', '1')
-        r.execute_command('ts.add', 'monkey', '100001', '1')
-        r.execute_command('ts.add', 'monkey', '100002', '1')
-        r.execute_command('ts.add', 'monkey', '100004', '1')
-        r.execute_command('ts.add', 'monkey', '1000000', '1')
-        r.execute_command('ts.add', 'monkey', '1000001', '1')
-        r.execute_command('ts.add', 'monkey', '10000011000001', '1')
-        r.execute_command('ts.add', 'monkey', '10000011000002', '1')
-        expected_result = [[0, b'1'], [1, b'1'], [2, b'1'], [50, b'1'], [51, b'1'],
-                           [500, b'1'], [501, b'1'], [3000, b'1'], [3001, b'1'],
-                           [10000, b'1'], [10001, b'1'], [100000, b'1'], [100001, b'1'],
-                           [100002, b'1'], [100004, b'1'], [1000000, b'1'], [1000001, b'1'],
-                           [10000011000001, b'1'], [10000011000002, b'1']]
-        assert expected_result == r.execute_command('TS.range', 'monkey', 0, '+')
-
-
-def test_ts_add_negative():
-    with Env().getClusterConnectionIfNeeded() as r:
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command('TS.CREATE', 'tester', 'ENCODING')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command('TS.CREATE', 'tester', 'ENCODING', 'bad-encoding')
-
-def test_ts_upsert():
-    if VALGRIND == 1:
-        Env().skip()
-    random.seed(5)
-    with Env().getClusterConnectionIfNeeded() as r:
-        DOUBLE_MAX = 1.7976931348623158E+308     # 64 bit floating point max value
-        MAX_INT64 = pow(2,63) - 1
-        key = 't1{1}'
-        key2 = 't2{1}'
-        r.execute_command('ts.create', key, 'CHUNK_SIZE', 128, 'DUPLICATE_POLICY', 'LAST')
-        r.execute_command('ts.create', key2, 'CHUNK_SIZE', 128)
-        j = 1
-        while True:
             info = TSInfo(r.execute_command("ts.info", key, 'DEBUG'))
-            if(len(info.chunks) > 1):
-                break
-            for i in range(1,10):
-                r.execute_command('ts.add', key, MAX_INT64 - j, DOUBLE_MAX - j)
-                r.execute_command('ts.add', key2, MAX_INT64 - j, DOUBLE_MAX - j)
-                j += 1
+            n_samples_2_chunk = info.total_samples
+            j = 1
+            while True:
+                info = TSInfo(r.execute_command("ts.info", key, 'DEBUG'))
+                if len(info.chunks) > 2:
+                    break
+                for i in range(1, 10):
+                    r.execute_command('ts.add', key, pow(j, 2), pow(j, 2))
+                    j += 1
 
-        info = TSInfo(r.execute_command("ts.info", key, 'DEBUG'))
-        n_samples_2_chunk = info.total_samples
-        j = 1
-        while True:
+            res = r.execute_command('ts.range', key, '-', pow((j - 1), 2))
+            expected = [[pow(d, 2), str(int(pow(d, 2))).encode('ascii')] for d in range(1, j)]
+            assert res == expected
             info = TSInfo(r.execute_command("ts.info", key, 'DEBUG'))
-            if(len(info.chunks) > 2):
-                break
-            for i in range(1,10):
-                r.execute_command('ts.add', key, pow(j, 2), pow(j, 2))
-                j += 1
+            assert len(info.chunks) == 3
+            total_samples = info.total_samples
+            assert len(res) + n_samples_2_chunk == total_samples
+            expected2 = expected.copy()
+            random.shuffle(expected2)
+            for i in range(0, len(expected2)):
+                r.execute_command('ts.add', key2, expected2[i][0], expected2[i][1])
+            res = r.execute_command('ts.range', key2, '-', pow((j - 1), 2))
+            assert res == expected
 
-        res = r.execute_command('ts.range', key, '-', pow((j-1), 2))
-        expected = [[pow(d, 2), str(int(pow(d, 2))).encode('ascii')] for d in range(1, j)]
-        assert res == expected
-        info = TSInfo(r.execute_command("ts.info", key, 'DEBUG'))
-        assert len(info.chunks) == 3
-        total_samples = info.total_samples
-        assert len(res) + n_samples_2_chunk == total_samples
-        expected2 = expected.copy()
-        random.shuffle(expected2)
-        for i in range(0, len(expected2)):
-            r.execute_command('ts.add', key2, expected2[i][0], expected2[i][1])
-        res = r.execute_command('ts.range', key2, '-', pow((j-1), 2))
-        assert res == expected
+            for k in range(0, pow(j, 2) + 1):
+                r.execute_command('ts.add', key, k, pow(k, 3))
 
-        for k in range (0, pow(j, 2) + 1):
-            r.execute_command('ts.add', key, k, pow(k,3))
+            res = r.execute_command('ts.range', key, '-', '+')
+            info = TSInfo(r.execute_command("ts.info", key, 'DEBUG'))
 
-        res = r.execute_command('ts.range', key, '-', '+')
-        info = TSInfo(r.execute_command("ts.info", key, 'DEBUG'))
+    def test_ts_upsert_downsampled(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            t1 = 't1{a}'
+            t2 = 't2{a}'
+            r.execute_command('TS.CREATE', t1)
+            r.execute_command('TS.CREATE', t2)
+            r.execute_command('TS.CREATERULE', t1, t2, 'AGGREGATION', 'max', 10)
+            r.execute_command('ts.add', t1, 1, 2)
+            r.execute_command('ts.add', t1, 3, 4)
+            r.execute_command('ts.add', t2, 10, 6)
+            r.execute_command('ts.add', t1, 11, 7)
+            res = r.execute_command('TS.range', t2, '-', '+')
+            assert res == [[0, b'4'], [10, b'6']]
 
-def test_ts_upsert_downsampled():
-    with Env().getClusterConnectionIfNeeded() as r:
-        t1 = 't1{a}'
-        t2 = 't2{a}'
-        r.execute_command('TS.CREATE', t1)
-        r.execute_command('TS.CREATE', t2)
-        r.execute_command('TS.CREATERULE', t1, t2, 'AGGREGATION', 'max', 10)
-        r.execute_command('ts.add', t1, 1, 2)
-        r.execute_command('ts.add', t1, 3, 4)
-        r.execute_command('ts.add', t2, 10, 6)
-        r.execute_command('ts.add', t1, 11, 7)
-        res = r.execute_command('TS.range', t2, '-', '+')
-        assert res == [[0, b'4'], [10, b'6']]
+            # override the downsampled key
+            r.execute_command('ts.add', t1, 21, 9)
+            res = r.execute_command('TS.range', t2, '-', '+')
+            assert res == [[0, b'4'], [10, b'7']]
 
-        #override the downsampled key
-        r.execute_command('ts.add', t1, 21, 9)
-        res = r.execute_command('TS.range', t2, '-', '+')
-        assert res == [[0, b'4'], [10, b'7']]
+            t3 = 't3{a}'
+            t4 = 't4{a}'
+            r.execute_command('TS.CREATE', t3)
+            r.execute_command('TS.CREATE', t4)
+            r.execute_command('ts.add', t4, 10, 6)
+            r.execute_command('ts.add', t4, 20, 9)
+            r.execute_command('ts.add', t4, 23, 9)
+            r.execute_command('TS.CREATERULE', t3, t4, 'AGGREGATION', 'max', 10)
 
+            # override the downsampled key
+            r.execute_command('ts.add', t3, 10, 22)
+            r.execute_command('ts.add', t3, 25, 29)
+            res = r.execute_command('TS.range', t4, '-', '+')
+            assert res == [[10, b'22'], [20, b'9'], [23, b'9']]
+            r.execute_command('ts.add', t3, 31, 3)
+            res = r.execute_command('TS.range', t4, '-', '+')
+            assert res == [[10, b'22'], [20, b'29'], [23, b'9']]
 
-        t3 = 't3{a}'
-        t4 = 't4{a}'
-        r.execute_command('TS.CREATE', t3)
-        r.execute_command('TS.CREATE', t4)
-        r.execute_command('ts.add', t4, 10, 6)
-        r.execute_command('ts.add', t4, 20, 9)
-        r.execute_command('ts.add', t4, 23, 9)
-        r.execute_command('TS.CREATERULE', t3, t4, 'AGGREGATION', 'max', 10)
+    def test_ts_upsert_bug(self):
+        # End Chunk space when add the value, then try adding value which will fit in the old chunk
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            t1 = 't1{1}'
+            r.execute_command('ts.create', t1, 'CHUNK_SIZE', 64, 'DUPLICATE_POLICY', 'LAST')
+            j = 1
+            mantisa = list('1111111111111111111111111111111111111111100000000000')
+            mantisa_len = len(mantisa)
+            exp = list('00000000000')
+            exp_len = len(exp)
+            c = 0
+            while True:
+                val = int('0' + ''.join(exp) + ''.join(mantisa), 2)
+                v = struct.unpack('d', struct.pack('Q', val))[0]
+                r.execute_command('ts.add', t1, j, v)
+                info = TSInfo(r.execute_command("ts.info", t1, 'DEBUG'))
+                if len(info.chunks) > 1:
+                    break
+                if j == 13:
+                    j += 100
+                elif j > 13:
+                    j += 500
+                else:
+                    j += 2
+                exp[exp_len - c - 1] = '1'
+                mantisa[mantisa_len - exp_len + c] = '1'
+                c += 1
 
-        #override the downsampled key
-        r.execute_command('ts.add', t3, 10, 22)
-        r.execute_command('ts.add', t3, 25, 29)
-        res = r.execute_command('TS.range', t4, '-', '+')
-        assert res == [[10, b'22'], [20, b'9'], [23, b'9']]
-        r.execute_command('ts.add', t3, 31, 3)
-        res = r.execute_command('TS.range', t4, '-', '+')
-        assert res == [[10, b'22'], [20, b'29'], [23, b'9']]
-
-# End Chunk space when add the value, than try adding value which will fit in the old chunk
-def test_ts_upsert_bug():
-    with Env().getClusterConnectionIfNeeded() as r:
-        t1 = 't1{1}'
-        r.execute_command('ts.create', t1, 'CHUNK_SIZE', 64, 'DUPLICATE_POLICY', 'LAST')
-        j = 1
-        mantisa = list('1111111111111111111111111111111111111111100000000000')
-        mantisa_len = len(mantisa)
-        exp = list('00000000000')
-        exp_len = len(exp)
-        c = 0
-        while True:
-            val = int('0' + ''.join(exp) + ''.join(mantisa), 2)
-            v = struct.unpack('d', struct.pack('Q', val))[0]
-            r.execute_command('ts.add', t1, j, v)
             info = TSInfo(r.execute_command("ts.info", t1, 'DEBUG'))
-            if(len(info.chunks) > 1):
-                break
-            if(j == 13):
-                j += 100
-            elif (j > 13):
-                j += 500
-            else:
-                j += 2
-            exp[exp_len - c - 1] = '1'
-            mantisa[mantisa_len - exp_len + c] = '1'
-            c += 1
+            first_chunk_last_ts = info.chunks[0][3]
+            res = r.execute_command("ts.del", t1, first_chunk_last_ts + 500, '+')
+            info = TSInfo(r.execute_command("ts.info", t1, 'DEBUG'))
+            first_chunk_last_ts = info.chunks[0][3]
+            res = r.execute_command("ts.range", t1, first_chunk_last_ts, first_chunk_last_ts)
+            first_chunk_last_val = res[0][1]
+            r.execute_command('ts.add', t1, first_chunk_last_ts + 100, first_chunk_last_val)
+            res2 = r.execute_command("ts.range", t1, first_chunk_last_ts, first_chunk_last_ts + 100)
+            info2 = TSInfo(r.execute_command("ts.info", t1, 'DEBUG'))
+            assert res2 == [res[0], [first_chunk_last_ts + 100, first_chunk_last_val]]
 
-        info = TSInfo(r.execute_command("ts.info", t1, 'DEBUG'))
-        first_chunk_last_ts = info.chunks[0][3]
-        res = r.execute_command("ts.del", t1, first_chunk_last_ts + 500, '+')
-        info = TSInfo(r.execute_command("ts.info", t1, 'DEBUG'))
-        first_chunk_last_ts = info.chunks[0][3]
-        res = r.execute_command("ts.range", t1, first_chunk_last_ts, first_chunk_last_ts)
-        first_chunk_last_val = res[0][1]
-        r.execute_command('ts.add', t1, first_chunk_last_ts + 100, first_chunk_last_val)
-        res2 = r.execute_command("ts.range", t1, first_chunk_last_ts, first_chunk_last_ts + 100)
-        info2 = TSInfo(r.execute_command("ts.info", t1, 'DEBUG'))
-        assert res2 == [res[0], [first_chunk_last_ts + 100, first_chunk_last_val]]
+    def test_ts_add_nan(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            for encoding in ['compressed', 'uncompressed']:
+                r.execute_command('FLUSHALL')
+                r.execute_command('ts.create', 'nan_key', 'ENCODING', encoding)
+                r.execute_command('ts.add', 'nan_key', 1, 'nan')
+                r.execute_command('ts.add', 'nan_key', 2, 'NaN')
+                r.execute_command('ts.add', 'nan_key', 3, 'NAN')
+                r.execute_command('ts.add', 'nan_key', 4, '-nan')
+                r.execute_command('ts.add', 'nan_key', 5, '-NaN')
+                r.execute_command('ts.add', 'nan_key', 6, '-NAN')
+                res = r.execute_command('ts.range', 'nan_key', '-', '+')
+                assert res == [[1, b'NaN'], [2, b'NaN'], [3, b'NaN'], [4, b'NaN'], [5, b'NaN'], [6, b'NaN']]
+
+                r.execute_command('FLUSHALL')
+                r.execute_command('ts.create', 'nan_key', 'ENCODING', encoding)
+                r.execute_command('ts.madd', 'nan_key', 1, 'nan', 'nan_key', 2, 'NaN', 'nan_key', 3, 'NAN', 'nan_key', 4, '-nan', 'nan_key', 5, '-NaN', 'nan_key', 6, '-NAN')
+                res = r.execute_command('ts.range', 'nan_key', '-', '+')
+                assert res == [[1, b'NaN'], [2, b'NaN'], [3, b'NaN'], [4, b'NaN'], [5, b'NaN'], [6, b'NaN']]
+
+                r.execute_command('FLUSHALL')
+                r.execute_command('ts.create', 'nan_key', 'DUPLICATE_POLICY', 'MIN', 'ENCODING', encoding)
+                r.execute_command('ts.add', 'nan_key', 1, 'nan')
+                with pytest.raises(redis.ResponseError):
+                    r.execute_command('ts.add', 'nan_key', 1, '6')
+
+                r.execute_command('FLUSHALL')
+                r.execute_command('ts.create', 'nan_key', 'DUPLICATE_POLICY', 'MAX', 'ENCODING', encoding)
+                r.execute_command('ts.add', 'nan_key', 1, '6')
+                with pytest.raises(redis.ResponseError):
+                    r.execute_command('ts.add', 'nan_key', 1, 'nan')
+
+                r.execute_command('FLUSHALL')
+                r.execute_command('ts.create', 'nan_key', 'DUPLICATE_POLICY', 'SUM', 'ENCODING', encoding)
+                r.execute_command('ts.add', 'nan_key', 1, '6')
+                with pytest.raises(redis.ResponseError):
+                    r.execute_command('ts.add', 'nan_key', 1, 'nan')
+
+
+class testTsAddClusterOnly:
+    def __init__(self):
+        self.env = Env(decodeResponses=True)
+
+    def test_add_different_slot_range(self):
+        env = self.env
+        env.flush()
+        if not env.isCluster():
+            env.skip()
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('config', 'set', 'ts-compaction-policy', 'sum:1M:1h') == 'OK', 'Failed to set compaction policy'
+            assert r.execute_command('ts.add', 'b', '1', '1') == 1, 'Failed to add data'
+            assert r.execute_command('type', 'b') == 'TSDB-TYPE', 'type is not TSDB-TYPE, result: ' + str(r.execute_command('type', 'a'))
+            assert r.execute_command('type', 'b_SUM_60000') != 'TSDB-TYPE', 'type is TSDB-TYPE, result: ' + str(r.execute_command('type', 'a_SUM_60000'))
+            assert r.execute_command('ts.add', '{b}', '1', '1') == 1, 'Failed to add data'
+            assert r.execute_command('type', '{b}') == 'TSDB-TYPE', 'type is not TSDB-TYPE, result: ' + str(r.execute_command('type', '{b}'))
+            assert r.execute_command('type', '{b}_SUM_60000') == 'TSDB-TYPE', 'type is not TSDB-TYPE, result: ' + str(r.execute_command('type', '{b}_SUM_60000'))
+            assert 'b_SUM_60000' not in r.execute_command('KEYS', '*'), 'Keys are not as expected: ' + str(r.execute_command('KEYS', '*'))
+
 
 def test_ts_add_fail(env):
     with pytest.raises(redis.ResponseError):
@@ -306,41 +375,3 @@ def test_ts_add_fail(env):
         env.cmd('TS.ADD', 'k', 1, '1,0')
     with pytest.raises(redis.ResponseError):
         env.cmd('TS.ADD', 'k', 1, '0x1')
-
-def test_ts_add_nan():
-    with Env().getClusterConnectionIfNeeded() as r:
-        for encoding in ['compressed', 'uncompressed']:
-            Env().flush()
-            r.execute_command('ts.create', 'nan_key', 'ENCODING', encoding)
-            r.execute_command('ts.add', 'nan_key', 1, 'nan')
-            r.execute_command('ts.add', 'nan_key', 2, 'NaN')
-            r.execute_command('ts.add', 'nan_key', 3, 'NAN')
-            r.execute_command('ts.add', 'nan_key', 4, '-nan')
-            r.execute_command('ts.add', 'nan_key', 5, '-NaN')
-            r.execute_command('ts.add', 'nan_key', 6, '-NAN')
-            res = r.execute_command('ts.range', 'nan_key', '-', '+')
-            assert res == [[1, b'NaN'], [2, b'NaN'], [3, b'NaN'], [4, b'NaN'], [5, b'NaN'], [6, b'NaN']]
-        
-            r.execute_command('flushall')
-            r.execute_command('ts.create', 'nan_key', 'ENCODING', encoding)
-            r.execute_command('ts.madd', 'nan_key', 1, 'nan', 'nan_key', 2, 'NaN', 'nan_key', 3, 'NAN', 'nan_key', 4, '-nan', 'nan_key', 5, '-NaN', 'nan_key', 6, '-NAN')
-            res = r.execute_command('ts.range', 'nan_key', '-', '+')
-            assert res == [[1, b'NaN'], [2, b'NaN'], [3, b'NaN'], [4, b'NaN'], [5, b'NaN'], [6, b'NaN']]
-
-            r.execute_command('flushall')
-            r.execute_command('ts.create', 'nan_key', 'DUPLICATE_POLICY', 'MIN', 'ENCODING', encoding)
-            r.execute_command('ts.add', 'nan_key', 1, 'nan')
-            with pytest.raises(redis.ResponseError):
-                r.execute_command('ts.add', 'nan_key', 1, '6')
-            
-            r.execute_command('flushall')
-            r.execute_command('ts.create', 'nan_key', 'DUPLICATE_POLICY', 'MAX', 'ENCODING', encoding)
-            r.execute_command('ts.add', 'nan_key', 1, '6')
-            with pytest.raises(redis.ResponseError):
-                r.execute_command('ts.add', 'nan_key', 1, 'nan')
-
-            r.execute_command('flushall')
-            r.execute_command('ts.create', 'nan_key', 'DUPLICATE_POLICY', 'SUM', 'ENCODING', encoding)
-            r.execute_command('ts.add', 'nan_key', 1, '6')
-            with pytest.raises(redis.ResponseError):
-                r.execute_command('ts.add', 'nan_key', 1, 'nan')

--- a/tests/flow/test_ts_create.py
+++ b/tests/flow/test_ts_create.py
@@ -8,90 +8,184 @@ from test_helper_classes import SAMPLE_SIZE, _get_ts_info, TSInfo
 from includes import *
 
 
-def test_create_params():
-    with Env().getClusterConnectionIfNeeded() as r:
-        # test string instead of value
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATE', 'invalid', 'RETENTION', 'retention')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATE', 'invalid', 'CHUNK_SIZE', 'chunk_size')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATE', 'invalid', 'ENCODING')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATE', 'invalid', 'ENCODING', 'bad-encoding-type')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATE', 'invalid', 'LABELS', 'key', 'val', 'RETENTION', 'abc')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATE', 'invalid', 'LABELS', 'key', 'val', 'RETENTION', '-2')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATE', 'invalid', 'LABELS', 'key', 'val', 'CHUNK_SIZE', 'abc')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATE', 'invalid', 'LABELS', 'key', 'val', 'CHUNK_SIZE', '-2')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATE', 'invalid', 'LABELS', 'key', 'val', 'CHUNK_SIZE', '4000000000')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATE', 'invalid', 'LABELS', 'key', 'val', 'ENCODING', 'bad-encoding-type')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATE', 'invalid', 'LABELS', 'key', 'val', 'DUPLICATE_POLICY', 'bla')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATE', 'invalid', 'LABELS', 'key', 'val', 'label', 'DUPLICATE_POLICY', 'bla')
+class testTsCreate:
+    def __init__(self):
+        self.env = Env()
 
-        # test for mem leak
-        assert r.execute_command('TS.CREATE', 't1', 'LABELS', 'key', 'val')
-        with pytest.raises(redis.ResponseError) as excinfo:
+    def test_create_params(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            # test string instead of value
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATE', 'invalid', 'RETENTION', 'retention')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATE', 'invalid', 'CHUNK_SIZE', 'chunk_size')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATE', 'invalid', 'ENCODING')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATE', 'invalid', 'ENCODING', 'bad-encoding-type')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATE', 'invalid', 'LABELS', 'key', 'val', 'RETENTION', 'abc')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATE', 'invalid', 'LABELS', 'key', 'val', 'RETENTION', '-2')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATE', 'invalid', 'LABELS', 'key', 'val', 'CHUNK_SIZE', 'abc')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATE', 'invalid', 'LABELS', 'key', 'val', 'CHUNK_SIZE', '-2')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATE', 'invalid', 'LABELS', 'key', 'val', 'CHUNK_SIZE', '4000000000')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATE', 'invalid', 'LABELS', 'key', 'val', 'ENCODING', 'bad-encoding-type')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATE', 'invalid', 'LABELS', 'key', 'val', 'DUPLICATE_POLICY', 'bla')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATE', 'invalid', 'LABELS', 'key', 'val', 'label', 'DUPLICATE_POLICY', 'bla')
+
+            # test for mem leak
             assert r.execute_command('TS.CREATE', 't1', 'LABELS', 'key', 'val')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATE', 't1', 'LABELS', 'key', 'val')
+
+            r.execute_command('TS.CREATE', 'a')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATE', 'a')  # filter exists
+
+    def test_create_retention(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', 'tester', 'RETENTION', 1000)
+
+            assert r.execute_command('TS.ADD', 'tester', 500, 10)
+            expected_result = [[500, b'10']]
+            actual_result = r.execute_command('TS.range', 'tester', '-', '+')
+            assert expected_result == actual_result
+            # check for (lastTimestamp - retension < 0)
+            assert _get_ts_info(r, 'tester').total_samples == 1
+
+            assert r.execute_command('TS.ADD', 'tester', 1001, 20)
+            expected_result = [[500, b'10'], [1001, b'20']]
+            actual_result = r.execute_command('TS.range', 'tester', '-', '+')
+            assert expected_result == actual_result
+            assert _get_ts_info(r, 'tester').total_samples == 2
+
+            assert r.execute_command('TS.ADD', 'tester', 2000, 30)
+            expected_result = [[1001, b'20'], [2000, b'30']]
+            actual_result = r.execute_command('TS.range', 'tester', '-', '+')
+            assert expected_result == actual_result
+            assert _get_ts_info(r, 'tester').total_samples == 2
+
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATE', 'negative', 'RETENTION', -10)
+
+    def test_create_with_negative_chunk_size(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATE', 'tester', 'CHUNK_SIZE', -10)
+
+    def test_check_retention_64bit(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            huge_timestamp = 4000000000  # larger than uint32
+            r.execute_command('TS.CREATE', 'tester', 'RETENTION', huge_timestamp)
+            assert _get_ts_info(r, 'tester').retention_msecs == huge_timestamp
+            for i in range(10):
+                r.execute_command('TS.ADD', 'tester', int(huge_timestamp * i / 4), i)
+            assert r.execute_command('TS.RANGE', 'tester', 0, "+") == \
+                   [[5000000000, b'5'], [6000000000, b'6'], [7000000000, b'7'],
+                    [8000000000, b'8'], [9000000000, b'9']]
+
+    def test_trim(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            for mode in ["UNCOMPRESSED", "COMPRESSED"]:
+                samples = 2000
+                chunk_size = 64 * SAMPLE_SIZE
+                total_chunk_count = math.ceil(float(samples) / float(chunk_size) * SAMPLE_SIZE)
+                r.execute_command('ts.create', 'trim_me', 'CHUNK_SIZE', chunk_size, 'RETENTION', 10, mode)
+                r.execute_command('ts.create', 'dont_trim_me', 'CHUNK_SIZE', chunk_size, mode)
+                for i in range(samples):
+                    r.execute_command('ts.add', 'trim_me', i, i * 1.1)
+                    r.execute_command('ts.add', 'dont_trim_me', i, i * 1.1)
+
+                trimmed_info = _get_ts_info(r, 'trim_me')
+                untrimmed_info = _get_ts_info(r, 'dont_trim_me')
+                assert 2 == trimmed_info.chunk_count
+                assert samples == untrimmed_info.total_samples
+                # extra test for uncompressed
+                if mode == "UNCOMPRESSED":
+                    assert 11 == trimmed_info.total_samples
+                    assert total_chunk_count == untrimmed_info.chunk_count
+
+                r.delete("trim_me")
+                r.delete("dont_trim_me")
+
+    def test_empty(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('ts.create', 'empty')
+            info = _get_ts_info(r, 'empty')
+            assert info.total_samples == 0
+            assert [] == r.execute_command('TS.range', 'empty', 0, "+")
+            assert [] == r.execute_command('TS.get', 'empty')
+
+            r.execute_command('ts.create', 'empty_uncompressed', 'uncompressed')
+            info = _get_ts_info(r, 'empty_uncompressed')
+            assert info.total_samples == 0
+            assert [] == r.execute_command('TS.range', 'empty_uncompressed', 0, "+")
+            assert [] == r.execute_command('TS.get', 'empty')
+
+    def test_issue299(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('ts.create', 'issue299')
+            for i in range(1000):
+                r.execute_command('ts.add', 'issue299', i * 10, i)
+            actual_result = r.execute_command('ts.range', 'issue299', 0, "+", 'aggregation', 'avg', 10)
+            assert actual_result[0] == [0, b'0']
+            actual_result = r.execute_command('ts.range', 'issue299', 0, "+", 'aggregation', 'avg', 100)
+            assert actual_result[0] == [0, b'4.5']
+
+            r.execute_command('del', 'issue299')
+            r.execute_command('ts.create', 'issue299')
+            for i in range(100, 1000):
+                r.execute_command('ts.add', 'issue299', i * 10, i)
+            actual_result = r.execute_command('ts.range', 'issue299', 0, "+", 'aggregation', 'avg', 10)
+            assert actual_result[0] != [0, b'0']
+
+    def test_expire(self):
+        env = self.env
+        env.flush()
+        env.skipOnCluster()
+        with env.getConnection() as r:
+            assert r.execute_command('ts.create', 'test') == b'OK'
+            assert r.execute_command('keys', '*') == [b'test']
+            assert r.execute_command('expire', 'test', 1) == 1
+            time.sleep(2)
+            assert r.execute_command('keys', '*') == []
+
+    def test_ts_create_encoding(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            for ENCODING in ['compressed', 'uncompressed']:
+                r.execute_command('FLUSHALL')
+                r.execute_command('ts.create', 't1', 'ENCODING', ENCODING)
+                env.assertEqual(TSInfo(r.execute_command('TS.INFO', 't1')).chunk_type, ENCODING.encode())
+                # backwards compatible check
+                r.execute_command('ts.create', 't1_bc', ENCODING)
+                env.assertEqual(TSInfo(r.execute_command('TS.INFO', 't1_bc')).chunk_type, ENCODING.encode())
 
 
-        r.execute_command('TS.CREATE', 'a')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATE', 'a')  # filter exists
-
-
-def test_create_retention():
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', 'tester', 'RETENTION', 1000)
-
-        assert r.execute_command('TS.ADD', 'tester', 500, 10)
-        expected_result = [[500, b'10']]
-        actual_result = r.execute_command('TS.range', 'tester', '-', '+')
-        assert expected_result == actual_result
-        # check for (lastTimestamp - retension < 0)
-        assert _get_ts_info(r, 'tester').total_samples == 1
-
-        assert r.execute_command('TS.ADD', 'tester', 1001, 20)
-        expected_result = [[500, b'10'], [1001, b'20']]
-        actual_result = r.execute_command('TS.range', 'tester', '-', '+')
-        assert expected_result == actual_result
-        assert _get_ts_info(r, 'tester').total_samples == 2
-
-        assert r.execute_command('TS.ADD', 'tester', 2000, 30)
-        expected_result = [[1001, b'20'], [2000, b'30']]
-        actual_result = r.execute_command('TS.range', 'tester', '-', '+')
-        assert expected_result == actual_result
-        assert _get_ts_info(r, 'tester').total_samples == 2
-
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATE', 'negative', 'RETENTION', -10)
-
-
-def test_create_with_negative_chunk_size():
-    with Env().getClusterConnectionIfNeeded() as r:
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATE', 'tester', 'CHUNK_SIZE', -10)
-
-
-def test_check_retention_64bit():
-    with Env().getClusterConnectionIfNeeded() as r:
-        huge_timestamp = 4000000000  # larger than uint32
-        r.execute_command('TS.CREATE', 'tester', 'RETENTION', huge_timestamp)
-        assert _get_ts_info(r, 'tester').retention_msecs == huge_timestamp
-        for i in range(10):
-            r.execute_command('TS.ADD', 'tester', int(huge_timestamp * i / 4), i)
-        assert r.execute_command('TS.RANGE', 'tester', 0, "+") == \
-               [[5000000000, b'5'], [6000000000, b'6'], [7000000000, b'7'],
-                [8000000000, b'8'], [9000000000, b'9']]
-
-
+# This test intentionally uses two separate Env() instances to simulate a Redis restart
+# (dump and restore across a fresh server). It cannot share an Env instance.
 def test_uncompressed():
     with Env().getClusterConnectionIfNeeded() as r:
         # test simple commands
@@ -118,82 +212,3 @@ def test_uncompressed():
         assert info.total_samples == 3 and info.memory_usage >= 4136
         # test deletion
         assert r.delete('not_compressed')
-
-
-def test_trim():
-    with Env().getClusterConnectionIfNeeded() as r:
-        for mode in ["UNCOMPRESSED", "COMPRESSED"]:
-            samples = 2000
-            chunk_size = 64 * SAMPLE_SIZE
-            total_chunk_count = math.ceil(float(samples) / float(chunk_size) * SAMPLE_SIZE)
-            r.execute_command('ts.create', 'trim_me', 'CHUNK_SIZE', chunk_size, 'RETENTION', 10, mode)
-            r.execute_command('ts.create', 'dont_trim_me', 'CHUNK_SIZE', chunk_size, mode)
-            for i in range(samples):
-                r.execute_command('ts.add', 'trim_me', i, i * 1.1)
-                r.execute_command('ts.add', 'dont_trim_me', i, i * 1.1)
-
-            trimmed_info = _get_ts_info(r, 'trim_me')
-            untrimmed_info = _get_ts_info(r, 'dont_trim_me')
-            assert 2 == trimmed_info.chunk_count
-            assert samples == untrimmed_info.total_samples
-            # extra test for uncompressed
-            if mode == "UNCOMPRESSED":
-                assert 11 == trimmed_info.total_samples
-                assert total_chunk_count == untrimmed_info.chunk_count
-
-            r.delete("trim_me")
-            r.delete("dont_trim_me")
-
-
-def test_empty():
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('ts.create', 'empty')
-        info = _get_ts_info(r, 'empty')
-        assert info.total_samples == 0
-        assert [] == r.execute_command('TS.range', 'empty', 0, "+")
-        assert [] == r.execute_command('TS.get', 'empty')
-
-        r.execute_command('ts.create', 'empty_uncompressed', 'uncompressed')
-        info = _get_ts_info(r, 'empty_uncompressed')
-        assert info.total_samples == 0
-        assert [] == r.execute_command('TS.range', 'empty_uncompressed', 0, "+")
-        assert [] == r.execute_command('TS.get', 'empty')
-
-
-def test_issue299():
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('ts.create', 'issue299')
-        for i in range(1000):
-            r.execute_command('ts.add', 'issue299', i * 10, i)
-        actual_result = r.execute_command('ts.range', 'issue299', 0, "+", 'aggregation', 'avg', 10)
-        assert actual_result[0] == [0, b'0']
-        actual_result = r.execute_command('ts.range', 'issue299', 0, "+", 'aggregation', 'avg', 100)
-        assert actual_result[0] == [0, b'4.5']
-
-        r.execute_command('del', 'issue299')
-        r.execute_command('ts.create', 'issue299')
-        for i in range(100, 1000):
-            r.execute_command('ts.add', 'issue299', i * 10, i)
-        actual_result = r.execute_command('ts.range', 'issue299', 0, "+", 'aggregation', 'avg', 10)
-        assert actual_result[0] != [0, b'0']
-
-
-def test_expire():
-    Env().skipOnCluster()
-    with Env().getConnection() as r:
-        assert r.execute_command('ts.create', 'test') == b'OK'
-        assert r.execute_command('keys', '*') == [b'test']
-        assert r.execute_command('expire', 'test', 1) == 1
-        time.sleep(2)
-        assert r.execute_command('keys', '*') == []
-
-def test_ts_create_encoding():
-    for ENCODING in ['compressed','uncompressed']:
-        e = Env()
-        e.flush()
-        with e.getClusterConnectionIfNeeded() as r:
-            r.execute_command('ts.create', 't1', 'ENCODING', ENCODING)
-            e.assertEqual(TSInfo(r.execute_command('TS.INFO', 't1')).chunk_type, ENCODING.encode())
-            # backwards compatible check
-            r.execute_command('ts.create', 't1_bc', ENCODING)
-            e.assertEqual(TSInfo(r.execute_command('TS.INFO', 't1_bc')).chunk_type, ENCODING.encode())

--- a/tests/flow/test_ts_createrule.py
+++ b/tests/flow/test_ts_createrule.py
@@ -13,495 +13,522 @@ from includes import *
 key_name = 'tester{abc}'
 agg_key_name = '{}_agg_max_10'.format(key_name)
 
-def test_compaction_rules(self):
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', key_name, 'CHUNK_SIZE', '360')
-        assert r.execute_command('TS.CREATE', agg_key_name)
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'avg', -10)
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'avg', 0)
-        assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'avg', 10)
 
-        start_ts = 1488823384
-        samples_count = 1500
-        _insert_data(r, key_name, start_ts, samples_count, 5)
-        last_ts = start_ts + samples_count + 10
-        r.execute_command('TS.ADD', key_name, last_ts, 5)
+class testTsCreaterule:
+    def __init__(self):
+        self.env = Env()
 
-        actual_result = r.execute_command('TS.RANGE', agg_key_name, start_ts, start_ts + samples_count)
+    def test_compaction_rules(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', key_name, 'CHUNK_SIZE', '360')
+            assert r.execute_command('TS.CREATE', agg_key_name)
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'avg', -10)
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'avg', 0)
+            assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'avg', 10)
 
-        assert len(actual_result) == samples_count / 10
+            start_ts = 1488823384
+            samples_count = 1500
+            _insert_data(r, key_name, start_ts, samples_count, 5)
+            last_ts = start_ts + samples_count + 10
+            r.execute_command('TS.ADD', key_name, last_ts, 5)
 
-        info = _get_ts_info(r, key_name)
-        assert info.rules == [[agg_key_name.encode('ascii'), 10, b'AVG', 0]]
+            actual_result = r.execute_command('TS.RANGE', agg_key_name, start_ts, start_ts + samples_count)
 
+            assert len(actual_result) == samples_count / 10
 
-def test_create_compaction_rule_with_wrong_aggregation():
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', key_name)
-        assert r.execute_command('TS.CREATE', agg_key_name)
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'MAXX', 10)
+            info = _get_ts_info(r, key_name)
+            assert info.rules == [[agg_key_name.encode('ascii'), 10, b'AVG', 0]]
 
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'MA', 10)
+    def test_create_compaction_rule_with_wrong_aggregation(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', key_name)
+            assert r.execute_command('TS.CREATE', agg_key_name)
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'MAXX', 10)
 
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'MA', 10)
 
-def test_create_compaction_rule_without_dest_series():
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', key_name)
-        with pytest.raises(redis.ResponseError) as excinfo:
+    def test_create_compaction_rule_without_dest_series(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', key_name)
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'MAX', 10)
+
+    def test_create_compaction_rule_twice(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', key_name)
+            assert r.execute_command('TS.CREATE', agg_key_name)
             assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'MAX', 10)
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'MAX', 10)
 
-
-def test_create_compaction_rule_twice():
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', key_name)
-        assert r.execute_command('TS.CREATE', agg_key_name)
-        assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'MAX', 10)
-        with pytest.raises(redis.ResponseError) as excinfo:
+    def test_create_compaction_rule_override_dest(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', key_name)
+            assert r.execute_command('TS.CREATE', 'tester2{abc}')
+            assert r.execute_command('TS.CREATE', agg_key_name)
             assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'MAX', 10)
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATERULE', 'tester2{abc}', agg_key_name, 'AGGREGATION', 'MAX', 10)
 
+    def test_create_compaction_rule_from_target(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', key_name)
+            assert r.execute_command('TS.CREATE', 'tester2{abc}')
+            assert r.execute_command('TS.CREATE', agg_key_name)
+            assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'MAX', 10)
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATERULE', agg_key_name, 'tester2{abc}', 'AGGREGATION', 'MAX', 10)
 
-def test_create_compaction_rule_override_dest():
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', key_name)
-        assert r.execute_command('TS.CREATE', 'tester2{abc}')
-        assert r.execute_command('TS.CREATE', agg_key_name)
-        assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'MAX', 10)
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATERULE', 'tester2{abc}', agg_key_name, 'AGGREGATION', 'MAX', 10)
+    def test_create_compaction_rule_own(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', key_name)
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATERULE', key_name, key_name, 'AGGREGATION', 'MAX', 10)
 
+    # test for mem leak
+    def test_create_compaction_zero_bucket_size(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', 't1{abc}', 'LABELS', 'key', 'val')
+            assert r.execute_command('TS.CREATE', 't2{abc}', 'LABELS', 'key', 'val')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.CREATERULE', 't1{abc}', 't2{abc}', 'AGGREGATION', 'sum', 0)
 
-def test_create_compaction_rule_from_target():
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', key_name)
-        assert r.execute_command('TS.CREATE', 'tester2{abc}')
-        assert r.execute_command('TS.CREATE', agg_key_name)
-        assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'MAX', 10)
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATERULE', agg_key_name, 'tester2{abc}', 'AGGREGATION', 'MAX', 10)
+    def test_create_compaction_rule_and_del_dest_series(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', key_name)
+            assert r.execute_command('TS.CREATE', agg_key_name)
+            assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'AVG', 10)
+            assert r.delete(agg_key_name)
 
+            start_ts = 1488823384
+            samples_count = 1500
+            _insert_data(r, key_name, start_ts, samples_count, 5)
 
-def test_create_compaction_rule_own():
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', key_name)
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATERULE', key_name, key_name, 'AGGREGATION', 'MAX', 10)
+    def test_std_var_func(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            raw_key = 'raw{abc}'
+            std_key = 'std_key{abc}'
+            var_key = 'var_key{abc}'
 
-# test for mem leak
-def test_create_compaction_zero_bucket_size():
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', 't1{abc}', 'LABELS', 'key', 'val')
-        assert r.execute_command('TS.CREATE', 't2{abc}', 'LABELS', 'key', 'val')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.CREATERULE', 't1{abc}', 't2{abc}', 'AGGREGATION', 'sum', 0)
+            random_numbers = 100
+            random.seed(0)
+            items = random.sample(range(random_numbers), random_numbers)
 
+            stdev = statistics.stdev(items)
+            var = statistics.variance(items)
+            assert r.execute_command('TS.CREATE', raw_key)
+            assert r.execute_command('TS.CREATE', std_key)
+            assert r.execute_command('TS.CREATE', var_key)
+            assert r.execute_command('TS.CREATERULE', raw_key, std_key, "AGGREGATION", 'std.s', random_numbers)
+            assert r.execute_command('TS.CREATERULE', raw_key, var_key, "AGGREGATION", 'var.s', random_numbers)
 
-def test_create_compaction_rule_and_del_dest_series():
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', key_name)
-        assert r.execute_command('TS.CREATE', agg_key_name)
-        assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'AVG', 10)
-        assert r.delete(agg_key_name)
+            for i in range(random_numbers):
+                r.execute_command('TS.ADD', raw_key, i, items[i])
+            r.execute_command('TS.ADD', raw_key, random_numbers, 0)  # close time bucket
 
-        start_ts = 1488823384
-        samples_count = 1500
-        _insert_data(r, key_name, start_ts, samples_count, 5)
+            assert abs(stdev - float(r.execute_command('TS.GET', std_key)[1])) < ALLOWED_ERROR
+            assert abs(var - float(r.execute_command('TS.GET', var_key)[1])) < ALLOWED_ERROR
 
+    def test_delete_key(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', key_name, 'CHUNK_SIZE', '360')
+            assert r.execute_command('TS.CREATE', agg_key_name)
+            assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'avg', 10)
+            assert r.delete(agg_key_name)
+            assert _get_ts_info(r, key_name).rules == []
 
-def test_std_var_func():
-    with Env().getClusterConnectionIfNeeded() as r:
-        raw_key = 'raw{abc}'
-        std_key = 'std_key{abc}'
-        var_key = 'var_key{abc}'
+            assert r.execute_command('TS.CREATE', agg_key_name)
+            assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'avg', 11)
+            assert r.delete(key_name)
+            assert _get_ts_info(r, agg_key_name).sourceKey is None
 
-        random_numbers = 100
-        random.seed(0)
-        items = random.sample(range(random_numbers), random_numbers)
+            assert r.execute_command('TS.CREATE', key_name)
+            assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'avg', 12)
+            assert _get_ts_info(r, key_name).rules == [[agg_key_name.encode('ascii'), 12, b'AVG', 0]]
 
-        stdev = statistics.stdev(items)
-        var = statistics.variance(items)
-        assert r.execute_command('TS.CREATE', raw_key)
-        assert r.execute_command('TS.CREATE', std_key)
-        assert r.execute_command('TS.CREATE', var_key)
-        assert r.execute_command('TS.CREATERULE', raw_key, std_key, "AGGREGATION", 'std.s', random_numbers)
-        assert r.execute_command('TS.CREATERULE', raw_key, var_key, "AGGREGATION", 'var.s', random_numbers)
-
-        for i in range(random_numbers):
-            r.execute_command('TS.ADD', raw_key, i, items[i])
-        r.execute_command('TS.ADD', raw_key, random_numbers, 0)  # close time bucket
-
-        assert abs(stdev - float(r.execute_command('TS.GET', std_key)[1])) < ALLOWED_ERROR
-        assert abs(var - float(r.execute_command('TS.GET', var_key)[1])) < ALLOWED_ERROR
-
-
-def test_delete_key():
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', key_name, 'CHUNK_SIZE', '360')
-        assert r.execute_command('TS.CREATE', agg_key_name)
-        assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'avg', 10)
-        assert r.delete(agg_key_name)
-        assert _get_ts_info(r, key_name).rules == []
-
-        assert r.execute_command('TS.CREATE', agg_key_name)
-        assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'avg', 11)
-        assert r.delete(key_name)
-        assert _get_ts_info(r, agg_key_name).sourceKey is None
-
-        assert r.execute_command('TS.CREATE', key_name)
-        assert r.execute_command('TS.CREATERULE', key_name, agg_key_name, 'AGGREGATION', 'avg', 12)
-        assert _get_ts_info(r, key_name).rules == [[agg_key_name.encode('ascii'), 12, b'AVG', 0]]
-
-
-def test_downsampling_current():
-    with Env().getClusterConnectionIfNeeded() as r:
-        key = 'src{a}'
-        agg_key = 'dest{a}'
-        type_list = ['', 'uncompressed']
-        agg_list = ['avg', 'twa', 'sum', 'min', 'max', 'count', 'range', 'first', 'last', 'std.p', 'std.s', 'var.p',
-                    'var.s']  # more
-        for chunk_type in type_list:
-            for agg_type in agg_list:
-                assert r.execute_command('TS.CREATE', key, chunk_type, "DUPLICATE_POLICY", "LAST")
-                assert r.execute_command('TS.CREATE', agg_key, chunk_type)
-                assert r.execute_command('TS.CREATERULE', key, agg_key, "AGGREGATION", agg_type, 10)
-
-                # present update
-                assert r.execute_command('TS.ADD', key, 3, 3) == 3
-                assert r.execute_command('TS.ADD', key, 5, 5) == 5
-                assert r.execute_command('TS.ADD', key, 7, 7) == 7
-                assert r.execute_command('TS.ADD', key, 5, 2) == 5
-                assert r.execute_command('TS.ADD', key, 10, 10) == 10
-
-                expected_result = r.execute_command('TS.RANGE', key, 0, '+', 'aggregation', agg_type, 10)
-                actual_result = r.execute_command('TS.RANGE', agg_key, 0, '+')
-                assert expected_result[0] == actual_result[0]
-
-                # present add
-                assert r.execute_command('TS.ADD', key, 11, 11) == 11
-                assert r.execute_command('TS.ADD', key, 15, 15) == 15
-                assert r.execute_command('TS.ADD', key, 14, 14) == 14
-                assert r.execute_command('TS.ADD', key, 20, 20) == 20
-
-                expected_result = r.execute_command('TS.RANGE', key, 0, '+', 'aggregation', agg_type, 10)
-                actual_result = r.execute_command('TS.RANGE', agg_key, 0, '+')
-                assert expected_result[0:1] == actual_result[0:1]
-
-                # present + past add
-                assert r.execute_command('TS.ADD', key, 23, 23) == 23
-                assert r.execute_command('TS.ADD', key, 15, 22) == 15
-                assert r.execute_command('TS.ADD', key, 27, 27) == 27
-                assert r.execute_command('TS.ADD', key, 23, 25) == 23
-                assert r.execute_command('TS.ADD', key, 30, 30) == 30
-
-                expected_result = r.execute_command('TS.RANGE', key, 0, '+', 'aggregation', agg_type, 10)
-                actual_result = r.execute_command('TS.RANGE', agg_key, 0, '+')
-                assert expected_result[0:3] == actual_result[0:3]
-                assert 3 == _get_ts_info(r, agg_key).total_samples
-                assert 11 == _get_ts_info(r, key).total_samples
-
-                r.execute_command('DEL', key)
-                r.execute_command('DEL', agg_key)
-
-
-def test_downsampling_extensive():
-    with Env().getClusterConnectionIfNeeded() as r:
-        key = 'tester{abc}'
-        fromTS = 10
-        toTS = 10000
-        type_list = ['', 'uncompressed']
-        for chunk_type in type_list:
+    def test_downsampling_current(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            key = 'src{a}'
+            agg_key = 'dest{a}'
+            type_list = ['', 'uncompressed']
             agg_list = ['avg', 'twa', 'sum', 'min', 'max', 'count', 'range', 'first', 'last', 'std.p', 'std.s', 'var.p',
                         'var.s']  # more
-            for agg in agg_list:
-                agg_key = _insert_agg_data(r, key, agg, chunk_type, fromTS, toTS,
-                                           key_create_args=['DUPLICATE_POLICY', 'LAST'])
+            for chunk_type in type_list:
+                for agg_type in agg_list:
+                    assert r.execute_command('TS.CREATE', key, chunk_type, "DUPLICATE_POLICY", "LAST")
+                    assert r.execute_command('TS.CREATE', agg_key, chunk_type)
+                    assert r.execute_command('TS.CREATERULE', key, agg_key, "AGGREGATION", agg_type, 10)
 
-                # sanity + check result have changed
-                expected_result1 = r.execute_command('TS.RANGE', key, fromTS, toTS, 'aggregation', agg, 10)
-                actual_result1 = r.execute_command('TS.RANGE', agg_key, fromTS, toTS)
-                assert expected_result1 == actual_result1
-                assert len(expected_result1) == 999
+                    # present update
+                    assert r.execute_command('TS.ADD', key, 3, 3) == 3
+                    assert r.execute_command('TS.ADD', key, 5, 5) == 5
+                    assert r.execute_command('TS.ADD', key, 7, 7) == 7
+                    assert r.execute_command('TS.ADD', key, 5, 2) == 5
+                    assert r.execute_command('TS.ADD', key, 10, 10) == 10
 
-                for i in range(fromTS + 5, toTS - 4, 10):
-                    assert r.execute_command('TS.ADD', key, i, 42)
+                    expected_result = r.execute_command('TS.RANGE', key, 0, '+', 'aggregation', agg_type, 10)
+                    actual_result = r.execute_command('TS.RANGE', agg_key, 0, '+')
+                    assert expected_result[0] == actual_result[0]
 
-                expected_result2 = r.execute_command('TS.RANGE', key, fromTS, toTS, 'aggregation', agg, 10)
-                actual_result2 = r.execute_command('TS.RANGE', agg_key, fromTS, toTS)
-                assert expected_result2 == actual_result2
+                    # present add
+                    assert r.execute_command('TS.ADD', key, 11, 11) == 11
+                    assert r.execute_command('TS.ADD', key, 15, 15) == 15
+                    assert r.execute_command('TS.ADD', key, 14, 14) == 14
+                    assert r.execute_command('TS.ADD', key, 20, 20) == 20
 
-                # remove aggs with identical results
-                compare_list = ['avg', 'twa', 'sum', 'min', 'range', 'std.p', 'std.s', 'var.p', 'var.s']
-                if agg in compare_list:
-                    assert expected_result1 != expected_result2
-                    assert actual_result1 != actual_result2
+                    expected_result = r.execute_command('TS.RANGE', key, 0, '+', 'aggregation', agg_type, 10)
+                    actual_result = r.execute_command('TS.RANGE', agg_key, 0, '+')
+                    assert expected_result[0:1] == actual_result[0:1]
 
-                r.execute_command('DEL', key)
-                r.execute_command('DEL', agg_key)
+                    # present + past add
+                    assert r.execute_command('TS.ADD', key, 23, 23) == 23
+                    assert r.execute_command('TS.ADD', key, 15, 22) == 15
+                    assert r.execute_command('TS.ADD', key, 27, 27) == 27
+                    assert r.execute_command('TS.ADD', key, 23, 25) == 23
+                    assert r.execute_command('TS.ADD', key, 30, 30) == 30
 
+                    expected_result = r.execute_command('TS.RANGE', key, 0, '+', 'aggregation', agg_type, 10)
+                    actual_result = r.execute_command('TS.RANGE', agg_key, 0, '+')
+                    assert expected_result[0:3] == actual_result[0:3]
+                    assert 3 == _get_ts_info(r, agg_key).total_samples
+                    assert 11 == _get_ts_info(r, key).total_samples
 
-def test_downsampling_rules(self):
-    """
-    Test downsmapling rules - avg,min,max,count,sum with 4 keys each.
-    Downsample in resolution of:
-    1sec (should be the same length as the original series),
-    3sec (number of samples is divisible by 10),
-    10s (number of samples is not divisible by 10),
-    1000sec (series should be empty since there are not enough samples)
-    Insert some data and check that the length, the values and the info of the downsample series are as expected.
-    """
-    with Env().getClusterConnectionIfNeeded() as r:
-        key = 'tester{abc}'
-        assert r.execute_command('TS.CREATE', key)
-        rules = ['avg', 'sum', 'count', 'max', 'min']
-        resolutions = [1, 3, 10, 1000]
-        for rule in rules:
-            for resolution in resolutions:
-                agg_key = '{}_{}_{}'.format(key, rule, resolution)
-                assert r.execute_command('TS.CREATE', agg_key)
-                assert r.execute_command('TS.CREATERULE', key, agg_key, 'AGGREGATION', rule, resolution)
+                    r.execute_command('DEL', key)
+                    r.execute_command('DEL', agg_key)
 
-        start_ts = 0
-        samples_count = 501
-        end_ts = start_ts + samples_count
-        values = list(range(samples_count))
-        _insert_data(r, key, start_ts, samples_count, values)
-        r.execute_command('TS.ADD', key, 3000, 7.77)
+    def test_downsampling_extensive(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            key = 'tester{abc}'
+            fromTS = 10
+            toTS = 10000
+            type_list = ['', 'uncompressed']
+            for chunk_type in type_list:
+                agg_list = ['avg', 'twa', 'sum', 'min', 'max', 'count', 'range', 'first', 'last', 'std.p', 'std.s', 'var.p',
+                            'var.s']  # more
+                for agg in agg_list:
+                    agg_key = _insert_agg_data(r, key, agg, chunk_type, fromTS, toTS,
+                                               key_create_args=['DUPLICATE_POLICY', 'LAST'])
 
-        for rule in rules:
-            for resolution in resolutions:
-                actual_result = r.execute_command('TS.RANGE', '{}_{}_{}'.format(key, rule, resolution),
-                                                  start_ts, end_ts)
-                assert len(actual_result) == math.ceil(samples_count / float(resolution))
-                expected_result = calc_rule(rule, values, resolution)
-                assert _get_series_value(actual_result) == expected_result
-                # last time stamp should be the beginning of the last bucket
-                assert _get_ts_info(r, '{}_{}_{}'.format(key, rule, resolution)).last_time_stamp == \
-                       (samples_count - 1) - (samples_count - 1) % resolution
+                    # sanity + check result have changed
+                    expected_result1 = r.execute_command('TS.RANGE', key, fromTS, toTS, 'aggregation', agg, 10)
+                    actual_result1 = r.execute_command('TS.RANGE', agg_key, fromTS, toTS)
+                    assert expected_result1 == actual_result1
+                    assert len(expected_result1) == 999
 
-        # test for results after empty buckets
-        r.execute_command('TS.ADD', key, 6000, 0)
-        for rule in rules:
-            for resolution in resolutions:
-                actual_result = r.execute_command('TS.RANGE', '{}_{}_{}'.format(key, rule, resolution),
-                                                  3000, 6000)
-                assert len(actual_result) == 1
-                assert _get_series_value(actual_result) == [7.77] or \
-                       _get_series_value(actual_result) == [1]
+                    for i in range(fromTS + 5, toTS - 4, 10):
+                        assert r.execute_command('TS.ADD', key, i, 42)
 
+                    expected_result2 = r.execute_command('TS.RANGE', key, fromTS, toTS, 'aggregation', agg, 10)
+                    actual_result2 = r.execute_command('TS.RANGE', agg_key, fromTS, toTS)
+                    assert expected_result2 == actual_result2
 
-def test_downsampling_alignment(self):
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', 't1{1}')
-        assert r.execute_command('TS.CREATE', 't2{1}')
-        assert r.execute_command('TS.CREATERULE', 't1{1}', 't2{1}', 'AGGREGATION', 'sum', 10, 5)
-        r.execute_command('TS.ADD', 't1{1}', 3, 4)
-        r.execute_command('TS.ADD', 't1{1}', 9, 8)
+                    # remove aggs with identical results
+                    compare_list = ['avg', 'twa', 'sum', 'min', 'range', 'std.p', 'std.s', 'var.p', 'var.s']
+                    if agg in compare_list:
+                        assert expected_result1 != expected_result2
+                        assert actual_result1 != actual_result2
 
-        # test regular add
-        expected_result = r.execute_command('TS.RANGE', 't1{1}', 0, 4, 'ALIGN', 5, 'AGGREGATION', 'sum', 10)
-        actual_result = r.execute_command('TS.RANGE', 't2{1}', 0, 4)
-        assert expected_result == actual_result
-        r.execute_command('TS.ADD', 't1{1}', 16, 8)
-        expected_result = r.execute_command('TS.RANGE', 't1{1}', 0, 9, 'ALIGN', 5, 'AGGREGATION', 'sum', 10)
-        actual_result = r.execute_command('TS.RANGE', 't2{1}', 0, 9)
-        assert expected_result == actual_result
+                    r.execute_command('DEL', key)
+                    r.execute_command('DEL', agg_key)
 
-        # test upsert
-        r.execute_command('TS.ADD', 't1{1}', 2, 8)
-        r.execute_command('TS.ADD', 't1{1}', 6, 3)
-        expected_result = r.execute_command('TS.RANGE', 't1{1}', 0, 9, 'ALIGN', 5, 'AGGREGATION', 'sum', 10)
-        actual_result = r.execute_command('TS.RANGE', 't2{1}', 0, 9)
-        assert expected_result == actual_result
+    def test_downsampling_rules(self):
+        """
+        Test downsmapling rules - avg,min,max,count,sum with 4 keys each.
+        Downsample in resolution of:
+        1sec (should be the same length as the original series),
+        3sec (number of samples is divisible by 10),
+        10s (number of samples is not divisible by 10),
+        1000sec (series should be empty since there are not enough samples)
+        Insert some data and check that the length, the values and the info of the downsample series are as expected.
+        """
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            key = 'tester{abc}'
+            assert r.execute_command('TS.CREATE', key)
+            rules = ['avg', 'sum', 'count', 'max', 'min']
+            resolutions = [1, 3, 10, 1000]
+            for rule in rules:
+                for resolution in resolutions:
+                    agg_key = '{}_{}_{}'.format(key, rule, resolution)
+                    assert r.execute_command('TS.CREATE', agg_key)
+                    assert r.execute_command('TS.CREATERULE', key, agg_key, 'AGGREGATION', rule, resolution)
 
-        # test upsert in latest bucket
-        r.execute_command('TS.ADD', 't1{1}', 15, 9)
-        r.execute_command('TS.ADD', 't1{1}', 30, 7)
-        expected_result = r.execute_command('TS.RANGE', 't1{1}', 0, 24, 'ALIGN', 5, 'AGGREGATION', 'sum', 10)
-        actual_result = r.execute_command('TS.RANGE', 't2{1}', 0, 24)
-        assert expected_result == actual_result
+            start_ts = 0
+            samples_count = 501
+            end_ts = start_ts + samples_count
+            values = list(range(samples_count))
+            _insert_data(r, key, start_ts, samples_count, values)
+            r.execute_command('TS.ADD', key, 3000, 7.77)
 
-def test_backfill_downsampling(self):
-    env = Env()
-    with env.getClusterConnectionIfNeeded() as r:
-        key = 'tester{a}'
-        type_list = ['', 'uncompressed']
-        for chunk_type in type_list:
-            agg_list = ['sum', 'min', 'max', 'count', 'first', 'last']  # more
-            for agg in agg_list:
-                agg_key = _insert_agg_data(r, key, agg, chunk_type, key_create_args=['DUPLICATE_POLICY', 'LAST'])
+            for rule in rules:
+                for resolution in resolutions:
+                    actual_result = r.execute_command('TS.RANGE', '{}_{}_{}'.format(key, rule, resolution),
+                                                      start_ts, end_ts)
+                    assert len(actual_result) == math.ceil(samples_count / float(resolution))
+                    expected_result = calc_rule(rule, values, resolution)
+                    assert _get_series_value(actual_result) == expected_result
+                    # last time stamp should be the beginning of the last bucket
+                    assert _get_ts_info(r, '{}_{}_{}'.format(key, rule, resolution)).last_time_stamp == \
+                           (samples_count - 1) - (samples_count - 1) % resolution
 
-                expected_result = r.execute_command('TS.RANGE', key, 10, 50, 'aggregation', agg, 10)
-                actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
-                assert expected_result == actual_result
-                assert r.execute_command('TS.ADD', key, 15, 50) == 15
-                expected_result = r.execute_command('TS.RANGE', key, 10, 50, 'aggregation', agg, 10)
-                actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
-                assert expected_result == actual_result
+            # test for results after empty buckets
+            r.execute_command('TS.ADD', key, 6000, 0)
+            for rule in rules:
+                for resolution in resolutions:
+                    actual_result = r.execute_command('TS.RANGE', '{}_{}_{}'.format(key, rule, resolution),
+                                                      3000, 6000)
+                    assert len(actual_result) == 1
+                    assert _get_series_value(actual_result) == [7.77] or \
+                           _get_series_value(actual_result) == [1]
 
-                # add in latest window
-                r.execute_command('TS.ADD', key, 1055, 50) == 1055
-                r.execute_command('TS.ADD', key, 1053, 55) == 1053
-                r.execute_command('TS.ADD', key, 1062, 60) == 1062
-                expected_result = r.execute_command('TS.RANGE', key, 10, 1060, 'aggregation', agg, 10)
-                actual_result = r.execute_command('TS.RANGE', agg_key, 10, 1060)
-                assert expected_result == actual_result
+    def test_downsampling_alignment(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', 't1{1}')
+            assert r.execute_command('TS.CREATE', 't2{1}')
+            assert r.execute_command('TS.CREATERULE', 't1{1}', 't2{1}', 'AGGREGATION', 'sum', 10, 5)
+            r.execute_command('TS.ADD', 't1{1}', 3, 4)
+            r.execute_command('TS.ADD', 't1{1}', 9, 8)
 
-                # update in latest window
-                r.execute_command('TS.ADD', key, 1065, 65) == 1065
-                r.execute_command('TS.ADD', key, 1066, 66) == 1066
-                r.execute_command('TS.ADD', key, 1001, 42) == 1001
-                r.execute_command('TS.ADD', key, 1075, 50) == 1075
-                expected_result = r.execute_command('TS.RANGE', key, 10, 1070, 'aggregation', agg, 10)
-                actual_result = r.execute_command('TS.RANGE', agg_key, 10, 1070)
-                env.assertEqual(expected_result, actual_result)
-                r.execute_command('DEL', key)
-                r.execute_command('DEL', agg_key)
+            # test regular add
+            expected_result = r.execute_command('TS.RANGE', 't1{1}', 0, 4, 'ALIGN', 5, 'AGGREGATION', 'sum', 10)
+            actual_result = r.execute_command('TS.RANGE', 't2{1}', 0, 4)
+            assert expected_result == actual_result
+            r.execute_command('TS.ADD', 't1{1}', 16, 8)
+            expected_result = r.execute_command('TS.RANGE', 't1{1}', 0, 9, 'ALIGN', 5, 'AGGREGATION', 'sum', 10)
+            actual_result = r.execute_command('TS.RANGE', 't2{1}', 0, 9)
+            assert expected_result == actual_result
 
+            # test upsert
+            r.execute_command('TS.ADD', 't1{1}', 2, 8)
+            r.execute_command('TS.ADD', 't1{1}', 6, 3)
+            expected_result = r.execute_command('TS.RANGE', 't1{1}', 0, 9, 'ALIGN', 5, 'AGGREGATION', 'sum', 10)
+            actual_result = r.execute_command('TS.RANGE', 't2{1}', 0, 9)
+            assert expected_result == actual_result
 
-def test_rule_timebucket_64bit(self):
-    Env().skipOnCluster()
-    with Env().getClusterConnectionIfNeeded() as r:
-        BELOW_32BIT_LIMIT = 2147483647
-        ABOVE_32BIT_LIMIT = 2147483648
-        r.execute_command("ts.create", 'test_key{test}', 'RETENTION', ABOVE_32BIT_LIMIT)
-        r.execute_command("ts.create", 'below_32bit_limit{test}')
-        r.execute_command("ts.create", 'above_32bit_limit{test}')
-        r.execute_command("ts.createrule", 'test_key{test}', 'below_32bit_limit{test}', 'AGGREGATION', 'max', BELOW_32BIT_LIMIT)
-        r.execute_command("ts.createrule", 'test_key{test}', 'above_32bit_limit{test}', 'AGGREGATION', 'max', ABOVE_32BIT_LIMIT)
-        info = _get_ts_info(r, 'test_key{test}')
-        assert info.rules[0][1] == BELOW_32BIT_LIMIT
-        assert info.rules[1][1] == ABOVE_32BIT_LIMIT
+            # test upsert in latest bucket
+            r.execute_command('TS.ADD', 't1{1}', 15, 9)
+            r.execute_command('TS.ADD', 't1{1}', 30, 7)
+            expected_result = r.execute_command('TS.RANGE', 't1{1}', 0, 24, 'ALIGN', 5, 'AGGREGATION', 'sum', 10)
+            actual_result = r.execute_command('TS.RANGE', 't2{1}', 0, 24)
+            assert expected_result == actual_result
 
-def test_create_rule_non_empty_src_series(self):
-    t1 = "t1{1}"
-    t2 = "t2{1}"
-    t3 = "t3{1}"
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", t1)
-        r.execute_command("ts.create", t2)
-        r.execute_command("ts.create", t3)
-        r.execute_command("ts.add", t1, 1, 1)
-        r.execute_command("ts.add", t1, 2, 2)
-        r.execute_command("ts.add", t1, 3, 3)
-        r.execute_command("ts.add", t1, 11, 11)
-        r.execute_command("ts.createrule", t1, t2, "AGGREGATION", "avg", 10)
-        res = r.execute_command("ts.range", t2, "-", "+", "LATEST")
-        assert res == []
-        r.execute_command("ts.createrule", t1, t3, "AGGREGATION", "avg", 10, 5)
-        res = r.execute_command("ts.range", t3, "-", "+", "LATEST")
-        assert res == []
+    def test_backfill_downsampling(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            key = 'tester{a}'
+            type_list = ['', 'uncompressed']
+            for chunk_type in type_list:
+                agg_list = ['sum', 'min', 'max', 'count', 'first', 'last']  # more
+                for agg in agg_list:
+                    agg_key = _insert_agg_data(r, key, agg, chunk_type, key_create_args=['DUPLICATE_POLICY', 'LAST'])
 
-def test_compaction_rules_with_nan():
-    """
-    Verify compaction rules correctly handle NaN values.
-    NaN values should be ignored by most aggregations, countnan/countall should count them.
-    Tests all aggregation types with both compressed and uncompressed chunks.
-    """
-    env = Env()
-    with env.getClusterConnectionIfNeeded() as r:
-        key = 'src_nan{abc}'
-        type_list = ['', 'uncompressed']
-        for chunk_type in type_list:
-            agg_list = ['sum', 'min', 'max', 'count', 'first', 'last', 'avg', 'range',
-                        'std.p', 'std.s', 'var.p', 'var.s']
+                    expected_result = r.execute_command('TS.RANGE', key, 10, 50, 'aggregation', agg, 10)
+                    actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
+                    assert expected_result == actual_result
+                    assert r.execute_command('TS.ADD', key, 15, 50) == 15
+                    expected_result = r.execute_command('TS.RANGE', key, 10, 50, 'aggregation', agg, 10)
+                    actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
+                    assert expected_result == actual_result
+
+                    # add in latest window
+                    r.execute_command('TS.ADD', key, 1055, 50) == 1055
+                    r.execute_command('TS.ADD', key, 1053, 55) == 1053
+                    r.execute_command('TS.ADD', key, 1062, 60) == 1062
+                    expected_result = r.execute_command('TS.RANGE', key, 10, 1060, 'aggregation', agg, 10)
+                    actual_result = r.execute_command('TS.RANGE', agg_key, 10, 1060)
+                    assert expected_result == actual_result
+
+                    # update in latest window
+                    r.execute_command('TS.ADD', key, 1065, 65) == 1065
+                    r.execute_command('TS.ADD', key, 1066, 66) == 1066
+                    r.execute_command('TS.ADD', key, 1001, 42) == 1001
+                    r.execute_command('TS.ADD', key, 1075, 50) == 1075
+                    expected_result = r.execute_command('TS.RANGE', key, 10, 1070, 'aggregation', agg, 10)
+                    actual_result = r.execute_command('TS.RANGE', agg_key, 10, 1070)
+                    env.assertEqual(expected_result, actual_result)
+                    r.execute_command('DEL', key)
+                    r.execute_command('DEL', agg_key)
+
+    def test_rule_timebucket_64bit(self):
+        env = self.env
+        env.flush()
+        env.skipOnCluster()
+        with env.getClusterConnectionIfNeeded() as r:
+            BELOW_32BIT_LIMIT = 2147483647
+            ABOVE_32BIT_LIMIT = 2147483648
+            r.execute_command("ts.create", 'test_key{test}', 'RETENTION', ABOVE_32BIT_LIMIT)
+            r.execute_command("ts.create", 'below_32bit_limit{test}')
+            r.execute_command("ts.create", 'above_32bit_limit{test}')
+            r.execute_command("ts.createrule", 'test_key{test}', 'below_32bit_limit{test}', 'AGGREGATION', 'max', BELOW_32BIT_LIMIT)
+            r.execute_command("ts.createrule", 'test_key{test}', 'above_32bit_limit{test}', 'AGGREGATION', 'max', ABOVE_32BIT_LIMIT)
+            info = _get_ts_info(r, 'test_key{test}')
+            assert info.rules[0][1] == BELOW_32BIT_LIMIT
+            assert info.rules[1][1] == ABOVE_32BIT_LIMIT
+
+    def test_create_rule_non_empty_src_series(self):
+        t1 = "t1{1}"
+        t2 = "t2{1}"
+        t3 = "t3{1}"
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", t1)
+            r.execute_command("ts.create", t2)
+            r.execute_command("ts.create", t3)
+            r.execute_command("ts.add", t1, 1, 1)
+            r.execute_command("ts.add", t1, 2, 2)
+            r.execute_command("ts.add", t1, 3, 3)
+            r.execute_command("ts.add", t1, 11, 11)
+            r.execute_command("ts.createrule", t1, t2, "AGGREGATION", "avg", 10)
+            res = r.execute_command("ts.range", t2, "-", "+", "LATEST")
+            assert res == []
+            r.execute_command("ts.createrule", t1, t3, "AGGREGATION", "avg", 10, 5)
+            res = r.execute_command("ts.range", t3, "-", "+", "LATEST")
+            assert res == []
+
+    def test_compaction_rules_with_nan(self):
+        """
+        Verify compaction rules correctly handle NaN values.
+        NaN values should be ignored by most aggregations, countnan/countall should count them.
+        Tests all aggregation types with both compressed and uncompressed chunks.
+        """
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            key = 'src_nan{abc}'
+            type_list = ['', 'uncompressed']
+            for chunk_type in type_list:
+                agg_list = ['sum', 'min', 'max', 'count', 'first', 'last', 'avg', 'range',
+                            'std.p', 'std.s', 'var.p', 'var.s']
+                for agg in agg_list:
+                    agg_key = f'{key}_agg_{agg}_10'
+
+                    r.execute_command('TS.CREATE', key, chunk_type)
+                    r.execute_command('TS.CREATE', agg_key, chunk_type)
+                    r.execute_command('TS.CREATERULE', key, agg_key, 'AGGREGATION', agg, 10)
+
+                    # Add data with NaN values mixed in: bucket 0-9 has values 10, NaN, 20
+                    r.execute_command('TS.ADD', key, 1, 10)
+                    r.execute_command('TS.ADD', key, 2, 'nan')
+                    r.execute_command('TS.ADD', key, 3, 20)
+
+                    # Close bucket 0-9 by adding sample to bucket 10-19
+                    r.execute_command('TS.ADD', key, 12, 'NaN')
+
+                    # Verify: compaction rule result should match TS.RANGE aggregation (both ignore NaN)
+                    expected_result = r.execute_command('TS.RANGE', key, 0, 9, 'AGGREGATION', agg, 10)
+                    actual_result = r.execute_command('TS.RANGE', agg_key, 0, 9)
+                    env.assertEqual(expected_result, actual_result,
+                                   message=f"Mismatch for {agg} with {chunk_type or 'compressed'}: expected {expected_result}, got {actual_result}")
+
+                    # Add more data to bucket 10-19
+                    r.execute_command('TS.ADD', key, 15, 100)
+                    r.execute_command('TS.ADD', key, 19, 120)
+
+                    # Close bucket 10-19 by adding sample to bucket 20-29
+                    r.execute_command('TS.ADD', key, 25, 200)
+
+                    # Verify: compaction rule result should match TS.RANGE aggregation (both ignore NaN)
+                    expected_result = r.execute_command('TS.RANGE', key, 0, 19, 'AGGREGATION', agg, 10)
+                    actual_result = r.execute_command('TS.RANGE', agg_key, 0, 19)
+                    env.assertEqual(expected_result, actual_result,
+                                   message=f"Mismatch for {agg} with {chunk_type or 'compressed'}: expected {expected_result}, got {actual_result}")
+                    r.execute_command('DEL', key)
+                    r.execute_command('DEL', agg_key)
+
+                # Test countnan and countall separately (they have special NaN handling)
+                for agg in ['countnan', 'countall']:
+                    agg_key = f'{key}_agg_{agg}_10'
+
+                    r.execute_command('TS.CREATE', key, chunk_type)
+                    r.execute_command('TS.CREATE', agg_key, chunk_type)
+                    r.execute_command('TS.CREATERULE', key, agg_key, 'AGGREGATION', agg, 10)
+
+                    # Add data with NaN values mixed in: bucket 0-9 has values 10, NaN, 20
+                    r.execute_command('TS.ADD', key, 1, 10)
+                    r.execute_command('TS.ADD', key, 2, 'nan')
+                    r.execute_command('TS.ADD', key, 3, 20)
+
+                    # Close bucket 0-9 by adding sample to bucket 10-19
+                    r.execute_command('TS.ADD', key, 15, 100)
+
+                    expected_result = r.execute_command('TS.RANGE', key, 0, 9, 'AGGREGATION', agg, 10)
+                    actual_result = r.execute_command('TS.RANGE', agg_key, 0, 9)
+                    env.assertEqual(expected_result, actual_result,
+                                   message=f"Mismatch for {agg} with {chunk_type or 'compressed'}: expected {expected_result}, got {actual_result}")
+
+                    r.execute_command('DEL', key)
+                    r.execute_command('DEL', agg_key)
+
+    def test_compaction_rules_nan_only_bucket(self):
+        """
+        Verify compaction rules correctly handle buckets containing ONLY NaN values.
+        """
+        import math
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            key = 'src_nan_only{abc}'
+            agg_list = ['max', 'min', 'sum', 'avg', 'range', 'std.p', 'std.s', 'var.p', 'var.s', 'first', 'last']
+
             for agg in agg_list:
                 agg_key = f'{key}_agg_{agg}_10'
 
-                r.execute_command('TS.CREATE', key, chunk_type)
-                r.execute_command('TS.CREATE', agg_key, chunk_type)
+                r.execute_command('TS.CREATE', key)
+                r.execute_command('TS.CREATE', agg_key)
                 r.execute_command('TS.CREATERULE', key, agg_key, 'AGGREGATION', agg, 10)
 
-                # Add data with NaN values mixed in: bucket 0-9 has values 10, NaN, 20
-                r.execute_command('TS.ADD', key, 1, 10)
-                r.execute_command('TS.ADD', key, 2, 'nan')
-                r.execute_command('TS.ADD', key, 3, 20)
+                # Add ONLY NaN values to bucket 0-9
+                r.execute_command('TS.ADD', key, 1, 'nan')
+                r.execute_command('TS.ADD', key, 5, 'nan')
+                r.execute_command('TS.ADD', key, 9, 'nan')
 
-                # Close bucket 0-9 by adding sample to bucket 10-19
-                r.execute_command('TS.ADD', key, 12, 'NaN')
-
-                # Verify: compaction rule result should match TS.RANGE aggregation (both ignore NaN)
-                expected_result = r.execute_command('TS.RANGE', key, 0, 9, 'AGGREGATION', agg, 10)
-                actual_result = r.execute_command('TS.RANGE', agg_key, 0, 9)
-                env.assertEqual(expected_result, actual_result,
-                               message=f"Mismatch for {agg} with {chunk_type or 'compressed'}: expected {expected_result}, got {actual_result}")
-
-                # Add more data to bucket 10-19
-                r.execute_command('TS.ADD', key, 15, 100)
-                r.execute_command('TS.ADD', key, 19, 120)
-
-                # Close bucket 10-19 by adding sample to bucket 20-29
-                r.execute_command('TS.ADD', key, 25, 200)
-
-                # Verify: compaction rule result should match TS.RANGE aggregation (both ignore NaN)
-                expected_result = r.execute_command('TS.RANGE', key, 0, 19, 'AGGREGATION', agg, 10)
-                actual_result = r.execute_command('TS.RANGE', agg_key, 0, 19)
-                env.assertEqual(expected_result, actual_result,
-                               message=f"Mismatch for {agg} with {chunk_type or 'compressed'}: expected {expected_result}, got {actual_result}")
-                r.execute_command('DEL', key)
-                r.execute_command('DEL', agg_key)
-
-            # Test countnan and countall separately (they have special NaN handling)
-            for agg in ['countnan', 'countall']:
-                agg_key = f'{key}_agg_{agg}_10'
-
-                r.execute_command('TS.CREATE', key, chunk_type)
-                r.execute_command('TS.CREATE', agg_key, chunk_type)
-                r.execute_command('TS.CREATERULE', key, agg_key, 'AGGREGATION', agg, 10)
-
-                # Add data with NaN values mixed in: bucket 0-9 has values 10, NaN, 20
-                r.execute_command('TS.ADD', key, 1, 10)
-                r.execute_command('TS.ADD', key, 2, 'nan')
-                r.execute_command('TS.ADD', key, 3, 20)
-
-                # Close bucket 0-9 by adding sample to bucket 10-19
+                # Close bucket 0-9 by adding a valid sample to bucket 10-19
                 r.execute_command('TS.ADD', key, 15, 100)
 
-                expected_result = r.execute_command('TS.RANGE', key, 0, 9, 'AGGREGATION', agg, 10)
+                # Get the compaction result for bucket 0-9
                 actual_result = r.execute_command('TS.RANGE', agg_key, 0, 9)
+
+                # For a bucket with ONLY NaN values, the result should match TS.RANGE behavior
+                # with aggregation on NaN-only data.
+                expected_result = r.execute_command('TS.RANGE', key, 0, 9, 'AGGREGATION', agg, 10)
+
                 env.assertEqual(expected_result, actual_result,
-                               message=f"Mismatch for {agg} with {chunk_type or 'compressed'}: expected {expected_result}, got {actual_result}")
+                               message=f"NaN-only bucket mismatch for {agg}: expected {expected_result}, got {actual_result}")
 
                 r.execute_command('DEL', key)
                 r.execute_command('DEL', agg_key)
-
-
-def test_compaction_rules_nan_only_bucket():
-    """
-    Verify compaction rules correctly handle buckets containing ONLY NaN values.
-    """
-    import math
-    env = Env()
-    with env.getClusterConnectionIfNeeded() as r:
-        key = 'src_nan_only{abc}'
-        agg_list = ['max', 'min', 'sum', 'avg', 'range', 'std.p', 'std.s', 'var.p', 'var.s', 'first', 'last']
-        
-        for agg in agg_list:
-            agg_key = f'{key}_agg_{agg}_10'
-            
-            r.execute_command('TS.CREATE', key)
-            r.execute_command('TS.CREATE', agg_key)
-            r.execute_command('TS.CREATERULE', key, agg_key, 'AGGREGATION', agg, 10)
-            
-            # Add ONLY NaN values to bucket 0-9
-            r.execute_command('TS.ADD', key, 1, 'nan')
-            r.execute_command('TS.ADD', key, 5, 'nan')
-            r.execute_command('TS.ADD', key, 9, 'nan')
-            
-            # Close bucket 0-9 by adding a valid sample to bucket 10-19
-            r.execute_command('TS.ADD', key, 15, 100)
-            
-            # Get the compaction result for bucket 0-9
-            actual_result = r.execute_command('TS.RANGE', agg_key, 0, 9)
-            
-            # For a bucket with ONLY NaN values, the result should match TS.RANGE behavior
-            # with aggregation on NaN-only data.
-            expected_result = r.execute_command('TS.RANGE', key, 0, 9, 'AGGREGATION', agg, 10)
-            
-            env.assertEqual(expected_result, actual_result,
-                           message=f"NaN-only bucket mismatch for {agg}: expected {expected_result}, got {actual_result}")
-            
-            r.execute_command('DEL', key)
-            r.execute_command('DEL', agg_key)

--- a/tests/flow/test_ts_delete.py
+++ b/tests/flow/test_ts_delete.py
@@ -5,625 +5,621 @@ from test_helper_classes import _get_ts_info, TSInfo
 from includes import *
 import random
 
-def test_ts_del_uncompressed():
-    # total samples = 101
-    sample_len = 101
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", 'test_key', 'uncompressed')
 
-        for i in range(sample_len):
-            assert i == r.execute_command("ts.add", 'test_key', i, '1')
+class testTsDelete:
+    def __init__(self):
+        self.env = Env()
 
-        res = r.execute_command('ts.range', 'test_key', 0, 100)
-        i = 0
-        for sample in res:
-            assert sample == [i, '1'.encode('ascii')]
-            i += 1
-        r.execute_command('ts.del', 'test_key', 0, 100)
-        res = r.execute_command('ts.range', 'test_key', 0, 100)
-        assert len(res) == 0
+    def test_ts_del_uncompressed(self):
+        # total samples = 101
+        sample_len = 101
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", 'test_key', 'uncompressed')
 
-#bug https://github.com/RedisTimeSeries/RedisTimeSeries/issues/1176
-def test_ts_del_first_sample_in_chunk():
-    _from = 1
-    _to = 300
-    del_from = 101
-    del_to = 258
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", 't1{1}', 'uncompressed', "DUPLICATE_POLICY", "LAST")
-        for i in range(_from, _to + 1):
-            r.execute_command("ts.add", 't1{1}', i, random.uniform(0, 1))
-        range1 = r.execute_command("ts.range", 't1{1}', '-', '+')
-        assert r.execute_command("ts.del", 't1{1}', del_from, del_to)
-        add_str = []
-        add_str.append("ts.madd")
-        for i in range(_from, del_to + 1):
-            add_str.append("t1{1}")
-            add_str.append(str(i))
-            add_str.append(str(random.uniform(0, 1)))
-        assert r.execute_command(*add_str)
-        range2 = r.execute_command("ts.range", 't1{1}', '-', '+')
-        assert len(range2) == len(range1)
+            for i in range(sample_len):
+                assert i == r.execute_command("ts.add", 'test_key', i, '1')
 
-def test_ts_del_last_chunk():
-    _from = 1
-    _to = 500
-    del_from = 101
-    del_to = 500
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', 't1{1}', 'compressed', 'CHUNK_SIZE', '128')
-        for i in range(_from, _to + 1):
-            r.execute_command("ts.add", 't1{1}', i, random.uniform(0, 1))
-        info = TSInfo(r.execute_command("ts.info", 't1{1}', 'DEBUG'))
-        n_chunks = len(info.chunks)
-        assert(n_chunks > 1)
-        assert r.execute_command("ts.del", 't1{1}', del_from, del_to)
-        info = TSInfo(r.execute_command("ts.info", 't1{1}', 'DEBUG'))
-        assert len(info.chunks) < n_chunks
-        assert len(info.chunks) > 1
-        res = r.execute_command("ts.get", 't1{1}')
-        assert res[0] == del_from - 1
-        res = r.execute_command("ts.range", 't1{1}', '-', '+')
-        assert res[len(res) - 1][0] == del_from - 1
-        assert r.execute_command("ts.del", 't1{1}', 0, del_from - 1)
-        info = TSInfo(r.execute_command("ts.info", 't1{1}', 'DEBUG'))
-        assert len(info.chunks) == 1
-        r.execute_command("ts.add", 't1{1}', 5, random.uniform(0, 1))
-        res = r.execute_command("ts.get", 't1{1}')
-        assert res[0] == 5
-        res = r.execute_command("ts.range", 't1{1}', '-', '+')
-        assert len(res) == 1
-        assert res[len(res) - 1][0] == 5
-
-def test_ts_del_last_sample_in_series():
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", 't1{1}', "DUPLICATE_POLICY", "LAST")
-        assert r.execute_command("ts.get", 't1{1}') == []
-        assert r.execute_command("ts.del", 't1{1}', '0', '10') == 0
-        assert r.execute_command("ts.get", 't1{1}') == []
-        r.execute_command("ts.add", 't1{1}', 1, 2)
-        r.execute_command("ts.add", 't1{1}', 5, 10)
-        assert r.execute_command("ts.del", 't1{1}', '5', '5')
-        assert r.execute_command("ts.get", 't1{1}') == [1, b'2']
-        assert r.execute_command("ts.del", 't1{1}', '1', '1')
-        assert r.execute_command("ts.get", 't1{1}') == []
-
-def test_ts_del_uncompressed_in_range():
-    sample_len = 101
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", 'test_key', 'uncompressed')
-
-        for i in range(sample_len):
-            assert i == r.execute_command("ts.add", 'test_key', i, '1')
-
-        res = r.execute_command('ts.range', 'test_key', 0, 100)
-        i = 0
-        for sample in res:
-            assert sample == [i, '1'.encode('ascii')]
-            i += 1
-        # delete 11 samples
-        assert 11 == r.execute_command('ts.del', 'test_key', 50, 60)
-        res = r.execute_command('ts.range', 'test_key', 0, 100)
-        assert len(res) == 90
-
-
-def test_ts_del_compressed():
-    sample_len = 101
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", 'test_key')
-
-        for i in range(sample_len):
-            assert i == r.execute_command("ts.add", 'test_key', i, '1')
-
-        res = r.execute_command('ts.range', 'test_key', 0, 100)
-        i = 0
-        for sample in res:
-            assert sample == [i, '1'.encode('ascii')]
-            i += 1
-        assert sample_len == r.execute_command('ts.del', 'test_key', 0, 100)
-        res = r.execute_command('ts.range', 'test_key', 0, 100)
-        assert len(res) == 0
-
-
-def test_ts_del_multi_chunk():
-    for CHUNK_TYPE in ["compressed","uncompressed"]:
-        sample_len = 1
-        e = Env()
-        with e.getClusterConnectionIfNeeded() as r:
-            r.execute_command("ts.create", 'test_key', CHUNK_TYPE)
-            while(_get_ts_info(r, 'test_key').chunk_count<2):
-                assert sample_len == r.execute_command("ts.add", 'test_key', sample_len, '1')
-                sample_len = sample_len + 1
-            sample_len = sample_len -1
-            res = r.execute_command('ts.range', 'test_key', 0, sample_len - 1)
-            i = 1
+            res = r.execute_command('ts.range', 'test_key', 0, 100)
+            i = 0
             for sample in res:
-                e.assertEqual(sample, [i, '1'.encode('ascii')])
+                assert sample == [i, '1'.encode('ascii')]
                 i += 1
-            assert sample_len - 1 == r.execute_command('ts.del', 'test_key', 0, sample_len - 1)
-            res = r.execute_command('ts.range', 'test_key', 0, sample_len)
-            e.assertEqual(_get_ts_info(r, 'test_key').chunk_count,1)
-            e.assertEqual(len(res), 1)
-        e.flush()
-
-def test_ts_del_with_plus():
-    e = Env()
-    with e.getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", 't{1}')
-        r.execute_command("ts.add", 't{1}', 1, 2)
-        r.execute_command("ts.add", 't{1}', 100, 10)
-        r.execute_command("ts.del", 't{1}', '-', '+')
-        res = r.execute_command("ts.range", 't{1}', '-', '+')
-        assert res == []
-
-def test_ts_del_compressed_out_range():
-    sample_len = 101
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", 'test_key')
-
-        for i in range(sample_len):
-            assert i + 100 == r.execute_command("ts.add", 'test_key', i + 100, '1')
-
-        res = r.execute_command('ts.range', 'test_key', 0 + 100, sample_len + 100 - 1)
-        i = 0
-        for sample in res:
-            assert sample == [i + 100, '1'.encode('ascii')]
-            i += 1
-        assert sample_len == r.execute_command('ts.del', 'test_key', 0, 500)
-        res = r.execute_command('ts.range', 'test_key', 0 + 100, sample_len + 100 - 1)
-        assert len(res) == 0
-
-
-def test_bad_del(self):
-    with Env().getClusterConnectionIfNeeded() as r:
-
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command("ts.del", "test_key", 100, 200)
-
-        r.execute_command("ts.add", 'test_key', 120, '1')
-        r.execute_command("ts.add", 'test_key', 140, '5')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command("ts.del", "test_key", 100)
-
-        dump = r.execute_command("dump", "test_key")
-        assert r.execute_command("restore", "test_key2", "0", dump)
-
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command("ts.del", "test_key", 100, '200a')
-
-        assert r.execute_command("ts.del", "test_key", 200, 100) == 0
-
-        assert r.execute_command("ts.del", "test_key", 100, 300) == 2
-
-        assert r.execute_command("ts.del", "test_key2", 100, 300) == 2
-
-        self.assertTrue(r.execute_command("SET", "BAD_X", "NOT_TS"))
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command("TS.DEL", "BAD_X", 100, 200)
-
-def test_del_retention_with_rules(self):
-    sample_len = 1010
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", 'test_key_2{1}', 'RETENTION', 1, 'compressed')
-        r.execute_command("ts.create", 'test_key_3{1}', 'compressed')
-        r.execute_command('ts.createrule', 'test_key_2{1}', 'test_key_3{1}', 'AGGREGATION', 'avg', 10)
-
-        for i in range(sample_len):
-            assert i == r.execute_command("ts.add", 'test_key_2{1}', i, 1)
-
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command("ts.del", "test_key_2{1}", 1, 10)
-
-        r.execute_command("ts.create", 'test_key_4{4}', 'RETENTION', 25, 'compressed')
-        r.execute_command("ts.create", 'test_key_5{4}', 'compressed')
-        r.execute_command('ts.createrule', 'test_key_4{4}', 'test_key_5{4}', 'AGGREGATION', 'avg', 10)
-
-        for i in range(30):
-            assert i == r.execute_command("ts.add", 'test_key_4{4}', i, 1)
-
-        with pytest.raises(redis.ResponseError) as excinfo:
-            r.execute_command("ts.del", "test_key_4{4}", 9, 10)
-
-
-def test_del_with_rules(self):
-    sample_len = 1010
-    e = Env()
-    with e.getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", 'test_key_2{1}', 'RETENTION', 5000, 'compressed')
-        r.execute_command("ts.create", 'test_key_3{1}', 'compressed')
-        r.execute_command('ts.createrule', 'test_key_2{1}', 'test_key_3{1}', 'AGGREGATION', 'sum', 10)
-
-        for i in range(70):
-            assert i == r.execute_command("ts.add", 'test_key_2{1}', i, 1)
-        for i in range(80, sample_len):
-            assert i == r.execute_command("ts.add", 'test_key_2{1}', i, 1)
-
-        res = r.execute_command('ts.range', 'test_key_3{1}', 0, 9)
-        e.assertEqual(len(res), 1)
-        assert res[0] == [0, b'10']
-        assert r.execute_command("ts.del", "test_key_2{1}", 0, 9) == 10
-        res = r.execute_command('ts.range', 'test_key_3{1}', 0, 9)
-        e.assertEqual(len(res), 0)
-
-        res = r.execute_command('ts.range', 'test_key_3{1}', 10, 19)
-        e.assertEqual(len(res), 1)
-        assert res[0] == [10, b'10']
-        assert r.execute_command("ts.del", "test_key_2{1}", 12, 14) == 3
-        res = r.execute_command('ts.range', 'test_key_3{1}', 10, 19)
-        e.assertEqual(len(res), 1)
-        assert res[0] == [10, b'7']
-
-        res = r.execute_command('ts.range', 'test_key_3{1}', 20, 39)
-        e.assertEqual(len(res), 2)
-        assert res == [[20, b'10'], [30, b'10']]
-        assert r.execute_command("ts.del", "test_key_2{1}", 28, 31) == 4
-        res = r.execute_command('ts.range', 'test_key_3{1}', 20, 39)
-        e.assertEqual(len(res), 2)
-        assert res == [[20, b'8'], [30, b'8']]
-
-        res = r.execute_command('ts.range', 'test_key_3{1}', 50, 89)
-        e.assertEqual(len(res), 3)
-        assert res == [[50, b'10'], [60, b'10'], [80, b'10']]
-        # Tests empty end bucket which is not the lastest bucket:
-        assert r.execute_command("ts.del", "test_key_2{1}", 58, 79) == 12
-        assert r.execute_command("ts.del", "test_key_2{1}", 80, 81) == 2
-        res = r.execute_command('ts.range', 'test_key_3{1}', 50, 89)
-        e.assertEqual(len(res), 2)
-        assert res == [[50, b'8'], [80, b'8']]
-
-        res = r.execute_command('ts.range', 'test_key_3{1}', 990, 1009)
-        e.assertEqual(len(res), 1)
-        assert res[0] == [990, b'10']
-        assert r.execute_command("ts.del", "test_key_2{1}", 995, 1002) == 8
-        res = r.execute_command('ts.range', 'test_key_3{1}', 990, 1009)
-        e.assertEqual(len(res), 1)
-        assert res == [[990, b'5']]
-        assert 1010 == r.execute_command("ts.add", 'test_key_2{1}', 1010, 1)
-        res = r.execute_command('ts.range', 'test_key_3{1}', 990, 1009)
-        e.assertEqual(len(res), 2)
-        assert res == [[990, b'5'], [1000, b'7']]
-
-        ##### delete chunk of a rule #####
-        r.execute_command("ts.create", 'test_key_{4}', 'RETENTION', 5000, 'CHUNK_SIZE', '1024', 'compressed')
-        r.execute_command("ts.create", 'test_key_{4}_agg', 'CHUNK_SIZE', '1024', 'compressed')
-        r.execute_command('ts.createrule', 'test_key_{4}', 'test_key_{4}_agg', 'AGGREGATION', 'sum', 10)
-
-        for i in range(2070):
-            assert i == r.execute_command("ts.add", 'test_key_{4}', i, 1)
-
-        res = r.execute_command('ts.range', 'test_key_{4}_agg', 1010, 2059)
-        e.assertEqual(len(res), 105)
-        assert r.execute_command("ts.del", "test_key_{4}", 1019, 2050) == 1032
-        res = r.execute_command('ts.range', 'test_key_{4}_agg', 1010, 2059)
-        e.assertEqual(len(res), 2)
-        assert res == [[1010, b'9'], [2050, b'9']]
-
-
-
-def test_del_with_rules_with_alignment(self):
-    sample_len = 1005
-    e = Env()
-    with e.getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", 'test_key_2{1}', 'RETENTION', 5000, 'compressed')
-        r.execute_command("ts.create", 'test_key_3{1}', 'compressed')
-        r.execute_command('ts.createrule', 'test_key_2{1}', 'test_key_3{1}', 'AGGREGATION', 'sum', 10, 5)
-
-        for i in range(65):
-            assert i == r.execute_command("ts.add", 'test_key_2{1}', i, 1)
-        for i in range(75, sample_len):
-            assert i == r.execute_command("ts.add", 'test_key_2{1}', i, 1)
-
-        res = r.execute_command('ts.range', 'test_key_3{1}', 0, 4)
-        e.assertEqual(len(res), 1)
-        assert res[0] == [0, b'5']
-        assert r.execute_command("ts.del", "test_key_2{1}", 0, 4) == 5
-        res = r.execute_command('ts.range', 'test_key_3{1}', 0, 4)
-        e.assertEqual(len(res), 0)
-
-        res = r.execute_command('ts.range', 'test_key_3{1}', 5, 14)
-        e.assertEqual(len(res), 1)
-        assert res[0] == [5, b'10']
-        assert r.execute_command("ts.del", "test_key_2{1}", 11, 13) == 3
-        res = r.execute_command('ts.range', 'test_key_3{1}', 5, 14)
-        e.assertEqual(len(res), 1)
-        assert res[0] == [5, b'7']
-
-        res = r.execute_command('ts.range', 'test_key_3{1}', 15, 34)
-        e.assertEqual(len(res), 2)
-        assert res == [[15, b'10'], [25, b'10']]
-        assert r.execute_command("ts.del", "test_key_2{1}", 23, 26) == 4
-        res = r.execute_command('ts.range', 'test_key_3{1}', 15, 34)
-        e.assertEqual(len(res), 2)
-        assert res == [[15, b'8'], [25, b'8']]
-
-        res = r.execute_command('ts.range', 'test_key_3{1}', 45, 84)
-        e.assertEqual(len(res), 3)
-        assert res == [[45, b'10'], [55, b'10'], [75, b'10']]
-        # Tests empty end bucket which is not the lastest bucket:
-        assert r.execute_command("ts.del", "test_key_2{1}", 53, 74) == 12
-        assert r.execute_command("ts.del", "test_key_2{1}", 75, 76) == 2
-        res = r.execute_command('ts.range', 'test_key_3{1}', 45, 84)
-        e.assertEqual(len(res), 2)
-        assert res == [[45, b'8'], [75, b'8']]
-
-        res = r.execute_command('ts.range', 'test_key_3{1}', 985, 1004)
-        e.assertEqual(len(res), 1)
-        assert res[0] == [985, b'10']
-        assert r.execute_command("ts.del", "test_key_2{1}", 990, 997) == 8
-        res = r.execute_command('ts.range', 'test_key_3{1}', 985, 1004)
-        e.assertEqual(len(res), 1)
-        assert res == [[985, b'5']]
-        assert 1005 == r.execute_command("ts.add", 'test_key_2{1}', 1005, 1)
-        res = r.execute_command('ts.range', 'test_key_3{1}', 985, 1004)
-        e.assertEqual(len(res), 2)
-        assert res == [[985, b'5'], [995, b'7']]
-
-        ##### delete chunk of a rule #####
-        r.execute_command("ts.create", 'test_key_{4}', 'RETENTION', 5000, 'CHUNK_SIZE', '1024', 'compressed')
-        r.execute_command("ts.create", 'test_key_{4}_agg', 'CHUNK_SIZE', '1024', 'compressed')
-        r.execute_command('ts.createrule', 'test_key_{4}', 'test_key_{4}_agg', 'AGGREGATION', 'sum', 10, 5)
-
-        for i in range(2070):
-            assert i == r.execute_command("ts.add", 'test_key_{4}', i, 1)
-
-        res = r.execute_command('ts.range', 'test_key_{4}_agg', 1005, 2054)
-        e.assertEqual(len(res), 105)
-        assert r.execute_command("ts.del", "test_key_{4}", 1014, 2045) == 1032
-        res = r.execute_command('ts.range', 'test_key_{4}_agg', 1005, 2054)
-        e.assertEqual(len(res), 2)
-        assert res == [[1005, b'9'], [2045, b'9']]
-
-def test_del_outside_retention_period(self):
-    e = Env()
-    t1 = 't1{1}'
-    t2 = 't2{1}'
-    t3 = 't3{1}'
-    t4 = 't4{1}'
-    t5 = 't5{1}'
-    t6 = 't6{1}'
-    with e.getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", t1, 'RETENTION', 20)
-        r.execute_command("ts.create", t2, 'RETENTION', 10)
-        r.execute_command('ts.createrule', t1, t2, 'AGGREGATION', 'sum', 10)
-
-        r.execute_command("ts.add", t1, 13, 13)
-        r.execute_command("ts.add", t1, 17, 17)
-        r.execute_command("ts.add", t1, 22, 22)
-        r.execute_command("ts.add", t1, 31, 31)
-
-
-        try:
-            res = r.execute_command("ts.del", t1, 5, 25)
-            assert False
-        except Exception as e:
-            assert str(e) == "TSDB: When a series has compactions, deleting samples or compaction buckets beyond the series retention period is not possible"
-
-        try:
-            r.execute_command("ts.del", t1, 5, 25)
-            assert False
-        except Exception as e:
-            assert str(e) == "TSDB: When a series has compactions, deleting samples or compaction buckets beyond the series retention period is not possible"
-
-
-        r.execute_command("ts.create", t3, 'RETENTION', 15)
-        r.execute_command("ts.create", t4, 'RETENTION', 10)
-        r.execute_command('ts.createrule', t3, t4, 'AGGREGATION', 'sum', 10)
-
-        r.execute_command("ts.add", t3, 13, 13)
-        r.execute_command("ts.add", t3, 19, 19)
-        r.execute_command("ts.add", t3, 22, 22)
-        r.execute_command("ts.add", t3, 30, 30)
-        try:
-            r.execute_command("ts.del", t3, 19, 25)
-            assert False
-        except Exception as e:
-            assert str(e) == "TSDB: When a series has compactions, deleting samples or compaction buckets beyond the series retention period is not possible"
-
-        r.execute_command("ts.create", t5)
-        r.execute_command("ts.create", t6)
-        r.execute_command('ts.createrule', t5, t6, 'AGGREGATION', 'sum', 10)
-
-        r.execute_command("ts.add", t5, 13, 13)
-        r.execute_command("ts.add", t5, 19, 19)
-        r.execute_command("ts.add", t5, 22, 22)
-        r.execute_command("ts.add", t5, 30, 30)
-        assert r.execute_command("ts.del", t5, 5, 30) == 4
-        assert r.execute_command("ts.range", t6, 5, 30) == []
-
-# bug: https://redislabs.atlassian.net/browse/MOD-4972
-# https://github.com/RedisTimeSeries/RedisTimeSeries/issues/1421
-def test_del_with_rules_bug_4972(self):
-    e = Env()
-    with e.getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", 't1{1}', 'compressed', 'RETENTION', 0)
-        r.execute_command("ts.create", 't2{1}', 'compressed', 'RETENTION', 0)
-        r.execute_command('ts.createrule', 't1{1}', 't2{1}', 'AGGREGATION', 'avg', 10)
-
-        r.execute_command("ts.add", 't1{1}', 1, 1)
-        r.execute_command("ts.add", 't1{1}', 3, 3)
-        r.execute_command("ts.add", 't1{1}', 11, 11)
-        r.execute_command("ts.del", 't1{1}', 10, 13)
-        res = r.execute_command('ts.range', 't1{1}', 0, 100)
-        assert res == [[1, b'1'], [3, b'3']]
-        res = r.execute_command('ts.range', 't2{1}', 0, 100)
-        assert res == []
-        r.execute_command("ts.add", 't1{1}', 22, 22)
-
-        res = r.execute_command('ts.range', 't1{1}', 0, 100)
-        assert res == [[1, b'1'], [3, b'3'], [22, b'22']]
-        res = r.execute_command('ts.range', 't2{1}', 0, 100)
-        assert res == [[0, b'2']]
-
-        r.execute_command("ts.add", 't1{1}', 24, 24)
-        r.execute_command("ts.add", 't1{1}', 30, 30)
-        r.execute_command("ts.add", 't1{1}', 40, 40)
-        res = r.execute_command('ts.range', 't1{1}', 0, 100)
-        assert res == [[1, b'1'], [3, b'3'], [22, b'22'], [24, b'24'], [30, b'30'], [40, b'40']]
-        res = r.execute_command('ts.range', 't2{1}', 0, 100)
-        assert res == [[0, b'2'], [20, b'23'], [30, b'30']]
-
-# bug: https://redislabs.atlassian.net/browse/MOD-4972
-# https://github.com/RedisTimeSeries/RedisTimeSeries/issues/1421
-def test_del_with_rules_bug_4972_2(self):
-    e = Env()
-    with e.getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", 't1{1}', 'compressed', 'RETENTION', 0)
-        r.execute_command("ts.create", 't2{1}', 'compressed', 'RETENTION', 0)
-        r.execute_command('ts.createrule', 't1{1}', 't2{1}', 'AGGREGATION', 'avg', 10)
-
-        r.execute_command("ts.add", 't1{1}', 1, 1)
-        r.execute_command("ts.add", 't1{1}', 3, 3)
-        r.execute_command("ts.del", 't1{1}', 0, 8)
-        res = r.execute_command('ts.range', 't1{1}', 0, 100)
-        assert res == []
-        res = r.execute_command('ts.range', 't2{1}', 0, 100)
-        assert res == []
-        r.execute_command("ts.add", 't1{1}', 11, 11)
-        r.execute_command("ts.add", 't1{1}', 13, 13)
-        r.execute_command("ts.add", 't1{1}', 24, 24)
-
-        res = r.execute_command('ts.range', 't1{1}', 0, 100)
-        assert res == [[11, b'11'], [13, b'13'], [24, b'24']]
-        res = r.execute_command('ts.range', 't2{1}', 0, 100)
-        assert res == [[10, b'12']]
-
-        r.execute_command("ts.add", 't1{1}', 30, 30)
-        r.execute_command("ts.add", 't1{1}', 40, 40)
-        res = r.execute_command('ts.range', 't1{1}', 0, 100)
-        assert res == [[11, b'11'], [13, b'13'], [24, b'24'], [30, b'30'], [40, b'40']]
-        res = r.execute_command('ts.range', 't2{1}', 0, 100)
-        assert res == [[10, b'12'], [20, b'24'], [30, b'30']]
-
-# bug: https://redislabs.atlassian.net/browse/MOD-4972
-# https://github.com/RedisTimeSeries/RedisTimeSeries/issues/1421
-def test_del_with_rules_bug_4972_3(self):
-    e = Env()
-    with e.getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", 't1{1}', 'compressed', 'RETENTION', 0)
-        r.execute_command("ts.create", 't2{1}', 'compressed', 'RETENTION', 0)
-        r.execute_command('ts.createrule', 't1{1}', 't2{1}', 'AGGREGATION', 'avg', 10)
-
-        r.execute_command("ts.add", 't1{1}', 1, 1)
-        r.execute_command("ts.add", 't1{1}', 3, 3)
-        r.execute_command("ts.add", 't1{1}', 11, 11)
-        r.execute_command("ts.del", 't1{1}', 2, 13)
-        res = r.execute_command('ts.range', 't1{1}', 0, 100)
-        assert res == [[1, b'1']]
-        res = r.execute_command('ts.range', 't2{1}', 0, 100)
-        assert res == []
-        r.execute_command("ts.add", 't1{1}', 22, 22)
-
-        res = r.execute_command('ts.range', 't1{1}', 0, 100)
-        assert res == [[1, b'1'], [22, b'22']]
-        res = r.execute_command('ts.range', 't2{1}', 0, 100)
-        assert res == [[0, b'1']]
-
-        r.execute_command("ts.add", 't1{1}', 24, 24)
-        r.execute_command("ts.add", 't1{1}', 30, 30)
-        r.execute_command("ts.add", 't1{1}', 40, 40)
-        res = r.execute_command('ts.range', 't1{1}', 0, 100)
-        assert res == [[1, b'1'], [22, b'22'], [24, b'24'], [30, b'30'], [40, b'40']]
-        res = r.execute_command('ts.range', 't2{1}', 0, 100)
-        assert res == [[0, b'1'], [20, b'23'], [30, b'30']]
-
-# bug: https://redislabs.atlassian.net/browse/MOD-4972
-# https://github.com/RedisTimeSeries/RedisTimeSeries/issues/1421
-def test_del_with_rules_bug_4972_4(self):
-    e = Env()
-    with e.getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", 't1{1}', 'compressed', 'RETENTION', 0)
-        r.execute_command("ts.create", 't2{1}', 'compressed', 'RETENTION', 0)
-        r.execute_command('ts.createrule', 't1{1}', 't2{1}', 'AGGREGATION', 'avg', 10)
-
-        r.execute_command("ts.add", 't1{1}', 1, 1)
-        r.execute_command("ts.add", 't1{1}', 3, 3)
-        r.execute_command("ts.add", 't1{1}', 21, 21)
-        r.execute_command("ts.del", 't1{1}', 21, 21)
-        r.execute_command("ts.add", 't1{1}', 8, 8)
-        r.execute_command("ts.add", 't1{1}', 13, 13)
-
-        res = r.execute_command('ts.range', 't1{1}', 0, 100)
-        assert res == [[1, b'1'], [3, b'3'], [8, b'8'], [13, b'13']]
-        res = r.execute_command('ts.range', 't2{1}', 0, 100)
-        assert res == [[0, b'4']]
-
-def test_del_with_rules_bug_4972_5(self):
-    e = Env(moduleArgs='DONT_ASSERT_ON_FAILIURE enable')
-    t1 = 't1{1}'
-    t2 = 't2{1}'
-    with e.getClusterConnectionIfNeeded() as r:
-        is_less_than_ver7_0_5 = is_redis_version_lower_than(r, "7.0.5", e.is_cluster())
-        if is_less_than_ver7_0_5:
-            return
-        # data was taken from test_dump_restore_dst_rule on version TS_OVERFLOW_RDB_VER
-        # the commands that used to create the data are:
-        # 127.0.0.1:6379> ts.create t1{1}
-        # OK
-        # 127.0.0.1:6379> ts.create t2{1}
-        # OK
-        # 127.0.0.1:6379> ts.createrule t1{1} t2{1} AGGREGATION avg 10
-        # OK
-        # 127.0.0.1:6379> ts.add t1{1} 5 5
-        # (integer) 5
-        # 127.0.0.1:6379> ts.add t1{1} 21 21
-        # (integer) 21
-        # 127.0.0.1:6379> ts.del t1{1} 21 21
-        # (integer) 1
-        data = b'\a\x81M \xc1\xf96\x0f\x10\a\x05\x05t1{1}\x02\x80\x00\x0fB@\x02P\x00\x02\x02\x02\x05\x04\x00\x00\x00\x00\x00\x00\x14@\x02\x01\x02\x00\x02\x00\x02\x00\x02\x01\x05\x05t2{1}\x02\n\x02\x00\x02\x04\x02\x14\x04\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x02\x01\x02P\x00\x02\x01\x02\x00\x02\x81@\x14\x00\x00\x00\x00\x00\x00\x02\x05\x02\x05\x02\x00\x02\x81@\x14\x00\x00\x00\x00\x00\x00\x02 \x02 \x05\xc36P\x00\x01\x00\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0{\x00\x01\x00\x00\x00\n\x00~\x12a\xa1V\xb1ep'
-        r.execute_command('restore', t1, 0, data)
-        data = b'\a\x81M \xc1\xf96\x0f\x10\a\x05\x05t2{1}\x02\x80\x00\x0fB@\x02P\x00\x02\x02\x02\x00\x04\x00\x00\x00\x00\x00\x00\x14@\x02\x01\x02\x00\x02\x01\x05\x05t1{1}\x02\x00\x02\x00\x02\x01\x02P\x00\x02\x01\x02\x00\x02\x81@\x14\x00\x00\x00\x00\x00\x00\x02\x00\x02\x00\x02\x00\x02\x81@\x14\x00\x00\x00\x00\x00\x00\x02 \x02 \x05\xc36P\x00\x01\x00\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0{\x00\x01\x00\x00\x00\n\x00}\xbfP[\xc1A\x84t'
-        r.execute_command('restore', t2, 0, data)
-        r.execute_command('ts.add', t1, 31, 31)
-        res = r.execute_command('ts.range', t1, '-', '+')
-        assert res == [[5, b'5'], [31, b'31']]
-        r.execute_command('ts.range', t2, '-', '+')
-        assert res == [[5, b'5'], [31, b'31']]
-
-def test_del_with_rules_bug_4972_6(self):
-    e = Env(moduleArgs='DONT_ASSERT_ON_FAILIURE enable')
-    t1 = 't1{1}'
-    t2 = 't2{1}'
-    with e.getClusterConnectionIfNeeded() as r:
-        is_less_than_ver7_0_5 = is_redis_version_lower_than(r, "7.0.5", e.is_cluster())
-        if is_less_than_ver7_0_5:
-            return
-        # data was taken from test_dump_restore_dst_rule on version TS_OVERFLOW_RDB_VER
-        # the commands that used to create the data are:
-        # 127.0.0.1:6379> ts.create t1{1}
-        # OK
-        # 127.0.0.1:6379> ts.create t2{1}
-        # OK
-        # 127.0.0.1:6379> ts.createrule t1{1} t2{1} AGGREGATION avg 10
-        # OK
-        # 127.0.0.1:6379> ts.add t1{1} 5 5
-        # (integer) 5
-        # 127.0.0.1:6379> ts.add t1{1} 21 21
-        # (integer) 21
-        # 127.0.0.1:6379> ts.del t1{1} 21 21
-        # (integer) 1
-        data = b'\a\x81M \xc1\xf96\x0f\x10\a\x05\x05t1{1}\x02\x80\x00\x0fB@\x02P\x00\x02\x02\x02\x05\x04\x00\x00\x00\x00\x00\x00\x14@\x02\x01\x02\x00\x02\x00\x02\x00\x02\x01\x05\x05t2{1}\x02\n\x02\x00\x02\x04\x02\x14\x04\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x02\x01\x02P\x00\x02\x01\x02\x00\x02\x81@\x14\x00\x00\x00\x00\x00\x00\x02\x05\x02\x05\x02\x00\x02\x81@\x14\x00\x00\x00\x00\x00\x00\x02 \x02 \x05\xc36P\x00\x01\x00\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0{\x00\x01\x00\x00\x00\n\x00~\x12a\xa1V\xb1ep'
-        r.execute_command('restore', t1, 0, data)
-        data = b'\a\x81M \xc1\xf96\x0f\x10\a\x05\x05t2{1}\x02\x80\x00\x0fB@\x02P\x00\x02\x02\x02\x00\x04\x00\x00\x00\x00\x00\x00\x14@\x02\x01\x02\x00\x02\x01\x05\x05t1{1}\x02\x00\x02\x00\x02\x01\x02P\x00\x02\x01\x02\x00\x02\x81@\x14\x00\x00\x00\x00\x00\x00\x02\x00\x02\x00\x02\x00\x02\x81@\x14\x00\x00\x00\x00\x00\x00\x02 \x02 \x05\xc36P\x00\x01\x00\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0{\x00\x01\x00\x00\x00\n\x00}\xbfP[\xc1A\x84t'
-        r.execute_command('restore', t2, 0, data)
-        r.execute_command('ts.add', t1, 7, 7)
-        r.execute_command('ts.add', t1, 19, 19)
-        res = r.execute_command('ts.range', t1, '-', '+')
-        assert res == [[5, b'5'], [7, b'7'], [19, b'19']]
-        res = r.execute_command('ts.range', t2, '-', '+')
-
-
-def test_ts_delete_with_rule_when_latest_timebucket_deleted(self):
-    with Env().getClusterConnectionIfNeeded() as r:
-        # Use a tag to make sure the samples and compacted keys have the same hashslot
-        # (otherwise the oss-cluster test will complain)
-        r.execute_command("TS.CREATE", "samples{tag}")
-        r.execute_command("TS.CREATE", "compacted{tag}")
-        r.execute_command("TS.CREATERULE", "samples{tag}", "compacted{tag}", "AGGREGATION", "avg", 1000)
-
-        r.execute_command("TS.ADD", "samples{tag}", 1000, 17)
-        r.execute_command("TS.ADD", "samples{tag}", 2000, 19)
-        r.execute_command("TS.ADD", "samples{tag}", 3000, 23)
-
-        # Now delete the sample in the latest time-bucket
-        r.execute_command("TS.DEL", "samples{tag}", 3000, 3000)
-
+            r.execute_command('ts.del', 'test_key', 0, 100)
+            res = r.execute_command('ts.range', 'test_key', 0, 100)
+            assert len(res) == 0
+
+    def test_ts_del_first_sample_in_chunk(self):
+        # bug https://github.com/RedisTimeSeries/RedisTimeSeries/issues/1176
+        _from = 1
+        _to = 300
+        del_from = 101
+        del_to = 258
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", 't1{1}', 'uncompressed', "DUPLICATE_POLICY", "LAST")
+            for i in range(_from, _to + 1):
+                r.execute_command("ts.add", 't1{1}', i, random.uniform(0, 1))
+            range1 = r.execute_command("ts.range", 't1{1}', '-', '+')
+            assert r.execute_command("ts.del", 't1{1}', del_from, del_to)
+            add_str = []
+            add_str.append("ts.madd")
+            for i in range(_from, del_to + 1):
+                add_str.append("t1{1}")
+                add_str.append(str(i))
+                add_str.append(str(random.uniform(0, 1)))
+            assert r.execute_command(*add_str)
+            range2 = r.execute_command("ts.range", 't1{1}', '-', '+')
+            assert len(range2) == len(range1)
+
+    def test_ts_del_last_chunk(self):
+        _from = 1
+        _to = 500
+        del_from = 101
+        del_to = 500
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', 't1{1}', 'compressed', 'CHUNK_SIZE', '128')
+            for i in range(_from, _to + 1):
+                r.execute_command("ts.add", 't1{1}', i, random.uniform(0, 1))
+            info = TSInfo(r.execute_command("ts.info", 't1{1}', 'DEBUG'))
+            n_chunks = len(info.chunks)
+            assert n_chunks > 1
+            assert r.execute_command("ts.del", 't1{1}', del_from, del_to)
+            info = TSInfo(r.execute_command("ts.info", 't1{1}', 'DEBUG'))
+            assert len(info.chunks) < n_chunks
+            assert len(info.chunks) > 1
+            res = r.execute_command("ts.get", 't1{1}')
+            assert res[0] == del_from - 1
+            res = r.execute_command("ts.range", 't1{1}', '-', '+')
+            assert res[len(res) - 1][0] == del_from - 1
+            assert r.execute_command("ts.del", 't1{1}', 0, del_from - 1)
+            info = TSInfo(r.execute_command("ts.info", 't1{1}', 'DEBUG'))
+            assert len(info.chunks) == 1
+            r.execute_command("ts.add", 't1{1}', 5, random.uniform(0, 1))
+            res = r.execute_command("ts.get", 't1{1}')
+            assert res[0] == 5
+            res = r.execute_command("ts.range", 't1{1}', '-', '+')
+            assert len(res) == 1
+            assert res[len(res) - 1][0] == 5
+
+    def test_ts_del_last_sample_in_series(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", 't1{1}', "DUPLICATE_POLICY", "LAST")
+            assert r.execute_command("ts.get", 't1{1}') == []
+            assert r.execute_command("ts.del", 't1{1}', '0', '10') == 0
+            assert r.execute_command("ts.get", 't1{1}') == []
+            r.execute_command("ts.add", 't1{1}', 1, 2)
+            r.execute_command("ts.add", 't1{1}', 5, 10)
+            assert r.execute_command("ts.del", 't1{1}', '5', '5')
+            assert r.execute_command("ts.get", 't1{1}') == [1, b'2']
+            assert r.execute_command("ts.del", 't1{1}', '1', '1')
+            assert r.execute_command("ts.get", 't1{1}') == []
+
+    def test_ts_del_uncompressed_in_range(self):
+        sample_len = 101
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", 'test_key', 'uncompressed')
+
+            for i in range(sample_len):
+                assert i == r.execute_command("ts.add", 'test_key', i, '1')
+
+            res = r.execute_command('ts.range', 'test_key', 0, 100)
+            i = 0
+            for sample in res:
+                assert sample == [i, '1'.encode('ascii')]
+                i += 1
+            # delete 11 samples
+            assert 11 == r.execute_command('ts.del', 'test_key', 50, 60)
+            res = r.execute_command('ts.range', 'test_key', 0, 100)
+            assert len(res) == 90
+
+    def test_ts_del_compressed(self):
+        sample_len = 101
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", 'test_key')
+
+            for i in range(sample_len):
+                assert i == r.execute_command("ts.add", 'test_key', i, '1')
+
+            res = r.execute_command('ts.range', 'test_key', 0, 100)
+            i = 0
+            for sample in res:
+                assert sample == [i, '1'.encode('ascii')]
+                i += 1
+            assert sample_len == r.execute_command('ts.del', 'test_key', 0, 100)
+            res = r.execute_command('ts.range', 'test_key', 0, 100)
+            assert len(res) == 0
+
+    def test_ts_del_multi_chunk(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            for CHUNK_TYPE in ["compressed", "uncompressed"]:
+                sample_len = 1
+                r.execute_command('FLUSHALL')
+                r.execute_command("ts.create", 'test_key', CHUNK_TYPE)
+                while _get_ts_info(r, 'test_key').chunk_count < 2:
+                    assert sample_len == r.execute_command("ts.add", 'test_key', sample_len, '1')
+                    sample_len = sample_len + 1
+                sample_len = sample_len - 1
+                res = r.execute_command('ts.range', 'test_key', 0, sample_len - 1)
+                i = 1
+                for sample in res:
+                    env.assertEqual(sample, [i, '1'.encode('ascii')])
+                    i += 1
+                assert sample_len - 1 == r.execute_command('ts.del', 'test_key', 0, sample_len - 1)
+                res = r.execute_command('ts.range', 'test_key', 0, sample_len)
+                env.assertEqual(_get_ts_info(r, 'test_key').chunk_count, 1)
+                env.assertEqual(len(res), 1)
+
+    def test_ts_del_with_plus(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", 't{1}')
+            r.execute_command("ts.add", 't{1}', 1, 2)
+            r.execute_command("ts.add", 't{1}', 100, 10)
+            r.execute_command("ts.del", 't{1}', '-', '+')
+            res = r.execute_command("ts.range", 't{1}', '-', '+')
+            assert res == []
+
+    def test_ts_del_compressed_out_range(self):
+        sample_len = 101
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", 'test_key')
+
+            for i in range(sample_len):
+                assert i + 100 == r.execute_command("ts.add", 'test_key', i + 100, '1')
+
+            res = r.execute_command('ts.range', 'test_key', 0 + 100, sample_len + 100 - 1)
+            i = 0
+            for sample in res:
+                assert sample == [i + 100, '1'.encode('ascii')]
+                i += 1
+            assert sample_len == r.execute_command('ts.del', 'test_key', 0, 500)
+            res = r.execute_command('ts.range', 'test_key', 0 + 100, sample_len + 100 - 1)
+            assert len(res) == 0
+
+    def test_bad_del(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command("ts.del", "test_key", 100, 200)
+
+            r.execute_command("ts.add", 'test_key', 120, '1')
+            r.execute_command("ts.add", 'test_key', 140, '5')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command("ts.del", "test_key", 100)
+
+            dump = r.execute_command("dump", "test_key")
+            assert r.execute_command("restore", "test_key2", "0", dump)
+
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command("ts.del", "test_key", 100, '200a')
+
+            assert r.execute_command("ts.del", "test_key", 200, 100) == 0
+            assert r.execute_command("ts.del", "test_key", 100, 300) == 2
+            assert r.execute_command("ts.del", "test_key2", 100, 300) == 2
+
+            env.assertTrue(r.execute_command("SET", "BAD_X", "NOT_TS"))
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command("TS.DEL", "BAD_X", 100, 200)
+
+    def test_del_retention_with_rules(self):
+        sample_len = 1010
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", 'test_key_2{1}', 'RETENTION', 1, 'compressed')
+            r.execute_command("ts.create", 'test_key_3{1}', 'compressed')
+            r.execute_command('ts.createrule', 'test_key_2{1}', 'test_key_3{1}', 'AGGREGATION', 'avg', 10)
+
+            for i in range(sample_len):
+                assert i == r.execute_command("ts.add", 'test_key_2{1}', i, 1)
+
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command("ts.del", "test_key_2{1}", 1, 10)
+
+            r.execute_command("ts.create", 'test_key_4{4}', 'RETENTION', 25, 'compressed')
+            r.execute_command("ts.create", 'test_key_5{4}', 'compressed')
+            r.execute_command('ts.createrule', 'test_key_4{4}', 'test_key_5{4}', 'AGGREGATION', 'avg', 10)
+
+            for i in range(30):
+                assert i == r.execute_command("ts.add", 'test_key_4{4}', i, 1)
+
+            with pytest.raises(redis.ResponseError) as excinfo:
+                r.execute_command("ts.del", "test_key_4{4}", 9, 10)
+
+    def test_del_with_rules(self):
+        sample_len = 1010
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", 'test_key_2{1}', 'RETENTION', 5000, 'compressed')
+            r.execute_command("ts.create", 'test_key_3{1}', 'compressed')
+            r.execute_command('ts.createrule', 'test_key_2{1}', 'test_key_3{1}', 'AGGREGATION', 'sum', 10)
+
+            for i in range(70):
+                assert i == r.execute_command("ts.add", 'test_key_2{1}', i, 1)
+            for i in range(80, sample_len):
+                assert i == r.execute_command("ts.add", 'test_key_2{1}', i, 1)
+
+            res = r.execute_command('ts.range', 'test_key_3{1}', 0, 9)
+            env.assertEqual(len(res), 1)
+            assert res[0] == [0, b'10']
+            assert r.execute_command("ts.del", "test_key_2{1}", 0, 9) == 10
+            res = r.execute_command('ts.range', 'test_key_3{1}', 0, 9)
+            env.assertEqual(len(res), 0)
+
+            res = r.execute_command('ts.range', 'test_key_3{1}', 10, 19)
+            env.assertEqual(len(res), 1)
+            assert res[0] == [10, b'10']
+            assert r.execute_command("ts.del", "test_key_2{1}", 12, 14) == 3
+            res = r.execute_command('ts.range', 'test_key_3{1}', 10, 19)
+            env.assertEqual(len(res), 1)
+            assert res[0] == [10, b'7']
+
+            res = r.execute_command('ts.range', 'test_key_3{1}', 20, 39)
+            env.assertEqual(len(res), 2)
+            assert res == [[20, b'10'], [30, b'10']]
+            assert r.execute_command("ts.del", "test_key_2{1}", 28, 31) == 4
+            res = r.execute_command('ts.range', 'test_key_3{1}', 20, 39)
+            env.assertEqual(len(res), 2)
+            assert res == [[20, b'8'], [30, b'8']]
+
+            res = r.execute_command('ts.range', 'test_key_3{1}', 50, 89)
+            env.assertEqual(len(res), 3)
+            assert res == [[50, b'10'], [60, b'10'], [80, b'10']]
+            # Tests empty end bucket which is not the lastest bucket:
+            assert r.execute_command("ts.del", "test_key_2{1}", 58, 79) == 12
+            assert r.execute_command("ts.del", "test_key_2{1}", 80, 81) == 2
+            res = r.execute_command('ts.range', 'test_key_3{1}', 50, 89)
+            env.assertEqual(len(res), 2)
+            assert res == [[50, b'8'], [80, b'8']]
+
+            res = r.execute_command('ts.range', 'test_key_3{1}', 990, 1009)
+            env.assertEqual(len(res), 1)
+            assert res[0] == [990, b'10']
+            assert r.execute_command("ts.del", "test_key_2{1}", 995, 1002) == 8
+            res = r.execute_command('ts.range', 'test_key_3{1}', 990, 1009)
+            env.assertEqual(len(res), 1)
+            assert res == [[990, b'5']]
+            assert 1010 == r.execute_command("ts.add", 'test_key_2{1}', 1010, 1)
+            res = r.execute_command('ts.range', 'test_key_3{1}', 990, 1009)
+            env.assertEqual(len(res), 2)
+            assert res == [[990, b'5'], [1000, b'7']]
+
+            ##### delete chunk of a rule #####
+            r.execute_command("ts.create", 'test_key_{4}', 'RETENTION', 5000, 'CHUNK_SIZE', '1024', 'compressed')
+            r.execute_command("ts.create", 'test_key_{4}_agg', 'CHUNK_SIZE', '1024', 'compressed')
+            r.execute_command('ts.createrule', 'test_key_{4}', 'test_key_{4}_agg', 'AGGREGATION', 'sum', 10)
+
+            for i in range(2070):
+                assert i == r.execute_command("ts.add", 'test_key_{4}', i, 1)
+
+            res = r.execute_command('ts.range', 'test_key_{4}_agg', 1010, 2059)
+            env.assertEqual(len(res), 105)
+            assert r.execute_command("ts.del", "test_key_{4}", 1019, 2050) == 1032
+            res = r.execute_command('ts.range', 'test_key_{4}_agg', 1010, 2059)
+            env.assertEqual(len(res), 2)
+            assert res == [[1010, b'9'], [2050, b'9']]
+
+    def test_del_with_rules_with_alignment(self):
+        sample_len = 1005
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", 'test_key_2{1}', 'RETENTION', 5000, 'compressed')
+            r.execute_command("ts.create", 'test_key_3{1}', 'compressed')
+            r.execute_command('ts.createrule', 'test_key_2{1}', 'test_key_3{1}', 'AGGREGATION', 'sum', 10, 5)
+
+            for i in range(65):
+                assert i == r.execute_command("ts.add", 'test_key_2{1}', i, 1)
+            for i in range(75, sample_len):
+                assert i == r.execute_command("ts.add", 'test_key_2{1}', i, 1)
+
+            res = r.execute_command('ts.range', 'test_key_3{1}', 0, 4)
+            env.assertEqual(len(res), 1)
+            assert res[0] == [0, b'5']
+            assert r.execute_command("ts.del", "test_key_2{1}", 0, 4) == 5
+            res = r.execute_command('ts.range', 'test_key_3{1}', 0, 4)
+            env.assertEqual(len(res), 0)
+
+            res = r.execute_command('ts.range', 'test_key_3{1}', 5, 14)
+            env.assertEqual(len(res), 1)
+            assert res[0] == [5, b'10']
+            assert r.execute_command("ts.del", "test_key_2{1}", 11, 13) == 3
+            res = r.execute_command('ts.range', 'test_key_3{1}', 5, 14)
+            env.assertEqual(len(res), 1)
+            assert res[0] == [5, b'7']
+
+            res = r.execute_command('ts.range', 'test_key_3{1}', 15, 34)
+            env.assertEqual(len(res), 2)
+            assert res == [[15, b'10'], [25, b'10']]
+            assert r.execute_command("ts.del", "test_key_2{1}", 23, 26) == 4
+            res = r.execute_command('ts.range', 'test_key_3{1}', 15, 34)
+            env.assertEqual(len(res), 2)
+            assert res == [[15, b'8'], [25, b'8']]
+
+            res = r.execute_command('ts.range', 'test_key_3{1}', 45, 84)
+            env.assertEqual(len(res), 3)
+            assert res == [[45, b'10'], [55, b'10'], [75, b'10']]
+            # Tests empty end bucket which is not the lastest bucket:
+            assert r.execute_command("ts.del", "test_key_2{1}", 53, 74) == 12
+            assert r.execute_command("ts.del", "test_key_2{1}", 75, 76) == 2
+            res = r.execute_command('ts.range', 'test_key_3{1}', 45, 84)
+            env.assertEqual(len(res), 2)
+            assert res == [[45, b'8'], [75, b'8']]
+
+            res = r.execute_command('ts.range', 'test_key_3{1}', 985, 1004)
+            env.assertEqual(len(res), 1)
+            assert res[0] == [985, b'10']
+            assert r.execute_command("ts.del", "test_key_2{1}", 990, 997) == 8
+            res = r.execute_command('ts.range', 'test_key_3{1}', 985, 1004)
+            env.assertEqual(len(res), 1)
+            assert res == [[985, b'5']]
+            assert 1005 == r.execute_command("ts.add", 'test_key_2{1}', 1005, 1)
+            res = r.execute_command('ts.range', 'test_key_3{1}', 985, 1004)
+            env.assertEqual(len(res), 2)
+            assert res == [[985, b'5'], [995, b'7']]
+
+            ##### delete chunk of a rule #####
+            r.execute_command("ts.create", 'test_key_{4}', 'RETENTION', 5000, 'CHUNK_SIZE', '1024', 'compressed')
+            r.execute_command("ts.create", 'test_key_{4}_agg', 'CHUNK_SIZE', '1024', 'compressed')
+            r.execute_command('ts.createrule', 'test_key_{4}', 'test_key_{4}_agg', 'AGGREGATION', 'sum', 10, 5)
+
+            for i in range(2070):
+                assert i == r.execute_command("ts.add", 'test_key_{4}', i, 1)
+
+            res = r.execute_command('ts.range', 'test_key_{4}_agg', 1005, 2054)
+            env.assertEqual(len(res), 105)
+            assert r.execute_command("ts.del", "test_key_{4}", 1014, 2045) == 1032
+            res = r.execute_command('ts.range', 'test_key_{4}_agg', 1005, 2054)
+            env.assertEqual(len(res), 2)
+            assert res == [[1005, b'9'], [2045, b'9']]
+
+    def test_del_outside_retention_period(self):
+        env = self.env
+        env.flush()
+        t1 = 't1{1}'
+        t2 = 't2{1}'
+        t3 = 't3{1}'
+        t4 = 't4{1}'
+        t5 = 't5{1}'
+        t6 = 't6{1}'
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", t1, 'RETENTION', 20)
+            r.execute_command("ts.create", t2, 'RETENTION', 10)
+            r.execute_command('ts.createrule', t1, t2, 'AGGREGATION', 'sum', 10)
+
+            r.execute_command("ts.add", t1, 13, 13)
+            r.execute_command("ts.add", t1, 17, 17)
+            r.execute_command("ts.add", t1, 22, 22)
+            r.execute_command("ts.add", t1, 31, 31)
+
+            try:
+                res = r.execute_command("ts.del", t1, 5, 25)
+                assert False
+            except Exception as ex:
+                assert str(ex) == "TSDB: When a series has compactions, deleting samples or compaction buckets beyond the series retention period is not possible"
+
+            try:
+                r.execute_command("ts.del", t1, 5, 25)
+                assert False
+            except Exception as ex:
+                assert str(ex) == "TSDB: When a series has compactions, deleting samples or compaction buckets beyond the series retention period is not possible"
+
+            r.execute_command("ts.create", t3, 'RETENTION', 15)
+            r.execute_command("ts.create", t4, 'RETENTION', 10)
+            r.execute_command('ts.createrule', t3, t4, 'AGGREGATION', 'sum', 10)
+
+            r.execute_command("ts.add", t3, 13, 13)
+            r.execute_command("ts.add", t3, 19, 19)
+            r.execute_command("ts.add", t3, 22, 22)
+            r.execute_command("ts.add", t3, 30, 30)
+            try:
+                r.execute_command("ts.del", t3, 19, 25)
+                assert False
+            except Exception as ex:
+                assert str(ex) == "TSDB: When a series has compactions, deleting samples or compaction buckets beyond the series retention period is not possible"
+
+            r.execute_command("ts.create", t5)
+            r.execute_command("ts.create", t6)
+            r.execute_command('ts.createrule', t5, t6, 'AGGREGATION', 'sum', 10)
+
+            r.execute_command("ts.add", t5, 13, 13)
+            r.execute_command("ts.add", t5, 19, 19)
+            r.execute_command("ts.add", t5, 22, 22)
+            r.execute_command("ts.add", t5, 30, 30)
+            assert r.execute_command("ts.del", t5, 5, 30) == 4
+            assert r.execute_command("ts.range", t6, 5, 30) == []
+
+    # bug: https://redislabs.atlassian.net/browse/MOD-4972
+    # https://github.com/RedisTimeSeries/RedisTimeSeries/issues/1421
+    def test_del_with_rules_bug_4972(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", 't1{1}', 'compressed', 'RETENTION', 0)
+            r.execute_command("ts.create", 't2{1}', 'compressed', 'RETENTION', 0)
+            r.execute_command('ts.createrule', 't1{1}', 't2{1}', 'AGGREGATION', 'avg', 10)
+
+            r.execute_command("ts.add", 't1{1}', 1, 1)
+            r.execute_command("ts.add", 't1{1}', 3, 3)
+            r.execute_command("ts.add", 't1{1}', 11, 11)
+            r.execute_command("ts.del", 't1{1}', 10, 13)
+            res = r.execute_command('ts.range', 't1{1}', 0, 100)
+            assert res == [[1, b'1'], [3, b'3']]
+            res = r.execute_command('ts.range', 't2{1}', 0, 100)
+            assert res == []
+            r.execute_command("ts.add", 't1{1}', 22, 22)
+
+            res = r.execute_command('ts.range', 't1{1}', 0, 100)
+            assert res == [[1, b'1'], [3, b'3'], [22, b'22']]
+            res = r.execute_command('ts.range', 't2{1}', 0, 100)
+            assert res == [[0, b'2']]
+
+            r.execute_command("ts.add", 't1{1}', 24, 24)
+            r.execute_command("ts.add", 't1{1}', 30, 30)
+            r.execute_command("ts.add", 't1{1}', 40, 40)
+            res = r.execute_command('ts.range', 't1{1}', 0, 100)
+            assert res == [[1, b'1'], [3, b'3'], [22, b'22'], [24, b'24'], [30, b'30'], [40, b'40']]
+            res = r.execute_command('ts.range', 't2{1}', 0, 100)
+            assert res == [[0, b'2'], [20, b'23'], [30, b'30']]
+
+    def test_del_with_rules_bug_4972_2(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", 't1{1}', 'compressed', 'RETENTION', 0)
+            r.execute_command("ts.create", 't2{1}', 'compressed', 'RETENTION', 0)
+            r.execute_command('ts.createrule', 't1{1}', 't2{1}', 'AGGREGATION', 'avg', 10)
+
+            r.execute_command("ts.add", 't1{1}', 1, 1)
+            r.execute_command("ts.add", 't1{1}', 3, 3)
+            r.execute_command("ts.del", 't1{1}', 0, 8)
+            res = r.execute_command('ts.range', 't1{1}', 0, 100)
+            assert res == []
+            res = r.execute_command('ts.range', 't2{1}', 0, 100)
+            assert res == []
+            r.execute_command("ts.add", 't1{1}', 11, 11)
+            r.execute_command("ts.add", 't1{1}', 13, 13)
+            r.execute_command("ts.add", 't1{1}', 24, 24)
+
+            res = r.execute_command('ts.range', 't1{1}', 0, 100)
+            assert res == [[11, b'11'], [13, b'13'], [24, b'24']]
+            res = r.execute_command('ts.range', 't2{1}', 0, 100)
+            assert res == [[10, b'12']]
+
+            r.execute_command("ts.add", 't1{1}', 30, 30)
+            r.execute_command("ts.add", 't1{1}', 40, 40)
+            res = r.execute_command('ts.range', 't1{1}', 0, 100)
+            assert res == [[11, b'11'], [13, b'13'], [24, b'24'], [30, b'30'], [40, b'40']]
+            res = r.execute_command('ts.range', 't2{1}', 0, 100)
+            assert res == [[10, b'12'], [20, b'24'], [30, b'30']]
+
+    def test_del_with_rules_bug_4972_3(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", 't1{1}', 'compressed', 'RETENTION', 0)
+            r.execute_command("ts.create", 't2{1}', 'compressed', 'RETENTION', 0)
+            r.execute_command('ts.createrule', 't1{1}', 't2{1}', 'AGGREGATION', 'avg', 10)
+
+            r.execute_command("ts.add", 't1{1}', 1, 1)
+            r.execute_command("ts.add", 't1{1}', 3, 3)
+            r.execute_command("ts.add", 't1{1}', 11, 11)
+            r.execute_command("ts.del", 't1{1}', 2, 13)
+            res = r.execute_command('ts.range', 't1{1}', 0, 100)
+            assert res == [[1, b'1']]
+            res = r.execute_command('ts.range', 't2{1}', 0, 100)
+            assert res == []
+            r.execute_command("ts.add", 't1{1}', 22, 22)
+
+            res = r.execute_command('ts.range', 't1{1}', 0, 100)
+            assert res == [[1, b'1'], [22, b'22']]
+            res = r.execute_command('ts.range', 't2{1}', 0, 100)
+            assert res == [[0, b'1']]
+
+            r.execute_command("ts.add", 't1{1}', 24, 24)
+            r.execute_command("ts.add", 't1{1}', 30, 30)
+            r.execute_command("ts.add", 't1{1}', 40, 40)
+            res = r.execute_command('ts.range', 't1{1}', 0, 100)
+            assert res == [[1, b'1'], [22, b'22'], [24, b'24'], [30, b'30'], [40, b'40']]
+            res = r.execute_command('ts.range', 't2{1}', 0, 100)
+            assert res == [[0, b'1'], [20, b'23'], [30, b'30']]
+
+    def test_del_with_rules_bug_4972_4(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", 't1{1}', 'compressed', 'RETENTION', 0)
+            r.execute_command("ts.create", 't2{1}', 'compressed', 'RETENTION', 0)
+            r.execute_command('ts.createrule', 't1{1}', 't2{1}', 'AGGREGATION', 'avg', 10)
+
+            r.execute_command("ts.add", 't1{1}', 1, 1)
+            r.execute_command("ts.add", 't1{1}', 3, 3)
+            r.execute_command("ts.add", 't1{1}', 21, 21)
+            r.execute_command("ts.del", 't1{1}', 21, 21)
+            r.execute_command("ts.add", 't1{1}', 8, 8)
+            r.execute_command("ts.add", 't1{1}', 13, 13)
+
+            res = r.execute_command('ts.range', 't1{1}', 0, 100)
+            assert res == [[1, b'1'], [3, b'3'], [8, b'8'], [13, b'13']]
+            res = r.execute_command('ts.range', 't2{1}', 0, 100)
+            assert res == [[0, b'4']]
+
+    def test_ts_delete_with_rule_when_latest_timebucket_deleted(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            # Use a tag to make sure the samples and compacted keys have the same hashslot
+            # (otherwise the oss-cluster test will complain)
+            r.execute_command("TS.CREATE", "samples{tag}")
+            r.execute_command("TS.CREATE", "compacted{tag}")
+            r.execute_command("TS.CREATERULE", "samples{tag}", "compacted{tag}", "AGGREGATION", "avg", 1000)
+
+            r.execute_command("TS.ADD", "samples{tag}", 1000, 17)
+            r.execute_command("TS.ADD", "samples{tag}", 2000, 19)
+            r.execute_command("TS.ADD", "samples{tag}", 3000, 23)
+
+            # Now delete the sample in the latest time-bucket
+            r.execute_command("TS.DEL", "samples{tag}", 3000, 3000)
+
+
+class testTsDeleteDontAssert:
+    def __init__(self):
+        self.env = Env(moduleArgs='DONT_ASSERT_ON_FAILIURE enable')
+
+    # bug: https://redislabs.atlassian.net/browse/MOD-4972
+    # https://github.com/RedisTimeSeries/RedisTimeSeries/issues/1421
+    def test_del_with_rules_bug_4972_5(self):
+        env = self.env
+        env.flush()
+        t1 = 't1{1}'
+        t2 = 't2{1}'
+        with env.getClusterConnectionIfNeeded() as r:
+            is_less_than_ver7_0_5 = is_redis_version_lower_than(r, "7.0.5", env.is_cluster())
+            if is_less_than_ver7_0_5:
+                return
+            data = b'\a\x81M \xc1\xf96\x0f\x10\a\x05\x05t1{1}\x02\x80\x00\x0fB@\x02P\x00\x02\x02\x02\x05\x04\x00\x00\x00\x00\x00\x00\x14@\x02\x01\x02\x00\x02\x00\x02\x00\x02\x01\x05\x05t2{1}\x02\n\x02\x00\x02\x04\x02\x14\x04\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x02\x01\x02P\x00\x02\x01\x02\x00\x02\x81@\x14\x00\x00\x00\x00\x00\x00\x02\x05\x02\x05\x02\x00\x02\x81@\x14\x00\x00\x00\x00\x00\x00\x02 \x02 \x05\xc36P\x00\x01\x00\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0{\x00\x01\x00\x00\x00\n\x00~\x12a\xa1V\xb1ep'
+            r.execute_command('restore', t1, 0, data)
+            data = b'\a\x81M \xc1\xf96\x0f\x10\a\x05\x05t2{1}\x02\x80\x00\x0fB@\x02P\x00\x02\x02\x02\x00\x04\x00\x00\x00\x00\x00\x00\x14@\x02\x01\x02\x00\x02\x01\x05\x05t1{1}\x02\x00\x02\x00\x02\x01\x02P\x00\x02\x01\x02\x00\x02\x81@\x14\x00\x00\x00\x00\x00\x00\x02\x00\x02\x00\x02\x00\x02\x81@\x14\x00\x00\x00\x00\x00\x00\x02 \x02 \x05\xc36P\x00\x01\x00\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0{\x00\x01\x00\x00\x00\n\x00}\xbfP[\xc1A\x84t'
+            r.execute_command('restore', t2, 0, data)
+            r.execute_command('ts.add', t1, 31, 31)
+            res = r.execute_command('ts.range', t1, '-', '+')
+            assert res == [[5, b'5'], [31, b'31']]
+            r.execute_command('ts.range', t2, '-', '+')
+            assert res == [[5, b'5'], [31, b'31']]
+
+    def test_del_with_rules_bug_4972_6(self):
+        env = self.env
+        env.flush()
+        t1 = 't1{1}'
+        t2 = 't2{1}'
+        with env.getClusterConnectionIfNeeded() as r:
+            is_less_than_ver7_0_5 = is_redis_version_lower_than(r, "7.0.5", env.is_cluster())
+            if is_less_than_ver7_0_5:
+                return
+            data = b'\a\x81M \xc1\xf96\x0f\x10\a\x05\x05t1{1}\x02\x80\x00\x0fB@\x02P\x00\x02\x02\x02\x05\x04\x00\x00\x00\x00\x00\x00\x14@\x02\x01\x02\x00\x02\x00\x02\x00\x02\x01\x05\x05t2{1}\x02\n\x02\x00\x02\x04\x02\x14\x04\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x02\x01\x02P\x00\x02\x01\x02\x00\x02\x81@\x14\x00\x00\x00\x00\x00\x00\x02\x05\x02\x05\x02\x00\x02\x81@\x14\x00\x00\x00\x00\x00\x00\x02 \x02 \x05\xc36P\x00\x01\x00\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0{\x00\x01\x00\x00\x00\n\x00~\x12a\xa1V\xb1ep'
+            r.execute_command('restore', t1, 0, data)
+            data = b'\a\x81M \xc1\xf96\x0f\x10\a\x05\x05t2{1}\x02\x80\x00\x0fB@\x02P\x00\x02\x02\x02\x00\x04\x00\x00\x00\x00\x00\x00\x14@\x02\x01\x02\x00\x02\x01\x05\x05t1{1}\x02\x00\x02\x00\x02\x01\x02P\x00\x02\x01\x02\x00\x02\x81@\x14\x00\x00\x00\x00\x00\x00\x02\x00\x02\x00\x02\x00\x02\x81@\x14\x00\x00\x00\x00\x00\x00\x02 \x02 \x05\xc36P\x00\x01\x00\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0\xff\x00\xe0{\x00\x01\x00\x00\x00\n\x00}\xbfP[\xc1A\x84t'
+            r.execute_command('restore', t2, 0, data)
+            r.execute_command('ts.add', t1, 7, 7)
+            r.execute_command('ts.add', t1, 19, 19)
+            res = r.execute_command('ts.range', t1, '-', '+')
+            assert res == [[5, b'5'], [7, b'7'], [19, b'19']]
+            res = r.execute_command('ts.range', t2, '-', '+')

--- a/tests/flow/test_ts_keyspace.py
+++ b/tests/flow/test_ts_keyspace.py
@@ -9,142 +9,146 @@ def assert_msg(env, msg, expected_type, expected_data):
     env.assertEqual(expected_type, msg['type'])
     env.assertEqual(expected_data, msg['data'])
 
+
 # Skip all tests on cluster because for each node we will need to configure to enable keyspace and then have a dedicated
 # connection that will handle the pubsub from that specific shard since keyspace notification are not broadcasted
 # across all nodes.
 
-def test_keyspace():
-    Env().skipOnCluster()
-    Env().skipOnVersionSmaller("6.2.0")
-    skip_on_rlec()
-    sample_len = 1024
-    env = Env()
-    with env.getClusterConnectionIfNeeded() as r:
-        r.execute_command('config', 'set', 'notify-keyspace-events', 'KEA')
+class testTsKeyspace:
+    def __init__(self):
+        self.env = Env()
 
-        pubsub = r.pubsub()
-        pubsub.psubscribe('__key*')
+    def test_keyspace(self):
+        env = self.env
+        env.flush()
+        env.skipOnCluster()
+        env.skipOnVersionSmaller("6.2.0")
+        skip_on_rlec()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('config', 'set', 'notify-keyspace-events', 'KEA')
 
-        time.sleep(1)
-        env.assertEqual('psubscribe', pubsub.get_message(timeout=1)['type'])
+            pubsub = r.pubsub()
+            pubsub.psubscribe('__key*')
 
-        r.execute_command('ts.add', 'tester{2}', 100, 1.1)
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.add')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester{2}')
+            time.sleep(1)
+            env.assertEqual('psubscribe', pubsub.get_message(timeout=1)['type'])
 
-        # Test MADD generate events for each key updated
-        r.execute_command("ts.madd", 'tester{2}', "*", 10, 'test_key2{2}', 2000, 20)
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.add')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester{2}')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.add')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'test_key2{2}')
+            r.execute_command('ts.add', 'tester{2}', 100, 1.1)
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.add')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester{2}')
 
-        # Test INCRBY generate event on key
-        r.execute_command("ts.INCRBY", 'tester{2}', "100")
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.incrby')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester{2}')
+            # Test MADD generate events for each key updated
+            r.execute_command("ts.madd", 'tester{2}', "*", 10, 'test_key2{2}', 2000, 20)
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.add')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester{2}')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.add')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'test_key2{2}')
 
-        # Test DECRBY generate event on key
-        r.execute_command("ts.DECRBY", 'tester{2}', "13")
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.decrby')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester{2}')
+            # Test INCRBY generate event on key
+            r.execute_command("ts.INCRBY", 'tester{2}', "100")
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.incrby')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester{2}')
 
-        # Test DEL generate event on key
-        r.execute_command("ts.DEL", 'tester{2}', "100", "100")
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.del')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester{2}')
+            # Test DECRBY generate event on key
+            r.execute_command("ts.DECRBY", 'tester{2}', "13")
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.decrby')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester{2}')
 
-        # Test ALTER generate event on key
-        r.execute_command("ts.ALTER", 'tester{2}', "LABELS", "abc", 123)
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.alter')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester{2}')
+            # Test DEL generate event on key
+            r.execute_command("ts.DEL", 'tester{2}', "100", "100")
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.del')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester{2}')
 
-def test_keyspace_create_rules():
-    Env().skipOnCluster()
-    Env().skipOnVersionSmaller("6.2.0")
-    skip_on_rlec()
-    sample_len = 1024
-    env = Env()
-    with env.getClusterConnectionIfNeeded() as r:
-        r.execute_command('config', 'set', 'notify-keyspace-events', 'KEA')
+            # Test ALTER generate event on key
+            r.execute_command("ts.ALTER", 'tester{2}', "LABELS", "abc", 123)
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.alter')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester{2}')
 
-        pubsub = r.pubsub()
-        pubsub.psubscribe('__key*')
+    def test_keyspace_create_rules(self):
+        env = self.env
+        env.flush()
+        env.skipOnCluster()
+        env.skipOnVersionSmaller("6.2.0")
+        skip_on_rlec()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('config', 'set', 'notify-keyspace-events', 'KEA')
 
-        time.sleep(1)
-        env.assertEqual('psubscribe', pubsub.get_message(timeout=1)['type'])
+            pubsub = r.pubsub()
+            pubsub.psubscribe('__key*')
 
-        r.execute_command('TS.CREATE', 'tester_src{2}')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.create')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_src{2}')
+            time.sleep(1)
+            env.assertEqual('psubscribe', pubsub.get_message(timeout=1)['type'])
 
-        r.execute_command('TS.CREATE', 'tester_dest{2}')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.create')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_dest{2}')
+            r.execute_command('TS.CREATE', 'tester_src{2}')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.create')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_src{2}')
 
-        r.execute_command('TS.CREATERULE', 'tester_src{2}', 'tester_dest{2}', 'AGGREGATION', 'COUNT', 10)
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.createrule:src')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_src{2}')
-
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.createrule:dest')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_dest{2}')
-
-        r.execute_command('TS.DELETERULE', 'tester_src{2}', 'tester_dest{2}')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.deleterule:src')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_src{2}')
-
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.deleterule:dest')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_dest{2}')
-
-
-def test_keyspace_rules_send():
-    Env().skipOnCluster()
-    Env().skipOnVersionSmaller("6.2.0")
-    skip_on_rlec()
-    sample_len = 1024
-    env = Env()
-    with env.getClusterConnectionIfNeeded() as r:
-        r.execute_command('config', 'set', 'notify-keyspace-events', 'KEA')
-
-        pubsub = r.pubsub()
-        pubsub.psubscribe('__key*')
-
-        time.sleep(1)
-        env.assertEqual('psubscribe', pubsub.get_message(timeout=1)['type'])
-
-        r.execute_command('TS.CREATE', 'tester_src{2}')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.create')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_src{2}')
-
-        r.execute_command('TS.CREATE', 'tester_dest{2}')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.create')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_dest{2}')
-
-        r.execute_command('TS.CREATERULE', 'tester_src{2}', 'tester_dest{2}', 'AGGREGATION', 'MAX', 1)
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.createrule:src')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_src{2}')
-
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.createrule:dest')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_dest{2}')
-
-        r.execute_command('ts.add', 'tester_src{2}', 100, 1.1)
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.add')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_src{2}')
-
-        for i in range(1000):
-            r.execute_command('ts.add', 'tester_src{2}', 101 + i, 1.1)
-
-            # First getting the event from the dest on the previous window
-            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.add:dest')
+            r.execute_command('TS.CREATE', 'tester_dest{2}')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.create')
             assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_dest{2}')
 
+            r.execute_command('TS.CREATERULE', 'tester_src{2}', 'tester_dest{2}', 'AGGREGATION', 'COUNT', 10)
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.createrule:src')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_src{2}')
+
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.createrule:dest')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_dest{2}')
+
+            r.execute_command('TS.DELETERULE', 'tester_src{2}', 'tester_dest{2}')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.deleterule:src')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_src{2}')
+
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.deleterule:dest')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_dest{2}')
+
+    def test_keyspace_rules_send(self):
+        env = self.env
+        env.flush()
+        env.skipOnCluster()
+        env.skipOnVersionSmaller("6.2.0")
+        skip_on_rlec()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('config', 'set', 'notify-keyspace-events', 'KEA')
+
+            pubsub = r.pubsub()
+            pubsub.psubscribe('__key*')
+
+            time.sleep(1)
+            env.assertEqual('psubscribe', pubsub.get_message(timeout=1)['type'])
+
+            r.execute_command('TS.CREATE', 'tester_src{2}')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.create')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_src{2}')
+
+            r.execute_command('TS.CREATE', 'tester_dest{2}')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.create')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_dest{2}')
+
+            r.execute_command('TS.CREATERULE', 'tester_src{2}', 'tester_dest{2}', 'AGGREGATION', 'MAX', 1)
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.createrule:src')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_src{2}')
+
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.createrule:dest')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_dest{2}')
+
+            r.execute_command('ts.add', 'tester_src{2}', 100, 1.1)
             assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.add')
             assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_src{2}')
 
-        r.execute_command('ts.incrby', 'tester_src{2}', 3)
+            for i in range(1000):
+                r.execute_command('ts.add', 'tester_src{2}', 101 + i, 1.1)
 
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.add:dest')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_dest{2}')
+                # First getting the event from the dest on the previous window
+                assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.add:dest')
+                assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_dest{2}')
 
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.incrby')
-        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_src{2}')
+                assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.add')
+                assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_src{2}')
+
+            r.execute_command('ts.incrby', 'tester_src{2}', 3)
+
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.add:dest')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_dest{2}')
+
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'ts.incrby')
+            assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', b'tester_src{2}')

--- a/tests/flow/test_ts_madd.py
+++ b/tests/flow/test_ts_madd.py
@@ -6,111 +6,125 @@ from RLTest import Env, StandardEnv
 from includes import *
 
 
-def test_madd():
-    sample_len = 1024
-    Env().skipOnCluster()
-    skip_on_rlec()
-    with Env().getConnection() as r:
-        r.execute_command("ts.create", 'test_key1')
-        r.execute_command("ts.create", 'test_key2')
-        r.execute_command("ts.create", 'test_key3')
+class testTsMadd:
+    def __init__(self):
+        self.env = Env()
 
-        for i in range(sample_len):
-            assert [i + 1000, i + 3000, i + 6000] == r.execute_command("ts.madd", 'test_key1', i + 1000, i,
-                                                                       'test_key2', i + 3000, i, 'test_key3',
-                                                                       i + 6000, i, )
+    def test_ooo_madd(self):
+        sample_len = 100
+        start_ts = 1600204334000
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command("ts.create", 'test_key1')
+            last_sample = None
+            samples = []
+            for i in range(0, sample_len, 3):
+                assert [start_ts + (i * 1000 + 2000), start_ts + (i * 1000 + 1000),
+                        start_ts + (i * 1000)] == r.execute_command("ts.madd", 'test_key1', start_ts + (i * 1000 + 2000), i,
+                                                                     'test_key1', start_ts + i * 1000 + 1000, i, 'test_key1',
+                                                                     start_ts + i * 1000, i)
+                samples.append([start_ts + (i * 1000), str(i).encode('ascii')])
+                samples.append([start_ts + (i * 1000 + 1000), str(i).encode('ascii')])
+                samples.append([start_ts + (i * 1000 + 2000), str(i).encode('ascii')])
+                last_sample = [start_ts + (i * 1000 + 2000), str(i).encode('ascii')]
 
-        res = r.execute_command('ts.range', 'test_key1', 1000, 1000 + sample_len)
-        i = 0
-        for sample in res:
-            assert sample == [1000 + i, str(i).encode('ascii')]
-            i += 1
+            assert r.execute_command('ts.get', 'test_key1') == last_sample
+            assert r.execute_command('ts.range', 'test_key1', '-', '+') == samples
 
-        res = r.execute_command('ts.range', 'test_key2', 3000, 3000 + sample_len)
-        i = 0
-        for sample in res:
-            assert sample == [3000 + i, str(i).encode('ascii')]
-            i += 1
+    def test_madd(self):
+        sample_len = 1024
+        env = self.env
+        env.flush()
+        env.skipOnCluster()
+        skip_on_rlec()
+        with env.getConnection() as r:
+            r.execute_command("ts.create", 'test_key1')
+            r.execute_command("ts.create", 'test_key2')
+            r.execute_command("ts.create", 'test_key3')
 
-        res = r.execute_command('ts.range', 'test_key3', 6000, 6000 + sample_len)
-        i = 0
-        for sample in res:
-            assert sample == [6000 + i, str(i).encode('ascii')]
-            i += 1
+            for i in range(sample_len):
+                assert [i + 1000, i + 3000, i + 6000] == r.execute_command("ts.madd", 'test_key1', i + 1000, i,
+                                                                           'test_key2', i + 3000, i, 'test_key3',
+                                                                           i + 6000, i, )
 
+            res = r.execute_command('ts.range', 'test_key1', 1000, 1000 + sample_len)
+            i = 0
+            for sample in res:
+                assert sample == [1000 + i, str(i).encode('ascii')]
+                i += 1
 
-def test_ooo_madd():
-    sample_len = 100
-    start_ts = 1600204334000
+            res = r.execute_command('ts.range', 'test_key2', 3000, 3000 + sample_len)
+            i = 0
+            for sample in res:
+                assert sample == [3000 + i, str(i).encode('ascii')]
+                i += 1
 
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command("ts.create", 'test_key1')
-        last_sample = None
-        samples = []
-        for i in range(0, sample_len, 3):
-            assert [start_ts + (i * 1000 + 2000), start_ts + (i * 1000 + 1000),
-                    start_ts + (i * 1000)] == r.execute_command("ts.madd", 'test_key1', start_ts + (i * 1000 + 2000), i,
-                                                                'test_key1', start_ts + i * 1000 + 1000, i, 'test_key1',
-                                                                start_ts + i * 1000, i)
-            samples.append([start_ts + (i * 1000), str(i).encode('ascii')])
-            samples.append([start_ts + (i * 1000 + 1000), str(i).encode('ascii')])
-            samples.append([start_ts + (i * 1000 + 2000), str(i).encode('ascii')])
-            last_sample = [start_ts + (i * 1000 + 2000), str(i).encode('ascii')]
+            res = r.execute_command('ts.range', 'test_key3', 6000, 6000 + sample_len)
+            i = 0
+            for sample in res:
+                assert sample == [6000 + i, str(i).encode('ascii')]
+                i += 1
 
-        assert r.execute_command('ts.get', 'test_key1') == last_sample
-        assert r.execute_command('ts.range', 'test_key1', '-', '+') == samples
+    def test_partial_madd(self):
+        env = self.env
+        env.flush()
+        env.skipOnCluster()
+        skip_on_rlec()
+        with env.getConnection() as r:
+            r.execute_command("ts.create", 'test_key1')
+            r.execute_command("ts.create", 'test_key2')
+            r.execute_command("ts.create", 'test_key3')
 
+            now = int(time.time() * 1000)
+            res = r.execute_command("ts.madd", 'test_key1', "*", 10, 'test_key2', 2000, 20, 'test_key3', 3000, 30)
+            assert now <= res[0]
+            assert 2000 == res[1]
+            assert 3000 == res[2]
 
-def test_partial_madd():
-    Env().skipOnCluster()
-    skip_on_rlec()
-    with Env().getConnection() as r:
-        r.execute_command("ts.create", 'test_key1')
-        r.execute_command("ts.create", 'test_key2')
-        r.execute_command("ts.create", 'test_key3')
-
-        now = int(time.time() * 1000)
-        res = r.execute_command("ts.madd", 'test_key1', "*", 10, 'test_key2', 2000, 20, 'test_key3', 3000, 30)
-        assert now <= res[0]
-        assert 2000 == res[1]
-        assert 3000 == res[2]
-
-        res = r.execute_command("ts.madd", 'test_key1', now + 1000, 10, 'test_key2', 1000, 20, 'test_key3', 3001, 30)
-        assert (now + 1000, 1000, 3001) == (res[0], res[1], res[2])
-        assert len(r.execute_command('ts.range', 'test_key1', "-", "+")) == 2
-        assert len(r.execute_command('ts.range', 'test_key2', "-", "+")) == 2
-        assert len(r.execute_command('ts.range', 'test_key3', "-", "+")) == 2
+            res = r.execute_command("ts.madd", 'test_key1', now + 1000, 10, 'test_key2', 1000, 20, 'test_key3', 3001, 30)
+            assert (now + 1000, 1000, 3001) == (res[0], res[1], res[2])
+            assert len(r.execute_command('ts.range', 'test_key1', "-", "+")) == 2
+            assert len(r.execute_command('ts.range', 'test_key2', "-", "+")) == 2
+            assert len(r.execute_command('ts.range', 'test_key3', "-", "+")) == 2
 
 
-def test_extensive_ts_madd():
-    Env().skipOnCluster()
-    skip_on_rlec()
-    with Env(decodeResponses=True).getConnection() as r:
-        r.execute_command("ts.create", 'test_key1')
-        r.execute_command("ts.create", 'test_key2')
-        pos = 1
-        lines = []
-        float_lines = []
-        with open("lemire_canada.txt","r") as file:
-            lines = file.readlines()
-        for line in lines:
-            float_v = float(line.strip())
-            res = r.execute_command("ts.madd", 'test_key1', pos, float_v, 'test_key2', pos, float_v)
-            assert res == [pos,pos]
-            pos=pos+1
-            float_lines.append(float_v)
-        returned_floats = r.execute_command('ts.range', 'test_key1', "-", "+")
-        assert len(returned_floats) == len(float_lines)
-        for pos,datapoint in enumerate(returned_floats,start=1):
-            assert pos == datapoint[0]
-            assert float_lines[pos-1] == float(datapoint[1])
+class testTsMaddDecode:
+    def __init__(self):
+        self.env = Env(decodeResponses=True)
+
+    def test_extensive_ts_madd(self):
+        env = self.env
+        env.flush()
+        env.skipOnCluster()
+        skip_on_rlec()
+        with env.getConnection() as r:
+            r.execute_command("ts.create", 'test_key1')
+            r.execute_command("ts.create", 'test_key2')
+            pos = 1
+            lines = []
+            float_lines = []
+            with open("lemire_canada.txt","r") as file:
+                lines = file.readlines()
+            for line in lines:
+                float_v = float(line.strip())
+                res = r.execute_command("ts.madd", 'test_key1', pos, float_v, 'test_key2', pos, float_v)
+                assert res == [pos, pos]
+                pos = pos + 1
+                float_lines.append(float_v)
+            returned_floats = r.execute_command('ts.range', 'test_key1', "-", "+")
+            assert len(returned_floats) == len(float_lines)
+            for pos, datapoint in enumerate(returned_floats, start=1):
+                assert pos == datapoint[0]
+                assert float_lines[pos - 1] == float(datapoint[1])
+
 
 def test_madd_some_failed_replicas():
-    if not Env().useSlaves:
-        Env().skip()
+    env = Env(decodeResponses=False)
+    if not env.useSlaves:
+        env.skip()
     # getSlaveConnection is not supported in cluster mode
-    Env().skipOnCluster()
-    env =  Env(decodeResponses=False)
+    env.skipOnCluster()
     res = env.cmd('CONFIG', 'GET', 'appendfsync')
     env.cmd('CONFIG', 'SET', 'appendfsync', 'always')
 

--- a/tests/flow/test_ts_multi_agg.py
+++ b/tests/flow/test_ts_multi_agg.py
@@ -3,794 +3,775 @@ import redis
 from includes import *
 
 
-def test_multi_agg_basic_range():
-    """Test TS.RANGE with multiple aggregators (min,max)."""
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_basic{a}')
-        for i in range(10):
-            r.execute_command('TS.ADD', 'magg_basic{a}', 1000 + i, 100 + i)
-        for i in range(10):
-            r.execute_command('TS.ADD', 'magg_basic{a}', 2000 + i, 200 + i)
+class testTsMultiAgg:
+    def __init__(self):
+        self.env = Env()
 
-        result = r.execute_command('TS.RANGE', 'magg_basic{a}', '-', '+', 'AGGREGATION', 'min,max', 1000)
-        assert len(result) == 2
-        assert result[0][0] == 1000
-        assert result[0][1] == b'100'
-        assert result[0][2] == b'109'
-        assert result[1][0] == 2000
-        assert result[1][1] == b'200'
-        assert result[1][2] == b'209'
+    def test_multi_agg_basic_range(self):
+        """Test TS.RANGE with multiple aggregators (min,max)."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_basic{a}')
+            for i in range(10):
+                r.execute_command('TS.ADD', 'magg_basic{a}', 1000 + i, 100 + i)
+            for i in range(10):
+                r.execute_command('TS.ADD', 'magg_basic{a}', 2000 + i, 200 + i)
 
+            result = r.execute_command('TS.RANGE', 'magg_basic{a}', '-', '+', 'AGGREGATION', 'min,max', 1000)
+            assert len(result) == 2
+            assert result[0][0] == 1000
+            assert result[0][1] == b'100'
+            assert result[0][2] == b'109'
+            assert result[1][0] == 2000
+            assert result[1][1] == b'200'
+            assert result[1][2] == b'209'
 
-def test_multi_agg_three_aggregators():
-    """Test TS.RANGE with three aggregators (min,max,avg)."""
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_three{a}')
-        for i in range(10):
-            r.execute_command('TS.ADD', 'magg_three{a}', 1000 + i, 100 + i)
+    def test_multi_agg_three_aggregators(self):
+        """Test TS.RANGE with three aggregators (min,max,avg)."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_three{a}')
+            for i in range(10):
+                r.execute_command('TS.ADD', 'magg_three{a}', 1000 + i, 100 + i)
 
-        result = r.execute_command('TS.RANGE', 'magg_three{a}', '-', '+', 'AGGREGATION', 'min,max,avg', 1000)
-        assert len(result) == 1
-        assert result[0][0] == 1000
-        assert result[0][1] == b'100'
-        assert result[0][2] == b'109'
-        assert float(result[0][3]) == pytest.approx(104.5, abs=0.01)
+            result = r.execute_command('TS.RANGE', 'magg_three{a}', '-', '+', 'AGGREGATION', 'min,max,avg', 1000)
+            assert len(result) == 1
+            assert result[0][0] == 1000
+            assert result[0][1] == b'100'
+            assert result[0][2] == b'109'
+            assert float(result[0][3]) == pytest.approx(104.5, abs=0.01)
 
+    def test_multi_agg_revrange(self):
+        """Test TS.REVRANGE with multiple aggregators."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_rev{a}')
+            for i in range(10):
+                r.execute_command('TS.ADD', 'magg_rev{a}', 1000 + i, 100 + i)
+            for i in range(10):
+                r.execute_command('TS.ADD', 'magg_rev{a}', 2000 + i, 200 + i)
 
-def test_multi_agg_revrange():
-    """Test TS.REVRANGE with multiple aggregators."""
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_rev{a}')
-        for i in range(10):
-            r.execute_command('TS.ADD', 'magg_rev{a}', 1000 + i, 100 + i)
-        for i in range(10):
-            r.execute_command('TS.ADD', 'magg_rev{a}', 2000 + i, 200 + i)
+            result = r.execute_command('TS.REVRANGE', 'magg_rev{a}', '-', '+', 'AGGREGATION', 'min,max', 1000)
+            assert len(result) == 2
+            assert result[0][0] == 2000
+            assert result[0][1] == b'200'
+            assert result[0][2] == b'209'
+            assert result[1][0] == 1000
+            assert result[1][1] == b'100'
+            assert result[1][2] == b'109'
 
-        result = r.execute_command('TS.REVRANGE', 'magg_rev{a}', '-', '+', 'AGGREGATION', 'min,max', 1000)
-        assert len(result) == 2
-        assert result[0][0] == 2000
-        assert result[0][1] == b'200'
-        assert result[0][2] == b'209'
-        assert result[1][0] == 1000
-        assert result[1][1] == b'100'
-        assert result[1][2] == b'109'
+    def test_multi_agg_mrange(self):
+        """Test TS.MRANGE with multiple aggregators."""
+        env = self.env
+        env.flush()
+        env.skipOnCluster()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_mr1{a}', 'LABELS', 'type', 'maggstock')
+            r.execute_command('TS.CREATE', 'magg_mr2{a}', 'LABELS', 'type', 'maggstock')
+            for i in range(10):
+                r.execute_command('TS.ADD', 'magg_mr1{a}', 1000 + i, 100 + i)
+                r.execute_command('TS.ADD', 'magg_mr2{a}', 1000 + i, 200 + i)
 
+            result = r.execute_command('TS.MRANGE', '-', '+',
+                                       'AGGREGATION', 'min,max', 1000,
+                                       'FILTER', 'type=maggstock')
+            assert len(result) == 2
 
-def test_multi_agg_mrange():
-    """Test TS.MRANGE with multiple aggregators."""
-    e = Env()
-    e.skipOnCluster()
-    with e.getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_mr1{a}', 'LABELS', 'type', 'maggstock')
-        r.execute_command('TS.CREATE', 'magg_mr2{a}', 'LABELS', 'type', 'maggstock')
-        for i in range(10):
-            r.execute_command('TS.ADD', 'magg_mr1{a}', 1000 + i, 100 + i)
-            r.execute_command('TS.ADD', 'magg_mr2{a}', 1000 + i, 200 + i)
+            series_by_key = {s[0]: s for s in result}
+            s1 = series_by_key[b'magg_mr1{a}']
+            s2 = series_by_key[b'magg_mr2{a}']
 
-        result = r.execute_command('TS.MRANGE', '-', '+',
-                                   'AGGREGATION', 'min,max', 1000,
-                                   'FILTER', 'type=maggstock')
-        assert len(result) == 2
+            assert s1[2] == [[1000, b'100', b'109']]
+            assert s2[2] == [[1000, b'200', b'209']]
 
-        series_by_key = {s[0]: s for s in result}
-        s1 = series_by_key[b'magg_mr1{a}']
-        s2 = series_by_key[b'magg_mr2{a}']
+    def test_multi_agg_mrevrange(self):
+        """Test TS.MREVRANGE with multiple aggregators."""
+        env = self.env
+        env.flush()
+        env.skipOnCluster()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_mrv{a}', 'LABELS', 'type', 'maggstock2')
+            for i in range(10):
+                r.execute_command('TS.ADD', 'magg_mrv{a}', 1000 + i, 100 + i)
+            for i in range(10):
+                r.execute_command('TS.ADD', 'magg_mrv{a}', 2000 + i, 200 + i)
 
-        assert s1[2] == [[1000, b'100', b'109']]
-        assert s2[2] == [[1000, b'200', b'209']]
+            result = r.execute_command('TS.MREVRANGE', '-', '+',
+                                       'AGGREGATION', 'sum,count', 1000,
+                                       'FILTER', 'type=maggstock2')
+            assert len(result) == 1
+            series = result[0]
+            assert series[0] == b'magg_mrv{a}'
+            data_points = series[2]
+            assert len(data_points) == 2
+            # reversed order: bucket 2000 first, then 1000
+            assert data_points[0][0] == 2000
+            assert data_points[0][1] == b'2045'  # sum(200..209)
+            assert data_points[0][2] == b'10'    # count
+            assert data_points[1][0] == 1000
+            assert data_points[1][1] == b'1045'  # sum(100..109)
+            assert data_points[1][2] == b'10'    # count
 
+    def test_multi_agg_groupby_error(self):
+        """Multiple aggregators with GROUPBY should return an error."""
+        env = self.env
+        env.flush()
+        env.skipOnCluster()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_grp{a}', 'LABELS', 'type', 'maggrp')
+            r.execute_command('TS.ADD', 'magg_grp{a}', 1000, 100)
 
-def test_multi_agg_mrevrange():
-    """Test TS.MREVRANGE with multiple aggregators."""
-    e = Env()
-    e.skipOnCluster()
-    with e.getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_mrv{a}', 'LABELS', 'type', 'maggstock2')
-        for i in range(10):
-            r.execute_command('TS.ADD', 'magg_mrv{a}', 1000 + i, 100 + i)
-        for i in range(10):
-            r.execute_command('TS.ADD', 'magg_mrv{a}', 2000 + i, 200 + i)
+            with pytest.raises(redis.ResponseError, match="GROUPBY"):
+                r.execute_command('TS.MRANGE', '-', '+',
+                                  'AGGREGATION', 'min,max', 1000,
+                                  'FILTER', 'type=maggrp',
+                                  'GROUPBY', 'type', 'REDUCE', 'max')
 
-        result = r.execute_command('TS.MREVRANGE', '-', '+',
-                                   'AGGREGATION', 'sum,count', 1000,
-                                   'FILTER', 'type=maggstock2')
-        assert len(result) == 1
-        series = result[0]
-        assert series[0] == b'magg_mrv{a}'
-        data_points = series[2]
-        assert len(data_points) == 2
-        # reversed order: bucket 2000 first, then 1000
-        assert data_points[0][0] == 2000
-        assert data_points[0][1] == b'2045'  # sum(200..209)
-        assert data_points[0][2] == b'10'    # count
-        assert data_points[1][0] == 1000
-        assert data_points[1][1] == b'1045'  # sum(100..109)
-        assert data_points[1][2] == b'10'    # count
+    def test_multi_agg_groupby_single_ok(self):
+        """Single aggregator with GROUPBY should still work."""
+        env = self.env
+        env.flush()
+        env.skipOnCluster()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_grps1{a}', 'LABELS', 'type', 'maggrps')
+            r.execute_command('TS.CREATE', 'magg_grps2{a}', 'LABELS', 'type', 'maggrps')
+            r.execute_command('TS.ADD', 'magg_grps1{a}', 1000, 100)
+            r.execute_command('TS.ADD', 'magg_grps1{a}', 1001, 200)
+            r.execute_command('TS.ADD', 'magg_grps2{a}', 1000, 150)
+            r.execute_command('TS.ADD', 'magg_grps2{a}', 1001, 50)
 
+            result = r.execute_command('TS.MRANGE', '-', '+',
+                                       'AGGREGATION', 'max', 1000,
+                                       'FILTER', 'type=maggrps',
+                                       'GROUPBY', 'type', 'REDUCE', 'max')
+            assert len(result) == 1
+            group = result[0]
+            assert group[0] == b'type=maggrps'
+            data_points = group[2]
+            assert len(data_points) == 1
+            assert data_points[0][0] == 1000
+            assert data_points[0][1] == b'200'  # max(200, 150) across the two series
 
-def test_multi_agg_groupby_error():
-    """Multiple aggregators with GROUPBY should return an error."""
-    e = Env()
-    e.skipOnCluster()
-    with e.getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_grp{a}', 'LABELS', 'type', 'maggrp')
-        r.execute_command('TS.ADD', 'magg_grp{a}', 1000, 100)
+    def test_multi_agg_with_count(self):
+        """COUNT should limit the number of buckets returned."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_cnt{a}')
+            for i in range(50):
+                r.execute_command('TS.ADD', 'magg_cnt{a}', 1000 + i, i)
 
-        with pytest.raises(redis.ResponseError, match="GROUPBY"):
-            r.execute_command('TS.MRANGE', '-', '+',
-                              'AGGREGATION', 'min,max', 1000,
-                              'FILTER', 'type=maggrp',
-                              'GROUPBY', 'type', 'REDUCE', 'max')
+            # Without COUNT: 5 buckets (1000-1009, 1010-1019, 1020-1029, 1030-1039, 1040-1049)
+            full_result = r.execute_command('TS.RANGE', 'magg_cnt{a}', '-', '+',
+                                            'AGGREGATION', 'min,max', 10)
+            assert len(full_result) == 5
+            assert full_result[0] == [1000, b'0', b'9']
+            assert full_result[1] == [1010, b'10', b'19']
 
+            # With COUNT 2: only first 2 buckets
+            result = r.execute_command('TS.RANGE', 'magg_cnt{a}', '-', '+',
+                                       'AGGREGATION', 'min,max', 10, 'COUNT', 2)
+            assert len(result) == 2
+            assert result[0] == [1000, b'0', b'9']
+            assert result[1] == [1010, b'10', b'19']
 
-def test_multi_agg_groupby_single_ok():
-    """Single aggregator with GROUPBY should still work."""
-    e = Env()
-    e.skipOnCluster()
-    with e.getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_grps1{a}', 'LABELS', 'type', 'maggrps')
-        r.execute_command('TS.CREATE', 'magg_grps2{a}', 'LABELS', 'type', 'maggrps')
-        r.execute_command('TS.ADD', 'magg_grps1{a}', 1000, 100)
-        r.execute_command('TS.ADD', 'magg_grps1{a}', 1001, 200)
-        r.execute_command('TS.ADD', 'magg_grps2{a}', 1000, 150)
-        r.execute_command('TS.ADD', 'magg_grps2{a}', 1001, 50)
+    def test_multi_agg_sum_count(self):
+        """Test sum,count aggregation."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_sc{a}')
+            r.execute_command('TS.ADD', 'magg_sc{a}', 1000, 10)
+            r.execute_command('TS.ADD', 'magg_sc{a}', 1001, 20)
+            r.execute_command('TS.ADD', 'magg_sc{a}', 1002, 30)
 
-        result = r.execute_command('TS.MRANGE', '-', '+',
-                                   'AGGREGATION', 'max', 1000,
-                                   'FILTER', 'type=maggrps',
-                                   'GROUPBY', 'type', 'REDUCE', 'max')
-        assert len(result) == 1
-        group = result[0]
-        assert group[0] == b'type=maggrps'
-        data_points = group[2]
-        assert len(data_points) == 1
-        assert data_points[0][0] == 1000
-        assert data_points[0][1] == b'200'  # max(200, 150) across the two series
+            result = r.execute_command('TS.RANGE', 'magg_sc{a}', '-', '+', 'AGGREGATION', 'sum,count', 1000)
+            assert len(result) == 1
+            assert result[0][0] == 1000
+            assert result[0][1] == b'60'
+            assert result[0][2] == b'3'
 
+    def test_multi_agg_candlestick(self):
+        """Test min,max,first,last aggregation for candlestick charts."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_cs{a}')
+            r.execute_command('TS.ADD', 'magg_cs{a}', 1000, 50)
+            r.execute_command('TS.ADD', 'magg_cs{a}', 1001, 30)
+            r.execute_command('TS.ADD', 'magg_cs{a}', 1002, 80)
+            r.execute_command('TS.ADD', 'magg_cs{a}', 1003, 60)
 
-def test_multi_agg_with_count():
-    """COUNT should limit the number of buckets returned."""
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_cnt{a}')
-        for i in range(50):
-            r.execute_command('TS.ADD', 'magg_cnt{a}', 1000 + i, i)
+            result = r.execute_command('TS.RANGE', 'magg_cs{a}', '-', '+',
+                                       'AGGREGATION', 'min,max,first,last', 1000)
+            assert len(result) == 1
+            assert result[0][0] == 1000
+            assert result[0][1] == b'30'
+            assert result[0][2] == b'80'
+            assert result[0][3] == b'50'
+            assert result[0][4] == b'60'
 
-        # Without COUNT: 5 buckets (1000-1009, 1010-1019, 1020-1029, 1030-1039, 1040-1049)
-        full_result = r.execute_command('TS.RANGE', 'magg_cnt{a}', '-', '+',
-                                        'AGGREGATION', 'min,max', 10)
-        assert len(full_result) == 5
-        assert full_result[0] == [1000, b'0', b'9']
-        assert full_result[1] == [1010, b'10', b'19']
+    def test_multi_agg_invalid_type_error(self):
+        """Invalid aggregation type in the list should return error."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_inv{a}')
+            r.execute_command('TS.ADD', 'magg_inv{a}', 1000, 100)
 
-        # With COUNT 2: only first 2 buckets
-        result = r.execute_command('TS.RANGE', 'magg_cnt{a}', '-', '+',
-                                   'AGGREGATION', 'min,max', 10, 'COUNT', 2)
-        assert len(result) == 2
-        assert result[0] == [1000, b'0', b'9']
-        assert result[1] == [1010, b'10', b'19']
+            with pytest.raises(redis.ResponseError):
+                r.execute_command('TS.RANGE', 'magg_inv{a}', '-', '+',
+                                  'AGGREGATION', 'min,invalid', 1000)
 
+    def test_multi_agg_empty_type_error(self):
+        """Empty aggregation type (trailing comma) should return error."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_empty{a}')
+            r.execute_command('TS.ADD', 'magg_empty{a}', 1000, 100)
 
-def test_multi_agg_sum_count():
-    """Test sum,count aggregation."""
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_sc{a}')
-        r.execute_command('TS.ADD', 'magg_sc{a}', 1000, 10)
-        r.execute_command('TS.ADD', 'magg_sc{a}', 1001, 20)
-        r.execute_command('TS.ADD', 'magg_sc{a}', 1002, 30)
+            with pytest.raises(redis.ResponseError):
+                r.execute_command('TS.RANGE', 'magg_empty{a}', '-', '+',
+                                  'AGGREGATION', 'min,', 1000)
 
-        result = r.execute_command('TS.RANGE', 'magg_sc{a}', '-', '+', 'AGGREGATION', 'sum,count', 1000)
-        assert len(result) == 1
-        assert result[0][0] == 1000
-        assert result[0][1] == b'60'
-        assert result[0][2] == b'3'
+    def test_multi_agg_duplicate_types(self):
+        """Duplicate aggregation types should be allowed."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_dup{a}')
+            r.execute_command('TS.ADD', 'magg_dup{a}', 1000, 100)
 
+            result = r.execute_command('TS.RANGE', 'magg_dup{a}', '-', '+',
+                                       'AGGREGATION', 'min,min', 1000)
+            assert len(result) == 1
+            assert result[0][1] == b'100'
+            assert result[0][2] == b'100'
 
-def test_multi_agg_candlestick():
-    """Test min,max,first,last aggregation for candlestick charts."""
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_cs{a}')
-        r.execute_command('TS.ADD', 'magg_cs{a}', 1000, 50)
-        r.execute_command('TS.ADD', 'magg_cs{a}', 1001, 30)
-        r.execute_command('TS.ADD', 'magg_cs{a}', 1002, 80)
-        r.execute_command('TS.ADD', 'magg_cs{a}', 1003, 60)
+    def test_multi_agg_with_twa(self):
+        """Test multi-agg when one of the aggregators is TWA."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_twa{a}')
+            r.execute_command('TS.ADD', 'magg_twa{a}', 8, 8)
+            r.execute_command('TS.ADD', 'magg_twa{a}', 9, 9)
+            r.execute_command('TS.ADD', 'magg_twa{a}', 10, 10)
+            r.execute_command('TS.ADD', 'magg_twa{a}', 13, 13)
+            r.execute_command('TS.ADD', 'magg_twa{a}', 14, 14)
+            r.execute_command('TS.ADD', 'magg_twa{a}', 23, 23)
 
-        result = r.execute_command('TS.RANGE', 'magg_cs{a}', '-', '+',
-                                   'AGGREGATION', 'min,max,first,last', 1000)
-        assert len(result) == 1
-        assert result[0][0] == 1000
-        assert result[0][1] == b'30'
-        assert result[0][2] == b'80'
-        assert result[0][3] == b'50'
-        assert result[0][4] == b'60'
+            # Compute expected TWA for bucket [10,20) (same as test_agg_twa case 1)
+            v1, v2, v3, v4, v5 = 9.0, 10.0, 13.0, 14.0, 23.0
+            t1, t2, t3, t4, t5 = 9.0, 10.0, 13.0, 14.0, 23.0
+            ta, tb = 10.0, 20.0
+            va = v1 + (v2 - v1) * (ta - t1) / (t2 - t1)
+            vb = v4 + (v5 - v4) * (tb - t4) / (t5 - t4)
+            s = (va + v2) * (t2 - ta) + (v2 + v3) * (t3 - t2) + (v3 + v4) * (t4 - t3) + (vb + v4) * (tb - t4)
+            expected_twa = s / (2 * (tb - ta))
 
+            result = r.execute_command('TS.RANGE', 'magg_twa{a}', 10, 20,
+                                       'AGGREGATION', 'min,max,twa', 10)
+            assert len(result) == 1
+            assert result[0][0] == 10
+            assert result[0][1] == b'10'    # min
+            assert result[0][2] == b'14'    # max
+            assert result[0][3] == str(int(expected_twa)).encode('ascii')  # twa
 
-def test_multi_agg_invalid_type_error():
-    """Invalid aggregation type in the list should return error."""
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_inv{a}')
-        r.execute_command('TS.ADD', 'magg_inv{a}', 1000, 100)
+    def test_multi_agg_twa_not_first_multi_bucket(self):
+        """Test that TWA produces correct results in multi-agg when it is NOT the first aggregation
+        and there are multiple buckets (exercising the bucket-boundary getLastSample code path)."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_twa_nf{a}')
+            # Data spanning 3 buckets of size 10: [0,10), [10,20), [20,30)
+            r.execute_command('TS.ADD', 'magg_twa_nf{a}', 2, 5)
+            r.execute_command('TS.ADD', 'magg_twa_nf{a}', 7, 10)
+            r.execute_command('TS.ADD', 'magg_twa_nf{a}', 12, 20)
+            r.execute_command('TS.ADD', 'magg_twa_nf{a}', 17, 30)
+            r.execute_command('TS.ADD', 'magg_twa_nf{a}', 22, 40)
+            r.execute_command('TS.ADD', 'magg_twa_nf{a}', 27, 50)
 
-        with pytest.raises(redis.ResponseError):
-            r.execute_command('TS.RANGE', 'magg_inv{a}', '-', '+',
-                              'AGGREGATION', 'min,invalid', 1000)
-
-
-def test_multi_agg_empty_type_error():
-    """Empty aggregation type (trailing comma) should return error."""
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_empty{a}')
-        r.execute_command('TS.ADD', 'magg_empty{a}', 1000, 100)
-
-        with pytest.raises(redis.ResponseError):
-            r.execute_command('TS.RANGE', 'magg_empty{a}', '-', '+',
-                              'AGGREGATION', 'min,', 1000)
-
-
-def test_multi_agg_duplicate_types():
-    """Duplicate aggregation types should be allowed."""
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_dup{a}')
-        r.execute_command('TS.ADD', 'magg_dup{a}', 1000, 100)
-
-        result = r.execute_command('TS.RANGE', 'magg_dup{a}', '-', '+',
-                                   'AGGREGATION', 'min,min', 1000)
-        assert len(result) == 1
-        assert result[0][1] == b'100'
-        assert result[0][2] == b'100'
-
-
-def test_multi_agg_with_twa():
-    """Test multi-agg when one of the aggregators is TWA."""
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_twa{a}')
-        r.execute_command('TS.ADD', 'magg_twa{a}', 8, 8)
-        r.execute_command('TS.ADD', 'magg_twa{a}', 9, 9)
-        r.execute_command('TS.ADD', 'magg_twa{a}', 10, 10)
-        r.execute_command('TS.ADD', 'magg_twa{a}', 13, 13)
-        r.execute_command('TS.ADD', 'magg_twa{a}', 14, 14)
-        r.execute_command('TS.ADD', 'magg_twa{a}', 23, 23)
-
-        # Compute expected TWA for bucket [10,20) (same as test_agg_twa case 1)
-        v1, v2, v3, v4, v5 = 9.0, 10.0, 13.0, 14.0, 23.0
-        t1, t2, t3, t4, t5 = 9.0, 10.0, 13.0, 14.0, 23.0
-        ta, tb = 10.0, 20.0
-        va = v1 + (v2 - v1) * (ta - t1) / (t2 - t1)
-        vb = v4 + (v5 - v4) * (tb - t4) / (t5 - t4)
-        s = (va + v2) * (t2 - ta) + (v2 + v3) * (t3 - t2) + (v3 + v4) * (t4 - t3) + (vb + v4) * (tb - t4)
-        expected_twa = s / (2 * (tb - ta))
-
-        result = r.execute_command('TS.RANGE', 'magg_twa{a}', 10, 20,
-                                   'AGGREGATION', 'min,max,twa', 10)
-        assert len(result) == 1
-        assert result[0][0] == 10
-        assert result[0][1] == b'10'    # min
-        assert result[0][2] == b'14'    # max
-        assert result[0][3] == str(int(expected_twa)).encode('ascii')  # twa
-
-
-def test_multi_agg_twa_not_first_multi_bucket():
-    """Test that TWA produces correct results in multi-agg when it is NOT the first aggregation
-    and there are multiple buckets (exercising the bucket-boundary getLastSample code path)."""
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_twa_nf{a}')
-        # Data spanning 3 buckets of size 10: [0,10), [10,20), [20,30)
-        r.execute_command('TS.ADD', 'magg_twa_nf{a}', 2, 5)
-        r.execute_command('TS.ADD', 'magg_twa_nf{a}', 7, 10)
-        r.execute_command('TS.ADD', 'magg_twa_nf{a}', 12, 20)
-        r.execute_command('TS.ADD', 'magg_twa_nf{a}', 17, 30)
-        r.execute_command('TS.ADD', 'magg_twa_nf{a}', 22, 40)
-        r.execute_command('TS.ADD', 'magg_twa_nf{a}', 27, 50)
-
-        # Get reference TWA values from single-agg query
-        twa_only = r.execute_command('TS.RANGE', 'magg_twa_nf{a}', '-', '+',
-                                     'AGGREGATION', 'twa', 10)
-        assert len(twa_only) == 3
-
-        # TWA as second aggregation (non-first position triggers the bug)
-        result = r.execute_command('TS.RANGE', 'magg_twa_nf{a}', '-', '+',
-                                   'AGGREGATION', 'sum,twa', 10)
-        assert len(result) == 3
-        for i in range(3):
-            assert result[i][0] == twa_only[i][0]
-            assert float(result[i][2]) == pytest.approx(float(twa_only[i][1]), abs=0.01), \
-                f"TWA mismatch in bucket {i}: multi-agg={result[i][2]}, single={twa_only[i][1]}"
-
-        # Also verify sum values are correct
-        assert float(result[0][1]) == pytest.approx(15.0, abs=0.01)   # 5 + 10
-        assert float(result[1][1]) == pytest.approx(50.0, abs=0.01)   # 20 + 30
-        assert float(result[2][1]) == pytest.approx(90.0, abs=0.01)   # 40 + 50
-
-        # Same test with REVRANGE
-        twa_only_rev = r.execute_command('TS.REVRANGE', 'magg_twa_nf{a}', '-', '+',
+            # Get reference TWA values from single-agg query
+            twa_only = r.execute_command('TS.RANGE', 'magg_twa_nf{a}', '-', '+',
                                          'AGGREGATION', 'twa', 10)
-        result_rev = r.execute_command('TS.REVRANGE', 'magg_twa_nf{a}', '-', '+',
+            assert len(twa_only) == 3
+
+            # TWA as second aggregation (non-first position triggers the bug)
+            result = r.execute_command('TS.RANGE', 'magg_twa_nf{a}', '-', '+',
                                        'AGGREGATION', 'sum,twa', 10)
-        assert len(result_rev) == 3
-        for i in range(3):
-            assert result_rev[i][0] == twa_only_rev[i][0]
-            assert float(result_rev[i][2]) == pytest.approx(float(twa_only_rev[i][1]), abs=0.01), \
-                f"REVRANGE TWA mismatch in bucket {i}: multi-agg={result_rev[i][2]}, single={twa_only_rev[i][1]}"
+            assert len(result) == 3
+            for i in range(3):
+                assert result[i][0] == twa_only[i][0]
+                assert float(result[i][2]) == pytest.approx(float(twa_only[i][1]), abs=0.01), \
+                    f"TWA mismatch in bucket {i}: multi-agg={result[i][2]}, single={twa_only[i][1]}"
 
-        # Test with TWA in the middle: avg,twa,count
-        result_mid = r.execute_command('TS.RANGE', 'magg_twa_nf{a}', '-', '+',
-                                       'AGGREGATION', 'avg,twa,count', 10)
-        assert len(result_mid) == 3
-        for i in range(3):
-            assert float(result_mid[i][2]) == pytest.approx(float(twa_only[i][1]), abs=0.01), \
-                f"TWA-in-middle mismatch in bucket {i}"
+            # Also verify sum values are correct
+            assert float(result[0][1]) == pytest.approx(15.0, abs=0.01)   # 5 + 10
+            assert float(result[1][1]) == pytest.approx(50.0, abs=0.01)   # 20 + 30
+            assert float(result[2][1]) == pytest.approx(90.0, abs=0.01)   # 40 + 50
 
+            # Same test with REVRANGE
+            twa_only_rev = r.execute_command('TS.REVRANGE', 'magg_twa_nf{a}', '-', '+',
+                                             'AGGREGATION', 'twa', 10)
+            result_rev = r.execute_command('TS.REVRANGE', 'magg_twa_nf{a}', '-', '+',
+                                           'AGGREGATION', 'sum,twa', 10)
+            assert len(result_rev) == 3
+            for i in range(3):
+                assert result_rev[i][0] == twa_only_rev[i][0]
+                assert float(result_rev[i][2]) == pytest.approx(float(twa_only_rev[i][1]), abs=0.01), \
+                    f"REVRANGE TWA mismatch in bucket {i}: multi-agg={result_rev[i][2]}, single={twa_only_rev[i][1]}"
 
-def test_multi_agg_empty_buckets_with_gaps():
-    """Test multi-agg with EMPTY flag and gaps between populated buckets.
+            # Test with TWA in the middle: avg,twa,count
+            result_mid = r.execute_command('TS.RANGE', 'magg_twa_nf{a}', '-', '+',
+                                           'AGGREGATION', 'avg,twa,count', 10)
+            assert len(result_mid) == 3
+            for i in range(3):
+                assert float(result_mid[i][2]) == pytest.approx(float(twa_only[i][1]), abs=0.01), \
+                    f"TWA-in-middle mismatch in bucket {i}"
 
-    This exercises fillEmptyBuckets in the multiAgg path where the output is
-    written to aux_chunk (a separate buffer) rather than in-place.
-    """
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_gap{a}')
-        # Bucket [1000, 2000): values 100-109
-        for i in range(10):
-            r.execute_command('TS.ADD', 'magg_gap{a}', 1000 + i, 100 + i)
-        # Bucket [2000, 3000): empty (gap)
-        # Bucket [3000, 4000): values 300-309
-        for i in range(10):
-            r.execute_command('TS.ADD', 'magg_gap{a}', 3000 + i, 300 + i)
-        # Bucket [4000, 5000): empty (gap)
-        # Bucket [5000, 6000): values 500-509
-        for i in range(10):
-            r.execute_command('TS.ADD', 'magg_gap{a}', 5000 + i, 500 + i)
+    def test_multi_agg_empty_buckets_with_gaps(self):
+        """Test multi-agg with EMPTY flag and gaps between populated buckets.
 
-        agg_types = ['min', 'max', 'count']
-        multi_agg_str = ','.join(agg_types)
+        This exercises fillEmptyBuckets in the multiAgg path where the output is
+        written to aux_chunk (a separate buffer) rather than in-place.
+        """
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_gap{a}')
+            # Bucket [1000, 2000): values 100-109
+            for i in range(10):
+                r.execute_command('TS.ADD', 'magg_gap{a}', 1000 + i, 100 + i)
+            # Bucket [2000, 3000): empty (gap)
+            # Bucket [3000, 4000): values 300-309
+            for i in range(10):
+                r.execute_command('TS.ADD', 'magg_gap{a}', 3000 + i, 300 + i)
+            # Bucket [4000, 5000): empty (gap)
+            # Bucket [5000, 6000): values 500-509
+            for i in range(10):
+                r.execute_command('TS.ADD', 'magg_gap{a}', 5000 + i, 500 + i)
 
-        # Verify multi-agg RANGE with EMPTY matches individual single-agg results
-        refs = [r.execute_command('TS.RANGE', 'magg_gap{a}', '-', '+',
-                                  'AGGREGATION', agg, 1000, 'EMPTY') for agg in agg_types]
-        result = r.execute_command('TS.RANGE', 'magg_gap{a}', '-', '+',
-                                   'AGGREGATION', multi_agg_str, 1000, 'EMPTY')
-        assert len(result) == len(refs[0]), \
-            f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
-        for i in range(len(result)):
-            assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
-            for a, agg in enumerate(agg_types):
-                assert result[i][1 + a] == refs[a][i][1], \
-                    f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
+            agg_types = ['min', 'max', 'count']
+            multi_agg_str = ','.join(agg_types)
 
-        # Verify multi-agg REVRANGE with EMPTY matches individual single-agg results
-        refs_rev = [r.execute_command('TS.REVRANGE', 'magg_gap{a}', '-', '+',
+            # Verify multi-agg RANGE with EMPTY matches individual single-agg results
+            refs = [r.execute_command('TS.RANGE', 'magg_gap{a}', '-', '+',
                                       'AGGREGATION', agg, 1000, 'EMPTY') for agg in agg_types]
-        result_rev = r.execute_command('TS.REVRANGE', 'magg_gap{a}', '-', '+',
+            result = r.execute_command('TS.RANGE', 'magg_gap{a}', '-', '+',
                                        'AGGREGATION', multi_agg_str, 1000, 'EMPTY')
-        assert len(result_rev) == len(refs_rev[0]), \
-            f"REVRANGE bucket count mismatch: multi-agg={len(result_rev)}, single-agg={len(refs_rev[0])}"
-        for i in range(len(result_rev)):
-            assert result_rev[i][0] == refs_rev[0][i][0], f"REVRANGE timestamp mismatch at bucket {i}"
-            for a, agg in enumerate(agg_types):
-                assert result_rev[i][1 + a] == refs_rev[a][i][1], \
-                    f"REVRANGE {agg} mismatch at bucket {i}: multi-agg={result_rev[i][1 + a]}, single={refs_rev[a][i][1]}"
+            assert len(result) == len(refs[0]), \
+                f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
+            for i in range(len(result)):
+                assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
+                for a, agg in enumerate(agg_types):
+                    assert result[i][1 + a] == refs[a][i][1], \
+                        f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
 
+            # Verify multi-agg REVRANGE with EMPTY matches individual single-agg results
+            refs_rev = [r.execute_command('TS.REVRANGE', 'magg_gap{a}', '-', '+',
+                                          'AGGREGATION', agg, 1000, 'EMPTY') for agg in agg_types]
+            result_rev = r.execute_command('TS.REVRANGE', 'magg_gap{a}', '-', '+',
+                                           'AGGREGATION', multi_agg_str, 1000, 'EMPTY')
+            assert len(result_rev) == len(refs_rev[0]), \
+                f"REVRANGE bucket count mismatch: multi-agg={len(result_rev)}, single-agg={len(refs_rev[0])}"
+            for i in range(len(result_rev)):
+                assert result_rev[i][0] == refs_rev[0][i][0], f"REVRANGE timestamp mismatch at bucket {i}"
+                for a, agg in enumerate(agg_types):
+                    assert result_rev[i][1 + a] == refs_rev[a][i][1], \
+                        f"REVRANGE {agg} mismatch at bucket {i}: multi-agg={result_rev[i][1 + a]}, single={refs_rev[a][i][1]}"
 
-def test_multi_agg_twa_empty_prefix_gap():
-    """Test multi-agg with TWA + EMPTY where there are empty buckets before the first data point.
+    def test_multi_agg_twa_empty_prefix_gap(self):
+        """Test multi-agg with TWA + EMPTY where there are empty buckets before the first data point.
 
-    This exercises the TWA_EMPTY_RANGE prefix path in AggregationIterator_GetNextChunk,
-    ensuring the output goes to aux_chunk (not enrichedChunk) when multiAgg is true.
-    """
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_twa_pfx{a}')
-        # Data starts at timestamp 30, query starts at 0 → buckets [0,10) and [10,20) are empty prefix
-        r.execute_command('TS.ADD', 'magg_twa_pfx{a}', 30, 100)
-        r.execute_command('TS.ADD', 'magg_twa_pfx{a}', 35, 200)
-        r.execute_command('TS.ADD', 'magg_twa_pfx{a}', 45, 300)
+        This exercises the TWA_EMPTY_RANGE prefix path in AggregationIterator_GetNextChunk,
+        ensuring the output goes to aux_chunk (not enrichedChunk) when multiAgg is true.
+        """
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_twa_pfx{a}')
+            # Data starts at timestamp 30, query starts at 0 → buckets [0,10) and [10,20) are empty prefix
+            r.execute_command('TS.ADD', 'magg_twa_pfx{a}', 30, 100)
+            r.execute_command('TS.ADD', 'magg_twa_pfx{a}', 35, 200)
+            r.execute_command('TS.ADD', 'magg_twa_pfx{a}', 45, 300)
 
-        agg_types = ['min', 'max', 'twa']
-        multi_agg_str = ','.join(agg_types)
+            agg_types = ['min', 'max', 'twa']
+            multi_agg_str = ','.join(agg_types)
 
-        # Get single-agg reference results
-        refs = [r.execute_command('TS.RANGE', 'magg_twa_pfx{a}', 0, 50,
-                                  'AGGREGATION', agg, 10, 'EMPTY') for agg in agg_types]
-
-        result = r.execute_command('TS.RANGE', 'magg_twa_pfx{a}', 0, 50,
-                                   'AGGREGATION', multi_agg_str, 10, 'EMPTY')
-
-        assert len(result) == len(refs[0]), \
-            f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
-        for i in range(len(result)):
-            assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
-            for a, agg in enumerate(agg_types):
-                assert result[i][1 + a] == refs[a][i][1], \
-                    f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
-
-        # Also test REVRANGE
-        refs_rev = [r.execute_command('TS.REVRANGE', 'magg_twa_pfx{a}', 0, 50,
+            # Get single-agg reference results
+            refs = [r.execute_command('TS.RANGE', 'magg_twa_pfx{a}', 0, 50,
                                       'AGGREGATION', agg, 10, 'EMPTY') for agg in agg_types]
-        result_rev = r.execute_command('TS.REVRANGE', 'magg_twa_pfx{a}', 0, 50,
+
+            result = r.execute_command('TS.RANGE', 'magg_twa_pfx{a}', 0, 50,
                                        'AGGREGATION', multi_agg_str, 10, 'EMPTY')
 
-        assert len(result_rev) == len(refs_rev[0]), \
-            f"REVRANGE bucket count mismatch: multi-agg={len(result_rev)}, single-agg={len(refs_rev[0])}"
-        for i in range(len(result_rev)):
-            assert result_rev[i][0] == refs_rev[0][i][0], f"REVRANGE timestamp mismatch at bucket {i}"
-            for a, agg in enumerate(agg_types):
-                assert result_rev[i][1 + a] == refs_rev[a][i][1], \
-                    f"REVRANGE {agg} mismatch at bucket {i}: multi-agg={result_rev[i][1 + a]}, single={refs_rev[a][i][1]}"
+            assert len(result) == len(refs[0]), \
+                f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
+            for i in range(len(result)):
+                assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
+                for a, agg in enumerate(agg_types):
+                    assert result[i][1 + a] == refs[a][i][1], \
+                        f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
 
+            # Also test REVRANGE
+            refs_rev = [r.execute_command('TS.REVRANGE', 'magg_twa_pfx{a}', 0, 50,
+                                          'AGGREGATION', agg, 10, 'EMPTY') for agg in agg_types]
+            result_rev = r.execute_command('TS.REVRANGE', 'magg_twa_pfx{a}', 0, 50,
+                                           'AGGREGATION', multi_agg_str, 10, 'EMPTY')
 
-def test_multi_agg_countnan_mixed():
-    """Test multi-agg mixing countnan/countall with standard aggregations.
+            assert len(result_rev) == len(refs_rev[0]), \
+                f"REVRANGE bucket count mismatch: multi-agg={len(result_rev)}, single-agg={len(refs_rev[0])}"
+            for i in range(len(result_rev)):
+                assert result_rev[i][0] == refs_rev[0][i][0], f"REVRANGE timestamp mismatch at bucket {i}"
+                for a, agg in enumerate(agg_types):
+                    assert result_rev[i][1 + a] == refs_rev[a][i][1], \
+                        f"REVRANGE {agg} mismatch at bucket {i}: multi-agg={result_rev[i][1 + a]}, single={refs_rev[a][i][1]}"
 
-    countnan uses nanValueValid (only NaN passes), countall uses allValueValid (everything passes).
-    The per-aggregation isValueValid gate must be checked independently for each aggregation,
-    not just the first one.
-    """
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_cnan{a}')
-        r.execute_command('TS.ADD', 'magg_cnan{a}', 1000, 10)
-        r.execute_command('TS.ADD', 'magg_cnan{a}', 1001, 'NaN')
-        r.execute_command('TS.ADD', 'magg_cnan{a}', 1002, 20)
-        r.execute_command('TS.ADD', 'magg_cnan{a}', 1003, 'NaN')
-        r.execute_command('TS.ADD', 'magg_cnan{a}', 1004, 30)
+    def test_multi_agg_countnan_mixed(self):
+        """Test multi-agg mixing countnan/countall with standard aggregations.
 
-        agg_types = ['sum', 'countnan', 'countall']
-        multi_agg_str = ','.join(agg_types)
+        countnan uses nanValueValid (only NaN passes), countall uses allValueValid (everything passes).
+        The per-aggregation isValueValid gate must be checked independently for each aggregation,
+        not just the first one.
+        """
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_cnan{a}')
+            r.execute_command('TS.ADD', 'magg_cnan{a}', 1000, 10)
+            r.execute_command('TS.ADD', 'magg_cnan{a}', 1001, 'NaN')
+            r.execute_command('TS.ADD', 'magg_cnan{a}', 1002, 20)
+            r.execute_command('TS.ADD', 'magg_cnan{a}', 1003, 'NaN')
+            r.execute_command('TS.ADD', 'magg_cnan{a}', 1004, 30)
 
-        refs = [r.execute_command('TS.RANGE', 'magg_cnan{a}', '-', '+',
-                                  'AGGREGATION', agg, 1000) for agg in agg_types]
+            agg_types = ['sum', 'countnan', 'countall']
+            multi_agg_str = ','.join(agg_types)
 
-        result = r.execute_command('TS.RANGE', 'magg_cnan{a}', '-', '+',
-                                   'AGGREGATION', multi_agg_str, 1000)
+            refs = [r.execute_command('TS.RANGE', 'magg_cnan{a}', '-', '+',
+                                      'AGGREGATION', agg, 1000) for agg in agg_types]
 
-        assert len(result) == len(refs[0]), \
-            f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
-        for i in range(len(result)):
-            assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
-            for a, agg in enumerate(agg_types):
-                assert result[i][1 + a] == refs[a][i][1], \
-                    f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
+            result = r.execute_command('TS.RANGE', 'magg_cnan{a}', '-', '+',
+                                       'AGGREGATION', multi_agg_str, 1000)
 
-        # Also test with countnan as the FIRST aggregation (gates all others in buggy code)
-        agg_types2 = ['countnan', 'min', 'max']
-        multi_agg_str2 = ','.join(agg_types2)
+            assert len(result) == len(refs[0]), \
+                f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
+            for i in range(len(result)):
+                assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
+                for a, agg in enumerate(agg_types):
+                    assert result[i][1 + a] == refs[a][i][1], \
+                        f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
 
-        refs2 = [r.execute_command('TS.RANGE', 'magg_cnan{a}', '-', '+',
-                                   'AGGREGATION', agg, 1000) for agg in agg_types2]
+            # Also test with countnan as the FIRST aggregation (gates all others in buggy code)
+            agg_types2 = ['countnan', 'min', 'max']
+            multi_agg_str2 = ','.join(agg_types2)
 
-        result2 = r.execute_command('TS.RANGE', 'magg_cnan{a}', '-', '+',
-                                    'AGGREGATION', multi_agg_str2, 1000)
+            refs2 = [r.execute_command('TS.RANGE', 'magg_cnan{a}', '-', '+',
+                                       'AGGREGATION', agg, 1000) for agg in agg_types2]
 
-        assert len(result2) == len(refs2[0]), \
-            f"bucket count mismatch (countnan-first): multi-agg={len(result2)}, single-agg={len(refs2[0])}"
-        for i in range(len(result2)):
-            assert result2[i][0] == refs2[0][i][0], f"timestamp mismatch at bucket {i}"
-            for a, agg in enumerate(agg_types2):
-                assert result2[i][1 + a] == refs2[a][i][1], \
-                    f"{agg} mismatch at bucket {i} (countnan-first): multi-agg={result2[i][1 + a]}, single={refs2[a][i][1]}"
+            result2 = r.execute_command('TS.RANGE', 'magg_cnan{a}', '-', '+',
+                                        'AGGREGATION', multi_agg_str2, 1000)
 
+            assert len(result2) == len(refs2[0]), \
+                f"bucket count mismatch (countnan-first): multi-agg={len(result2)}, single-agg={len(refs2[0])}"
+            for i in range(len(result2)):
+                assert result2[i][0] == refs2[0][i][0], f"timestamp mismatch at bucket {i}"
+                for a, agg in enumerate(agg_types2):
+                    assert result2[i][1 + a] == refs2[a][i][1], \
+                        f"{agg} mismatch at bucket {i} (countnan-first): multi-agg={result2[i][1 + a]}, single={refs2[a][i][1]}"
 
-def test_multi_agg_nan_only_bucket_mixed_validators():
-    """Test multi-agg where a bucket has ONLY NaN values and validators disagree.
+    def test_multi_agg_nan_only_bucket_mixed_validators(self):
+        """Test multi-agg where a bucket has ONLY NaN values and validators disagree."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_nanonly{a}')
+            # Bucket [1000, 2000): normal values
+            r.execute_command('TS.ADD', 'magg_nanonly{a}', 1000, 10)
+            r.execute_command('TS.ADD', 'magg_nanonly{a}', 1001, 20)
+            # Bucket [2000, 3000): only NaN values
+            r.execute_command('TS.ADD', 'magg_nanonly{a}', 2000, 'NaN')
+            r.execute_command('TS.ADD', 'magg_nanonly{a}', 2001, 'NaN')
+            # Bucket [3000, 4000): normal values again
+            r.execute_command('TS.ADD', 'magg_nanonly{a}', 3000, 30)
 
-    When mixing countall (accepts NaN) with min (rejects NaN), a NaN-only bucket must
-    use finalizeEmpty for min (producing NaN) rather than finalize (which would produce
-    DBL_MAX from an empty context). This verifies per-aggregation validity tracking.
+            agg_types = ['countall', 'min', 'max']
+            multi_agg_str = ','.join(agg_types)
 
-    Uses EMPTY so all aggregations produce the same bucket count in both single-agg
-    and multi-agg modes (without EMPTY, single-agg min/max skip NaN-only buckets while
-    multi-agg emits them because countall had valid samples).
-    """
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_nanonly{a}')
-        # Bucket [1000, 2000): normal values
-        r.execute_command('TS.ADD', 'magg_nanonly{a}', 1000, 10)
-        r.execute_command('TS.ADD', 'magg_nanonly{a}', 1001, 20)
-        # Bucket [2000, 3000): only NaN values
-        r.execute_command('TS.ADD', 'magg_nanonly{a}', 2000, 'NaN')
-        r.execute_command('TS.ADD', 'magg_nanonly{a}', 2001, 'NaN')
-        # Bucket [3000, 4000): normal values again
-        r.execute_command('TS.ADD', 'magg_nanonly{a}', 3000, 30)
-
-        agg_types = ['countall', 'min', 'max']
-        multi_agg_str = ','.join(agg_types)
-
-        refs = [r.execute_command('TS.RANGE', 'magg_nanonly{a}', '-', '+',
-                                  'AGGREGATION', agg, 1000, 'EMPTY') for agg in agg_types]
-        result = r.execute_command('TS.RANGE', 'magg_nanonly{a}', '-', '+',
-                                   'AGGREGATION', multi_agg_str, 1000, 'EMPTY')
-
-        assert len(result) == len(refs[0]), \
-            f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
-        for i in range(len(result)):
-            assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
-            for a, agg in enumerate(agg_types):
-                assert result[i][1 + a] == refs[a][i][1], \
-                    f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
-
-
-def test_multi_agg_countnan_first_with_twa():
-    """Test that TWA init uses correct validator when countnan is the first aggregation.
-
-    When aggs are 'countnan,twa', the TWA init loop must NOT use countnan's
-    nanValueValid (only NaN passes) to find the prev-bucket sample for interpolation.
-    It must use non-NaN validity (what TWA needs) regardless of aggregation order.
-
-    Uses EMPTY so all aggregations produce the same bucket count (without EMPTY,
-    single-agg countnan skips buckets with no NaN values while multi-agg emits them
-    because TWA had valid samples).
-    """
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_cntwa{a}')
-        r.execute_command('TS.ADD', 'magg_cntwa{a}', 5, 50)
-        r.execute_command('TS.ADD', 'magg_cntwa{a}', 15, 150)
-        r.execute_command('TS.ADD', 'magg_cntwa{a}', 25, 250)
-
-        agg_types = ['countnan', 'twa']
-        multi_agg_str = ','.join(agg_types)
-
-        refs = [r.execute_command('TS.RANGE', 'magg_cntwa{a}', 10, 30,
-                                  'AGGREGATION', agg, 10, 'EMPTY') for agg in agg_types]
-        result = r.execute_command('TS.RANGE', 'magg_cntwa{a}', 10, 30,
-                                   'AGGREGATION', multi_agg_str, 10, 'EMPTY')
-
-        assert len(result) == len(refs[0]), \
-            f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
-        for i in range(len(result)):
-            assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
-            for a, agg in enumerate(agg_types):
-                assert result[i][1 + a] == refs[a][i][1], \
-                    f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
-
-
-def test_multi_agg_twa_nan_only_bucket_with_countall():
-    """TWA must get interpolated value (not finalizeEmpty) in a NaN-only bucket when
-    another aggregation with a different validator accepts the NaN values.
-
-    Scenario: countall,twa with a bucket containing only NaN values.
-    countall accepts NaN → validSamplesInBucket=true → finalizeBucket enters the
-    'else' branch. TWA's validPerAgg is false (it rejected NaN), so it must use
-    twa_compute_empty_bucket_value for interpolation, not finalizeEmpty.
-
-    """
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_twa_nan1{a}')
-        # Bucket [1000, 2000): normal values (used for TWA interpolation)
-        r.execute_command('TS.ADD', 'magg_twa_nan1{a}', 1000, 100)
-        r.execute_command('TS.ADD', 'magg_twa_nan1{a}', 1500, 150)
-        # Bucket [2000, 3000): NaN-only → triggers the bug
-        r.execute_command('TS.ADD', 'magg_twa_nan1{a}', 2000, 'NaN')
-        r.execute_command('TS.ADD', 'magg_twa_nan1{a}', 2500, 'NaN')
-        # Bucket [3000, 4000): normal values (used for TWA interpolation)
-        r.execute_command('TS.ADD', 'magg_twa_nan1{a}', 3000, 300)
-        r.execute_command('TS.ADD', 'magg_twa_nan1{a}', 3500, 350)
-
-        agg_types = ['countall', 'twa']
-        multi_agg_str = ','.join(agg_types)
-
-        refs = [r.execute_command('TS.RANGE', 'magg_twa_nan1{a}', '-', '+',
-                                  'AGGREGATION', agg, 1000, 'EMPTY') for agg in agg_types]
-        result = r.execute_command('TS.RANGE', 'magg_twa_nan1{a}', '-', '+',
-                                   'AGGREGATION', multi_agg_str, 1000, 'EMPTY')
-
-        assert len(result) == len(refs[0]), \
-            f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
-        for i in range(len(result)):
-            assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
-            for a, agg in enumerate(agg_types):
-                assert result[i][1 + a] == refs[a][i][1], \
-                    f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
-
-        # Also verify REVRANGE
-        refs_rev = [r.execute_command('TS.REVRANGE', 'magg_twa_nan1{a}', '-', '+',
+            refs = [r.execute_command('TS.RANGE', 'magg_nanonly{a}', '-', '+',
                                       'AGGREGATION', agg, 1000, 'EMPTY') for agg in agg_types]
-        result_rev = r.execute_command('TS.REVRANGE', 'magg_twa_nan1{a}', '-', '+',
+            result = r.execute_command('TS.RANGE', 'magg_nanonly{a}', '-', '+',
                                        'AGGREGATION', multi_agg_str, 1000, 'EMPTY')
 
-        assert len(result_rev) == len(refs_rev[0])
-        for i in range(len(result_rev)):
-            assert result_rev[i][0] == refs_rev[0][i][0]
-            for a, agg in enumerate(agg_types):
-                assert result_rev[i][1 + a] == refs_rev[a][i][1], \
-                    f"REVRANGE {agg} mismatch at bucket {i}: multi={result_rev[i][1 + a]}, single={refs_rev[a][i][1]}"
+            assert len(result) == len(refs[0]), \
+                f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
+            for i in range(len(result)):
+                assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
+                for a, agg in enumerate(agg_types):
+                    assert result[i][1 + a] == refs[a][i][1], \
+                        f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
 
+    def test_multi_agg_countnan_first_with_twa(self):
+        """Test that TWA init uses correct validator when countnan is the first aggregation."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_cntwa{a}')
+            r.execute_command('TS.ADD', 'magg_cntwa{a}', 5, 50)
+            r.execute_command('TS.ADD', 'magg_cntwa{a}', 15, 150)
+            r.execute_command('TS.ADD', 'magg_cntwa{a}', 25, 250)
 
-def test_multi_agg_twa_nan_only_last_bucket():
-    """TWA must get interpolated value in a NaN-only LAST bucket when mixed with countall.
+            agg_types = ['countnan', 'twa']
+            multi_agg_str = ','.join(agg_types)
 
-    This specifically exercises the _finalize code path (not finalizeBucket), which is
-    reached when the last bucket in the iteration has unfinalized context.
-    """
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_twa_nan2{a}')
-        # Bucket [1000, 2000): normal values
-        r.execute_command('TS.ADD', 'magg_twa_nan2{a}', 1000, 100)
-        r.execute_command('TS.ADD', 'magg_twa_nan2{a}', 1500, 150)
-        # Bucket [2000, 3000): NaN-only, and this is the LAST bucket
-        r.execute_command('TS.ADD', 'magg_twa_nan2{a}', 2000, 'NaN')
-        r.execute_command('TS.ADD', 'magg_twa_nan2{a}', 2500, 'NaN')
+            refs = [r.execute_command('TS.RANGE', 'magg_cntwa{a}', 10, 30,
+                                      'AGGREGATION', agg, 10, 'EMPTY') for agg in agg_types]
+            result = r.execute_command('TS.RANGE', 'magg_cntwa{a}', 10, 30,
+                                       'AGGREGATION', multi_agg_str, 10, 'EMPTY')
 
-        agg_types = ['countall', 'twa']
-        multi_agg_str = ','.join(agg_types)
+            assert len(result) == len(refs[0]), \
+                f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
+            for i in range(len(result)):
+                assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
+                for a, agg in enumerate(agg_types):
+                    assert result[i][1 + a] == refs[a][i][1], \
+                        f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
 
-        refs = [r.execute_command('TS.RANGE', 'magg_twa_nan2{a}', '-', '+',
-                                  'AGGREGATION', agg, 1000, 'EMPTY') for agg in agg_types]
-        result = r.execute_command('TS.RANGE', 'magg_twa_nan2{a}', '-', '+',
-                                   'AGGREGATION', multi_agg_str, 1000, 'EMPTY')
+    def test_multi_agg_twa_nan_only_bucket_with_countall(self):
+        """TWA must get interpolated value (not finalizeEmpty) in a NaN-only bucket when
+        another aggregation with a different validator accepts the NaN values."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_twa_nan1{a}')
+            # Bucket [1000, 2000): normal values (used for TWA interpolation)
+            r.execute_command('TS.ADD', 'magg_twa_nan1{a}', 1000, 100)
+            r.execute_command('TS.ADD', 'magg_twa_nan1{a}', 1500, 150)
+            # Bucket [2000, 3000): NaN-only → triggers the bug
+            r.execute_command('TS.ADD', 'magg_twa_nan1{a}', 2000, 'NaN')
+            r.execute_command('TS.ADD', 'magg_twa_nan1{a}', 2500, 'NaN')
+            # Bucket [3000, 4000): normal values (used for TWA interpolation)
+            r.execute_command('TS.ADD', 'magg_twa_nan1{a}', 3000, 300)
+            r.execute_command('TS.ADD', 'magg_twa_nan1{a}', 3500, 350)
 
-        assert len(result) == len(refs[0]), \
-            f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
-        for i in range(len(result)):
-            assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
-            for a, agg in enumerate(agg_types):
-                assert result[i][1 + a] == refs[a][i][1], \
-                    f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
+            agg_types = ['countall', 'twa']
+            multi_agg_str = ','.join(agg_types)
 
-
-def test_multi_agg_twa_nan_only_with_countnan():
-    """TWA with countnan (instead of countall) and NaN-only bucket.
-
-    countnan uses nanValueValid (only NaN passes), so in a NaN-only bucket:
-    countnan accepts NaN → validSamplesInBucket=true, but TWA rejects NaN.
-    TWA must still get the interpolated value, not finalizeEmpty.
-    """
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_twa_nan3{a}')
-        r.execute_command('TS.ADD', 'magg_twa_nan3{a}', 1000, 100)
-        r.execute_command('TS.ADD', 'magg_twa_nan3{a}', 1500, 150)
-        r.execute_command('TS.ADD', 'magg_twa_nan3{a}', 2000, 'NaN')
-        r.execute_command('TS.ADD', 'magg_twa_nan3{a}', 2500, 'NaN')
-        r.execute_command('TS.ADD', 'magg_twa_nan3{a}', 3000, 300)
-        r.execute_command('TS.ADD', 'magg_twa_nan3{a}', 3500, 350)
-
-        agg_types = ['countnan', 'twa']
-        multi_agg_str = ','.join(agg_types)
-
-        refs = [r.execute_command('TS.RANGE', 'magg_twa_nan3{a}', '-', '+',
-                                  'AGGREGATION', agg, 1000, 'EMPTY') for agg in agg_types]
-        result = r.execute_command('TS.RANGE', 'magg_twa_nan3{a}', '-', '+',
-                                   'AGGREGATION', multi_agg_str, 1000, 'EMPTY')
-
-        assert len(result) == len(refs[0]), \
-            f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
-        for i in range(len(result)):
-            assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
-            for a, agg in enumerate(agg_types):
-                assert result[i][1 + a] == refs[a][i][1], \
-                    f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
-
-
-def test_multi_agg_multiple_gaps_memmove():
-    """Test multi-agg with multiple gaps that trigger the fillEmptyBuckets overlap path.
-
-    When multiple gaps exist, fillEmptyBuckets is called multiple times within a single
-    GetNextChunk invocation. This tests that aux_chunk num_samples is correctly tracked
-    and memmove operations don't corrupt data.
-    """
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_mgap{a}')
-        # Create 5 populated buckets with gaps between each
-        for bucket_start in [1000, 3000, 5000, 7000, 9000]:
-            for i in range(5):
-                r.execute_command('TS.ADD', 'magg_mgap{a}', bucket_start + i,
-                                 bucket_start + i)
-
-        agg_types = ['min', 'max', 'count', 'sum']
-        multi_agg_str = ','.join(agg_types)
-
-        refs = [r.execute_command('TS.RANGE', 'magg_mgap{a}', '-', '+',
-                                  'AGGREGATION', agg, 1000, 'EMPTY') for agg in agg_types]
-        result = r.execute_command('TS.RANGE', 'magg_mgap{a}', '-', '+',
-                                   'AGGREGATION', multi_agg_str, 1000, 'EMPTY')
-
-        assert len(result) == len(refs[0]), \
-            f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
-        for i in range(len(result)):
-            assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
-            for a, agg in enumerate(agg_types):
-                assert result[i][1 + a] == refs[a][i][1], \
-                    f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
-
-        # Also verify REVRANGE with multiple gaps
-        refs_rev = [r.execute_command('TS.REVRANGE', 'magg_mgap{a}', '-', '+',
+            refs = [r.execute_command('TS.RANGE', 'magg_twa_nan1{a}', '-', '+',
                                       'AGGREGATION', agg, 1000, 'EMPTY') for agg in agg_types]
-        result_rev = r.execute_command('TS.REVRANGE', 'magg_mgap{a}', '-', '+',
+            result = r.execute_command('TS.RANGE', 'magg_twa_nan1{a}', '-', '+',
                                        'AGGREGATION', multi_agg_str, 1000, 'EMPTY')
 
-        assert len(result_rev) == len(refs_rev[0]), \
-            f"REVRANGE bucket count mismatch: multi-agg={len(result_rev)}, single-agg={len(refs_rev[0])}"
-        for i in range(len(result_rev)):
-            assert result_rev[i][0] == refs_rev[0][i][0], f"REVRANGE timestamp mismatch at bucket {i}"
-            for a, agg in enumerate(agg_types):
-                assert result_rev[i][1 + a] == refs_rev[a][i][1], \
-                    f"REVRANGE {agg} mismatch at bucket {i}: multi={result_rev[i][1 + a]}, single={refs_rev[a][i][1]}"
+            assert len(result) == len(refs[0]), \
+                f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
+            for i in range(len(result)):
+                assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
+                for a, agg in enumerate(agg_types):
+                    assert result[i][1 + a] == refs[a][i][1], \
+                        f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
 
+            # Also verify REVRANGE
+            refs_rev = [r.execute_command('TS.REVRANGE', 'magg_twa_nan1{a}', '-', '+',
+                                          'AGGREGATION', agg, 1000, 'EMPTY') for agg in agg_types]
+            result_rev = r.execute_command('TS.REVRANGE', 'magg_twa_nan1{a}', '-', '+',
+                                           'AGGREGATION', multi_agg_str, 1000, 'EMPTY')
 
-def test_multi_agg_twa_with_gaps_and_countall():
-    """Combined test: TWA + countall + EMPTY + multiple gaps.
+            assert len(result_rev) == len(refs_rev[0])
+            for i in range(len(result_rev)):
+                assert result_rev[i][0] == refs_rev[0][i][0]
+                for a, agg in enumerate(agg_types):
+                    assert result_rev[i][1 + a] == refs_rev[a][i][1], \
+                        f"REVRANGE {agg} mismatch at bucket {i}: multi={result_rev[i][1 + a]}, single={refs_rev[a][i][1]}"
 
-    This exercises both findings simultaneously: TWA interpolation in the
-    finalizeBucket else-branch AND the fillEmptyBuckets overlap path with
-    aux_chunk, including TWA-specific empty bucket filling.
-    """
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_combo{a}')
-        # Bucket [0, 10): values
-        r.execute_command('TS.ADD', 'magg_combo{a}', 2, 20)
-        r.execute_command('TS.ADD', 'magg_combo{a}', 5, 50)
-        # Bucket [10, 20): NaN-only → TWA needs interpolation, countall accepts
-        r.execute_command('TS.ADD', 'magg_combo{a}', 12, 'NaN')
-        # Bucket [20, 30): empty gap (no samples at all)
-        # Bucket [30, 40): values
-        r.execute_command('TS.ADD', 'magg_combo{a}', 32, 320)
-        r.execute_command('TS.ADD', 'magg_combo{a}', 38, 380)
+    def test_multi_agg_twa_nan_only_last_bucket(self):
+        """TWA must get interpolated value in a NaN-only LAST bucket when mixed with countall."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_twa_nan2{a}')
+            # Bucket [1000, 2000): normal values
+            r.execute_command('TS.ADD', 'magg_twa_nan2{a}', 1000, 100)
+            r.execute_command('TS.ADD', 'magg_twa_nan2{a}', 1500, 150)
+            # Bucket [2000, 3000): NaN-only, and this is the LAST bucket
+            r.execute_command('TS.ADD', 'magg_twa_nan2{a}', 2000, 'NaN')
+            r.execute_command('TS.ADD', 'magg_twa_nan2{a}', 2500, 'NaN')
 
-        agg_types = ['countall', 'min', 'twa']
-        multi_agg_str = ','.join(agg_types)
+            agg_types = ['countall', 'twa']
+            multi_agg_str = ','.join(agg_types)
 
-        refs = [r.execute_command('TS.RANGE', 'magg_combo{a}', 0, 39,
-                                  'AGGREGATION', agg, 10, 'EMPTY') for agg in agg_types]
-        result = r.execute_command('TS.RANGE', 'magg_combo{a}', 0, 39,
-                                   'AGGREGATION', multi_agg_str, 10, 'EMPTY')
+            refs = [r.execute_command('TS.RANGE', 'magg_twa_nan2{a}', '-', '+',
+                                      'AGGREGATION', agg, 1000, 'EMPTY') for agg in agg_types]
+            result = r.execute_command('TS.RANGE', 'magg_twa_nan2{a}', '-', '+',
+                                       'AGGREGATION', multi_agg_str, 1000, 'EMPTY')
 
-        assert len(result) == len(refs[0]), \
-            f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
-        for i in range(len(result)):
-            assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
-            for a, agg in enumerate(agg_types):
-                assert result[i][1 + a] == refs[a][i][1], \
-                    f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
+            assert len(result) == len(refs[0]), \
+                f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
+            for i in range(len(result)):
+                assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
+                for a, agg in enumerate(agg_types):
+                    assert result[i][1 + a] == refs[a][i][1], \
+                        f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
 
+    def test_multi_agg_twa_nan_only_with_countnan(self):
+        """TWA with countnan (instead of countall) and NaN-only bucket."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_twa_nan3{a}')
+            r.execute_command('TS.ADD', 'magg_twa_nan3{a}', 1000, 100)
+            r.execute_command('TS.ADD', 'magg_twa_nan3{a}', 1500, 150)
+            r.execute_command('TS.ADD', 'magg_twa_nan3{a}', 2000, 'NaN')
+            r.execute_command('TS.ADD', 'magg_twa_nan3{a}', 2500, 'NaN')
+            r.execute_command('TS.ADD', 'magg_twa_nan3{a}', 3000, 300)
+            r.execute_command('TS.ADD', 'magg_twa_nan3{a}', 3500, 350)
 
-def test_multi_agg_twa_edge_gap_no_surrounding_samples():
-    """Test multi-agg with TWA + EMPTY where empty buckets are at the EDGE of the data
-    and have no surrounding samples on one side.
-    """
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_edge{a}')
-        # Data only in bucket [0, 10)
-        r.execute_command('TS.ADD', 'magg_edge{a}', 2, 20)
-        r.execute_command('TS.ADD', 'magg_edge{a}', 7, 70)
-        # Buckets [10, 20) and [20, 30) are empty trailing gaps with no data after
+            agg_types = ['countnan', 'twa']
+            multi_agg_str = ','.join(agg_types)
 
-        agg_types = ['min', 'max', 'twa']
-        multi_agg_str = ','.join(agg_types)
+            refs = [r.execute_command('TS.RANGE', 'magg_twa_nan3{a}', '-', '+',
+                                      'AGGREGATION', agg, 1000, 'EMPTY') for agg in agg_types]
+            result = r.execute_command('TS.RANGE', 'magg_twa_nan3{a}', '-', '+',
+                                       'AGGREGATION', multi_agg_str, 1000, 'EMPTY')
 
-        refs = [r.execute_command('TS.RANGE', 'magg_edge{a}', 0, 30,
-                                  'AGGREGATION', agg, 10, 'EMPTY') for agg in agg_types]
-        result = r.execute_command('TS.RANGE', 'magg_edge{a}', 0, 30,
-                                   'AGGREGATION', multi_agg_str, 10, 'EMPTY')
+            assert len(result) == len(refs[0]), \
+                f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
+            for i in range(len(result)):
+                assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
+                for a, agg in enumerate(agg_types):
+                    assert result[i][1 + a] == refs[a][i][1], \
+                        f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
 
-        assert len(result) == len(refs[0]), \
-            f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
-        for i in range(len(result)):
-            assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
-            for a, agg in enumerate(agg_types):
-                assert result[i][1 + a] == refs[a][i][1], \
-                    f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
+    def test_multi_agg_multiple_gaps_memmove(self):
+        """Test multi-agg with multiple gaps that trigger the fillEmptyBuckets overlap path."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_mgap{a}')
+            # Create 5 populated buckets with gaps between each
+            for bucket_start in [1000, 3000, 5000, 7000, 9000]:
+                for i in range(5):
+                    r.execute_command('TS.ADD', 'magg_mgap{a}', bucket_start + i,
+                                     bucket_start + i)
 
-        # Also test leading gap (data only at the end)
-        r.execute_command('TS.CREATE', 'magg_edge2{a}')
-        r.execute_command('TS.ADD', 'magg_edge2{a}', 22, 220)
-        r.execute_command('TS.ADD', 'magg_edge2{a}', 27, 270)
+            agg_types = ['min', 'max', 'count', 'sum']
+            multi_agg_str = ','.join(agg_types)
 
-        refs2 = [r.execute_command('TS.RANGE', 'magg_edge2{a}', 0, 30,
-                                   'AGGREGATION', agg, 10, 'EMPTY') for agg in agg_types]
-        result2 = r.execute_command('TS.RANGE', 'magg_edge2{a}', 0, 30,
-                                    'AGGREGATION', multi_agg_str, 10, 'EMPTY')
+            refs = [r.execute_command('TS.RANGE', 'magg_mgap{a}', '-', '+',
+                                      'AGGREGATION', agg, 1000, 'EMPTY') for agg in agg_types]
+            result = r.execute_command('TS.RANGE', 'magg_mgap{a}', '-', '+',
+                                       'AGGREGATION', multi_agg_str, 1000, 'EMPTY')
 
-        assert len(result2) == len(refs2[0]), \
-            f"leading gap: bucket count mismatch: multi-agg={len(result2)}, single-agg={len(refs2[0])}"
-        for i in range(len(result2)):
-            assert result2[i][0] == refs2[0][i][0], f"leading gap: timestamp mismatch at bucket {i}"
-            for a, agg in enumerate(agg_types):
-                assert result2[i][1 + a] == refs2[a][i][1], \
-                    f"leading gap: {agg} mismatch at bucket {i}: multi-agg={result2[i][1 + a]}, single={refs2[a][i][1]}"
+            assert len(result) == len(refs[0]), \
+                f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
+            for i in range(len(result)):
+                assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
+                for a, agg in enumerate(agg_types):
+                    assert result[i][1 + a] == refs[a][i][1], \
+                        f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
 
+            # Also verify REVRANGE with multiple gaps
+            refs_rev = [r.execute_command('TS.REVRANGE', 'magg_mgap{a}', '-', '+',
+                                          'AGGREGATION', agg, 1000, 'EMPTY') for agg in agg_types]
+            result_rev = r.execute_command('TS.REVRANGE', 'magg_mgap{a}', '-', '+',
+                                           'AGGREGATION', multi_agg_str, 1000, 'EMPTY')
 
-def test_createrule_multi_agg_error():
-    """TS.CREATERULE should reject multiple aggregators."""
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'magg_cr1{a}')
-        r.execute_command('TS.CREATE', 'magg_cr2{a}')
+            assert len(result_rev) == len(refs_rev[0]), \
+                f"REVRANGE bucket count mismatch: multi-agg={len(result_rev)}, single-agg={len(refs_rev[0])}"
+            for i in range(len(result_rev)):
+                assert result_rev[i][0] == refs_rev[0][i][0], f"REVRANGE timestamp mismatch at bucket {i}"
+                for a, agg in enumerate(agg_types):
+                    assert result_rev[i][1 + a] == refs_rev[a][i][1], \
+                        f"REVRANGE {agg} mismatch at bucket {i}: multi={result_rev[i][1 + a]}, single={refs_rev[a][i][1]}"
 
-        with pytest.raises(redis.ResponseError, match="exactly one"):
-            r.execute_command('TS.CREATERULE', 'magg_cr1{a}', 'magg_cr2{a}',
-                              'AGGREGATION', 'min,max', 1000)
+    def test_multi_agg_twa_with_gaps_and_countall(self):
+        """Combined test: TWA + countall + EMPTY + multiple gaps."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_combo{a}')
+            # Bucket [0, 10): values
+            r.execute_command('TS.ADD', 'magg_combo{a}', 2, 20)
+            r.execute_command('TS.ADD', 'magg_combo{a}', 5, 50)
+            # Bucket [10, 20): NaN-only → TWA needs interpolation, countall accepts
+            r.execute_command('TS.ADD', 'magg_combo{a}', 12, 'NaN')
+            # Bucket [20, 30): empty gap (no samples at all)
+            # Bucket [30, 40): values
+            r.execute_command('TS.ADD', 'magg_combo{a}', 32, 320)
+            r.execute_command('TS.ADD', 'magg_combo{a}', 38, 380)
+
+            agg_types = ['countall', 'min', 'twa']
+            multi_agg_str = ','.join(agg_types)
+
+            refs = [r.execute_command('TS.RANGE', 'magg_combo{a}', 0, 39,
+                                      'AGGREGATION', agg, 10, 'EMPTY') for agg in agg_types]
+            result = r.execute_command('TS.RANGE', 'magg_combo{a}', 0, 39,
+                                       'AGGREGATION', multi_agg_str, 10, 'EMPTY')
+
+            assert len(result) == len(refs[0]), \
+                f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
+            for i in range(len(result)):
+                assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
+                for a, agg in enumerate(agg_types):
+                    assert result[i][1 + a] == refs[a][i][1], \
+                        f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
+
+    def test_multi_agg_twa_edge_gap_no_surrounding_samples(self):
+        """Test multi-agg with TWA + EMPTY where empty buckets are at the EDGE of the data."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_edge{a}')
+            # Data only in bucket [0, 10)
+            r.execute_command('TS.ADD', 'magg_edge{a}', 2, 20)
+            r.execute_command('TS.ADD', 'magg_edge{a}', 7, 70)
+
+            agg_types = ['min', 'max', 'twa']
+            multi_agg_str = ','.join(agg_types)
+
+            refs = [r.execute_command('TS.RANGE', 'magg_edge{a}', 0, 30,
+                                      'AGGREGATION', agg, 10, 'EMPTY') for agg in agg_types]
+            result = r.execute_command('TS.RANGE', 'magg_edge{a}', 0, 30,
+                                       'AGGREGATION', multi_agg_str, 10, 'EMPTY')
+
+            assert len(result) == len(refs[0]), \
+                f"bucket count mismatch: multi-agg={len(result)}, single-agg={len(refs[0])}"
+            for i in range(len(result)):
+                assert result[i][0] == refs[0][i][0], f"timestamp mismatch at bucket {i}"
+                for a, agg in enumerate(agg_types):
+                    assert result[i][1 + a] == refs[a][i][1], \
+                        f"{agg} mismatch at bucket {i}: multi-agg={result[i][1 + a]}, single={refs[a][i][1]}"
+
+            # Also test leading gap (data only at the end)
+            r.execute_command('TS.CREATE', 'magg_edge2{a}')
+            r.execute_command('TS.ADD', 'magg_edge2{a}', 22, 220)
+            r.execute_command('TS.ADD', 'magg_edge2{a}', 27, 270)
+
+            refs2 = [r.execute_command('TS.RANGE', 'magg_edge2{a}', 0, 30,
+                                       'AGGREGATION', agg, 10, 'EMPTY') for agg in agg_types]
+            result2 = r.execute_command('TS.RANGE', 'magg_edge2{a}', 0, 30,
+                                        'AGGREGATION', multi_agg_str, 10, 'EMPTY')
+
+            assert len(result2) == len(refs2[0]), \
+                f"leading gap: bucket count mismatch: multi-agg={len(result2)}, single-agg={len(refs2[0])}"
+            for i in range(len(result2)):
+                assert result2[i][0] == refs2[0][i][0], f"leading gap: timestamp mismatch at bucket {i}"
+                for a, agg in enumerate(agg_types):
+                    assert result2[i][1 + a] == refs2[a][i][1], \
+                        f"leading gap: {agg} mismatch at bucket {i}: multi-agg={result2[i][1 + a]}, single={refs2[a][i][1]}"
+
+    def test_createrule_multi_agg_error(self):
+        """TS.CREATERULE should reject multiple aggregators."""
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'magg_cr1{a}')
+            r.execute_command('TS.CREATE', 'magg_cr2{a}')
+
+            with pytest.raises(redis.ResponseError, match="exactly one"):
+                r.execute_command('TS.CREATERULE', 'magg_cr1{a}', 'magg_cr2{a}',
+                                  'AGGREGATION', 'min,max', 1000)

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -11,1228 +11,1253 @@ from utils import timeit
 import random
 from datetime import datetime
 
+class testTsRange:
+    def __init__(self):
+        self.env = Env()
+
+    def test_range_query(self):
+        env = self.env
+        env.flush()
+        start_ts = 1488823384
+        samples_count = 1500
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', 'tester', 'uncompressed', 'RETENTION', samples_count - 100)
+            _insert_data(r, 'tester', start_ts, samples_count, 5)
+
+            expected_result = [[start_ts + i, str(5).encode('ascii')] for i in range(99, 151)]
+            actual_result = r.execute_command('TS.range', 'tester', start_ts + 50, start_ts + 150)
+            assert expected_result == actual_result
+            rev_result = r.execute_command('TS.revrange', 'tester', start_ts + 50, start_ts + 150)
+            rev_result.reverse()
+            assert expected_result == rev_result
+
+            # test out of range returns empty list
+            assert [] == r.execute_command('TS.range', 'tester', int(start_ts * 2), '+')
+            assert [] == r.execute_command('TS.range', 'tester', int(start_ts / 3), int(start_ts / 2))
+
+            assert [] == r.execute_command('TS.revrange', 'tester', int(start_ts * 2), '+')
+            assert [] == r.execute_command('TS.revrange', 'tester', int(start_ts / 3), int(start_ts / 2))
+
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.RANGE', 'tester', 'string', '+')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.RANGE', 'tester', 0, 'string')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.RANGE', 'tester', 0, -1)
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.RANGE', 'tester', -1, 1000)
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.RANGE', 'nonexist', 0, '+')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.RANGE', 'tester', 0, '+', '', 'aggregation')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.RANGE', 'tester', 0, '+', 'count', 'number')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.RANGE', 'tester', 0, '+', 'count')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.RANGE', 'tester', 0, '+', 'aggregation', 'count', 'number')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.RANGE', 'tester', 0, '+', 'aggregation', 'count')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.RANGE', 'tester', 0, '+', 'aggregation', '')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.RANGE', 'tester', 0, '+', 'aggregation', 'not_aggregation_function')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.RANGE', 'tester', 0, '+', 'aggregation', '')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'FILTER_BY_VALUE')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'FILTER_BY_TS')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'FILTER_BY_TS', 'FILTER_BY_VALUE')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'FILTER_BY_VALUE', 'FILTER_BY_TS')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'FILTER_BY_VALUE', 10, 'FILTER_BY_TS')
+
+
+
+    def test_range_midrange(self):
+        env = self.env
+        env.flush()
+        samples_count = 5000
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', 'tester', 'UNCOMPRESSED')
+            for i in range(samples_count):
+                r.execute_command('TS.ADD', 'tester', i, i)
+            res = r.execute_command('TS.RANGE', 'tester', samples_count - 500, samples_count)
+            assert len(res) == 500  # sample_count is not in range() so not included
+            res = r.execute_command('TS.RANGE', 'tester', samples_count - 1500, samples_count - 1000)
+            assert len(res) == 501
+
+            # test for empty range between two full ranges
+            for i in range(samples_count):
+                r.execute_command('TS.ADD', 'tester', samples_count * 2 + i, i)
+            res = r.execute_command('TS.RANGE', 'tester', int(samples_count * 1.1), int(samples_count + 1.2))
+            assert res == []
+
+
+
+    def test_range_with_agg_query(self):
+        env = self.env
+        env.flush()
+        start_ts = 1488823384
+        samples_count = 1500
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', 'tester')
+            _insert_data(r, 'tester', start_ts, samples_count, 5)
+
+            expected_result = [[1488823000, b'116'], [1488823500, b'500'], [1488824000, b'500'], [1488824500, b'384']]
+            actual_result = r.execute_command('TS.range', 'tester', start_ts, start_ts + samples_count, 'AGGREGATION',
+                                              'count', 500)
+            assert expected_result == actual_result
+
+            # test first aggregation is not [0,0] if out of range
+            expected_result = [[1488823000, b'116'], [1488823500, b'500']]
+            actual_result = r.execute_command('TS.range', 'tester', 1488822000, 1488823999, b'AGGREGATION',
+                                              'count', 500)
+            assert expected_result == actual_result
 
-def test_range_query():
-    start_ts = 1488823384
-    samples_count = 1500
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', 'tester', 'uncompressed', 'RETENTION', samples_count - 100)
-        _insert_data(r, 'tester', start_ts, samples_count, 5)
-
-        expected_result = [[start_ts + i, str(5).encode('ascii')] for i in range(99, 151)]
-        actual_result = r.execute_command('TS.range', 'tester', start_ts + 50, start_ts + 150)
-        assert expected_result == actual_result
-        rev_result = r.execute_command('TS.revrange', 'tester', start_ts + 50, start_ts + 150)
-        rev_result.reverse()
-        assert expected_result == rev_result
-
-        # test out of range returns empty list
-        assert [] == r.execute_command('TS.range', 'tester', int(start_ts * 2), '+')
-        assert [] == r.execute_command('TS.range', 'tester', int(start_ts / 3), int(start_ts / 2))
-
-        assert [] == r.execute_command('TS.revrange', 'tester', int(start_ts * 2), '+')
-        assert [] == r.execute_command('TS.revrange', 'tester', int(start_ts / 3), int(start_ts / 2))
-
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', 'string', '+')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', 0, 'string')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', 0, -1)
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', -1, 1000)
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'nonexist', 0, '+')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', 0, '+', '', 'aggregation')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', 0, '+', 'count', 'number')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', 0, '+', 'count')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', 0, '+', 'aggregation', 'count', 'number')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', 0, '+', 'aggregation', 'count')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', 0, '+', 'aggregation', '')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', 0, '+', 'aggregation', 'not_aggregation_function')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', 0, '+', 'aggregation', '')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'FILTER_BY_VALUE')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'FILTER_BY_TS')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'FILTER_BY_TS', 'FILTER_BY_VALUE')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'FILTER_BY_VALUE', 'FILTER_BY_TS')
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.RANGE', 'tester', '-', '+', 'FILTER_BY_VALUE', 10, 'FILTER_BY_TS')
-
-
-def test_range_midrange():
-    samples_count = 5000
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', 'tester', 'UNCOMPRESSED')
-        for i in range(samples_count):
-            r.execute_command('TS.ADD', 'tester', i, i)
-        res = r.execute_command('TS.RANGE', 'tester', samples_count - 500, samples_count)
-        assert len(res) == 500  # sample_count is not in range() so not included
-        res = r.execute_command('TS.RANGE', 'tester', samples_count - 1500, samples_count - 1000)
-        assert len(res) == 501
-
-        # test for empty range between two full ranges
-        for i in range(samples_count):
-            r.execute_command('TS.ADD', 'tester', samples_count * 2 + i, i)
-        res = r.execute_command('TS.RANGE', 'tester', int(samples_count * 1.1), int(samples_count + 1.2))
-        assert res == []
-
-
-def test_range_with_agg_query():
-    start_ts = 1488823384
-    samples_count = 1500
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', 'tester')
-        _insert_data(r, 'tester', start_ts, samples_count, 5)
-
-        expected_result = [[1488823000, b'116'], [1488823500, b'500'], [1488824000, b'500'], [1488824500, b'384']]
-        actual_result = r.execute_command('TS.range', 'tester', start_ts, start_ts + samples_count, 'AGGREGATION',
-                                          'count', 500)
-        assert expected_result == actual_result
-
-        # test first aggregation is not [0,0] if out of range
-        expected_result = [[1488823000, b'116'], [1488823500, b'500']]
-        actual_result = r.execute_command('TS.range', 'tester', 1488822000, 1488823999, b'AGGREGATION',
-                                          'count', 500)
-        assert expected_result == actual_result
-
-        with pytest.raises(redis.ResponseError) as excinfo:
-            assert r.execute_command('TS.range', 'tester', start_ts, start_ts + samples_count, 'AGGREGATION',
-                                     'count', -1)
-
-
-def test_agg_std_p():
-    with Env().getClusterConnectionIfNeeded() as r:
-        agg_key = _insert_agg_data(r, 'tester{a}', 'std.p')
+            with pytest.raises(redis.ResponseError) as excinfo:
+                assert r.execute_command('TS.range', 'tester', start_ts, start_ts + samples_count, 'AGGREGATION',
+                                         'count', -1)
 
-        expected_result = [[10, b'25.869'], [20, b'25.869'], [30, b'25.869'], [40, b'25.869']]
-        actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
-        for i in range(len(expected_result)):
-            assert abs(float(expected_result[i][1]) - float(actual_result[i][1])) < ALLOWED_ERROR
 
 
-def test_agg_std_s():
-    with Env().getClusterConnectionIfNeeded() as r:
-        agg_key = _insert_agg_data(r, 'tester{a}', 'std.s')
+    def test_agg_std_p(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            agg_key = _insert_agg_data(r, 'tester{a}', 'std.p')
 
-        expected_result = [[10, b'27.269'], [20, b'27.269'], [30, b'27.269'], [40, b'27.269']]
-        actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
-        for i in range(len(expected_result)):
-            assert abs(float(expected_result[i][1]) - float(actual_result[i][1])) < ALLOWED_ERROR
+            expected_result = [[10, b'25.869'], [20, b'25.869'], [30, b'25.869'], [40, b'25.869']]
+            actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
+            for i in range(len(expected_result)):
+                assert abs(float(expected_result[i][1]) - float(actual_result[i][1])) < ALLOWED_ERROR
 
 
-def test_agg_var_p():
-    with Env().getClusterConnectionIfNeeded() as r:
-        agg_key = _insert_agg_data(r, 'tester{a}', 'var.p')
 
-        expected_result = [[10, b'669.25'], [20, b'669.25'], [30, b'669.25'], [40, b'669.25']]
-        actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
-        for i in range(len(expected_result)):
-            assert abs(float(expected_result[i][1]) - float(actual_result[i][1])) < ALLOWED_ERROR
+    def test_agg_std_s(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            agg_key = _insert_agg_data(r, 'tester{a}', 'std.s')
 
+            expected_result = [[10, b'27.269'], [20, b'27.269'], [30, b'27.269'], [40, b'27.269']]
+            actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
+            for i in range(len(expected_result)):
+                assert abs(float(expected_result[i][1]) - float(actual_result[i][1])) < ALLOWED_ERROR
 
-def test_agg_var_s():
-    with Env().getClusterConnectionIfNeeded() as r:
-        agg_key = _insert_agg_data(r, 'tester{a}', 'var.s')
 
-        expected_result = [[10, b'743.611'], [20, b'743.611'], [30, b'743.611'], [40, b'743.611']]
-        actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
-        for i in range(len(expected_result)):
-            assert abs(float(expected_result[i][1]) - float(actual_result[i][1])) < ALLOWED_ERROR
 
+    def test_agg_var_p(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            agg_key = _insert_agg_data(r, 'tester{a}', 'var.p')
 
-def test_agg_sum():
-    with Env().getClusterConnectionIfNeeded() as r:
-        agg_key = _insert_agg_data(r, 'tester{a}', 'sum')
+            expected_result = [[10, b'669.25'], [20, b'669.25'], [30, b'669.25'], [40, b'669.25']]
+            actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
+            for i in range(len(expected_result)):
+                assert abs(float(expected_result[i][1]) - float(actual_result[i][1])) < ALLOWED_ERROR
 
-        expected_result = [[10, b'1565'], [20, b'2565'], [30, b'3565'], [40, b'4565']]
-        actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
-        assert expected_result == actual_result
 
 
-def test_agg_count():
-    with Env().getClusterConnectionIfNeeded() as r:
-        agg_key = _insert_agg_data(r, 'tester{a}', 'count')
+    def test_agg_var_s(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            agg_key = _insert_agg_data(r, 'tester{a}', 'var.s')
 
-        expected_result = [[10, b'10'], [20, b'10'], [30, b'10'], [40, b'10']]
-        actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
-        assert expected_result == actual_result
+            expected_result = [[10, b'743.611'], [20, b'743.611'], [30, b'743.611'], [40, b'743.611']]
+            actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
+            for i in range(len(expected_result)):
+                assert abs(float(expected_result[i][1]) - float(actual_result[i][1])) < ALLOWED_ERROR
 
 
-def test_agg_first():
-    with Env().getClusterConnectionIfNeeded() as r:
-        agg_key = _insert_agg_data(r, 'tester{a}', 'first')
 
-        expected_result = [[10, b'131'], [20, b'231'], [30, b'331'], [40, b'431']]
-        actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
-        assert expected_result == actual_result
+    def test_agg_sum(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            agg_key = _insert_agg_data(r, 'tester{a}', 'sum')
 
+            expected_result = [[10, b'1565'], [20, b'2565'], [30, b'3565'], [40, b'4565']]
+            actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
+            assert expected_result == actual_result
 
-def test_agg_last():
-    with Env().getClusterConnectionIfNeeded() as r:
-        agg_key = _insert_agg_data(r, 'tester{a}', 'last')
 
-        expected_result = [[10, b'184'], [20, b'284'], [30, b'384'], [40, b'484']]
-        actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
-        assert expected_result == actual_result
 
+    def test_agg_count(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            agg_key = _insert_agg_data(r, 'tester{a}', 'count')
 
-def test_agg_range():
-    with Env().getClusterConnectionIfNeeded() as r:
-        agg_key = _insert_agg_data(r, 'tester{a}', 'range')
-
-        expected_result = [[10, b'74'], [20, b'74'], [30, b'74'], [40, b'74']]
-        actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
-        assert expected_result == actual_result
-
-
-def test_range_count():
-    start_ts = 1511885908
-    samples_count = 50
-
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('TS.CREATE', 'tester1')
-        for i in range(samples_count):
-            r.execute_command('TS.ADD', 'tester1', start_ts + i, i)
-        full_results = r.execute_command('TS.RANGE', 'tester1', 0, '+')
-        assert len(full_results) == samples_count
-        count_results = r.execute_command('TS.RANGE', 'tester1', 0, '+', b'COUNT', 10)
-        assert count_results == full_results[:10]
-        count_results = r.execute_command('TS.RANGE', 'tester1', 0, '+', b'COUNT', 10, b'AGGREGATION', 'COUNT', 3)
-        assert len(count_results) == 10
-        count_results = r.execute_command('TS.RANGE', 'tester1', 0, '+', b'AGGREGATION', 'COUNT', 4, b'COUNT', 10)
-        assert len(count_results) == 10
-        count_results = r.execute_command('TS.RANGE', 'tester1', 0, '+', 'COUNT', 10, b'AGGREGATION', 'COUNT', 4)
-        assert len(count_results) == 10
-        count_results = r.execute_command('TS.RANGE', 'tester1', 0, '+', b'AGGREGATION', 'COUNT', 3)
-        assert len(count_results) == math.ceil(samples_count / 3.0)
-
-
-def test_agg_min():
-    with Env().getClusterConnectionIfNeeded() as r:
-        agg_key = _insert_agg_data(r, 'tester{a}', 'min')
-
-        expected_result = [[10, b'123'], [20, b'223'], [30, b'323'], [40, b'423']]
-        actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
-        assert expected_result == actual_result
-
-
-def test_agg_max():
-    with Env().getClusterConnectionIfNeeded() as r:
-        agg_key = _insert_agg_data(r, 'tester{a}', 'max')
-
-        expected_result = [[10, b'197'], [20, b'297'], [30, b'397'], [40, b'497']]
-        actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
-        assert expected_result == actual_result
-
-
-def test_agg_avg():
-    with Env().getClusterConnectionIfNeeded() as r:
-        agg_key = _insert_agg_data(r, 'tester{a}', 'avg')
-
-        expected_result = [[10, b'156.5'], [20, b'256.5'], [30, b'356.5'], [40, b'456.5']]
-        actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
-        assert expected_result == actual_result
-
-        #test overflow
-        MAX_DOUBLE = 1.7976931348623157E+308
-        assert r.execute_command('TS.CREATE', 'ts1')
-        assert r.execute_command('TS.ADD', 'ts1', 1, MAX_DOUBLE - 10)
-        assert r.execute_command('TS.ADD', 'ts1', 2, MAX_DOUBLE - 8)
-        assert r.execute_command('TS.ADD', 'ts1', 3, MAX_DOUBLE - 6)
-
-        actual_result = r.execute_command('TS.RANGE', 'ts1', 0, 3, 'AGGREGATION', 'avg', 5)
-        #MAX_DOUBLE - 10 equals MAX_DOUBLE cause of precision limit
-
-        # If this test fails in the future it means
-        # it run on an OS/compiler that doesn't support long double need to remove the comment below
-        if(VALGRIND or (sizeof(c_longdouble) == 8)):
-            assert actual_result == [[0, b'1.7976931348623155E308']]
-        else:
-            assert actual_result == [[0, b'1.7976931348623157E308']]
-
-        MIN_DOUBLE = -1.7976931348623157E+308
-        assert r.execute_command('TS.CREATE', 'ts2')
-        assert r.execute_command('TS.ADD', 'ts2', 1, MIN_DOUBLE + 10)
-        assert r.execute_command('TS.ADD', 'ts2', 2, MIN_DOUBLE + 8)
-        assert r.execute_command('TS.ADD', 'ts2', 3, MIN_DOUBLE + 6)
-
-        actual_result = r.execute_command('TS.RANGE', 'ts2', 0, 3, 'AGGREGATION', 'avg', 5)
-        #MIN_DOUBLE + 10 equals MIN_DOUBLE cause of precision limit
-        if(VALGRIND or (sizeof(c_longdouble) == 8)):
-            assert actual_result == [[0, b'-1.7976931348623155E308']]
-        else:
-            assert actual_result == [[0, b'-1.7976931348623157E308']]
-
-def test_agg_twa():
-    #https://redislabs.atlassian.net/jira/software/c/projects/PM/boards/263?modal=detail&selectedIssue=PM-1229
-    with Env().getClusterConnectionIfNeeded() as r:
-        #case 1:
-        assert r.execute_command('TS.CREATE', 'ts1')
-        assert r.execute_command('TS.ADD', 'ts1', 8, 8)
-        assert r.execute_command('TS.ADD', 'ts1', 9, 9)
-        assert r.execute_command('TS.ADD', 'ts1', 10, 10)
-        assert r.execute_command('TS.ADD', 'ts1', 13, 13)
-        assert r.execute_command('TS.ADD', 'ts1', 14, 14)
-        assert r.execute_command('TS.ADD', 'ts1', 23, 23)
-        v1, v2, v3, v4, v5 = 9.0, 10.0, 13.0, 14.0, 23.0
-        t1, t2, t3, t4, t5 = 9.0, 10.0, 13.0, 14.0, 23.0
-        ta, tb = 10.0, 20.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        vb = v4+(v5-v4)*(tb-t4)/(t5-t4)
-        s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (v3+v4)*(t4-t3) + (vb+v4)*(tb-t4)
-        res = s / (2*(tb-ta))
-        expected_result = [10, str(int(res)).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts1', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts1', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-
-        #case 2:
-        assert r.execute_command('TS.CREATE', 'ts2')
-        assert r.execute_command('TS.ADD', 'ts2', 8, 8)
-        assert r.execute_command('TS.ADD', 'ts2', 9, 9)
-        assert r.execute_command('TS.ADD', 'ts2', 13, 13)
-        assert r.execute_command('TS.ADD', 'ts2', 14, 14)
-        assert r.execute_command('TS.ADD', 'ts2', 23, 23)
-        v1, v2, v3, v4 = 9.0, 13.0, 14.0, 23.0
-        t1, t2, t3, t4 = 9.0, 13.0, 14.0, 23.0
-        ta, tb = 10.0, 20.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        vb = v3+(v4-v3)*(tb-t3)/(t4-t3)
-        s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (vb+v3)*(tb-t3)
-        res = s / (2*(tb-ta))
-        expected_result = [10, str(int(res)).encode('ascii')]
-
-        actual_result = r.execute_command('TS.RANGE', 'ts2', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts2', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-
-        #case 3:
-        assert r.execute_command('TS.CREATE', 'ts3')
-        assert r.execute_command('TS.ADD', 'ts3', 8, 8)
-        assert r.execute_command('TS.ADD', 'ts3', 9, 9)
-        assert r.execute_command('TS.ADD', 'ts3', 13, 13)
-        assert r.execute_command('TS.ADD', 'ts3', 14, 14)
-        assert r.execute_command('TS.ADD', 'ts3', 26, 26)
-        v1, v2, v3, v4 = 9.0, 13.0, 14.0, 26.0
-        t1, t2, t3, t4 = 9.0, 13.0, 14.0, 26.0
-        ta, tb = 10.0, 20.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        vb = v3+(v4-v3)*(tb-t3)/(t4-t3)
-        s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (vb+v3)*(tb-t3)
-        res = s / (2*(tb-ta))
-        expected_result = [10, str(int(res)).encode('ascii')]
-
-        actual_result = r.execute_command('TS.RANGE', 'ts3', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts3', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-
-        #case 4:
-        assert r.execute_command('TS.CREATE', 'ts4')
-        assert r.execute_command('TS.ADD', 'ts4', 8, 8)
-        assert r.execute_command('TS.ADD', 'ts4', 9, 9)
-        assert r.execute_command('TS.ADD', 'ts4', 13, 13)
-        assert r.execute_command('TS.ADD', 'ts4', 14, 14)
-        assert r.execute_command('TS.ADD', 'ts4', 27, 27)
-        v1, v2, v3, v4 = 9.0, 13.0, 14.0, 27.0
-        t1, t2, t3, t4 = 9.0, 13.0, 14.0, 27.0
-        ta, tb = 10.0, 20.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        vb = v3+(v4-v3)*(tb-t3)/(t4-t3)
-        s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (vb+v3)*(tb-t3)
-        res = s / (2*(tb-ta))
-        expected_result = [10, str(int(res)).encode('ascii')]
-
-        actual_result = r.execute_command('TS.RANGE', 'ts4', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts4', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-
-        #case 5:
-        assert r.execute_command('TS.CREATE', 'ts5')
-        assert r.execute_command('TS.ADD', 'ts5', 3, 3)
-        assert r.execute_command('TS.ADD', 'ts5', 7, 7)
-        assert r.execute_command('TS.ADD', 'ts5', 13, 13)
-        assert r.execute_command('TS.ADD', 'ts5', 14, 14)
-        assert r.execute_command('TS.ADD', 'ts5', 27, 27)
-        v1, v2, v3, v4 = 7.0, 13.0, 14.0, 27.0
-        t1, t2, t3, t4 = 7.0, 13.0, 14.0, 27.0
-        ta, tb = 10.0, 20.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        vb = v3+(v4-v3)*(tb-t3)/(t4-t3)
-        s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (vb+v3)*(tb-t3)
-        res = s / (2*(tb-ta))
-        expected_result = [10, str(int(res)).encode('ascii')]
-
-        actual_result = r.execute_command('TS.RANGE', 'ts5', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts5', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-
-        #case 6:
-        assert r.execute_command('TS.CREATE', 'ts6')
-        assert r.execute_command('TS.ADD', 'ts6', 3, 3)
-        assert r.execute_command('TS.ADD', 'ts6', 6, 6)
-        assert r.execute_command('TS.ADD', 'ts6', 13, 13)
-        assert r.execute_command('TS.ADD', 'ts6', 14, 14)
-        assert r.execute_command('TS.ADD', 'ts6', 27, 27)
-        v1, v2, v3, v4 = 6.0, 13.0, 14.0, 27.0
-        t1, t2, t3, t4 = 6.0, 13.0, 14.0, 27.0
-        ta, tb = 10.0, 20.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        vb = v3+(v4-v3)*(tb-t3)/(t4-t3)
-        s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (vb+v3)*(tb-t3)
-        res = s / (2*(tb-ta))
-        expected_result = [10, str(int(res)).encode('ascii')]
-
-        actual_result = r.execute_command('TS.RANGE', 'ts6', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts6', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-
-        #case 7:
-        assert r.execute_command('TS.CREATE', 'ts7')
-        assert r.execute_command('TS.ADD', 'ts7', 3, 3)
-        assert r.execute_command('TS.ADD', 'ts7', 9, 9)
-        assert r.execute_command('TS.ADD', 'ts7', 13, 13)
-        assert r.execute_command('TS.ADD', 'ts7', 22, 22)
-        v1, v2, v3 = 9.0, 13.0, 22.0
-        t1, t2, t3 = 9.0, 13.0, 22.0
-        ta, tb = 10.0, 20.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        vb = v2+(v3-v2)*(tb-t2)/(t3-t2)
-        s = (va+v2)*(t2-ta) + (vb+v2)*(tb-t2)
-        res = s / (2*(tb-ta))
-        expected_result = [10, str(int(res)).encode('ascii')]
-
-        actual_result = r.execute_command('TS.RANGE', 'ts7', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts7', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-
-        #case 8:
-        assert r.execute_command('TS.CREATE', 'ts8')
-        assert r.execute_command('TS.ADD', 'ts8', 3, 3)
-        assert r.execute_command('TS.ADD', 'ts8', 13, 13)
-        assert r.execute_command('TS.ADD', 'ts8', 28, 28)
-        v1, v2, v3 = 3.0, 13.0, 28.0
-        t1, t2, t3 = 3.0, 13.0, 28.0
-        ta, tb = 10.0, 20.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        vb = v2+(v3-v2)*(tb-t2)/(t3-t2)
-        s = (va+v2)*(t2-ta) + (vb+v2)*(tb-t2)
-        res = s / (2.0*(tb-ta))
-        expected_result = [10, str(int(res)).encode('ascii')]
-
-        actual_result = r.execute_command('TS.RANGE', 'ts8', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts8', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-
-        #case 9:
-        assert r.execute_command('TS.CREATE', 'ts9')
-        assert r.execute_command('TS.ADD', 'ts9', 13, 13)
-        assert r.execute_command('TS.ADD', 'ts9', 28, 28)
-        v1, v2, = 13.0, 28.0
-        t1, t2, = 13.0, 28.0
-        ta, tb = 10.0, 20.0
-        vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
-        s = (v1+vb)*(tb-t1)
-        res = s / (2.0*(tb-t1))
-        expected_result = [10, str(res).encode('ascii')]
-
-        actual_result = r.execute_command('TS.RANGE', 'ts9', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts9', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-
-        #case 10:
-        assert r.execute_command('TS.CREATE', 'ts10')
-        assert r.execute_command('TS.ADD', 'ts10', 13, 13)
-        assert r.execute_command('TS.ADD', 'ts10', 21, 21)
-        v1, v2, = 13.0, 21.0
-        t1, t2, = 13.0, 21.0
-        ta, tb = 10.0, 20.0
-        vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
-        s = (v1+vb)*(tb-t1)
-        res = s / (2.0*(tb-t1))
-        expected_result = [10, str(res).encode('ascii')]
-
-        actual_result = r.execute_command('TS.RANGE', 'ts10', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts10', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-
-        #case 11:
-        assert r.execute_command('TS.CREATE', 'ts11')
-        assert r.execute_command('TS.ADD', 'ts11', 17, 17)
-        assert r.execute_command('TS.ADD', 'ts11', 21, 21)
-        v1, v2, = 17.0, 21.0
-        t1, t2, = 17.0, 21.0
-        ta, tb = 10.0, 20.0
-        vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
-        s = (v1+vb)*(tb-t1)
-        res = s / (2.0*(tb-t1))
-        expected_result = [10, str(res).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts11', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts11', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-
-        #case 12:
-        assert r.execute_command('TS.CREATE', 'ts12')
-        assert r.execute_command('TS.ADD', 'ts12', 3, 3)
-        assert r.execute_command('TS.ADD', 'ts12', 17, 17)
-        v1, v2, = 3.0, 17.0
-        t1, t2, = 3.0, 17.0
-        ta, tb = 10.0, 20.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        s = (va+v2)*(t2-ta)
-        res = s / (2.0*(t2-ta))
-        expected_result = [10, str(res).encode('ascii')]
-
-        actual_result = r.execute_command('TS.RANGE', 'ts12', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts12', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-
-        #case 14:
-        assert r.execute_command('TS.CREATE', 'ts14')
-        assert r.execute_command('TS.ADD', 'ts14', 5, 5)
-        assert r.execute_command('TS.ADD', 'ts14', 12, 12)
-        v1, v2, = 5.0, 12.0
-        t1, t2, = 5.0, 12.0
-        ta, tb = 10.0, 20.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        s = (va+v2)*(t2-ta)
-        res = s / (2.0*(t2-ta))
-        expected_result = [10, str(int(res)).encode('ascii')]
-
-        actual_result = r.execute_command('TS.RANGE', 'ts14', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts14', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-
-        #case 15:
-        assert r.execute_command('TS.CREATE', 'ts15')
-        assert r.execute_command('TS.ADD', 'ts15', 7, 7)
-        assert r.execute_command('TS.ADD', 'ts15', 15, 15)
-        v1, v2, = 7.0, 15.0
-        t1, t2, = 7.0, 15.0
-        ta, tb = 10.0, 20.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        s = (va+v2)*(t2-ta)
-        res = s / (2.0*(t2-ta))
-        expected_result = [10, str(res).encode('ascii')]
-
-        actual_result = r.execute_command('TS.RANGE', 'ts15', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts15', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-
-        #case 16:
-        assert r.execute_command('TS.CREATE', 'ts16')
-        assert r.execute_command('TS.ADD', 'ts16', 15, 15)
-        res = 15
-        expected_result = [10, str(res).encode('ascii')]
-
-        actual_result = r.execute_command('TS.RANGE', 'ts16', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts16', 10, 20, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-
-        #case 17:
-        assert r.execute_command('TS.CREATE', 'ts17')
-        assert r.execute_command('TS.ADD', 'ts17', 0, 5) == 0
-        assert r.execute_command('TS.ADD', 'ts17', 9, 12)
-        v1, v2, = 5, 12.0
-        t1, t2, = 0, 9.0
-        ta, tb = 0, 10.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        s = (va+v2)*(t2-ta)
-        res = s / (2.0*(t2-ta))
-        expected_result = [0, str(res).encode('ascii')]
-
-        actual_result = r.execute_command('TS.RANGE', 'ts17', 0, 10, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts17', 0, 10, 'AGGREGATION', 'twa', 10)
-        assert actual_result[0] == expected_result
-
-        #case 18:
-        assert r.execute_command('TS.CREATE', 'ts18')
-        assert r.execute_command('TS.ADD', 'ts18', 10, 100)
-        assert r.execute_command('TS.ADD', 'ts18', 13, 110)
-        assert r.execute_command('TS.ADD', 'ts18', 15, 115)
-        assert r.execute_command('TS.ADD', 'ts18', 19, 109)
-        assert r.execute_command('TS.ADD', 'ts18', 25, 130)
-        v1, v2, v3, v4, v5 = 100.0, 110.0, 115.0, 109.0, 130.0
-        t1, t2, t3, t4, t5 = 10.0, 13.0, 15.0, 19.0, 25.0
-        ta, tb = 12.0, 20.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        vb = v4+(v5-v4)*(tb-t4)/(t5-t4)
-        s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (v3+v4)*(t4-t3) + (vb+v4)*(tb-t4)
-        res = s / (2.0*(tb-ta))
-        expected_result = [0, str(res).encode('ascii')]
-
-        # Test case #1:
-        actual_result = r.execute_command('TS.RANGE', 'ts18', 12, 20, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts18', 12, 20, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.RANGE', 'ts18', 12, 20, 'AGGREGATION', 'twa', 1000)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts18', 12, 20, 'AGGREGATION', 'twa', 1000)
-        assert actual_result[0] == expected_result
-
-        ta, tb = 11.0, 30.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (v3+v4)*(t4-t3) + (v5+v4)*(t5-t4)
-        res = s / (2.0*(t5-ta))
-        expected_result = [0, str(res).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts18', 11, 30, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts18', 11, 30, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-
-        # Test case #2:
-        ta, tb = 11.0, 20.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        vb = v4+(v5-v4)*(tb-t4)/(t5-t4)
-        s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (v3+v4)*(t4-t3) + (vb+v4)*(tb-t4)
-        res = s / (2.0*(tb-ta))
-        expected_result = [0, str(res).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts18', 11, 20, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts18', 11, 20, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-
-        # Test case #3:
-        ta, tb = 12.0, 24.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        vb = v4+(v5-v4)*(tb-t4)/(t5-t4)
-        s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (v3+v4)*(t4-t3) + (vb+v4)*(tb-t4)
-        res = s / (2*(tb-ta))
-        expected_result = [0, str(res).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts18', 12, 24, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts18', 12, 24, 'AGGREGATION', 'twa', 100)
-        round(float(actual_result[0][1]), 10) == round(res, 10)
-        assert actual_result[0][0] == expected_result[0]
-
-        # Test case #4:
-        ta, tb = 11.0, 24.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        vb = v4+(v5-v4)*(tb-t4)/(t5-t4)
-        s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (v3+v4)*(t4-t3) + (vb+v4)*(tb-t4)
-        res = s / (2.0*(tb-ta))
-        expected_result = [0, str(res).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts18', 11, 24, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts18', 11, 24, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-
-        # Test case #5:
-        ta, tb = 8.0, 26.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        s = (v1+v2)*(t2-t1) + (v2+v3)*(t3-t2) + (v3+v4)*(t4-t3) + (v5+v4)*(t5-t4)
-        res = s / (2.0*(t5-t1))
-        expected_result = [0, str(res).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts18', 8, 26, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        expected_result = [0, str(res).encode('ascii')]
-        actual_result = r.execute_command('TS.REVRANGE', 'ts18', 8, 26, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-
-        # Test case #6:
-        ta, tb = 8.0, 30.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        s = (v1+v2)*(t2-t1) + (v2+v3)*(t3-t2) + (v3+v4)*(t4-t3) + (v5+v4)*(t5-t4)
-        res = s / (2.0*(t5-t1))
-        expected_result = [0, str(res).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts18', 8, 30, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        expected_result = [0, str(res).encode('ascii')]
-        actual_result = r.execute_command('TS.REVRANGE', 'ts18', 8, 30, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-
-        # Test case #7:
-        ta, tb = 9.0, 30.0
-        s = (v1+v2)*(t2-t1) + (v2+v3)*(t3-t2) + (v3+v4)*(t4-t3) + (v5+v4)*(t5-t4)
-        res = s / (2.0*(t5-t1))
-        expected_result = [0, str(res).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts18', 9, 30, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        expected_result = [0, str(res).encode('ascii')]
-        actual_result = r.execute_command('TS.REVRANGE', 'ts18', 9, 30, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-
-        #Test case 19:
-        assert r.execute_command('TS.CREATE', 'ts19')
-        assert r.execute_command('TS.ADD', 'ts19', 10, 100)
-        assert r.execute_command('TS.ADD', 'ts19', 20, 110)
-
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts19', 16, 18, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts19', 16, 18, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-
-
-        v1, v2 = 100.0, 110.0
-        t1, t2 = 10.0, 20.0
-        ta, tb = 16.0, 18.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
-        res = (va + vb)/2.0
-        expected_result = [0, str(int(res)).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts19', 16, 18, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts19', 16, 18, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result[0] == expected_result
-
-        #Test case 20:
-        ta, tb = 12.0, 14.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
-        res = (va + vb)/2.0
-        expected_result = [0, str(int(res)).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts19', 12, 14, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result[0] == expected_result
-        expected_result = [0, str(int(res)).encode('ascii')]
-        actual_result = r.execute_command('TS.REVRANGE', 'ts19', 12, 14, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result[0] == expected_result
-
-        #Test case 21:
-        ta, tb = 14.0, 19.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
-        res = (va + vb)/2.0
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts19', 14, 19, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts19', 14, 19, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-
-        expected_result = [0, str(res).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts19', 14, 19, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts19', 14, 19, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result[0] == expected_result
-
-        ta, tb = 11.0, 16.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
-        res = (va + vb)/2.0
-        expected_result = [0, str(res).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts19', 11, 16, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result[0] == expected_result
-        expected_result = [0, str(res).encode('ascii')]
-        actual_result = r.execute_command('TS.REVRANGE', 'ts19', 11, 16, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result[0] == expected_result
-
-        #Test case 22:
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts19', 11, 15, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts19', 11, 15, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-
-        #case 4:
-        assert r.execute_command('TS.CREATE', 'ts20')
-        assert r.execute_command('TS.ADD', 'ts20', 20, 100)
-        assert r.execute_command('TS.ADD', 'ts20', 30, 110)
-        v1, v2 = 100.0, 110.0
-        t1, t2 = 20.0, 30.0
-
-        # Test case #13:
-        ta, tb = 14.0, 22.0
-        vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
-        res = (v1 + vb)/2.0
-        expected_result = [0, str(int(res)).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 14, 22, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 14, 22, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-
-        # Test case #14:
-        ta, tb = 14.0, 28.0
-        vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
-        res = (v1 + vb)/2.0
-        expected_result = [0, str(int(res)).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 14, 28, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 14, 28, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-
-        # Test case #15:
-        ta, tb = 16.0, 22.0
-        vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
-        res = (v1 + vb)/2.0
-        expected_result = [0, str(int(res)).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 16, 22, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 16, 22, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-
-        # Test case #16:
-        ta, tb = 16.0, 28.0
-        vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
-        res = (v1 + vb)/2.0
-        expected_result = [0, str(int(res)).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 16, 28, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 16, 28, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-
-        # Test case #17:
-        ta, tb = 24.0, 32.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        res = (va + v2)/2.0
-        expected_result = [0, str(int(res)).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 24, 32, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 24, 32, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-
-        # Test case #18:
-        ta, tb = 26.0, 32.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        res = (va + v2)/2.0
-        expected_result = [0, str(int(res)).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 26, 32, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 26, 32, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-
-        # Test case #19:
-        ta, tb = 24.0, 38.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        res = (va + v2)/2.0
-        expected_result = [0, str(int(res)).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 24, 38, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 24, 38, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-
-        # Test case #20:
-        ta, tb = 26.0, 38.0
-        va = v1+(v2-v1)*(ta-t1)/(t2-t1)
-        res = (va + v2)/2.0
-        expected_result = [0, str(int(res)).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 26, 38, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 26, 38, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-
-        #Test case 21:
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 32, 34, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 32, 34, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 32, 34, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 32, 34, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result == expected_result
-
-        #Test case 22:
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 32, 100, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 32, 100, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 32, 100, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 32, 100, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result == expected_result
-
-        #Test case 23:
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 38, 100, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 38, 100, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 38, 100, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 38, 100, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result == expected_result
-
-        #Test case 24:
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 16, 18, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 16, 18, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 16, 18, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 16, 18, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result == expected_result
-
-        #Test case 25:
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 10, 18, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 10, 18, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 10, 18, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 10, 18, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result == expected_result
-
-        #Test case 26:
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 10, 14, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 10, 14, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts20', 10, 14, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts20', 10, 14, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result == expected_result
-
-        #case 8:
-        assert r.execute_command('TS.CREATE', 'ts21')
-        assert r.execute_command('TS.ADD', 'ts21', 20, 100)
-
-        # Test case #27:
-        expected_result = [0, str(100).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts21', 10, 30, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        expected_result = [0, str(100).encode('ascii')]
-        actual_result = r.execute_command('TS.REVRANGE', 'ts21', 10, 30, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-
-        # Test case #28:
-        expected_result = [0, str(100).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts21', 10, 20, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        expected_result = [0, str(100).encode('ascii')]
-        actual_result = r.execute_command('TS.REVRANGE', 'ts21', 10, 20, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-
-        # Test case #29:
-        expected_result = [0, str(100).encode('ascii')]
-        actual_result = r.execute_command('TS.RANGE', 'ts21', 20, 30, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-        expected_result = [0, str(100).encode('ascii')]
-        actual_result = r.execute_command('TS.REVRANGE', 'ts21', 20, 30, 'AGGREGATION', 'twa', 100)
-        assert actual_result[0] == expected_result
-
-        # Test case #30:
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts21', 10, 15, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts21', 10, 15, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts21', 10, 15, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts21', 10, 15, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result == expected_result
-
-        # Test case #35:
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts21', 25, 35, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts21', 25, 35, 'AGGREGATION', 'twa', 100)
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.RANGE', 'ts21', 25, 35, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result == expected_result
-        expected_result = []
-        actual_result = r.execute_command('TS.REVRANGE', 'ts21', 25, 35, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result == expected_result
-
-        # Test case 100:
-        assert r.execute_command('TS.CREATE', 'ts22')
-        assert r.execute_command('TS.ADD', 'ts22', 20, 100)
-        assert r.execute_command('TS.ADD', 'ts22', 50, 130)
-        v1, v2 = 100.0, 130.0
-        t1, t2 = 20.0, 50.0
-        ta, tb = 20.0, 50.0
-        res = (v1 + v2)/2.0
-        expected_result = [[0, str(int(res)).encode('ascii')]]
-        actual_result = r.execute_command('TS.RANGE', 'ts22', 20, 50, 'AGGREGATION', 'twa', 100, 'EMPTY')
-        assert actual_result == expected_result
-        m = (130.0 - 100.0)/(50.0 - 20.0)
-        va_fun = lambda ta: v1 + (ta - t1)*m
-        expected_result = []
-        for i in range(20, 60, 10):
-            va = va_fun(i)
-            vb = va_fun(min(i+10, 50))
-            res = (va + vb)/2.0
-            expected_result += [[i, str(int(res)).encode('ascii')]]
-        actual_result = r.execute_command('TS.RANGE', 'ts22', 20, 50, 'AGGREGATION', 'twa', 10, 'EMPTY')
-        assert actual_result == expected_result
-        expected_result.reverse()
-        actual_result = r.execute_command('TS.REVRANGE', 'ts22', 20, 50, 'AGGREGATION', 'twa', 10, 'EMPTY')
-        assert actual_result == expected_result
-
-        # Test case 101:
-        assert r.execute_command('TS.CREATE', 'ts23')
-        assert r.execute_command('TS.ADD', 'ts23', 40, 100)
-        assert r.execute_command('TS.ADD', 'ts23', 50, 130)
-        res = (130.0 + 100.0)/2.0
-        expected_result = [[40, str(int(res)).encode('ascii')], [50, str(130).encode('ascii')]]
-        actual_result = r.execute_command('TS.RANGE', 'ts23', 29, 70, 'AGGREGATION', 'twa', 10, 'EMPTY')
-        assert actual_result == expected_result
-        expected_result.reverse()
-        actual_result = r.execute_command('TS.REVRANGE', 'ts23', 29, 70, 'AGGREGATION', 'twa', 10, 'EMPTY')
-        assert actual_result == expected_result
-
-        expected_result.reverse()
-        actual_result = r.execute_command('TS.RANGE', 'ts23', 39, 70, 'AGGREGATION', 'twa', 10, 'EMPTY')
-        assert actual_result == expected_result
-        expected_result.reverse()
-        actual_result = r.execute_command('TS.REVRANGE', 'ts23', 39, 70, 'AGGREGATION', 'twa', 10, 'EMPTY')
-        assert actual_result == expected_result
-
-def test_series_ordering():
-    with Env().getClusterConnectionIfNeeded() as r:
-        sample_len = 1024
-        chunk_size = 4
-
-        r.execute_command("ts.create", 'test_key', 0, chunk_size)
-        for i in range(sample_len):
-            r.execute_command("ts.add", 'test_key', i, i)
-
-        res = r.execute_command('ts.range', 'test_key', 0, sample_len)
-        i = 0
-        for sample in res:
-            assert sample == [i, str(i).encode('ascii')]
-            i += 1
-
-
-def test_sanity():
-    start_ts = 1511885909
-    samples_count = 1500
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', 'tester', 'RETENTION', '0', 'CHUNK_SIZE', '1024', 'LABELS', 'name',
-                                 'brown', 'color', 'pink')
-        _insert_data(r, 'tester', start_ts, samples_count, 5)
-
-        expected_result = [[start_ts + i, str(5).encode('ascii')] for i in range(samples_count)]
-        actual_result = r.execute_command('TS.range', 'tester', start_ts, start_ts + samples_count)
-        assert expected_result == actual_result
-        expected_result = [
-            b'totalSamples', 1500,
-            b'firstTimestamp', start_ts, b'chunkCount', 1,
-            b'labels', [[b'name', b'brown'], [b'color', b'pink']],
-            b'lastTimestamp', start_ts + samples_count - 1,
-            b'chunkSize', 1024, b'retentionTime', 0,
-            b'sourceKey', None, b'rules', [], b'ignoreMaxTimeDiff', 0, b'ignoreMaxValDiff', b'0']
-        assert TSInfo(expected_result) == _get_ts_info(r, 'tester')
-
-
-def test_sanity_pipeline():
-    start_ts = 1488823384
-    samples_count = 1500
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', 'tester')
-        with r.pipeline(transaction=False) as p:
-            p.set("name", "danni")
-            _insert_data(p, 'tester', start_ts, samples_count, 5)
-            p.execute()
-        expected_result = [[start_ts + i, str(5).encode('ascii')] for i in range(samples_count)]
-        actual_result = r.execute_command('TS.range', 'tester', start_ts, start_ts + samples_count)
-        assert expected_result == actual_result
-
-def test_large_compressed_range():
-    random.seed()
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', 't1', 'compressed', 'RETENTION', '0', 'CHUNK_SIZE', '128')
-        _len = 400
-        n_samples_dict = {}
-        ts = random.randint(2, _len) # For taking more space and chunks
-        for i in range(_len):
-            r.execute_command('TS.ADD', 't1', ts , i)
-            n_samples_dict[ts] = i
-            ts += random.randint(2, _len) # For taking more space and chunks
-
-        res = r.execute_command('ts.range', 't1', '-', '+')
-        assert len(res) == _len
-
-        for key1, val1 in n_samples_dict.items():
-            for key2, val2 in n_samples_dict.items():
-                if(key2 < key1):
-                    continue
-                res = r.execute_command('ts.range', 't1', key1, key2)
-                assert len(res) == val2 - val1 + 1
-                res = r.execute_command('ts.range', 't1', key1 - 1, key2 + 1)
-                assert len(res) == val2 - val1 + 1
-
-def test_large_compressed_revrange():
-    random.seed()
-    with Env().getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', 't1', 'compressed', 'RETENTION', '0', 'CHUNK_SIZE', '128')
-        _len = 400
-        n_samples_dict = {}
-        ts = random.randint(2, _len) # For taking more space and chunks
-        for i in range(_len):
-            r.execute_command('TS.ADD', 't1', ts , i)
-            n_samples_dict[ts] = i
-            ts += random.randint(2, _len) # For taking more space and chunks
-
-        res = r.execute_command('ts.range', 't1', '-', '+')
-        assert len(res) == _len
-
-        for key1, val1 in n_samples_dict.items():
-            for key2, val2 in n_samples_dict.items():
-                if(key2 < key1):
-                    continue
-                res = r.execute_command('ts.revrange', 't1', key1, key2)
-                assert len(res) == val2 - val1 + 1
-                res = r.execute_command('ts.revrange', 't1', key1 - 1, key2 + 1)
-                assert len(res) == val2 - val1 + 1
-
-def test_issue358():
-    filepath = "./issue358.txt"
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('ts.create', 'issue358')
-
-        with open(filepath) as fp:
-            line = fp.readline()
-            while line:
-                line = fp.readline()
-                if line != '':
-                    r.execute_command(*line.split())
-        range_res = r.execute_command('ts.range', 'issue358', 1582848000, '+')[0][1]
-        get_res = r.execute_command('ts.get', 'issue358')[1]
-        assert range_res == get_res
-
-
-def test_filter_by():
-    start_ts = 1511885909
-    samples_count = 1500
-    env = Env()
-    with env.getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', 'tester', 'RETENTION', '0', 'CHUNK_SIZE', '1024', 'LABELS', 'name',
-                                 'brown', 'color', 'pink')
-        _insert_data(r, 'tester', start_ts, samples_count, list(i for i in range(samples_count)))
-
-        res = r.execute_command('ts.range', 'tester', start_ts, '+', 'FILTER_BY_VALUE', 40, 52)
-
-        assert len(res) == 13
-        assert [int(sample[1]) for sample in res] == list(range(40, 53))
-
-        res = r.execute_command('ts.range', 'tester', start_ts, '+',
-                                'FILTER_BY_TS', start_ts + 1021, start_ts + 1022, start_ts + 1025, start_ts + 1029)
-        env.assertEqual(res, [[start_ts + 1021, b'1021'], [start_ts + 1022, b'1022'], [start_ts + 1025, b'1025'],
-                              [start_ts + 1029, b'1029']])
-
-        res = r.execute_command('ts.range', 'tester', start_ts, '+',
-                                'FILTER_BY_TS', start_ts + 1021, start_ts + 1021, start_ts + 1022, start_ts + 1022, start_ts + 1025, start_ts + 1029, start_ts + 1029)
-        env.assertEqual(res, [[start_ts + 1021, b'1021'], [start_ts + 1022, b'1022'], [start_ts + 1025, b'1025'],
-                              [start_ts + 1029, b'1029']])
-
-        res = r.execute_command('ts.range', 'tester', start_ts, '+',
-                                'FILTER_BY_TS', start_ts + 1021, start_ts + 1022, start_ts + 1023, start_ts + 1025,
-                                start_ts + 1029,
-                                'FILTER_BY_VALUE', 1022, 1025)
-        env.assertEqual(res, [[start_ts + 1022, b'1022'], [start_ts + 1023, b'1023'], [start_ts + 1025, b'1025']])
-
-def test_filter_by_extensive():
-    env = Env()
-    #skip cause it takes too much time
-    env.skipOnCluster()
-    env.skipOnAOF()
-    env.skipOnSlave()
-    max_samples_count = 40
-    for ENCODING in ['uncompressed']:
-        for ev_odd in ['even', 'odd']:
-            if(ev_odd == 'even'):
-                start_ts = 2
+            expected_result = [[10, b'10'], [20, b'10'], [30, b'10'], [40, b'10']]
+            actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
+            assert expected_result == actual_result
+
+
+
+    def test_agg_first(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            agg_key = _insert_agg_data(r, 'tester{a}', 'first')
+
+            expected_result = [[10, b'131'], [20, b'231'], [30, b'331'], [40, b'431']]
+            actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
+            assert expected_result == actual_result
+
+
+
+    def test_agg_last(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            agg_key = _insert_agg_data(r, 'tester{a}', 'last')
+
+            expected_result = [[10, b'184'], [20, b'284'], [30, b'384'], [40, b'484']]
+            actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
+            assert expected_result == actual_result
+
+
+
+    def test_agg_range(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            agg_key = _insert_agg_data(r, 'tester{a}', 'range')
+
+            expected_result = [[10, b'74'], [20, b'74'], [30, b'74'], [40, b'74']]
+            actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
+            assert expected_result == actual_result
+
+
+
+    def test_range_count(self):
+        env = self.env
+        env.flush()
+        start_ts = 1511885908
+        samples_count = 50
+
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('TS.CREATE', 'tester1')
+            for i in range(samples_count):
+                r.execute_command('TS.ADD', 'tester1', start_ts + i, i)
+            full_results = r.execute_command('TS.RANGE', 'tester1', 0, '+')
+            assert len(full_results) == samples_count
+            count_results = r.execute_command('TS.RANGE', 'tester1', 0, '+', b'COUNT', 10)
+            assert count_results == full_results[:10]
+            count_results = r.execute_command('TS.RANGE', 'tester1', 0, '+', b'COUNT', 10, b'AGGREGATION', 'COUNT', 3)
+            assert len(count_results) == 10
+            count_results = r.execute_command('TS.RANGE', 'tester1', 0, '+', b'AGGREGATION', 'COUNT', 4, b'COUNT', 10)
+            assert len(count_results) == 10
+            count_results = r.execute_command('TS.RANGE', 'tester1', 0, '+', 'COUNT', 10, b'AGGREGATION', 'COUNT', 4)
+            assert len(count_results) == 10
+            count_results = r.execute_command('TS.RANGE', 'tester1', 0, '+', b'AGGREGATION', 'COUNT', 3)
+            assert len(count_results) == math.ceil(samples_count / 3.0)
+
+
+
+    def test_agg_min(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            agg_key = _insert_agg_data(r, 'tester{a}', 'min')
+
+            expected_result = [[10, b'123'], [20, b'223'], [30, b'323'], [40, b'423']]
+            actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
+            assert expected_result == actual_result
+
+
+
+    def test_agg_max(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            agg_key = _insert_agg_data(r, 'tester{a}', 'max')
+
+            expected_result = [[10, b'197'], [20, b'297'], [30, b'397'], [40, b'497']]
+            actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
+            assert expected_result == actual_result
+
+
+
+    def test_agg_avg(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            agg_key = _insert_agg_data(r, 'tester{a}', 'avg')
+
+            expected_result = [[10, b'156.5'], [20, b'256.5'], [30, b'356.5'], [40, b'456.5']]
+            actual_result = r.execute_command('TS.RANGE', agg_key, 10, 50)
+            assert expected_result == actual_result
+
+            #test overflow
+            MAX_DOUBLE = 1.7976931348623157E+308
+            assert r.execute_command('TS.CREATE', 'ts1')
+            assert r.execute_command('TS.ADD', 'ts1', 1, MAX_DOUBLE - 10)
+            assert r.execute_command('TS.ADD', 'ts1', 2, MAX_DOUBLE - 8)
+            assert r.execute_command('TS.ADD', 'ts1', 3, MAX_DOUBLE - 6)
+
+            actual_result = r.execute_command('TS.RANGE', 'ts1', 0, 3, 'AGGREGATION', 'avg', 5)
+            #MAX_DOUBLE - 10 equals MAX_DOUBLE cause of precision limit
+
+            # If this test fails in the future it means
+            # it run on an OS/compiler that doesn't support long double need to remove the comment below
+            if(VALGRIND or (sizeof(c_longdouble) == 8)):
+                assert actual_result == [[0, b'1.7976931348623155E308']]
             else:
-                start_ts = 3
-            env.flush()
-            with env.getClusterConnectionIfNeeded() as r:
-                assert r.execute_command('TS.CREATE', 't1', ENCODING, 'RETENTION', '0', 'CHUNK_SIZE', '512')
-                # 32 samples in chunk, 40 samples: 2 chunk in total
-                # inset even numbers
-                for samples_count in range(0, max_samples_count + 1):
-                    last_ts = start_ts + samples_count*2
-                    r.execute_command('TS.ADD', 't1', last_ts, last_ts)
+                assert actual_result == [[0, b'1.7976931348623157E308']]
 
-                    for rev in [False, True]:
-                        query = 'ts.revrange' if rev else 'ts.range'
-                        for first_ts in range(0, last_ts + 3):
-                            str_first_ts = str(first_ts)
-                            for second_ts in range(first_ts, last_ts + 3):
-                                str_second_ts = str(second_ts)
-                                expected_res = []
-                                reminder = 0 if ev_odd == 'even' else 1
-                                if(first_ts%2 == reminder and first_ts >= start_ts and first_ts <= last_ts):
-                                    expected_res.append([first_ts, str_first_ts.encode()])
-                                if(first_ts != second_ts and second_ts%2 == reminder and second_ts >= start_ts and second_ts <= last_ts):
-                                    if(rev): #prepend
-                                        expected_res.insert(0, [second_ts, str_second_ts.encode()])
-                                    else:    # append
-                                        expected_res.append([second_ts, str_second_ts.encode()])
-                                res = r.execute_command(query, 't1', '-', '+', 'FILTER_BY_TS', first_ts, second_ts)
-                                env.assertEqual(res, expected_res)
+            MIN_DOUBLE = -1.7976931348623157E+308
+            assert r.execute_command('TS.CREATE', 'ts2')
+            assert r.execute_command('TS.ADD', 'ts2', 1, MIN_DOUBLE + 10)
+            assert r.execute_command('TS.ADD', 'ts2', 2, MIN_DOUBLE + 8)
+            assert r.execute_command('TS.ADD', 'ts2', 3, MIN_DOUBLE + 6)
 
-def get_bucket(timsetamp, alignment_ts, aggregation_bucket_size):
-    return timsetamp - ((timsetamp - alignment_ts) % aggregation_bucket_size)
+            actual_result = r.execute_command('TS.RANGE', 'ts2', 0, 3, 'AGGREGATION', 'avg', 5)
+            #MIN_DOUBLE + 10 equals MIN_DOUBLE cause of precision limit
+            if(VALGRIND or (sizeof(c_longdouble) == 8)):
+                assert actual_result == [[0, b'-1.7976931348623155E308']]
+            else:
+                assert actual_result == [[0, b'-1.7976931348623157E308']]
 
-def test_max_extensive():
-    env = Env()
-    #skip cause it takes too much time
-    env.skipOnCluster()
-    env.skipOnAOF()
-    env.skipOnSlave()
-    max_samples_count = 40
-    n_chunk_samples = 32
-    random_values = [None]*(max_samples_count*3)
-    random.seed()
-    try:
-        for i in range(0, max_samples_count*3):
-            random_values[i] = random.uniform(0, max_samples_count)
-        max_val = random.uniform(max_samples_count, max_samples_count + 10)
-        for ENCODING in ['uncompressed', 'compressed']:
+
+    def test_agg_twa(self):
+        env = self.env
+        env.flush()
+        #https://redislabs.atlassian.net/jira/software/c/projects/PM/boards/263?modal=detail&selectedIssue=PM-1229
+        with env.getClusterConnectionIfNeeded() as r:
+            #case 1:
+            assert r.execute_command('TS.CREATE', 'ts1')
+            assert r.execute_command('TS.ADD', 'ts1', 8, 8)
+            assert r.execute_command('TS.ADD', 'ts1', 9, 9)
+            assert r.execute_command('TS.ADD', 'ts1', 10, 10)
+            assert r.execute_command('TS.ADD', 'ts1', 13, 13)
+            assert r.execute_command('TS.ADD', 'ts1', 14, 14)
+            assert r.execute_command('TS.ADD', 'ts1', 23, 23)
+            v1, v2, v3, v4, v5 = 9.0, 10.0, 13.0, 14.0, 23.0
+            t1, t2, t3, t4, t5 = 9.0, 10.0, 13.0, 14.0, 23.0
+            ta, tb = 10.0, 20.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            vb = v4+(v5-v4)*(tb-t4)/(t5-t4)
+            s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (v3+v4)*(t4-t3) + (vb+v4)*(tb-t4)
+            res = s / (2*(tb-ta))
+            expected_result = [10, str(int(res)).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts1', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts1', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+
+            #case 2:
+            assert r.execute_command('TS.CREATE', 'ts2')
+            assert r.execute_command('TS.ADD', 'ts2', 8, 8)
+            assert r.execute_command('TS.ADD', 'ts2', 9, 9)
+            assert r.execute_command('TS.ADD', 'ts2', 13, 13)
+            assert r.execute_command('TS.ADD', 'ts2', 14, 14)
+            assert r.execute_command('TS.ADD', 'ts2', 23, 23)
+            v1, v2, v3, v4 = 9.0, 13.0, 14.0, 23.0
+            t1, t2, t3, t4 = 9.0, 13.0, 14.0, 23.0
+            ta, tb = 10.0, 20.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            vb = v3+(v4-v3)*(tb-t3)/(t4-t3)
+            s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (vb+v3)*(tb-t3)
+            res = s / (2*(tb-ta))
+            expected_result = [10, str(int(res)).encode('ascii')]
+
+            actual_result = r.execute_command('TS.RANGE', 'ts2', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts2', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+
+            #case 3:
+            assert r.execute_command('TS.CREATE', 'ts3')
+            assert r.execute_command('TS.ADD', 'ts3', 8, 8)
+            assert r.execute_command('TS.ADD', 'ts3', 9, 9)
+            assert r.execute_command('TS.ADD', 'ts3', 13, 13)
+            assert r.execute_command('TS.ADD', 'ts3', 14, 14)
+            assert r.execute_command('TS.ADD', 'ts3', 26, 26)
+            v1, v2, v3, v4 = 9.0, 13.0, 14.0, 26.0
+            t1, t2, t3, t4 = 9.0, 13.0, 14.0, 26.0
+            ta, tb = 10.0, 20.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            vb = v3+(v4-v3)*(tb-t3)/(t4-t3)
+            s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (vb+v3)*(tb-t3)
+            res = s / (2*(tb-ta))
+            expected_result = [10, str(int(res)).encode('ascii')]
+
+            actual_result = r.execute_command('TS.RANGE', 'ts3', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts3', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+
+            #case 4:
+            assert r.execute_command('TS.CREATE', 'ts4')
+            assert r.execute_command('TS.ADD', 'ts4', 8, 8)
+            assert r.execute_command('TS.ADD', 'ts4', 9, 9)
+            assert r.execute_command('TS.ADD', 'ts4', 13, 13)
+            assert r.execute_command('TS.ADD', 'ts4', 14, 14)
+            assert r.execute_command('TS.ADD', 'ts4', 27, 27)
+            v1, v2, v3, v4 = 9.0, 13.0, 14.0, 27.0
+            t1, t2, t3, t4 = 9.0, 13.0, 14.0, 27.0
+            ta, tb = 10.0, 20.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            vb = v3+(v4-v3)*(tb-t3)/(t4-t3)
+            s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (vb+v3)*(tb-t3)
+            res = s / (2*(tb-ta))
+            expected_result = [10, str(int(res)).encode('ascii')]
+
+            actual_result = r.execute_command('TS.RANGE', 'ts4', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts4', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+
+            #case 5:
+            assert r.execute_command('TS.CREATE', 'ts5')
+            assert r.execute_command('TS.ADD', 'ts5', 3, 3)
+            assert r.execute_command('TS.ADD', 'ts5', 7, 7)
+            assert r.execute_command('TS.ADD', 'ts5', 13, 13)
+            assert r.execute_command('TS.ADD', 'ts5', 14, 14)
+            assert r.execute_command('TS.ADD', 'ts5', 27, 27)
+            v1, v2, v3, v4 = 7.0, 13.0, 14.0, 27.0
+            t1, t2, t3, t4 = 7.0, 13.0, 14.0, 27.0
+            ta, tb = 10.0, 20.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            vb = v3+(v4-v3)*(tb-t3)/(t4-t3)
+            s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (vb+v3)*(tb-t3)
+            res = s / (2*(tb-ta))
+            expected_result = [10, str(int(res)).encode('ascii')]
+
+            actual_result = r.execute_command('TS.RANGE', 'ts5', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts5', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+
+            #case 6:
+            assert r.execute_command('TS.CREATE', 'ts6')
+            assert r.execute_command('TS.ADD', 'ts6', 3, 3)
+            assert r.execute_command('TS.ADD', 'ts6', 6, 6)
+            assert r.execute_command('TS.ADD', 'ts6', 13, 13)
+            assert r.execute_command('TS.ADD', 'ts6', 14, 14)
+            assert r.execute_command('TS.ADD', 'ts6', 27, 27)
+            v1, v2, v3, v4 = 6.0, 13.0, 14.0, 27.0
+            t1, t2, t3, t4 = 6.0, 13.0, 14.0, 27.0
+            ta, tb = 10.0, 20.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            vb = v3+(v4-v3)*(tb-t3)/(t4-t3)
+            s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (vb+v3)*(tb-t3)
+            res = s / (2*(tb-ta))
+            expected_result = [10, str(int(res)).encode('ascii')]
+
+            actual_result = r.execute_command('TS.RANGE', 'ts6', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts6', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+
+            #case 7:
+            assert r.execute_command('TS.CREATE', 'ts7')
+            assert r.execute_command('TS.ADD', 'ts7', 3, 3)
+            assert r.execute_command('TS.ADD', 'ts7', 9, 9)
+            assert r.execute_command('TS.ADD', 'ts7', 13, 13)
+            assert r.execute_command('TS.ADD', 'ts7', 22, 22)
+            v1, v2, v3 = 9.0, 13.0, 22.0
+            t1, t2, t3 = 9.0, 13.0, 22.0
+            ta, tb = 10.0, 20.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            vb = v2+(v3-v2)*(tb-t2)/(t3-t2)
+            s = (va+v2)*(t2-ta) + (vb+v2)*(tb-t2)
+            res = s / (2*(tb-ta))
+            expected_result = [10, str(int(res)).encode('ascii')]
+
+            actual_result = r.execute_command('TS.RANGE', 'ts7', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts7', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+
+            #case 8:
+            assert r.execute_command('TS.CREATE', 'ts8')
+            assert r.execute_command('TS.ADD', 'ts8', 3, 3)
+            assert r.execute_command('TS.ADD', 'ts8', 13, 13)
+            assert r.execute_command('TS.ADD', 'ts8', 28, 28)
+            v1, v2, v3 = 3.0, 13.0, 28.0
+            t1, t2, t3 = 3.0, 13.0, 28.0
+            ta, tb = 10.0, 20.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            vb = v2+(v3-v2)*(tb-t2)/(t3-t2)
+            s = (va+v2)*(t2-ta) + (vb+v2)*(tb-t2)
+            res = s / (2.0*(tb-ta))
+            expected_result = [10, str(int(res)).encode('ascii')]
+
+            actual_result = r.execute_command('TS.RANGE', 'ts8', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts8', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+
+            #case 9:
+            assert r.execute_command('TS.CREATE', 'ts9')
+            assert r.execute_command('TS.ADD', 'ts9', 13, 13)
+            assert r.execute_command('TS.ADD', 'ts9', 28, 28)
+            v1, v2, = 13.0, 28.0
+            t1, t2, = 13.0, 28.0
+            ta, tb = 10.0, 20.0
+            vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
+            s = (v1+vb)*(tb-t1)
+            res = s / (2.0*(tb-t1))
+            expected_result = [10, str(res).encode('ascii')]
+
+            actual_result = r.execute_command('TS.RANGE', 'ts9', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts9', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+
+            #case 10:
+            assert r.execute_command('TS.CREATE', 'ts10')
+            assert r.execute_command('TS.ADD', 'ts10', 13, 13)
+            assert r.execute_command('TS.ADD', 'ts10', 21, 21)
+            v1, v2, = 13.0, 21.0
+            t1, t2, = 13.0, 21.0
+            ta, tb = 10.0, 20.0
+            vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
+            s = (v1+vb)*(tb-t1)
+            res = s / (2.0*(tb-t1))
+            expected_result = [10, str(res).encode('ascii')]
+
+            actual_result = r.execute_command('TS.RANGE', 'ts10', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts10', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+
+            #case 11:
+            assert r.execute_command('TS.CREATE', 'ts11')
+            assert r.execute_command('TS.ADD', 'ts11', 17, 17)
+            assert r.execute_command('TS.ADD', 'ts11', 21, 21)
+            v1, v2, = 17.0, 21.0
+            t1, t2, = 17.0, 21.0
+            ta, tb = 10.0, 20.0
+            vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
+            s = (v1+vb)*(tb-t1)
+            res = s / (2.0*(tb-t1))
+            expected_result = [10, str(res).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts11', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts11', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+
+            #case 12:
+            assert r.execute_command('TS.CREATE', 'ts12')
+            assert r.execute_command('TS.ADD', 'ts12', 3, 3)
+            assert r.execute_command('TS.ADD', 'ts12', 17, 17)
+            v1, v2, = 3.0, 17.0
+            t1, t2, = 3.0, 17.0
+            ta, tb = 10.0, 20.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            s = (va+v2)*(t2-ta)
+            res = s / (2.0*(t2-ta))
+            expected_result = [10, str(res).encode('ascii')]
+
+            actual_result = r.execute_command('TS.RANGE', 'ts12', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts12', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+
+            #case 14:
+            assert r.execute_command('TS.CREATE', 'ts14')
+            assert r.execute_command('TS.ADD', 'ts14', 5, 5)
+            assert r.execute_command('TS.ADD', 'ts14', 12, 12)
+            v1, v2, = 5.0, 12.0
+            t1, t2, = 5.0, 12.0
+            ta, tb = 10.0, 20.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            s = (va+v2)*(t2-ta)
+            res = s / (2.0*(t2-ta))
+            expected_result = [10, str(int(res)).encode('ascii')]
+
+            actual_result = r.execute_command('TS.RANGE', 'ts14', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts14', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+
+            #case 15:
+            assert r.execute_command('TS.CREATE', 'ts15')
+            assert r.execute_command('TS.ADD', 'ts15', 7, 7)
+            assert r.execute_command('TS.ADD', 'ts15', 15, 15)
+            v1, v2, = 7.0, 15.0
+            t1, t2, = 7.0, 15.0
+            ta, tb = 10.0, 20.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            s = (va+v2)*(t2-ta)
+            res = s / (2.0*(t2-ta))
+            expected_result = [10, str(res).encode('ascii')]
+
+            actual_result = r.execute_command('TS.RANGE', 'ts15', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts15', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+
+            #case 16:
+            assert r.execute_command('TS.CREATE', 'ts16')
+            assert r.execute_command('TS.ADD', 'ts16', 15, 15)
+            res = 15
+            expected_result = [10, str(res).encode('ascii')]
+
+            actual_result = r.execute_command('TS.RANGE', 'ts16', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts16', 10, 20, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+
+            #case 17:
+            assert r.execute_command('TS.CREATE', 'ts17')
+            assert r.execute_command('TS.ADD', 'ts17', 0, 5) == 0
+            assert r.execute_command('TS.ADD', 'ts17', 9, 12)
+            v1, v2, = 5, 12.0
+            t1, t2, = 0, 9.0
+            ta, tb = 0, 10.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            s = (va+v2)*(t2-ta)
+            res = s / (2.0*(t2-ta))
+            expected_result = [0, str(res).encode('ascii')]
+
+            actual_result = r.execute_command('TS.RANGE', 'ts17', 0, 10, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts17', 0, 10, 'AGGREGATION', 'twa', 10)
+            assert actual_result[0] == expected_result
+
+            #case 18:
+            assert r.execute_command('TS.CREATE', 'ts18')
+            assert r.execute_command('TS.ADD', 'ts18', 10, 100)
+            assert r.execute_command('TS.ADD', 'ts18', 13, 110)
+            assert r.execute_command('TS.ADD', 'ts18', 15, 115)
+            assert r.execute_command('TS.ADD', 'ts18', 19, 109)
+            assert r.execute_command('TS.ADD', 'ts18', 25, 130)
+            v1, v2, v3, v4, v5 = 100.0, 110.0, 115.0, 109.0, 130.0
+            t1, t2, t3, t4, t5 = 10.0, 13.0, 15.0, 19.0, 25.0
+            ta, tb = 12.0, 20.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            vb = v4+(v5-v4)*(tb-t4)/(t5-t4)
+            s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (v3+v4)*(t4-t3) + (vb+v4)*(tb-t4)
+            res = s / (2.0*(tb-ta))
+            expected_result = [0, str(res).encode('ascii')]
+
+            # Test case #1:
+            actual_result = r.execute_command('TS.RANGE', 'ts18', 12, 20, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts18', 12, 20, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.RANGE', 'ts18', 12, 20, 'AGGREGATION', 'twa', 1000)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts18', 12, 20, 'AGGREGATION', 'twa', 1000)
+            assert actual_result[0] == expected_result
+
+            ta, tb = 11.0, 30.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (v3+v4)*(t4-t3) + (v5+v4)*(t5-t4)
+            res = s / (2.0*(t5-ta))
+            expected_result = [0, str(res).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts18', 11, 30, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts18', 11, 30, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+
+            # Test case #2:
+            ta, tb = 11.0, 20.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            vb = v4+(v5-v4)*(tb-t4)/(t5-t4)
+            s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (v3+v4)*(t4-t3) + (vb+v4)*(tb-t4)
+            res = s / (2.0*(tb-ta))
+            expected_result = [0, str(res).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts18', 11, 20, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts18', 11, 20, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+
+            # Test case #3:
+            ta, tb = 12.0, 24.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            vb = v4+(v5-v4)*(tb-t4)/(t5-t4)
+            s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (v3+v4)*(t4-t3) + (vb+v4)*(tb-t4)
+            res = s / (2*(tb-ta))
+            expected_result = [0, str(res).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts18', 12, 24, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts18', 12, 24, 'AGGREGATION', 'twa', 100)
+            round(float(actual_result[0][1]), 10) == round(res, 10)
+            assert actual_result[0][0] == expected_result[0]
+
+            # Test case #4:
+            ta, tb = 11.0, 24.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            vb = v4+(v5-v4)*(tb-t4)/(t5-t4)
+            s = (va+v2)*(t2-ta) + (v2+v3)*(t3-t2) + (v3+v4)*(t4-t3) + (vb+v4)*(tb-t4)
+            res = s / (2.0*(tb-ta))
+            expected_result = [0, str(res).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts18', 11, 24, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts18', 11, 24, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+
+            # Test case #5:
+            ta, tb = 8.0, 26.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            s = (v1+v2)*(t2-t1) + (v2+v3)*(t3-t2) + (v3+v4)*(t4-t3) + (v5+v4)*(t5-t4)
+            res = s / (2.0*(t5-t1))
+            expected_result = [0, str(res).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts18', 8, 26, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            expected_result = [0, str(res).encode('ascii')]
+            actual_result = r.execute_command('TS.REVRANGE', 'ts18', 8, 26, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+
+            # Test case #6:
+            ta, tb = 8.0, 30.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            s = (v1+v2)*(t2-t1) + (v2+v3)*(t3-t2) + (v3+v4)*(t4-t3) + (v5+v4)*(t5-t4)
+            res = s / (2.0*(t5-t1))
+            expected_result = [0, str(res).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts18', 8, 30, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            expected_result = [0, str(res).encode('ascii')]
+            actual_result = r.execute_command('TS.REVRANGE', 'ts18', 8, 30, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+
+            # Test case #7:
+            ta, tb = 9.0, 30.0
+            s = (v1+v2)*(t2-t1) + (v2+v3)*(t3-t2) + (v3+v4)*(t4-t3) + (v5+v4)*(t5-t4)
+            res = s / (2.0*(t5-t1))
+            expected_result = [0, str(res).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts18', 9, 30, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            expected_result = [0, str(res).encode('ascii')]
+            actual_result = r.execute_command('TS.REVRANGE', 'ts18', 9, 30, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+
+            #Test case 19:
+            assert r.execute_command('TS.CREATE', 'ts19')
+            assert r.execute_command('TS.ADD', 'ts19', 10, 100)
+            assert r.execute_command('TS.ADD', 'ts19', 20, 110)
+
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts19', 16, 18, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts19', 16, 18, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+
+
+            v1, v2 = 100.0, 110.0
+            t1, t2 = 10.0, 20.0
+            ta, tb = 16.0, 18.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
+            res = (va + vb)/2.0
+            expected_result = [0, str(int(res)).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts19', 16, 18, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts19', 16, 18, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result[0] == expected_result
+
+            #Test case 20:
+            ta, tb = 12.0, 14.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
+            res = (va + vb)/2.0
+            expected_result = [0, str(int(res)).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts19', 12, 14, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result[0] == expected_result
+            expected_result = [0, str(int(res)).encode('ascii')]
+            actual_result = r.execute_command('TS.REVRANGE', 'ts19', 12, 14, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result[0] == expected_result
+
+            #Test case 21:
+            ta, tb = 14.0, 19.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
+            res = (va + vb)/2.0
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts19', 14, 19, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts19', 14, 19, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+
+            expected_result = [0, str(res).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts19', 14, 19, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts19', 14, 19, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result[0] == expected_result
+
+            ta, tb = 11.0, 16.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
+            res = (va + vb)/2.0
+            expected_result = [0, str(res).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts19', 11, 16, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result[0] == expected_result
+            expected_result = [0, str(res).encode('ascii')]
+            actual_result = r.execute_command('TS.REVRANGE', 'ts19', 11, 16, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result[0] == expected_result
+
+            #Test case 22:
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts19', 11, 15, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts19', 11, 15, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+
+            #case 4:
+            assert r.execute_command('TS.CREATE', 'ts20')
+            assert r.execute_command('TS.ADD', 'ts20', 20, 100)
+            assert r.execute_command('TS.ADD', 'ts20', 30, 110)
+            v1, v2 = 100.0, 110.0
+            t1, t2 = 20.0, 30.0
+
+            # Test case #13:
+            ta, tb = 14.0, 22.0
+            vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
+            res = (v1 + vb)/2.0
+            expected_result = [0, str(int(res)).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 14, 22, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 14, 22, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+
+            # Test case #14:
+            ta, tb = 14.0, 28.0
+            vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
+            res = (v1 + vb)/2.0
+            expected_result = [0, str(int(res)).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 14, 28, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 14, 28, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+
+            # Test case #15:
+            ta, tb = 16.0, 22.0
+            vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
+            res = (v1 + vb)/2.0
+            expected_result = [0, str(int(res)).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 16, 22, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 16, 22, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+
+            # Test case #16:
+            ta, tb = 16.0, 28.0
+            vb = v1+(v2-v1)*(tb-t1)/(t2-t1)
+            res = (v1 + vb)/2.0
+            expected_result = [0, str(int(res)).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 16, 28, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 16, 28, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+
+            # Test case #17:
+            ta, tb = 24.0, 32.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            res = (va + v2)/2.0
+            expected_result = [0, str(int(res)).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 24, 32, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 24, 32, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+
+            # Test case #18:
+            ta, tb = 26.0, 32.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            res = (va + v2)/2.0
+            expected_result = [0, str(int(res)).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 26, 32, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 26, 32, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+
+            # Test case #19:
+            ta, tb = 24.0, 38.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            res = (va + v2)/2.0
+            expected_result = [0, str(int(res)).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 24, 38, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 24, 38, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+
+            # Test case #20:
+            ta, tb = 26.0, 38.0
+            va = v1+(v2-v1)*(ta-t1)/(t2-t1)
+            res = (va + v2)/2.0
+            expected_result = [0, str(int(res)).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 26, 38, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 26, 38, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+
+            #Test case 21:
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 32, 34, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 32, 34, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 32, 34, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 32, 34, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result == expected_result
+
+            #Test case 22:
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 32, 100, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 32, 100, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 32, 100, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 32, 100, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result == expected_result
+
+            #Test case 23:
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 38, 100, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 38, 100, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 38, 100, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 38, 100, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result == expected_result
+
+            #Test case 24:
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 16, 18, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 16, 18, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 16, 18, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 16, 18, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result == expected_result
+
+            #Test case 25:
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 10, 18, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 10, 18, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 10, 18, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 10, 18, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result == expected_result
+
+            #Test case 26:
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 10, 14, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 10, 14, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts20', 10, 14, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts20', 10, 14, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result == expected_result
+
+            #case 8:
+            assert r.execute_command('TS.CREATE', 'ts21')
+            assert r.execute_command('TS.ADD', 'ts21', 20, 100)
+
+            # Test case #27:
+            expected_result = [0, str(100).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts21', 10, 30, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            expected_result = [0, str(100).encode('ascii')]
+            actual_result = r.execute_command('TS.REVRANGE', 'ts21', 10, 30, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+
+            # Test case #28:
+            expected_result = [0, str(100).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts21', 10, 20, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            expected_result = [0, str(100).encode('ascii')]
+            actual_result = r.execute_command('TS.REVRANGE', 'ts21', 10, 20, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+
+            # Test case #29:
+            expected_result = [0, str(100).encode('ascii')]
+            actual_result = r.execute_command('TS.RANGE', 'ts21', 20, 30, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+            expected_result = [0, str(100).encode('ascii')]
+            actual_result = r.execute_command('TS.REVRANGE', 'ts21', 20, 30, 'AGGREGATION', 'twa', 100)
+            assert actual_result[0] == expected_result
+
+            # Test case #30:
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts21', 10, 15, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts21', 10, 15, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts21', 10, 15, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts21', 10, 15, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result == expected_result
+
+            # Test case #35:
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts21', 25, 35, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts21', 25, 35, 'AGGREGATION', 'twa', 100)
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.RANGE', 'ts21', 25, 35, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result == expected_result
+            expected_result = []
+            actual_result = r.execute_command('TS.REVRANGE', 'ts21', 25, 35, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result == expected_result
+
+            # Test case 100:
+            assert r.execute_command('TS.CREATE', 'ts22')
+            assert r.execute_command('TS.ADD', 'ts22', 20, 100)
+            assert r.execute_command('TS.ADD', 'ts22', 50, 130)
+            v1, v2 = 100.0, 130.0
+            t1, t2 = 20.0, 50.0
+            ta, tb = 20.0, 50.0
+            res = (v1 + v2)/2.0
+            expected_result = [[0, str(int(res)).encode('ascii')]]
+            actual_result = r.execute_command('TS.RANGE', 'ts22', 20, 50, 'AGGREGATION', 'twa', 100, 'EMPTY')
+            assert actual_result == expected_result
+            m = (130.0 - 100.0)/(50.0 - 20.0)
+            va_fun = lambda ta: v1 + (ta - t1)*m
+            expected_result = []
+            for i in range(20, 60, 10):
+                va = va_fun(i)
+                vb = va_fun(min(i+10, 50))
+                res = (va + vb)/2.0
+                expected_result += [[i, str(int(res)).encode('ascii')]]
+            actual_result = r.execute_command('TS.RANGE', 'ts22', 20, 50, 'AGGREGATION', 'twa', 10, 'EMPTY')
+            assert actual_result == expected_result
+            expected_result.reverse()
+            actual_result = r.execute_command('TS.REVRANGE', 'ts22', 20, 50, 'AGGREGATION', 'twa', 10, 'EMPTY')
+            assert actual_result == expected_result
+
+            # Test case 101:
+            assert r.execute_command('TS.CREATE', 'ts23')
+            assert r.execute_command('TS.ADD', 'ts23', 40, 100)
+            assert r.execute_command('TS.ADD', 'ts23', 50, 130)
+            res = (130.0 + 100.0)/2.0
+            expected_result = [[40, str(int(res)).encode('ascii')], [50, str(130).encode('ascii')]]
+            actual_result = r.execute_command('TS.RANGE', 'ts23', 29, 70, 'AGGREGATION', 'twa', 10, 'EMPTY')
+            assert actual_result == expected_result
+            expected_result.reverse()
+            actual_result = r.execute_command('TS.REVRANGE', 'ts23', 29, 70, 'AGGREGATION', 'twa', 10, 'EMPTY')
+            assert actual_result == expected_result
+
+            expected_result.reverse()
+            actual_result = r.execute_command('TS.RANGE', 'ts23', 39, 70, 'AGGREGATION', 'twa', 10, 'EMPTY')
+            assert actual_result == expected_result
+            expected_result.reverse()
+            actual_result = r.execute_command('TS.REVRANGE', 'ts23', 39, 70, 'AGGREGATION', 'twa', 10, 'EMPTY')
+            assert actual_result == expected_result
+
+
+    def test_series_ordering(self):
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            sample_len = 1024
+            chunk_size = 4
+
+            r.execute_command("ts.create", 'test_key', 0, chunk_size)
+            for i in range(sample_len):
+                r.execute_command("ts.add", 'test_key', i, i)
+
+            res = r.execute_command('ts.range', 'test_key', 0, sample_len)
+            i = 0
+            for sample in res:
+                assert sample == [i, str(i).encode('ascii')]
+                i += 1
+
+
+
+    def test_sanity(self):
+        env = self.env
+        env.flush()
+        start_ts = 1511885909
+        samples_count = 1500
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', 'tester', 'RETENTION', '0', 'CHUNK_SIZE', '1024', 'LABELS', 'name',
+                                     'brown', 'color', 'pink')
+            _insert_data(r, 'tester', start_ts, samples_count, 5)
+
+            expected_result = [[start_ts + i, str(5).encode('ascii')] for i in range(samples_count)]
+            actual_result = r.execute_command('TS.range', 'tester', start_ts, start_ts + samples_count)
+            assert expected_result == actual_result
+            expected_result = [
+                b'totalSamples', 1500,
+                b'firstTimestamp', start_ts, b'chunkCount', 1,
+                b'labels', [[b'name', b'brown'], [b'color', b'pink']],
+                b'lastTimestamp', start_ts + samples_count - 1,
+                b'chunkSize', 1024, b'retentionTime', 0,
+                b'sourceKey', None, b'rules', [], b'ignoreMaxTimeDiff', 0, b'ignoreMaxValDiff', b'0']
+            assert TSInfo(expected_result) == _get_ts_info(r, 'tester')
+
+
+
+    def test_sanity_pipeline(self):
+        env = self.env
+        env.flush()
+        start_ts = 1488823384
+        samples_count = 1500
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', 'tester')
+            with r.pipeline(transaction=False) as p:
+                p.set("name", "danni")
+                _insert_data(p, 'tester', start_ts, samples_count, 5)
+                p.execute()
+            expected_result = [[start_ts + i, str(5).encode('ascii')] for i in range(samples_count)]
+            actual_result = r.execute_command('TS.range', 'tester', start_ts, start_ts + samples_count)
+            assert expected_result == actual_result
+
+
+    def test_large_compressed_range(self):
+        env = self.env
+        env.flush()
+        random.seed()
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', 't1', 'compressed', 'RETENTION', '0', 'CHUNK_SIZE', '128')
+            _len = 400
+            n_samples_dict = {}
+            ts = random.randint(2, _len) # For taking more space and chunks
+            for i in range(_len):
+                r.execute_command('TS.ADD', 't1', ts , i)
+                n_samples_dict[ts] = i
+                ts += random.randint(2, _len) # For taking more space and chunks
+
+            res = r.execute_command('ts.range', 't1', '-', '+')
+            assert len(res) == _len
+
+            for key1, val1 in n_samples_dict.items():
+                for key2, val2 in n_samples_dict.items():
+                    if(key2 < key1):
+                        continue
+                    res = r.execute_command('ts.range', 't1', key1, key2)
+                    assert len(res) == val2 - val1 + 1
+                    res = r.execute_command('ts.range', 't1', key1 - 1, key2 + 1)
+                    assert len(res) == val2 - val1 + 1
+
+
+    def test_large_compressed_revrange(self):
+        env = self.env
+        env.flush()
+        random.seed()
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', 't1', 'compressed', 'RETENTION', '0', 'CHUNK_SIZE', '128')
+            _len = 400
+            n_samples_dict = {}
+            ts = random.randint(2, _len) # For taking more space and chunks
+            for i in range(_len):
+                r.execute_command('TS.ADD', 't1', ts , i)
+                n_samples_dict[ts] = i
+                ts += random.randint(2, _len) # For taking more space and chunks
+
+            res = r.execute_command('ts.range', 't1', '-', '+')
+            assert len(res) == _len
+
+            for key1, val1 in n_samples_dict.items():
+                for key2, val2 in n_samples_dict.items():
+                    if(key2 < key1):
+                        continue
+                    res = r.execute_command('ts.revrange', 't1', key1, key2)
+                    assert len(res) == val2 - val1 + 1
+                    res = r.execute_command('ts.revrange', 't1', key1 - 1, key2 + 1)
+                    assert len(res) == val2 - val1 + 1
+
+
+    def test_issue358(self):
+        env = self.env
+        env.flush()
+        filepath = "./issue358.txt"
+        with env.getClusterConnectionIfNeeded() as r:
+            r.execute_command('ts.create', 'issue358')
+
+            with open(filepath) as fp:
+                line = fp.readline()
+                while line:
+                    line = fp.readline()
+                    if line != '':
+                        r.execute_command(*line.split())
+            range_res = r.execute_command('ts.range', 'issue358', 1582848000, '+')[0][1]
+            get_res = r.execute_command('ts.get', 'issue358')[1]
+            assert range_res == get_res
+
+
+
+    def test_filter_by(self):
+        env = self.env
+        env.flush()
+        start_ts = 1511885909
+        samples_count = 1500
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', 'tester', 'RETENTION', '0', 'CHUNK_SIZE', '1024', 'LABELS', 'name',
+                                     'brown', 'color', 'pink')
+            _insert_data(r, 'tester', start_ts, samples_count, list(i for i in range(samples_count)))
+
+            res = r.execute_command('ts.range', 'tester', start_ts, '+', 'FILTER_BY_VALUE', 40, 52)
+
+            assert len(res) == 13
+            assert [int(sample[1]) for sample in res] == list(range(40, 53))
+
+            res = r.execute_command('ts.range', 'tester', start_ts, '+',
+                                    'FILTER_BY_TS', start_ts + 1021, start_ts + 1022, start_ts + 1025, start_ts + 1029)
+            env.assertEqual(res, [[start_ts + 1021, b'1021'], [start_ts + 1022, b'1022'], [start_ts + 1025, b'1025'],
+                                  [start_ts + 1029, b'1029']])
+
+            res = r.execute_command('ts.range', 'tester', start_ts, '+',
+                                    'FILTER_BY_TS', start_ts + 1021, start_ts + 1021, start_ts + 1022, start_ts + 1022, start_ts + 1025, start_ts + 1029, start_ts + 1029)
+            env.assertEqual(res, [[start_ts + 1021, b'1021'], [start_ts + 1022, b'1022'], [start_ts + 1025, b'1025'],
+                                  [start_ts + 1029, b'1029']])
+
+            res = r.execute_command('ts.range', 'tester', start_ts, '+',
+                                    'FILTER_BY_TS', start_ts + 1021, start_ts + 1022, start_ts + 1023, start_ts + 1025,
+                                    start_ts + 1029,
+                                    'FILTER_BY_VALUE', 1022, 1025)
+            env.assertEqual(res, [[start_ts + 1022, b'1022'], [start_ts + 1023, b'1023'], [start_ts + 1025, b'1025']])
+
+
+    def test_filter_by_extensive(self):
+        env = self.env
+        env.flush()
+        #skip cause it takes too much time
+        env.skipOnCluster()
+        env.skipOnAOF()
+        env.skipOnSlave()
+        max_samples_count = 40
+        for ENCODING in ['uncompressed']:
             for ev_odd in ['even', 'odd']:
                 if(ev_odd == 'even'):
                     start_ts = 2
@@ -1245,32 +1270,344 @@ def test_max_extensive():
                     # inset even numbers
                     for samples_count in range(0, max_samples_count + 1):
                         last_ts = start_ts + samples_count*2
-                        r.execute_command('TS.ADD', 't1', last_ts, random_values[samples_count])
+                        r.execute_command('TS.ADD', 't1', last_ts, last_ts)
 
                         for rev in [False, True]:
                             query = 'ts.revrange' if rev else 'ts.range'
-                            for bucket_size in [1, 2, 3, 5, 7, 10, n_chunk_samples - 1,
-                            n_chunk_samples, n_chunk_samples+1, (2*n_chunk_samples)-1,
-                            (2*n_chunk_samples), (2*n_chunk_samples)+1, (3*n_chunk_samples)-1,
-                            (3*n_chunk_samples), (3*n_chunk_samples)+1]:
-                                for alignment in [0, 2, 5, 7]:
-                                    normalized_alignment = alignment%bucket_size
-                                    for max_index in range(start_ts, last_ts + 1):
-                                        r.execute_command('TS.ADD', 't1', max_index, max_val, 'ON_DUPLICATE', 'last')
-                                        start_ts_bucket = (start_ts - normalized_alignment)//bucket_size
-                                        max_bucket_reply_index = (max_index - normalized_alignment)//bucket_size - start_ts_bucket
-                                        max_bucket_ts = max(0, max_index - ((max_index - normalized_alignment)%bucket_size))
-                                        res = r.execute_command(query, 't1', '-', '+', 'ALIGN', alignment, 'AGGREGATION', 'max', bucket_size)
-                                        if rev:
-                                            max_bucket_reply_index = len(res) - 1 - max_bucket_reply_index
-                                        expected_res = [max_bucket_ts, str(max_val).encode()]
-                                        env.assertEqual(res[max_bucket_reply_index], expected_res)
+                            for first_ts in range(0, last_ts + 3):
+                                str_first_ts = str(first_ts)
+                                for second_ts in range(first_ts, last_ts + 3):
+                                    str_second_ts = str(second_ts)
+                                    expected_res = []
+                                    reminder = 0 if ev_odd == 'even' else 1
+                                    if(first_ts%2 == reminder and first_ts >= start_ts and first_ts <= last_ts):
+                                        expected_res.append([first_ts, str_first_ts.encode()])
+                                    if(first_ts != second_ts and second_ts%2 == reminder and second_ts >= start_ts and second_ts <= last_ts):
+                                        if(rev): #prepend
+                                            expected_res.insert(0, [second_ts, str_second_ts.encode()])
+                                        else:    # append
+                                            expected_res.append([second_ts, str_second_ts.encode()])
+                                    res = r.execute_command(query, 't1', '-', '+', 'FILTER_BY_TS', first_ts, second_ts)
+                                    env.assertEqual(res, expected_res)
 
-                                        #restore to the old val
-                                        r.execute_command('TS.ADD', 't1', max_index, random_values[i], 'ON_DUPLICATE', 'last')
-    except Exception as e:
-        print(seed)
-        raise e
+
+    def test_max_extensive(self):
+        env = self.env
+        env.flush()
+        #skip cause it takes too much time
+        env.skipOnCluster()
+        env.skipOnAOF()
+        env.skipOnSlave()
+        max_samples_count = 40
+        n_chunk_samples = 32
+        random_values = [None]*(max_samples_count*3)
+        random.seed()
+        try:
+            for i in range(0, max_samples_count*3):
+                random_values[i] = random.uniform(0, max_samples_count)
+            max_val = random.uniform(max_samples_count, max_samples_count + 10)
+            for ENCODING in ['uncompressed', 'compressed']:
+                for ev_odd in ['even', 'odd']:
+                    if(ev_odd == 'even'):
+                        start_ts = 2
+                    else:
+                        start_ts = 3
+                    env.flush()
+                    with env.getClusterConnectionIfNeeded() as r:
+                        assert r.execute_command('TS.CREATE', 't1', ENCODING, 'RETENTION', '0', 'CHUNK_SIZE', '512')
+                        # 32 samples in chunk, 40 samples: 2 chunk in total
+                        # inset even numbers
+                        for samples_count in range(0, max_samples_count + 1):
+                            last_ts = start_ts + samples_count*2
+                            r.execute_command('TS.ADD', 't1', last_ts, random_values[samples_count])
+
+                            for rev in [False, True]:
+                                query = 'ts.revrange' if rev else 'ts.range'
+                                for bucket_size in [1, 2, 3, 5, 7, 10, n_chunk_samples - 1,
+                                n_chunk_samples, n_chunk_samples+1, (2*n_chunk_samples)-1,
+                                (2*n_chunk_samples), (2*n_chunk_samples)+1, (3*n_chunk_samples)-1,
+                                (3*n_chunk_samples), (3*n_chunk_samples)+1]:
+                                    for alignment in [0, 2, 5, 7]:
+                                        normalized_alignment = alignment%bucket_size
+                                        for max_index in range(start_ts, last_ts + 1):
+                                            r.execute_command('TS.ADD', 't1', max_index, max_val, 'ON_DUPLICATE', 'last')
+                                            start_ts_bucket = (start_ts - normalized_alignment)//bucket_size
+                                            max_bucket_reply_index = (max_index - normalized_alignment)//bucket_size - start_ts_bucket
+                                            max_bucket_ts = max(0, max_index - ((max_index - normalized_alignment)%bucket_size))
+                                            res = r.execute_command(query, 't1', '-', '+', 'ALIGN', alignment, 'AGGREGATION', 'max', bucket_size)
+                                            if rev:
+                                                max_bucket_reply_index = len(res) - 1 - max_bucket_reply_index
+                                            expected_res = [max_bucket_ts, str(max_val).encode()]
+                                            env.assertEqual(res[max_bucket_reply_index], expected_res)
+
+                                            #restore to the old val
+                                            r.execute_command('TS.ADD', 't1', max_index, random_values[i], 'ON_DUPLICATE', 'last')
+        except Exception as e:
+            print(seed)
+            raise e
+
+
+    def test_latest_flag_with_deleted_source(self):
+        """
+        Test scenario:
+         - Create a compaction key.
+         - Delete the source key and recreate it. It will not have the compaction rule.
+         - Query dst key with LATEST flag to test we handle this case without a crash.
+        """
+        env = self.env
+        env.flush()
+        src = 't1{1}'
+        dst = 't2{1}'
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', src)
+            assert r.execute_command('TS.CREATE', dst)
+            assert r.execute_command('TS.CREATERULE', src, dst, 'AGGREGATION', 'SUM', 10)
+
+            # Delete src, recreate it and query with LATEST flag
+            assert r.execute_command('DEL', src)
+            assert r.execute_command('TS.CREATE', src, '100', '100')
+            assert r.execute_command('TS.RANGE', dst, '-', '+', 'LATEST', 'AGGREGATION', 'sum', 10) == []
+            assert r.execute_command('TS.REVRANGE', dst, '-', '+', 'LATEST', 'AGGREGATION', 'sum', 10) == []
+            # Delete src, recreate it with a sample in it and query with LATEST flag
+            assert r.execute_command('DEL', src)
+            assert r.execute_command('TS.ADD', src, '100', '100')
+            assert r.execute_command('TS.RANGE', dst, '-', '+', 'LATEST', 'AGGREGATION', 'sum', 10) == []
+            assert r.execute_command('TS.GET', dst, 'LATEST') == []
+
+            # Run the same test with non-empty key
+            r.execute_command('DEL', src, dst)
+            assert r.execute_command('TS.CREATE', src)
+            assert r.execute_command('TS.CREATE', dst)
+            assert r.execute_command('TS.CREATERULE', src, dst, 'AGGREGATION', 'SUM', 10)
+            for i in range(100):
+                r.execute_command('TS.ADD', src, i, i)
+
+            # Delete src, recreate it and query with LATEST flag
+            assert r.execute_command('DEL', src)
+            assert r.execute_command('TS.CREATE', src, '100', '100')
+            assert r.execute_command('TS.RANGE', dst, '-', '+', 'LATEST', 'AGGREGATION', 'sum', 10) != []
+            assert r.execute_command('TS.GET', dst, 'LATEST') != []
+            # Delete src, recreate it with a sample in it and query with LATEST flag
+            assert r.execute_command('DEL', src)
+            assert r.execute_command('TS.ADD', src, '100', '100')
+            assert r.execute_command('TS.RANGE', dst, '-', '+', 'LATEST', 'AGGREGATION', 'sum', 10) != []
+            assert r.execute_command('TS.GET', dst, 'LATEST') != []
+
+
+
+    def test_ts_range_NaN_values(self):
+        """
+        Validates that all the aggregation functions handle NaN values correctly.
+        NaN values should be treated as empty buckets when the EMPTY flag is set.
+        Aggregation functions should ignore NaN values.
+        """
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            for encoding in ['compressed', 'uncompressed']:
+                r.execute_command('FLUSHALL')
+                key = 'ts_nan_test{a}{encoding}'
+            
+                # Create a series with mixed NaN and valid values
+                # Bucket 0-99: values 10, NaN, 20, NaN, 30 (valid: 10, 20, 30)
+                # Bucket 100-199: only NaN values (should be treated as empty)
+                # Bucket 200-299: values 40, 50 (valid: 40, 50)
+                r.execute_command('TS.CREATE', key, 'ENCODING', encoding)
+            
+                # Bucket 0-99: mixed NaN and valid values
+                r.execute_command('TS.ADD', key, 10, 10)
+                r.execute_command('TS.ADD', key, 20, 'nan')
+                r.execute_command('TS.ADD', key, 30, 20)
+                r.execute_command('TS.ADD', key, 40, 'nan')
+                r.execute_command('TS.ADD', key, 50, 30)
+            
+                # Bucket 100-199: only NaN values
+                r.execute_command('TS.ADD', key, 110, 'nan')
+                r.execute_command('TS.ADD', key, 120, 'nan')
+                r.execute_command('TS.ADD', key, 130, 'nan')
+            
+                # Bucket 200-299: valid values only
+                r.execute_command('TS.ADD', key, 210, 40)
+                r.execute_command('TS.ADD', key, 220, 50)
+            
+                # Test 1: Aggregations should ignore NaN values
+                # sum of valid values in bucket 0-99: 10 + 20 + 30 = 60
+                result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'sum', 100)
+                assert len(result) == 1
+                assert result[0][0] == 0
+                assert float(result[0][1]) == 60.0
+            
+                # count should only count valid (non-NaN) samples
+                result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'count', 100)
+                assert len(result) == 1
+                assert float(result[0][1]) == 3.0  # 3 valid samples
+            
+                result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'min', 100)
+                assert len(result) == 1
+                assert float(result[0][1]) == 10.0
+            
+                result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'max', 100)
+                assert len(result) == 1
+                assert float(result[0][1]) == 30.0
+            
+                result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'avg', 100)
+                assert len(result) == 1
+                assert float(result[0][1]) == 20.0
+            
+                result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'first', 100)
+                assert len(result) == 1
+                assert float(result[0][1]) == 10.0
+            
+                result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'last', 100)
+                assert len(result) == 1
+                assert float(result[0][1]) == 30.0
+            
+                result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'range', 100)
+                assert len(result) == 1
+                assert float(result[0][1]) == 20.0
+            
+                # Test 2: Bucket with only NaN should be skipped (no EMPTY flag)
+                # Query all three buckets - bucket 100-199 should be missing
+                result = r.execute_command('TS.RANGE', key, 0, 299, 'AGGREGATION', 'sum', 100)
+                assert len(result) == 2  # Only 2 buckets (0 and 200), bucket 100 is skipped
+                assert result[0][0] == 0    # First bucket
+                assert result[1][0] == 200  # Third bucket (second is skipped)
+                assert float(result[0][1]) == 60.0   # sum of bucket 0
+                assert float(result[1][1]) == 90.0   # sum of bucket 200: 40 + 50
+            
+                # Test 3: Bucket with only NaN should return NaN with EMPTY flag
+                result = r.execute_command('TS.RANGE', key, 0, 299, 'AGGREGATION', 'sum', 100, 'EMPTY')
+                assert len(result) == 3  # All 3 buckets
+                assert result[0][0] == 0
+                assert result[1][0] == 100
+                assert result[2][0] == 200
+                assert float(result[0][1]) == 60.0
+                assert float(result[1][1]) == 0 # empty bucket
+                assert float(result[2][1]) == 90.0
+            
+                # Test 4: REVRANGE should also handle NaN correctly
+                result = r.execute_command('TS.REVRANGE', key, 0, 299, 'AGGREGATION', 'sum', 100)
+                assert len(result) == 2  # Only 2 buckets, reversed
+                assert result[0][0] == 200
+                assert result[1][0] == 0
+            
+                # Test 5: count aggregation - empty bucket should return 0 with EMPTY flag
+                result = r.execute_command('TS.RANGE', key, 0, 299, 'AGGREGATION', 'count', 100, 'EMPTY')
+                assert len(result) == 3
+                assert float(result[0][1]) == 3.0   # 3 valid samples in bucket 0
+                assert float(result[1][1]) == 0.0   # 0 valid samples in bucket 100
+                assert float(result[2][1]) == 2.0   # 2 valid samples in bucket 200
+            
+                # Test 6: Test aggregations with EMPTY flag on NaN-only bucket (100-199)
+                # Expected values: NaN for most, 0 for sum/count, 0 for last (last valid before bucket),
+                # interpolated for twa (has samples before and after)
+                expected_empty_bucket_values = {
+                    'sum': 0.0,
+                    'count': 0.0,
+                    'min': float('nan'),
+                    'max': float('nan'),
+                    'avg': float('nan'),
+                    'first': float('nan'),
+                    'last': 30.0,  # last valid value before bucket (from ts=50)
+                    'range': float('nan'),
+                    'std.p': float('nan'),
+                    'std.s': float('nan'),
+                    'var.p': float('nan'),
+                    'var.s': float('nan'),
+                    'twa': 'interpolated',  # special case: has surrounding samples, should not be NaN
+                }
+            
+                for agg_func, expected in expected_empty_bucket_values.items():
+                    result = r.execute_command('TS.RANGE', key, 0, 199, 'AGGREGATION', agg_func, 100, 'EMPTY')
+                    assert len(result) == 2, f"{agg_func}: expected 2 results"
+                    actual = float(result[1][1])
+                    if expected == 'interpolated':
+                        assert not math.isnan(actual), f"{agg_func}: expected interpolated value, got NaN"
+                    elif math.isnan(expected):
+                        assert math.isnan(actual), f"{agg_func}: expected NaN, got {actual}"
+                    else:
+                        assert actual == expected, f"{agg_func}: expected {expected}, got {actual}"
+            
+                # Test 7: Query only the NaN-only bucket without EMPTY - should return empty
+                result = r.execute_command('TS.RANGE', key, 100, 199, 'AGGREGATION', 'sum', 100)
+                assert len(result) == 0  # No results - bucket is effectively empty
+            
+                # Test 8: 'last' and 'twa' return NaN when NO sample exists before the bucket
+                key_no_before = 'ts_nan_no_before{a}'
+                r.execute_command('TS.CREATE', key_no_before, 'ENCODING', encoding)
+                r.execute_command('TS.ADD', key_no_before, 100, 'nan')  # NaN in bucket 100-199
+                r.execute_command('TS.ADD', key_no_before, 200, 50)     # Valid sample after
+            
+                for agg_func in ['last', 'twa']:
+                    result = r.execute_command('TS.RANGE', key_no_before, 100, 199, 'AGGREGATION', agg_func, 100, 'EMPTY')
+                    assert len(result) == 1
+                    assert math.isnan(float(result[0][1])), f"{agg_func}: expected NaN when no sample before bucket, got {result[0][1]}"
+
+
+
+    def test_ts_range_countNaN(self):
+        """
+        Validate COUNTNAN aggregation function
+        """
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            for encoding in ['compressed', 'uncompressed']:
+                r.execute_command('FLUSHALL')
+                key = 'ts_countNaN_test{a}'
+                r.execute_command('TS.CREATE', key, 'ENCODING', encoding)
+                r.execute_command('TS.ADD', key, 10, 10)
+                r.execute_command('TS.ADD', key, 20, 'nan')
+                r.execute_command('TS.ADD', key, 30, 20)
+                r.execute_command('TS.ADD', key, 40, 'nan')
+                r.execute_command('TS.ADD', key, 50, 30)
+                result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'countnan', 100)
+                assert len(result) == 1
+                assert float(result[0][1]) == 2.0
+                result = r.execute_command('TS.REVRANGE', key, 0, 99, 'AGGREGATION', 'countnan', 10, 'EMPTY')
+                assert len(result) == 5
+                assert float(result[0][1]) == 0.0
+                assert float(result[1][1]) == 1.0
+                assert float(result[2][1]) == 0.0
+                assert float(result[3][1]) == 1.0
+                assert float(result[4][1]) == 0.0
+
+                result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'countnan', 50)
+                assert len(result) == 1
+                assert float(result[0][1]) == 2.0
+
+
+    def test_ts_range_countAll(self):
+        """
+        Validate COUNTALL aggregation function
+        """
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            for encoding in ['compressed', 'uncompressed']:
+                r.execute_command('FLUSHALL')
+                key = 'ts_countAll_test{a}'
+                r.execute_command('TS.CREATE', key, 'ENCODING', encoding)
+                r.execute_command('TS.ADD', key, 10, 10)
+                r.execute_command('TS.ADD', key, 20, 'nan')
+                r.execute_command('TS.ADD', key, 30, 20)
+                r.execute_command('TS.ADD', key, 40, 'nan')
+                r.execute_command('TS.ADD', key, 50, 30)
+                result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'countall', 100)
+                assert len(result) == 1
+                assert float(result[0][1]) == 5.0
+                result = r.execute_command('TS.REVRANGE', key, 0, 99, 'AGGREGATION', 'countall', 10, 'EMPTY')
+                assert len(result) == 5
+                assert float(result[0][1]) == 1.0
+                assert float(result[1][1]) == 1.0
+                assert float(result[2][1]) == 1.0
+                assert float(result[3][1]) == 1.0
+
+
+
+def get_bucket(timsetamp, alignment_ts, aggregation_bucket_size):
+    return timsetamp - ((timsetamp - alignment_ts) % aggregation_bucket_size)
+
 
 def build_expected_aligned_data(start_ts, end_ts, agg_size, alignment_ts):
     expected_data = []
@@ -1291,646 +1628,429 @@ def build_expected_aligned_data(start_ts, end_ts, agg_size, alignment_ts):
     return expected_data
 
 
-def test_aggreataion_alignment():
-    start_ts = 1511885909
-    samples_count = 1200
-    env = Env(decodeResponses=True)
-    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
-        assert r.execute_command('TS.CREATE', 'tester')
-        _insert_data(r1, 'tester', start_ts, samples_count, list(i for i in range(samples_count)))
-
-        agg_size = 60
-        expected_data = build_expected_aligned_data(start_ts, start_ts + samples_count, agg_size, start_ts)
-
-        assert expected_data == \
-               decode_if_needed(r1.execute_command('TS.range', 'tester', start_ts, '+', 'ALIGN', 'start', 'AGGREGATION', 'count', agg_size))
-
-        assert expected_data == \
-               decode_if_needed(r1.execute_command('TS.range', 'tester', start_ts, '+', 'ALIGN', '-', 'AGGREGATION', 'count', agg_size))
-
-        specific_ts = start_ts + 50
-        expected_data = build_expected_aligned_data(start_ts, start_ts + samples_count, agg_size, specific_ts)
-        assert expected_data == \
-               decode_if_needed(r1.execute_command('TS.range', 'tester', '-', '+', 'ALIGN', specific_ts, 'AGGREGATION', 'count', agg_size))
-
-        end_ts = start_ts + samples_count - 1
-        expected_data = build_expected_aligned_data(start_ts, start_ts + samples_count, agg_size, end_ts)
-        assert expected_data == \
-               decode_if_needed(r1.execute_command('TS.range', 'tester', '-', end_ts, 'ALIGN', 'end', 'AGGREGATION', 'count', agg_size))
-        assert expected_data == \
-               decode_if_needed(r1.execute_command('TS.range', 'tester', '-', end_ts, 'ALIGN', '+', 'AGGREGATION', 'count', agg_size))
-
-def test_empty():
-    agg_size = 10
-    env = Env(decodeResponses=True)
-    with env.getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', 't1')
-        assert r.execute_command('TS.add', 't1', 15, 1)
-        assert r.execute_command('TS.add', 't1', 17, 4)
-        assert r.execute_command('TS.add', 't1', 51, 3)
-        assert r.execute_command('TS.add', 't1', 73, 5)
-        assert r.execute_command('TS.add', 't1', 75, 3)
-        assert r.execute_command('TS.CREATE', 't2')
-        assert r.execute_command('TS.add', 't2', 10, 1)
-        assert r.execute_command('TS.add', 't2', 30, 4)
-        expected_data = [[10, '4'], [20, 'NaN'], [30, 'NaN'], [40, 'NaN'], [50, '3'], [60, 'NaN'], [70, '5']]
-        assert expected_data == \
-        decode_if_needed(r.execute_command('TS.range', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'EMPTY'))
-        expected_data.reverse()
-        assert expected_data == \
-        decode_if_needed(r.execute_command('TS.revrange', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'EMPTY'))
-
-        expected_data_2 = [[10, '4'], [20, '4'], [30, '4'], [40, '4'], [50, '3'], [60, '3'], [70, '3']]
-        assert expected_data_2 == \
-        decode_if_needed(r.execute_command('TS.range', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'last', agg_size, 'EMPTY'))
-        expected_data_3 = [[70, '5'], [60, '5'], [50, '3'], [40, '3'], [30, '3'], [20, '3'], [10, '1']]
-        assert expected_data_3 == \
-        decode_if_needed(r.execute_command('TS.revrange', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'last', agg_size, 'EMPTY'))
-
-        expected_data = [[10, '5'], [20, '0'], [30, '0'], [40, '0'], [50, '3'], [60, '0'], [70, '8']]
-        assert expected_data == \
-        decode_if_needed(r.execute_command('TS.range', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'sum', agg_size, 'EMPTY'))
-        expected_data.reverse()
-        assert expected_data == \
-        decode_if_needed(r.execute_command('TS.revrange', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'sum', agg_size, 'EMPTY'))
-
-        expected_data = [[10, '1'], [20, 'NaN'], [30, '4']]
-        assert expected_data == \
-        decode_if_needed(r.execute_command('TS.range', 't2', '0', '30', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'EMPTY'))
-        expected_data.reverse()
-        assert expected_data == \
-        decode_if_needed(r.execute_command('TS.revrange', 't2', '0', '30', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'EMPTY'))
 
 
-def test_bucket_timestamp():
-    agg_size = 10
-    env = Env(decodeResponses=True)
-    with env.getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', 't1')
-        assert r.execute_command('TS.add', 't1', 15, 1)
-        assert r.execute_command('TS.add', 't1', 17, 4)
-        assert r.execute_command('TS.add', 't1', 51, 3)
-        assert r.execute_command('TS.add', 't1', 73, 5)
-        assert r.execute_command('TS.add', 't1', 75, 3)
 
-        expected_data = [[10, '4'], [50, '3'], [70, '5']]
-        assert expected_data == \
-        decode_if_needed(r.execute_command('TS.range', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'BUCKETTIMESTAMP', '-'))
-        expected_data.reverse()
-        assert expected_data == \
-        decode_if_needed(r.execute_command('TS.revrange', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'BUCKETTIMESTAMP', '-'))
+class testTsRangeDecode:
+    def __init__(self):
+        self.env = Env(decodeResponses=True)
 
-        expected_data = [[15, '4'], [55, '3'], [75, '5']]
-        assert expected_data == \
-        decode_if_needed(r.execute_command('TS.range', 't1', '0', '74', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'BUCKETTIMESTAMP', '~'))
-        expected_data.reverse()
-        assert expected_data == \
-        decode_if_needed(r.execute_command('TS.revrange', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'BUCKETTIMESTAMP', '~'))
+    def test_aggreataion_alignment(self):
+        env = self.env
+        env.flush()
+        start_ts = 1511885909
+        samples_count = 1200
+        with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+            assert r.execute_command('TS.CREATE', 'tester')
+            _insert_data(r1, 'tester', start_ts, samples_count, list(i for i in range(samples_count)))
 
-        expected_data = [[20, '4'], [60, '3'], [80, '5']]
-        assert expected_data == \
-        decode_if_needed(r.execute_command('TS.range', 't1', '0', '74', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'BUCKETTIMESTAMP', '+'))
-        expected_data.reverse()
-        assert expected_data == \
-        decode_if_needed(r.execute_command('TS.revrange', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'BUCKETTIMESTAMP', '+'))
+            agg_size = 60
+            expected_data = build_expected_aligned_data(start_ts, start_ts + samples_count, agg_size, start_ts)
 
-def test_latest_flag_range():
-    env = Env(decodeResponses=True)
-    key1 = 't1{1}'
-    key2 = 't2{1}'
-    with env.getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', key1)
-        assert r.execute_command('TS.CREATE', key2)
-        assert r.execute_command('TS.CREATERULE', key1, key2, 'AGGREGATION', 'SUM', 10)
-        assert r.execute_command('TS.add', key1, 1, 1)
-        assert r.execute_command('TS.add', key1, 2, 3)
-        assert r.execute_command('TS.add', key1, 11, 7)
-        assert r.execute_command('TS.add', key1, 13, 1)
-        res = r.execute_command('TS.range', key1, 0, 20)
-        assert res == [[1, '1'], [2, '3'], [11, '7'], [13, '1']] or res == [[1, b'1'], [2, b'3'], [11, b'7'], [13, b'1']]
-        res = r.execute_command('TS.range', key2, 0, 10)
-        assert res == [[0, '4']] or res == [[0, b'4']]
-        res = r.execute_command('TS.range', key2, 0, 10, "LATEST")
-        assert res == [[0, '4'], [10, '8']] or res == [[0, b'4'], [10, b'8']]
-        res = r.execute_command('TS.range', key2, 0, 9, "LATEST")
-        assert res == [[0, '4']] or res == [[0, b'4']]
-        res = r.execute_command('TS.range', key2, 0, 1, "LATEST")
-        assert res == [[0, '4']] or res == [[0, b'4']]
-        res = r.execute_command('TS.range', key2, 20, 30, "LATEST")
-        assert res == []
-        res = r.execute_command('TS.range', key2, 11, 30, "LATEST")
-        assert res == []
+            assert expected_data == \
+                   decode_if_needed(r1.execute_command('TS.range', 'tester', start_ts, '+', 'ALIGN', 'start', 'AGGREGATION', 'count', agg_size))
 
-        # make sure LATEST haven't changed anything in the keys
-        res = r.execute_command('TS.range', key2, 0, 10)
-        assert res == [[0, '4']] or res == [[0, b'4']]
-        res = r.execute_command('TS.range', key1, 0, 20)
-        assert res == [[1, '1'], [2, '3'], [11, '7'], [13, '1']] or res == [[1, b'1'], [2, b'3'], [11, b'7'], [13, b'1']]
+            assert expected_data == \
+                   decode_if_needed(r1.execute_command('TS.range', 'tester', start_ts, '+', 'ALIGN', '-', 'AGGREGATION', 'count', agg_size))
 
-#https://github.com/RedisTimeSeries/RedisTimeSeries/issues/1247
-def test_latest_flag_range_plus():
-        env = Env(decodeResponses=True)
-        key3 = 't3{1}'
-        key4 = 't4{1}'
+            specific_ts = start_ts + 50
+            expected_data = build_expected_aligned_data(start_ts, start_ts + samples_count, agg_size, specific_ts)
+            assert expected_data == \
+                   decode_if_needed(r1.execute_command('TS.range', 'tester', '-', '+', 'ALIGN', specific_ts, 'AGGREGATION', 'count', agg_size))
+
+            end_ts = start_ts + samples_count - 1
+            expected_data = build_expected_aligned_data(start_ts, start_ts + samples_count, agg_size, end_ts)
+            assert expected_data == \
+                   decode_if_needed(r1.execute_command('TS.range', 'tester', '-', end_ts, 'ALIGN', 'end', 'AGGREGATION', 'count', agg_size))
+            assert expected_data == \
+                   decode_if_needed(r1.execute_command('TS.range', 'tester', '-', end_ts, 'ALIGN', '+', 'AGGREGATION', 'count', agg_size))
+
+
+    def test_empty(self):
+        env = self.env
+        env.flush()
+        agg_size = 10
         with env.getClusterConnectionIfNeeded() as r:
-            assert r.execute_command('TS.CREATE', key3)
-            assert r.execute_command('TS.CREATE', key4)
-            assert r.execute_command('TS.CREATERULE', key3, key4, 'AGGREGATION', 'RANGE', 10)
-            assert r.execute_command('TS.add', key3, 10, 20)
-            assert r.execute_command('TS.add', key3, 11, 30)
-            res = r.execute_command('TS.range', key4, 0, 10000, "LATEST")
-            assert res == [[10, '10']] or res == [[10, b'10']]
-            res = r.execute_command('TS.range', key4, "-", "+", "LATEST")
-            assert res == [[10, '10']] or res == [[10, b'10']]
+            assert r.execute_command('TS.CREATE', 't1')
+            assert r.execute_command('TS.add', 't1', 15, 1)
+            assert r.execute_command('TS.add', 't1', 17, 4)
+            assert r.execute_command('TS.add', 't1', 51, 3)
+            assert r.execute_command('TS.add', 't1', 73, 5)
+            assert r.execute_command('TS.add', 't1', 75, 3)
+            assert r.execute_command('TS.CREATE', 't2')
+            assert r.execute_command('TS.add', 't2', 10, 1)
+            assert r.execute_command('TS.add', 't2', 30, 4)
+            expected_data = [[10, '4'], [20, 'NaN'], [30, 'NaN'], [40, 'NaN'], [50, '3'], [60, 'NaN'], [70, '5']]
+            assert expected_data == \
+            decode_if_needed(r.execute_command('TS.range', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'EMPTY'))
+            expected_data.reverse()
+            assert expected_data == \
+            decode_if_needed(r.execute_command('TS.revrange', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'EMPTY'))
 
-def test_latest_flag_revrange():
-    env = Env(decodeResponses=True)
-    key1 = 't1{1}'
-    key2 = 't2{1}'
-    with env.getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', key1)
-        assert r.execute_command('TS.CREATE', key2)
-        assert r.execute_command('TS.CREATERULE', key1, key2, 'AGGREGATION', 'SUM', 10)
-        assert r.execute_command('TS.add', key1, 1, 1)
-        assert r.execute_command('TS.add', key1, 2, 3)
-        assert r.execute_command('TS.add', key1, 11, 7)
-        assert r.execute_command('TS.add', key1, 13, 1)
-        res = r.execute_command('TS.range', key1, 0, 20)
-        assert res == [[1, '1'], [2, '3'], [11, '7'], [13, '1']] or res == [[1, b'1'], [2, b'3'], [11, b'7'], [13, b'1']]
-        res = r.execute_command('TS.revrange', key2, 0, 10)
-        assert res == [[0, '4']] or res == [[0, b'4']]
-        res = r.execute_command('TS.revrange', key2, 0, 10, "LATEST")
-        assert res == [[10, '8'], [0, '4']] or res == [[10, b'8'], [0, b'4']]
-        res = r.execute_command('TS.revrange', key2, 0, 9, "LATEST")
-        assert res == [[0, '4']] or res == [[0, b'4']]
+            expected_data_2 = [[10, '4'], [20, '4'], [30, '4'], [40, '4'], [50, '3'], [60, '3'], [70, '3']]
+            assert expected_data_2 == \
+            decode_if_needed(r.execute_command('TS.range', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'last', agg_size, 'EMPTY'))
+            expected_data_3 = [[70, '5'], [60, '5'], [50, '3'], [40, '3'], [30, '3'], [20, '3'], [10, '1']]
+            assert expected_data_3 == \
+            decode_if_needed(r.execute_command('TS.revrange', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'last', agg_size, 'EMPTY'))
 
-        # make sure LATEST haven't changed anything in the keys
-        res = r.execute_command('TS.revrange', key2, 0, 10)
-        assert res == [[0, '4']] or res == [[0, b'4']]
-        res = r.execute_command('TS.range', key1, 0, 20)
-        assert res == [[1, '1'], [2, '3'], [11, '7'], [13, '1']] or res == [[1, b'1'], [2, b'3'], [11, b'7'], [13, b'1']]
+            expected_data = [[10, '5'], [20, '0'], [30, '0'], [40, '0'], [50, '3'], [60, '0'], [70, '8']]
+            assert expected_data == \
+            decode_if_needed(r.execute_command('TS.range', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'sum', agg_size, 'EMPTY'))
+            expected_data.reverse()
+            assert expected_data == \
+            decode_if_needed(r.execute_command('TS.revrange', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'sum', agg_size, 'EMPTY'))
 
-# issue: #1370
-def test_multi_chunk_revrange():
-    env = Env(decodeResponses=True)
-    t1 = 't1{1}'
-    with env.getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', t1, 'CHUNK_SIZE', 128)
-        n_samples = 10000
-
-        # Fill 1 chunks
-        for i in range(1, 103):
-            assert r.execute_command('TS.ADD', t1, i, i)
-
-        # fill 2 chunks
-        for i in range(120, 220):
-            assert r.execute_command('TS.ADD', t1, i, i)
-
-        res = r.execute_command('TS.revrange', t1, 110, 215, 'AGGREGATION', 'count', 2*n_samples)
-        assert res == [[0, '96']] or res == [[0, b'96']]
-
-def test_errors():
-    env = Env(decodeResponses=True)
-    t1 = 't1{1}'
-    t2 = 't2{1}'
-    with env.getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', t1, 'CHUNK_SIZE', 128)
-        assert r.execute_command('ts.add', t1, 1, 1)
-        try:
-            r.execute_command('ts.range', t1, 0, 10, 'AGGREGATION', 'avg', 5, 'BUCKETTIMESTAMP', 'high')
-            assert False
-        except Exception as e:
-            assert str(e) == 'TSDB: unknown BUCKETTIMESTAMP parameter'
-
-        assert r.execute_command('TS.CREATE', t2, 'CHUNK_SIZE', 128)
-        try:
-            r.execute_command('TS.CREATERULE', t1, t2, 'AGGREGATION', 'avg', 5, 'high')
-            assert False
-        except Exception as e:
-            assert str(e) == "TSDB: Couldn't parse alignTimestamp"
+            expected_data = [[10, '1'], [20, 'NaN'], [30, '4']]
+            assert expected_data == \
+            decode_if_needed(r.execute_command('TS.range', 't2', '0', '30', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'EMPTY'))
+            expected_data.reverse()
+            assert expected_data == \
+            decode_if_needed(r.execute_command('TS.revrange', 't2', '0', '30', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'EMPTY'))
 
 
-def test_latest_flag_with_deleted_source():
-    """
-    Test scenario:
-     - Create a compaction key.
-     - Delete the source key and recreate it. It will not have the compaction rule.
-     - Query dst key with LATEST flag to test we handle this case without a crash.
-    """
-    env = Env(decodeResponses=True)
-    src = 't1{1}'
-    dst = 't2{1}'
-    with env.getClusterConnectionIfNeeded() as r:
-        assert r.execute_command('TS.CREATE', src)
-        assert r.execute_command('TS.CREATE', dst)
-        assert r.execute_command('TS.CREATERULE', src, dst, 'AGGREGATION', 'SUM', 10)
 
-        # Delete src, recreate it and query with LATEST flag
-        assert r.execute_command('DEL', src)
-        assert r.execute_command('TS.CREATE', src, '100', '100')
-        assert r.execute_command('TS.RANGE', dst, '-', '+', 'LATEST', 'AGGREGATION', 'sum', 10) == []
-        assert r.execute_command('TS.REVRANGE', dst, '-', '+', 'LATEST', 'AGGREGATION', 'sum', 10) == []
-        # Delete src, recreate it with a sample in it and query with LATEST flag
-        assert r.execute_command('DEL', src)
-        assert r.execute_command('TS.ADD', src, '100', '100')
-        assert r.execute_command('TS.RANGE', dst, '-', '+', 'LATEST', 'AGGREGATION', 'sum', 10) == []
-        assert r.execute_command('TS.GET', dst, 'LATEST') == []
+    def test_bucket_timestamp(self):
+        env = self.env
+        env.flush()
+        agg_size = 10
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', 't1')
+            assert r.execute_command('TS.add', 't1', 15, 1)
+            assert r.execute_command('TS.add', 't1', 17, 4)
+            assert r.execute_command('TS.add', 't1', 51, 3)
+            assert r.execute_command('TS.add', 't1', 73, 5)
+            assert r.execute_command('TS.add', 't1', 75, 3)
 
-        # Run the same test with non-empty key
-        r.execute_command('DEL', src, dst)
-        assert r.execute_command('TS.CREATE', src)
-        assert r.execute_command('TS.CREATE', dst)
-        assert r.execute_command('TS.CREATERULE', src, dst, 'AGGREGATION', 'SUM', 10)
-        for i in range(100):
-            r.execute_command('TS.ADD', src, i, i)
+            expected_data = [[10, '4'], [50, '3'], [70, '5']]
+            assert expected_data == \
+            decode_if_needed(r.execute_command('TS.range', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'BUCKETTIMESTAMP', '-'))
+            expected_data.reverse()
+            assert expected_data == \
+            decode_if_needed(r.execute_command('TS.revrange', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'BUCKETTIMESTAMP', '-'))
 
-        # Delete src, recreate it and query with LATEST flag
-        assert r.execute_command('DEL', src)
-        assert r.execute_command('TS.CREATE', src, '100', '100')
-        assert r.execute_command('TS.RANGE', dst, '-', '+', 'LATEST', 'AGGREGATION', 'sum', 10) != []
-        assert r.execute_command('TS.GET', dst, 'LATEST') != []
-        # Delete src, recreate it with a sample in it and query with LATEST flag
-        assert r.execute_command('DEL', src)
-        assert r.execute_command('TS.ADD', src, '100', '100')
-        assert r.execute_command('TS.RANGE', dst, '-', '+', 'LATEST', 'AGGREGATION', 'sum', 10) != []
-        assert r.execute_command('TS.GET', dst, 'LATEST') != []
+            expected_data = [[15, '4'], [55, '3'], [75, '5']]
+            assert expected_data == \
+            decode_if_needed(r.execute_command('TS.range', 't1', '0', '74', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'BUCKETTIMESTAMP', '~'))
+            expected_data.reverse()
+            assert expected_data == \
+            decode_if_needed(r.execute_command('TS.revrange', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'BUCKETTIMESTAMP', '~'))
+
+            expected_data = [[20, '4'], [60, '3'], [80, '5']]
+            assert expected_data == \
+            decode_if_needed(r.execute_command('TS.range', 't1', '0', '74', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'BUCKETTIMESTAMP', '+'))
+            expected_data.reverse()
+            assert expected_data == \
+            decode_if_needed(r.execute_command('TS.revrange', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'BUCKETTIMESTAMP', '+'))
 
 
-def test_ts_range_count_validation():
-    """
-    Validate COUNT argument is non-positive for TS.RANGE family commands
-    """
-    env = Env(decodeResponses=True)
-    env.skipOnCluster()
-    key = 'x'
-    with env.getClusterConnectionIfNeeded() as r:
-        for i in range(10):
-            r.execute_command('TS.ADD', key, i, i)
+    def test_latest_flag_range(self):
+        env = self.env
+        env.flush()
+        key1 = 't1{1}'
+        key2 = 't2{1}'
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', key1)
+            assert r.execute_command('TS.CREATE', key2)
+            assert r.execute_command('TS.CREATERULE', key1, key2, 'AGGREGATION', 'SUM', 10)
+            assert r.execute_command('TS.add', key1, 1, 1)
+            assert r.execute_command('TS.add', key1, 2, 3)
+            assert r.execute_command('TS.add', key1, 11, 7)
+            assert r.execute_command('TS.add', key1, 13, 1)
+            res = r.execute_command('TS.range', key1, 0, 20)
+            assert res == [[1, '1'], [2, '3'], [11, '7'], [13, '1']] or res == [[1, b'1'], [2, b'3'], [11, b'7'], [13, b'1']]
+            res = r.execute_command('TS.range', key2, 0, 10)
+            assert res == [[0, '4']] or res == [[0, b'4']]
+            res = r.execute_command('TS.range', key2, 0, 10, "LATEST")
+            assert res == [[0, '4'], [10, '8']] or res == [[0, b'4'], [10, b'8']]
+            res = r.execute_command('TS.range', key2, 0, 9, "LATEST")
+            assert res == [[0, '4']] or res == [[0, b'4']]
+            res = r.execute_command('TS.range', key2, 0, 1, "LATEST")
+            assert res == [[0, '4']] or res == [[0, b'4']]
+            res = r.execute_command('TS.range', key2, 20, 30, "LATEST")
+            assert res == []
+            res = r.execute_command('TS.range', key2, 11, 30, "LATEST")
+            assert res == []
 
-    env.expect('TS.RANGE', key, '-', '+', 'COUNT', '0').error().contains('TSDB: Invalid COUNT value')
-    env.expect('TS.RANGE', key, '-', '+', 'COUNT', '-1').error().contains('TSDB: Invalid COUNT value')
-    env.expect('TS.RANGE', key, '-', '+', 'COUNT', '-2').error().contains('TSDB: Invalid COUNT value')
-    env.expect('TS.REVRANGE', key, '-', '+', 'COUNT', '-1000').error().contains('TSDB: Invalid COUNT value')
-    env.expect('TS.MRANGE', '-', '+', 'COUNT', '-2', 'FILTER', 'a=x').error().contains('TSDB: Invalid COUNT value')
-    env.expect('TS.MREVRANGE', '-', '+', 'COUNT', '0', 'FILTER', 'a=x').error().contains('TSDB: Invalid COUNT value')
-
-    assert r.execute_command('TS.RANGE', key, '-', '+', 'COUNT', 2) == [[0, '0'], [1, '1']]
-    assert r.execute_command('TS.RANGE', key, '-', '+', 'COUNT', 2, 'AGGREGATION', 'sum', 5) == [[0, '10'], [5, '35']]
+            # make sure LATEST haven't changed anything in the keys
+            res = r.execute_command('TS.range', key2, 0, 10)
+            assert res == [[0, '4']] or res == [[0, b'4']]
+            res = r.execute_command('TS.range', key1, 0, 20)
+            assert res == [[1, '1'], [2, '3'], [11, '7'], [13, '1']] or res == [[1, b'1'], [2, b'3'], [11, b'7'], [13, b'1']]
 
 
-def test_ts_range_NaN_values():
-    """
-    Validates that all the aggregation functions handle NaN values correctly.
-    NaN values should be treated as empty buckets when the EMPTY flag is set.
-    Aggregation functions should ignore NaN values.
-    """
-    with Env().getClusterConnectionIfNeeded() as r:
-        for encoding in ['compressed', 'uncompressed']:
-            Env().flush()
-            key = 'ts_nan_test{a}{encoding}'
-            
-            # Create a series with mixed NaN and valid values
-            # Bucket 0-99: values 10, NaN, 20, NaN, 30 (valid: 10, 20, 30)
-            # Bucket 100-199: only NaN values (should be treated as empty)
-            # Bucket 200-299: values 40, 50 (valid: 40, 50)
-            r.execute_command('TS.CREATE', key, 'ENCODING', encoding)
-            
-            # Bucket 0-99: mixed NaN and valid values
-            r.execute_command('TS.ADD', key, 10, 10)
-            r.execute_command('TS.ADD', key, 20, 'nan')
-            r.execute_command('TS.ADD', key, 30, 20)
-            r.execute_command('TS.ADD', key, 40, 'nan')
-            r.execute_command('TS.ADD', key, 50, 30)
-            
-            # Bucket 100-199: only NaN values
-            r.execute_command('TS.ADD', key, 110, 'nan')
-            r.execute_command('TS.ADD', key, 120, 'nan')
-            r.execute_command('TS.ADD', key, 130, 'nan')
-            
-            # Bucket 200-299: valid values only
-            r.execute_command('TS.ADD', key, 210, 40)
-            r.execute_command('TS.ADD', key, 220, 50)
-            
-            # Test 1: Aggregations should ignore NaN values
-            # sum of valid values in bucket 0-99: 10 + 20 + 30 = 60
-            result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'sum', 100)
+    def test_latest_flag_range_plus(self):
+            env = self.env
+            env.flush()
+            key3 = 't3{1}'
+            key4 = 't4{1}'
+            with env.getClusterConnectionIfNeeded() as r:
+                assert r.execute_command('TS.CREATE', key3)
+                assert r.execute_command('TS.CREATE', key4)
+                assert r.execute_command('TS.CREATERULE', key3, key4, 'AGGREGATION', 'RANGE', 10)
+                assert r.execute_command('TS.add', key3, 10, 20)
+                assert r.execute_command('TS.add', key3, 11, 30)
+                res = r.execute_command('TS.range', key4, 0, 10000, "LATEST")
+                assert res == [[10, '10']] or res == [[10, b'10']]
+                res = r.execute_command('TS.range', key4, "-", "+", "LATEST")
+                assert res == [[10, '10']] or res == [[10, b'10']]
+
+
+    def test_latest_flag_revrange(self):
+        env = self.env
+        env.flush()
+        key1 = 't1{1}'
+        key2 = 't2{1}'
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', key1)
+            assert r.execute_command('TS.CREATE', key2)
+            assert r.execute_command('TS.CREATERULE', key1, key2, 'AGGREGATION', 'SUM', 10)
+            assert r.execute_command('TS.add', key1, 1, 1)
+            assert r.execute_command('TS.add', key1, 2, 3)
+            assert r.execute_command('TS.add', key1, 11, 7)
+            assert r.execute_command('TS.add', key1, 13, 1)
+            res = r.execute_command('TS.range', key1, 0, 20)
+            assert res == [[1, '1'], [2, '3'], [11, '7'], [13, '1']] or res == [[1, b'1'], [2, b'3'], [11, b'7'], [13, b'1']]
+            res = r.execute_command('TS.revrange', key2, 0, 10)
+            assert res == [[0, '4']] or res == [[0, b'4']]
+            res = r.execute_command('TS.revrange', key2, 0, 10, "LATEST")
+            assert res == [[10, '8'], [0, '4']] or res == [[10, b'8'], [0, b'4']]
+            res = r.execute_command('TS.revrange', key2, 0, 9, "LATEST")
+            assert res == [[0, '4']] or res == [[0, b'4']]
+
+            # make sure LATEST haven't changed anything in the keys
+            res = r.execute_command('TS.revrange', key2, 0, 10)
+            assert res == [[0, '4']] or res == [[0, b'4']]
+            res = r.execute_command('TS.range', key1, 0, 20)
+            assert res == [[1, '1'], [2, '3'], [11, '7'], [13, '1']] or res == [[1, b'1'], [2, b'3'], [11, b'7'], [13, b'1']]
+
+
+    def test_multi_chunk_revrange(self):
+        env = self.env
+        env.flush()
+        t1 = 't1{1}'
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', t1, 'CHUNK_SIZE', 128)
+            n_samples = 10000
+
+            # Fill 1 chunks
+            for i in range(1, 103):
+                assert r.execute_command('TS.ADD', t1, i, i)
+
+            # fill 2 chunks
+            for i in range(120, 220):
+                assert r.execute_command('TS.ADD', t1, i, i)
+
+            res = r.execute_command('TS.revrange', t1, 110, 215, 'AGGREGATION', 'count', 2*n_samples)
+            assert res == [[0, '96']] or res == [[0, b'96']]
+
+
+    def test_errors(self):
+        env = self.env
+        env.flush()
+        t1 = 't1{1}'
+        t2 = 't2{1}'
+        with env.getClusterConnectionIfNeeded() as r:
+            assert r.execute_command('TS.CREATE', t1, 'CHUNK_SIZE', 128)
+            assert r.execute_command('ts.add', t1, 1, 1)
+            try:
+                r.execute_command('ts.range', t1, 0, 10, 'AGGREGATION', 'avg', 5, 'BUCKETTIMESTAMP', 'high')
+                assert False
+            except Exception as e:
+                assert str(e) == 'TSDB: unknown BUCKETTIMESTAMP parameter'
+
+            assert r.execute_command('TS.CREATE', t2, 'CHUNK_SIZE', 128)
+            try:
+                r.execute_command('TS.CREATERULE', t1, t2, 'AGGREGATION', 'avg', 5, 'high')
+                assert False
+            except Exception as e:
+                assert str(e) == "TSDB: Couldn't parse alignTimestamp"
+
+
+
+    def test_ts_range_count_validation(self):
+        """
+        Validate COUNT argument is non-positive for TS.RANGE family commands
+        """
+        env = self.env
+        env.flush()
+        env.skipOnCluster()
+        key = 'x'
+        with env.getClusterConnectionIfNeeded() as r:
+            for i in range(10):
+                r.execute_command('TS.ADD', key, i, i)
+
+        env.expect('TS.RANGE', key, '-', '+', 'COUNT', '0').error().contains('TSDB: Invalid COUNT value')
+        env.expect('TS.RANGE', key, '-', '+', 'COUNT', '-1').error().contains('TSDB: Invalid COUNT value')
+        env.expect('TS.RANGE', key, '-', '+', 'COUNT', '-2').error().contains('TSDB: Invalid COUNT value')
+        env.expect('TS.REVRANGE', key, '-', '+', 'COUNT', '-1000').error().contains('TSDB: Invalid COUNT value')
+        env.expect('TS.MRANGE', '-', '+', 'COUNT', '-2', 'FILTER', 'a=x').error().contains('TSDB: Invalid COUNT value')
+        env.expect('TS.MREVRANGE', '-', '+', 'COUNT', '0', 'FILTER', 'a=x').error().contains('TSDB: Invalid COUNT value')
+
+        assert r.execute_command('TS.RANGE', key, '-', '+', 'COUNT', 2) == [[0, '0'], [1, '1']]
+        assert r.execute_command('TS.RANGE', key, '-', '+', 'COUNT', 2, 'AGGREGATION', 'sum', 5) == [[0, '10'], [5, '35']]
+
+
+
+    def test_twa_nan_interpolation(self):
+        """
+        Test that TWA aggregation correctly skips NaN samples when fetching samples
+        before/after the query range for interpolation.    
+        """
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            # Test case 1: NaN sample immediately before query range should be skipped
+            # The valid sample before NaN should be used for interpolation instead
+            key1 = 'twa_nan_before{tag}'
+            r.execute_command('TS.CREATE', key1)
+            r.execute_command('TS.ADD', key1, 5, 5)    # Valid sample - should be used for interpolation
+            r.execute_command('TS.ADD', key1, 8, 'nan') # NaN right before range - should be skipped
+            r.execute_command('TS.ADD', key1, 12, 12)  # Sample in query range
+            r.execute_command('TS.ADD', key1, 18, 18)  # Sample in query range
+            r.execute_command('TS.ADD', key1, 25, 25)  # Sample after query range
+        
+            # Query range 10-20, bucket size 10
+            # TWA should interpolate from sample at ts=5 (value=5), not from NaN at ts=8
+            result = r.execute_command('TS.RANGE', key1, 10, 20, 'AGGREGATION', 'twa', 10)
             assert len(result) == 1
-            assert result[0][0] == 0
-            assert float(result[0][1]) == 60.0
-            
-            # count should only count valid (non-NaN) samples
-            result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'count', 100)
+            # The result should be a valid number (not NaN)
+            value = float(result[0][1])
+            assert not math.isnan(value), f"TWA should not use NaN for interpolation, got {value}"
+        
+            # Test case 2: Multiple NaN samples before query range - all should be skipped
+            key2 = 'twa_nan_multi_before{tag}'
+            r.execute_command('TS.CREATE', key2)
+            r.execute_command('TS.ADD', key2, 3, 3)    # Valid sample - should be used
+            r.execute_command('TS.ADD', key2, 5, 'nan')
+            r.execute_command('TS.ADD', key2, 7, 'nan')
+            r.execute_command('TS.ADD', key2, 9, 'nan') # Multiple NaNs before range
+            r.execute_command('TS.ADD', key2, 12, 12)  # In query range
+            r.execute_command('TS.ADD', key2, 18, 18)  # In query range
+            r.execute_command('TS.ADD', key2, 25, 25)  # After range
+        
+            result = r.execute_command('TS.RANGE', key2, 10, 20, 'AGGREGATION', 'twa', 10)
             assert len(result) == 1
-            assert float(result[0][1]) == 3.0  # 3 valid samples
-            
-            result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'min', 100)
+            value = float(result[0][1])
+            assert not math.isnan(value), f"TWA should skip multiple NaN samples, got {value}"
+        
+            # Test case 3: NaN samples after query range should also be skipped
+            key3 = 'twa_nan_after{tag}'
+            r.execute_command('TS.CREATE', key3)
+            r.execute_command('TS.ADD', key3, 5, 5)
+            r.execute_command('TS.ADD', key3, 12, 12)
+            r.execute_command('TS.ADD', key3, 18, 18)
+            r.execute_command('TS.ADD', key3, 22, 'nan')  # NaN right after range
+            r.execute_command('TS.ADD', key3, 25, 25)     # Valid sample after NaN
+        
+            result = r.execute_command('TS.RANGE', key3, 10, 20, 'AGGREGATION', 'twa', 10)
             assert len(result) == 1
-            assert float(result[0][1]) == 10.0
-            
-            result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'max', 100)
+            value = float(result[0][1])
+            assert not math.isnan(value), f"TWA should skip NaN after range, got {value}"
+        
+            # Test case 4: REVRANGE should also handle NaN interpolation correctly
+            result = r.execute_command('TS.REVRANGE', key1, 10, 20, 'AGGREGATION', 'twa', 10)
             assert len(result) == 1
-            assert float(result[0][1]) == 30.0
-            
-            result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'avg', 100)
-            assert len(result) == 1
-            assert float(result[0][1]) == 20.0
-            
-            result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'first', 100)
-            assert len(result) == 1
-            assert float(result[0][1]) == 10.0
-            
-            result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'last', 100)
-            assert len(result) == 1
-            assert float(result[0][1]) == 30.0
-            
-            result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'range', 100)
-            assert len(result) == 1
-            assert float(result[0][1]) == 20.0
-            
-            # Test 2: Bucket with only NaN should be skipped (no EMPTY flag)
-            # Query all three buckets - bucket 100-199 should be missing
-            result = r.execute_command('TS.RANGE', key, 0, 299, 'AGGREGATION', 'sum', 100)
-            assert len(result) == 2  # Only 2 buckets (0 and 200), bucket 100 is skipped
-            assert result[0][0] == 0    # First bucket
-            assert result[1][0] == 200  # Third bucket (second is skipped)
-            assert float(result[0][1]) == 60.0   # sum of bucket 0
-            assert float(result[1][1]) == 90.0   # sum of bucket 200: 40 + 50
-            
-            # Test 3: Bucket with only NaN should return NaN with EMPTY flag
-            result = r.execute_command('TS.RANGE', key, 0, 299, 'AGGREGATION', 'sum', 100, 'EMPTY')
-            assert len(result) == 3  # All 3 buckets
-            assert result[0][0] == 0
-            assert result[1][0] == 100
-            assert result[2][0] == 200
-            assert float(result[0][1]) == 60.0
-            assert float(result[1][1]) == 0 # empty bucket
-            assert float(result[2][1]) == 90.0
-            
-            # Test 4: REVRANGE should also handle NaN correctly
-            result = r.execute_command('TS.REVRANGE', key, 0, 299, 'AGGREGATION', 'sum', 100)
-            assert len(result) == 2  # Only 2 buckets, reversed
-            assert result[0][0] == 200
-            assert result[1][0] == 0
-            
-            # Test 5: count aggregation - empty bucket should return 0 with EMPTY flag
-            result = r.execute_command('TS.RANGE', key, 0, 299, 'AGGREGATION', 'count', 100, 'EMPTY')
+            value = float(result[0][1])
+            assert not math.isnan(value), f"REVRANGE TWA should not use NaN for interpolation, got {value}"
+
+
+
+    def test_twa_nan_only_bucket(self):
+        """
+        Test that TWA correctly handles buckets containing only NaN samples.
+        When a bucket has only NaN samples, TWA should not use uninitialized values
+        for interpolation in subsequent buckets.
+        """
+        env = self.env
+        env.flush()
+        with env.getClusterConnectionIfNeeded() as r:
+            # Test case 1: TS.RANGE with NaN-only bucket in the middle
+            key1 = 'twa_nan_only_bucket_range{tag}'
+            r.execute_command('TS.CREATE', key1)
+            r.execute_command('TS.ADD', key1, 5, 10)     # Bucket 0-10: valid sample
+            r.execute_command('TS.ADD', key1, 15, 'nan') # Bucket 10-20: only NaN
+            r.execute_command('TS.ADD', key1, 25, 30)    # Bucket 20-30: valid sample
+            r.execute_command('TS.ADD', key1, 35, 40)    # Bucket 30-40: valid sample
+        
+            # Query across all buckets with EMPTY to include NaN-only bucket
+            result = r.execute_command('TS.RANGE', key1, 0, 40, 'AGGREGATION', 'twa', 10, 'EMPTY')
+            assert len(result) == 4
+        
+            # Bucket 0 (0-10): has sample at 5 with value 10 - should be valid
+            bucket0_value = float(result[0][1])
+            assert not math.isnan(bucket0_value), "Bucket 0 should have valid TWA value"
+        
+            # Bucket 1 (10-20): only NaN sample - TWA with EMPTY interpolates from surrounding samples
+            # (sample at ts=5 value=10 before, sample at ts=25 value=30 after)
+            bucket1_value = float(result[1][1])
+            assert not math.isnan(bucket1_value), "TWA+EMPTY interpolates NaN-only bucket from neighbors"
+            # Key test: the interpolated value should be reasonable (between 10 and 30)
+            assert bucket1_value > 0, f"TWA should not use timestamp=0, got {bucket1_value}"
+        
+            # Bucket 2 (20-30): has sample at 25 with value 30 - should be valid
+            # This is the key test: interpolation should work correctly, NOT from bogus (0,0) values
+            bucket2_value = float(result[2][1])
+            assert not math.isnan(bucket2_value), "Bucket after NaN-only bucket should have valid TWA"
+            assert bucket2_value > 0, f"TWA should not use timestamp=0 for interpolation, got {bucket2_value}"
+        
+            # Bucket 3 (30-40): should interpolate correctly from bucket 2
+            bucket3_value = float(result[3][1])
+            assert not math.isnan(bucket3_value), "Bucket 3 should have valid TWA value"
+        
+            # Test case 2: REVRANGE with NaN-only bucket
+            result_rev = r.execute_command('TS.REVRANGE', key1, 0, 40, 'AGGREGATION', 'twa', 10, 'EMPTY')
+            assert len(result_rev) == 4
+            # Results should be same as RANGE but reversed
+            bucket2_rev = float(result_rev[1][1])  # Bucket 20-30 is second from end
+            assert not math.isnan(bucket2_rev), "REVRANGE: bucket after NaN-only should have valid TWA"
+            assert bucket2_rev > 0, f"REVRANGE: TWA should not use timestamp=0, got {bucket2_rev}"
+        
+            # Test case 3: First bucket is NaN-only (edge case - tests initial state)
+            # No sample before first bucket, so TWA cannot interpolate backward
+            key2 = 'twa_nan_first_bucket{tag}'
+            r.execute_command('TS.CREATE', key2)
+            r.execute_command('TS.ADD', key2, 5, 'nan')  # Bucket 0-10: only NaN
+            r.execute_command('TS.ADD', key2, 15, 20)    # Bucket 10-20: valid sample
+            r.execute_command('TS.ADD', key2, 25, 30)    # Bucket 20-30: valid sample
+        
+            result = r.execute_command('TS.RANGE', key2, 0, 30, 'AGGREGATION', 'twa', 10, 'EMPTY')
             assert len(result) == 3
-            assert float(result[0][1]) == 3.0   # 3 valid samples in bucket 0
-            assert float(result[1][1]) == 0.0   # 0 valid samples in bucket 100
-            assert float(result[2][1]) == 2.0   # 2 valid samples in bucket 200
-            
-            # Test 6: Test aggregations with EMPTY flag on NaN-only bucket (100-199)
-            # Expected values: NaN for most, 0 for sum/count, 0 for last (last valid before bucket),
-            # interpolated for twa (has samples before and after)
-            expected_empty_bucket_values = {
-                'sum': 0.0,
-                'count': 0.0,
-                'min': float('nan'),
-                'max': float('nan'),
-                'avg': float('nan'),
-                'first': float('nan'),
-                'last': 30.0,  # last valid value before bucket (from ts=50)
-                'range': float('nan'),
-                'std.p': float('nan'),
-                'std.s': float('nan'),
-                'var.p': float('nan'),
-                'var.s': float('nan'),
-                'twa': 'interpolated',  # special case: has surrounding samples, should not be NaN
-            }
-            
-            for agg_func, expected in expected_empty_bucket_values.items():
-                result = r.execute_command('TS.RANGE', key, 0, 199, 'AGGREGATION', agg_func, 100, 'EMPTY')
-                assert len(result) == 2, f"{agg_func}: expected 2 results"
-                actual = float(result[1][1])
-                if expected == 'interpolated':
-                    assert not math.isnan(actual), f"{agg_func}: expected interpolated value, got NaN"
-                elif math.isnan(expected):
-                    assert math.isnan(actual), f"{agg_func}: expected NaN, got {actual}"
-                else:
-                    assert actual == expected, f"{agg_func}: expected {expected}, got {actual}"
-            
-            # Test 7: Query only the NaN-only bucket without EMPTY - should return empty
-            result = r.execute_command('TS.RANGE', key, 100, 199, 'AGGREGATION', 'sum', 100)
-            assert len(result) == 0  # No results - bucket is effectively empty
-            
-            # Test 8: 'last' and 'twa' return NaN when NO sample exists before the bucket
-            key_no_before = 'ts_nan_no_before{a}'
-            r.execute_command('TS.CREATE', key_no_before, 'ENCODING', encoding)
-            r.execute_command('TS.ADD', key_no_before, 100, 'nan')  # NaN in bucket 100-199
-            r.execute_command('TS.ADD', key_no_before, 200, 50)     # Valid sample after
-            
-            for agg_func in ['last', 'twa']:
-                result = r.execute_command('TS.RANGE', key_no_before, 100, 199, 'AGGREGATION', agg_func, 100, 'EMPTY')
-                assert len(result) == 1
-                assert math.isnan(float(result[0][1])), f"{agg_func}: expected NaN when no sample before bucket, got {result[0][1]}"
+        
+            # First bucket is NaN-only with no sample before - may be NaN or interpolated forward
+            # The key test is that subsequent buckets are NOT corrupted
+        
+            # Second bucket should NOT be corrupted by first bucket's uninitialized values
+            bucket1_value = float(result[1][1])
+            assert not math.isnan(bucket1_value), "Second bucket should have valid TWA"
+            # The value should be reasonable (not affected by bogus timestamp=0)
+            assert bucket1_value > 0, f"TWA should not interpolate from timestamp=0, got {bucket1_value}"
+        
+            # Test case 4: Compaction rule with NaN-only bucket
+            src_key = 'twa_compaction_src{tag}'
+            dst_key = 'twa_compaction_dst{tag}'
+            r.execute_command('TS.CREATE', src_key)
+            r.execute_command('TS.CREATE', dst_key)
+            r.execute_command('TS.CREATERULE', src_key, dst_key, 'AGGREGATION', 'twa', 10)
+        
+            # Add samples: bucket 0-10 valid, bucket 10-20 NaN only, bucket 20-30 valid
+            r.execute_command('TS.ADD', src_key, 5, 100)   # Bucket 0-10
+            r.execute_command('TS.ADD', src_key, 15, 'nan') # Bucket 10-20: only NaN
+            r.execute_command('TS.ADD', src_key, 25, 200)   # Bucket 20-30
+            r.execute_command('TS.ADD', src_key, 35, 300)   # Trigger compaction for bucket 20-30
+        
+            # Check destination series
+            result = r.execute_command('TS.RANGE', dst_key, 0, '+')
+        
+            # Should have bucket 0 (finalized when bucket 1 started) and bucket 2 
+            # (finalized when bucket 3 started). Bucket 1 had only NaN so no output.
+            assert len(result) >= 1, "Compaction should produce at least one bucket"
+        
+            for ts, val in result:
+                value = float(val)
+                assert not math.isnan(value), f"Compacted TWA at {ts} should not be NaN"
+                # Key check: value should be reasonable, not corrupted by (0,0) interpolation
+                assert value > 0, f"Compacted TWA at {ts} should be > 0, got {value}"
 
 
-def test_twa_nan_interpolation():
-    """
-    Test that TWA aggregation correctly skips NaN samples when fetching samples
-    before/after the query range for interpolation.    
-    """
-    with Env().getClusterConnectionIfNeeded() as r:
-        # Test case 1: NaN sample immediately before query range should be skipped
-        # The valid sample before NaN should be used for interpolation instead
-        key1 = 'twa_nan_before{tag}'
-        r.execute_command('TS.CREATE', key1)
-        r.execute_command('TS.ADD', key1, 5, 5)    # Valid sample - should be used for interpolation
-        r.execute_command('TS.ADD', key1, 8, 'nan') # NaN right before range - should be skipped
-        r.execute_command('TS.ADD', key1, 12, 12)  # Sample in query range
-        r.execute_command('TS.ADD', key1, 18, 18)  # Sample in query range
-        r.execute_command('TS.ADD', key1, 25, 25)  # Sample after query range
-        
-        # Query range 10-20, bucket size 10
-        # TWA should interpolate from sample at ts=5 (value=5), not from NaN at ts=8
-        result = r.execute_command('TS.RANGE', key1, 10, 20, 'AGGREGATION', 'twa', 10)
-        assert len(result) == 1
-        # The result should be a valid number (not NaN)
-        value = float(result[0][1])
-        assert not math.isnan(value), f"TWA should not use NaN for interpolation, got {value}"
-        
-        # Test case 2: Multiple NaN samples before query range - all should be skipped
-        key2 = 'twa_nan_multi_before{tag}'
-        r.execute_command('TS.CREATE', key2)
-        r.execute_command('TS.ADD', key2, 3, 3)    # Valid sample - should be used
-        r.execute_command('TS.ADD', key2, 5, 'nan')
-        r.execute_command('TS.ADD', key2, 7, 'nan')
-        r.execute_command('TS.ADD', key2, 9, 'nan') # Multiple NaNs before range
-        r.execute_command('TS.ADD', key2, 12, 12)  # In query range
-        r.execute_command('TS.ADD', key2, 18, 18)  # In query range
-        r.execute_command('TS.ADD', key2, 25, 25)  # After range
-        
-        result = r.execute_command('TS.RANGE', key2, 10, 20, 'AGGREGATION', 'twa', 10)
-        assert len(result) == 1
-        value = float(result[0][1])
-        assert not math.isnan(value), f"TWA should skip multiple NaN samples, got {value}"
-        
-        # Test case 3: NaN samples after query range should also be skipped
-        key3 = 'twa_nan_after{tag}'
-        r.execute_command('TS.CREATE', key3)
-        r.execute_command('TS.ADD', key3, 5, 5)
-        r.execute_command('TS.ADD', key3, 12, 12)
-        r.execute_command('TS.ADD', key3, 18, 18)
-        r.execute_command('TS.ADD', key3, 22, 'nan')  # NaN right after range
-        r.execute_command('TS.ADD', key3, 25, 25)     # Valid sample after NaN
-        
-        result = r.execute_command('TS.RANGE', key3, 10, 20, 'AGGREGATION', 'twa', 10)
-        assert len(result) == 1
-        value = float(result[0][1])
-        assert not math.isnan(value), f"TWA should skip NaN after range, got {value}"
-        
-        # Test case 4: REVRANGE should also handle NaN interpolation correctly
-        result = r.execute_command('TS.REVRANGE', key1, 10, 20, 'AGGREGATION', 'twa', 10)
-        assert len(result) == 1
-        value = float(result[0][1])
-        assert not math.isnan(value), f"REVRANGE TWA should not use NaN for interpolation, got {value}"
 
-
-def test_twa_nan_only_bucket():
-    """
-    Test that TWA correctly handles buckets containing only NaN samples.
-    When a bucket has only NaN samples, TWA should not use uninitialized values
-    for interpolation in subsequent buckets.
-    """
-    with Env().getClusterConnectionIfNeeded() as r:
-        # Test case 1: TS.RANGE with NaN-only bucket in the middle
-        key1 = 'twa_nan_only_bucket_range{tag}'
-        r.execute_command('TS.CREATE', key1)
-        r.execute_command('TS.ADD', key1, 5, 10)     # Bucket 0-10: valid sample
-        r.execute_command('TS.ADD', key1, 15, 'nan') # Bucket 10-20: only NaN
-        r.execute_command('TS.ADD', key1, 25, 30)    # Bucket 20-30: valid sample
-        r.execute_command('TS.ADD', key1, 35, 40)    # Bucket 30-40: valid sample
-        
-        # Query across all buckets with EMPTY to include NaN-only bucket
-        result = r.execute_command('TS.RANGE', key1, 0, 40, 'AGGREGATION', 'twa', 10, 'EMPTY')
-        assert len(result) == 4
-        
-        # Bucket 0 (0-10): has sample at 5 with value 10 - should be valid
-        bucket0_value = float(result[0][1])
-        assert not math.isnan(bucket0_value), "Bucket 0 should have valid TWA value"
-        
-        # Bucket 1 (10-20): only NaN sample - TWA with EMPTY interpolates from surrounding samples
-        # (sample at ts=5 value=10 before, sample at ts=25 value=30 after)
-        bucket1_value = float(result[1][1])
-        assert not math.isnan(bucket1_value), "TWA+EMPTY interpolates NaN-only bucket from neighbors"
-        # Key test: the interpolated value should be reasonable (between 10 and 30)
-        assert bucket1_value > 0, f"TWA should not use timestamp=0, got {bucket1_value}"
-        
-        # Bucket 2 (20-30): has sample at 25 with value 30 - should be valid
-        # This is the key test: interpolation should work correctly, NOT from bogus (0,0) values
-        bucket2_value = float(result[2][1])
-        assert not math.isnan(bucket2_value), "Bucket after NaN-only bucket should have valid TWA"
-        assert bucket2_value > 0, f"TWA should not use timestamp=0 for interpolation, got {bucket2_value}"
-        
-        # Bucket 3 (30-40): should interpolate correctly from bucket 2
-        bucket3_value = float(result[3][1])
-        assert not math.isnan(bucket3_value), "Bucket 3 should have valid TWA value"
-        
-        # Test case 2: REVRANGE with NaN-only bucket
-        result_rev = r.execute_command('TS.REVRANGE', key1, 0, 40, 'AGGREGATION', 'twa', 10, 'EMPTY')
-        assert len(result_rev) == 4
-        # Results should be same as RANGE but reversed
-        bucket2_rev = float(result_rev[1][1])  # Bucket 20-30 is second from end
-        assert not math.isnan(bucket2_rev), "REVRANGE: bucket after NaN-only should have valid TWA"
-        assert bucket2_rev > 0, f"REVRANGE: TWA should not use timestamp=0, got {bucket2_rev}"
-        
-        # Test case 3: First bucket is NaN-only (edge case - tests initial state)
-        # No sample before first bucket, so TWA cannot interpolate backward
-        key2 = 'twa_nan_first_bucket{tag}'
-        r.execute_command('TS.CREATE', key2)
-        r.execute_command('TS.ADD', key2, 5, 'nan')  # Bucket 0-10: only NaN
-        r.execute_command('TS.ADD', key2, 15, 20)    # Bucket 10-20: valid sample
-        r.execute_command('TS.ADD', key2, 25, 30)    # Bucket 20-30: valid sample
-        
-        result = r.execute_command('TS.RANGE', key2, 0, 30, 'AGGREGATION', 'twa', 10, 'EMPTY')
-        assert len(result) == 3
-        
-        # First bucket is NaN-only with no sample before - may be NaN or interpolated forward
-        # The key test is that subsequent buckets are NOT corrupted
-        
-        # Second bucket should NOT be corrupted by first bucket's uninitialized values
-        bucket1_value = float(result[1][1])
-        assert not math.isnan(bucket1_value), "Second bucket should have valid TWA"
-        # The value should be reasonable (not affected by bogus timestamp=0)
-        assert bucket1_value > 0, f"TWA should not interpolate from timestamp=0, got {bucket1_value}"
-        
-        # Test case 4: Compaction rule with NaN-only bucket
-        src_key = 'twa_compaction_src{tag}'
-        dst_key = 'twa_compaction_dst{tag}'
-        r.execute_command('TS.CREATE', src_key)
-        r.execute_command('TS.CREATE', dst_key)
-        r.execute_command('TS.CREATERULE', src_key, dst_key, 'AGGREGATION', 'twa', 10)
-        
-        # Add samples: bucket 0-10 valid, bucket 10-20 NaN only, bucket 20-30 valid
-        r.execute_command('TS.ADD', src_key, 5, 100)   # Bucket 0-10
-        r.execute_command('TS.ADD', src_key, 15, 'nan') # Bucket 10-20: only NaN
-        r.execute_command('TS.ADD', src_key, 25, 200)   # Bucket 20-30
-        r.execute_command('TS.ADD', src_key, 35, 300)   # Trigger compaction for bucket 20-30
-        
-        # Check destination series
-        result = r.execute_command('TS.RANGE', dst_key, 0, '+')
-        
-        # Should have bucket 0 (finalized when bucket 1 started) and bucket 2 
-        # (finalized when bucket 3 started). Bucket 1 had only NaN so no output.
-        assert len(result) >= 1, "Compaction should produce at least one bucket"
-        
-        for ts, val in result:
-            value = float(val)
-            assert not math.isnan(value), f"Compacted TWA at {ts} should not be NaN"
-            # Key check: value should be reasonable, not corrupted by (0,0) interpolation
-            assert value > 0, f"Compacted TWA at {ts} should be > 0, got {value}"
-
-
-def test_ts_range_countNaN():
-    """
-    Validate COUNTNAN aggregation function
-    """
-    with Env().getClusterConnectionIfNeeded() as r:
-        for encoding in ['compressed', 'uncompressed']:
-            Env().flush()
-            key = 'ts_countNaN_test{a}'
-            r.execute_command('TS.CREATE', key, 'ENCODING', encoding)
-            r.execute_command('TS.ADD', key, 10, 10)
-            r.execute_command('TS.ADD', key, 20, 'nan')
-            r.execute_command('TS.ADD', key, 30, 20)
-            r.execute_command('TS.ADD', key, 40, 'nan')
-            r.execute_command('TS.ADD', key, 50, 30)
-            result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'countnan', 100)
-            assert len(result) == 1
-            assert float(result[0][1]) == 2.0
-            result = r.execute_command('TS.REVRANGE', key, 0, 99, 'AGGREGATION', 'countnan', 10, 'EMPTY')
-            assert len(result) == 5
-            assert float(result[0][1]) == 0.0
-            assert float(result[1][1]) == 1.0
-            assert float(result[2][1]) == 0.0
-            assert float(result[3][1]) == 1.0
-            assert float(result[4][1]) == 0.0
-
-            result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'countnan', 50)
-            assert len(result) == 1
-            assert float(result[0][1]) == 2.0
-
-def test_ts_range_countAll():
-    """
-    Validate COUNTALL aggregation function
-    """
-    with Env().getClusterConnectionIfNeeded() as r:
-        for encoding in ['compressed', 'uncompressed']:
-            Env().flush()
-            key = 'ts_countAll_test{a}'
-            r.execute_command('TS.CREATE', key, 'ENCODING', encoding)
-            r.execute_command('TS.ADD', key, 10, 10)
-            r.execute_command('TS.ADD', key, 20, 'nan')
-            r.execute_command('TS.ADD', key, 30, 20)
-            r.execute_command('TS.ADD', key, 40, 'nan')
-            r.execute_command('TS.ADD', key, 50, 30)
-            result = r.execute_command('TS.RANGE', key, 0, 99, 'AGGREGATION', 'countall', 100)
-            assert len(result) == 1
-            assert float(result[0][1]) == 5.0
-            result = r.execute_command('TS.REVRANGE', key, 0, 99, 'AGGREGATION', 'countall', 10, 'EMPTY')
-            assert len(result) == 5
-            assert float(result[0][1]) == 1.0
-            assert float(result[1][1]) == 1.0
-            assert float(result[2][1]) == 1.0
-            assert float(result[3][1]) == 1.0
-            assert float(result[4][1]) == 1.0

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -403,8 +403,8 @@ STATFILE=${STATFILE:-$ROOT/bin/artifacts/tests/status}
 
 PARALLEL=${PARALLEL:-1}
 
-# due to Python "Can't pickle local object" problem in RLTest
-[[ $OS == macos ]] && PARALLEL=0
+# RLTest uses set_start_method('fork'), not spawn, so pickling is not involved
+# and parallel execution works correctly on macOS.
 
 [[ $EXT == 1 || $EXT == run || $BB == 1 || $GDB == 1 ]] && PARALLEL=0
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to the Python test harness and flow tests, but the broad refactor (shared `Env` instances and revised skip/flush behavior) could cause intermittent failures if test isolation assumptions were missed.
> 
> **Overview**
> **Speeds up flow tests and improves isolation** by converting many standalone tests into class-based suites that reuse a single `Env()` instance and call `env.flush()` between cases, rather than repeatedly starting new Redis instances.
> 
> **Adjusts cluster/skip handling** by creating `Env` once and invoking `skipOnCluster()` on that instance, and splits cluster-only coverage (e.g. `test_add_different_slot_range`) into a dedicated suite.
> 
> **Expands/reshapes NaN and rule/ACL coverage** by adding/relocating tests around NaN inputs (`TS.ADD`/`TS.MADD`, compaction rules including NaN-only buckets), dump/restore rule cleanup, and ensuring `TS.INFO` does not delete rules when ACL-restricted.
> 
> **Updates RLTest termination behavior** so generous `terminateRetries`/`terminateRetrySecs` are only set under Valgrind/sanitizer, avoiding an always-on shutdown sleep in normal runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdb6ebabd8bda7c45cddc5530c7c4dead13328c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->