### PR TITLE
MOD-15262 - Align TimeSeries with the RedisModule_GetUserUserName API changes

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -5,7 +5,8 @@ struct RedisModuleCtx;
 struct RedisModuleString;
 struct RedisModuleUser *(*RedisModule_GetModuleUserFromUserName)(struct RedisModuleString *name);
 struct RedisModuleString *(*RedisModule_GetCurrentUserName)(struct RedisModuleCtx *ctx);
-struct RedisModuleString *(*RedisModule_GetUserUsername)(struct RedisModuleCtx *ctx, const struct RedisModuleUser *user);
+struct RedisModuleString *(*RedisModule_GetUserUsername)(struct RedisModuleCtx *ctx,
+                                                         const struct RedisModuleUser *user);
 void (*RedisModule_FreeString)(struct RedisModuleCtx *ctx, struct RedisModuleString *str);
 int (*RedisModule_ACLCheckKeyPrefixPermissions)(struct RedisModuleUser *user,
                                                 struct RedisModuleString *prefix,

--- a/src/common.h
+++ b/src/common.h
@@ -5,7 +5,7 @@ struct RedisModuleCtx;
 struct RedisModuleString;
 struct RedisModuleUser *(*RedisModule_GetModuleUserFromUserName)(struct RedisModuleString *name);
 struct RedisModuleString *(*RedisModule_GetCurrentUserName)(struct RedisModuleCtx *ctx);
-struct RedisModuleString *(*RedisModule_GetUserUsername)(const struct RedisModuleUser *user);
+struct RedisModuleString *(*RedisModule_GetUserUsername)(struct RedisModuleCtx *ctx, const struct RedisModuleUser *user);
 void (*RedisModule_FreeString)(struct RedisModuleCtx *ctx, struct RedisModuleString *str);
 int (*RedisModule_ACLCheckKeyPrefixPermissions)(struct RedisModuleUser *user,
                                                 struct RedisModuleString *prefix,

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -457,7 +457,7 @@ static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
     // Check if the requested user is already set on the context
     const RedisModuleUser *currentUser = RedisModule_GetContextUser(ctx);
     if (currentUser) {
-        RedisModuleString *currentName = RedisModule_GetUserUsername(currentUser);
+        RedisModuleString *currentName = RedisModule_GetUserUsername(ctx, currentUser);
         if (currentName) {
             int cmp = RedisModule_StringCompare(currentName, userName);
             RedisModule_FreeString(ctx, currentName);

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -459,8 +459,11 @@ static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
     if (currentUser) {
         RedisModuleString *currentName = RedisModule_GetUserUsername(ctx, currentUser);
         if (currentName) {
-            if (RedisModule_StringCompare(currentName, userName) == 0)
+            const int cmp = RedisModule_StringCompare(currentName, userName);
+            RedisModule_FreeString(ctx, currentName);
+            if (cmp == 0) {
                 return; // Same user already set, nothing to do
+            }
         }
         RedisModule_FreeModuleUser((RedisModuleUser *)currentUser);
         RedisModule_SetContextUser(ctx, NULL);

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -459,11 +459,8 @@ static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
     if (currentUser) {
         RedisModuleString *currentName = RedisModule_GetUserUsername(ctx, currentUser);
         if (currentName) {
-            int cmp = RedisModule_StringCompare(currentName, userName);
-            RedisModule_FreeString(ctx, currentName);
-            if (cmp == 0) {
+            if (RedisModule_StringCompare(currentName, userName) == 0)
                 return; // Same user already set, nothing to do
-            }
         }
         RedisModule_FreeModuleUser((RedisModuleUser *)currentUser);
         RedisModule_SetContextUser(ctx, NULL);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk mechanical API alignment; main risk is build/runtime compatibility if linked against an older RedisModulesSDK where `RedisModule_GetUserUsername` still uses the previous signature.
> 
> **Overview**
> Aligns TimeSeries’ module-API shim to the upstream `RedisModule_GetUserUsername` signature change by adding a `RedisModuleCtx *` parameter in `common.h`.
> 
> Updates the LibMR integration’s context-user reuse check to call `RedisModule_GetUserUsername(ctx, user)` and makes the username comparison variable `const` (no behavior change intended beyond matching the new API).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2125bb7cf5eb9bdea5a2c5d8c5e6aabb5f4992b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->