### PR TITLE
Tal.ba/feat/make setup

### DIFF
--- a/.install/install_script.sh
+++ b/.install/install_script.sh
@@ -269,46 +269,78 @@ resolve_abstract() {
     ' "$3"
 }
 
-# Bootstrap: ensure awk and a package-manager refresh are ready.
+# Snapshot of every package the host's package database currently considers
+# installed, one name per line. Built once up-front so per-package lookups
+# are local grep calls rather than ~17 forks of `brew list` / `dpkg-query`
+# / `rpm -q` (~10s saved on macOS, ~3s on apt). Empty for tdnf because we
+# can't trust the metadata cheaply on minimal Mariner/AzureLinux images;
+# tdnf already handles "already installed" gracefully on its own.
+INSTALLED_PKGS_FILE="$(mktemp)"
+trap 'rm -f "$INSTALLED_PKGS_FILE"' EXIT
 case "$PM" in
-    apt)
-        export DEBIAN_FRONTEND=noninteractive
-        $MODE apt-get update -qq
-        ;;
-    dnf|yum|tdnf)
-        $MODE $PM -y makecache 2>/dev/null || true
-        ;;
-    apk)
-        $MODE apk update -q
-        ;;
+    apt)         dpkg-query -W -f='${Package}\n'      2>/dev/null > "$INSTALLED_PKGS_FILE" || true ;;
+    dnf|yum)     rpm -qa --queryformat '%{NAME}\n'    2>/dev/null > "$INSTALLED_PKGS_FILE" || true ;;
+    apk)         apk info                             2>/dev/null > "$INSTALLED_PKGS_FILE" || true ;;
+    brew)        brew list --formula -1               2>/dev/null > "$INSTALLED_PKGS_FILE" || true ;;
 esac
 
-# Resolve every abstract dep -> concatenate -> single install call.
+# is_pkg_installed <pkg>  -> 0 if already present, non-zero otherwise.
+is_pkg_installed() {
+    grep -Fxq "$1" "$INSTALLED_PKGS_FILE"
+}
+
+# Resolve every abstract dep -> concrete list -> drop already-installed.
 all_pkgs=""
+missing_pkgs=""
 while IFS= read -r abs; do
     [ -z "$abs" ] && continue
     pkgs=$(resolve_abstract "$abs" "$PM" "$DEPS_YAML")
     [ -z "$pkgs" ] && continue
-    all_pkgs="$all_pkgs $pkgs"
+    for p in $pkgs; do
+        all_pkgs="$all_pkgs $p"
+        # tdnf path skips probing — it short-circuits already-installed
+        # packages itself (and Mariner's rpm db sometimes isn't populated
+        # until after tdnf makecache).
+        if [ "$PM" = "tdnf" ] || ! is_pkg_installed "$p"; then
+            missing_pkgs="$missing_pkgs $p"
+        fi
+    done
 done <<EOF_DEPS
 $(extract_flat_list system "$DEPS_YAML")
 EOF_DEPS
 
-if [ -n "${all_pkgs# }" ]; then
-    echo "install_script.sh: installing: $all_pkgs"
+if [ -z "${missing_pkgs# }" ]; then
+    echo "install_script.sh: all $(echo $all_pkgs | wc -w | tr -d ' ') deps already installed; nothing to do"
+else
+    echo "install_script.sh: installing missing:$missing_pkgs"
+
+    # Refresh package-manager metadata only now that we know we'll install.
     case "$PM" in
-        apt)  $MODE apt-get install -yqq --no-install-recommends $all_pkgs ;;
-        dnf)  $MODE dnf -y install --allowerasing $all_pkgs ;;
-        yum)  $MODE yum -y install $all_pkgs ;;
-        apk)  $MODE apk add --no-cache $all_pkgs ;;
-        brew) $MODE brew install $all_pkgs ;;
+        apt)
+            export DEBIAN_FRONTEND=noninteractive
+            $MODE apt-get update -qq
+            ;;
+        dnf|yum|tdnf)
+            $MODE $PM -y makecache 2>/dev/null || true
+            ;;
+        apk)
+            $MODE apk update -q
+            ;;
+    esac
+
+    case "$PM" in
+        apt)  $MODE apt-get install -yqq --no-install-recommends $missing_pkgs ;;
+        dnf)  $MODE dnf -y install --allowerasing $missing_pkgs ;;
+        yum)  $MODE yum -y install $missing_pkgs ;;
+        apk)  $MODE apk add --no-cache $missing_pkgs ;;
+        brew) $MODE brew install $missing_pkgs ;;
         tdnf)
             # tdnf has no --skip-broken and aborts the whole transaction if
             # any one package is missing from the repos (CBL-Mariner /
             # AzureLinux ship a small subset compared to apt/dnf). Install
             # one at a time so an individual missing package is just a
             # warning, not a build failure.
-            for pkg in $all_pkgs; do
+            for pkg in $missing_pkgs; do
                 if ! $MODE tdnf -y install "$pkg" >/dev/null 2>&1; then
                     echo "  (tdnf: skipped unavailable package '$pkg')"
                 fi

--- a/.install/install_script.sh
+++ b/.install/install_script.sh
@@ -1,22 +1,337 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# Install build/test dependencies for redistimeseries.
+#
+# Two modes:
+#
+#   1) Abstract (preferred). Reads ../dependencies.yaml and resolves abstract
+#      dep names (gcc, openssl_dev, ...) to concrete packages for the host's
+#      package manager. Activated for every OSNICK listed under
+#      `migrated_osnicks` in that YAML. After packages are installed, runs
+#      .install/quirks/<osnick>.sh if it exists.
+#
+#   2) Legacy. Falls back to sourcing the existing .install/<distro>_<ver>.sh
+#      script when the OSNICK is not yet migrated. This is what the old
+#      install_script.sh always did, kept verbatim so non-migrated OSes
+#      continue to work unchanged during the rollout.
+#
+# OS detection mirrors sbin/pack.sh: uses readies' `bin/platform --osnick`
+# when available so the install nick matches the release-artefact nick, with
+# a /etc/os-release fallback for environments that don't ship readies.
+#
+# Usage: install_script.sh [MODE]
+#   MODE   "sudo" or "" (whether to wrap install commands with sudo)
 
-OS_TYPE=$(uname -s)
-MODE=$1 # whether to install using sudo or not
+set -eu
 
-if [[ $OS_TYPE = 'Darwin' ]]
-then
-    OS='macos'
-else
-    VERSION=$(grep '^VERSION_ID=' /etc/os-release | sed 's/"//g')
-    VERSION=${VERSION#"VERSION_ID="}
-    OS_NAME=$(grep '^NAME=' /etc/os-release | sed 's/"//g')
-    OS_NAME=${OS_NAME#"NAME="}
-    [[ $OS_NAME == 'Rocky Linux' ]] && VERSION=${VERSION%.*} # remove minor version for Rocky Linux
-    OS=$(echo "$OS_NAME" | tr '[:upper:]' '[:lower:]')_${VERSION}
-    OS=$(echo $OS | sed 's/[/ ]/_/g') # replace spaces and slashes with underscores
+MODE="${1:-}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+DEPS_YAML="$ROOT/dependencies.yaml"
+
+# ----------------------------------------------------------------------------
+# Detect OSNICK (mirrors sbin/pack.sh)
+# ----------------------------------------------------------------------------
+
+OSNICK=""
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    OSNICK="macos"
+elif [ -x "$ROOT/deps/readies/bin/platform" ] && command -v python3 >/dev/null 2>&1; then
+    OSNICK="$("$ROOT/deps/readies/bin/platform" --osnick 2>/dev/null || true)"
+    # AlmaLinux is reported as `centosN`; override to alma<major> like pack.sh.
+    if [ -r /etc/os-release ]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        [ "${ID:-}" = "almalinux" ] && OSNICK="alma${VERSION_ID%%.*}"
+    fi
+    # Normalise to the nicknames our Dockerfile.<nick> files use.
+    case "$OSNICK" in
+        amzn2)        OSNICK="amazonlinux2"     ;;
+        amzn2023)     OSNICK="amazonlinux2023"  ;;
+        centos8|ol8)  OSNICK="rocky8"           ;;
+        centos9)      OSNICK="rocky9"           ;;
+        centos10)     OSNICK="rocky10"          ;;
+    esac
 fi
-echo $OS
 
-source ${OS}.sh $MODE
+if [ -z "$OSNICK" ] && [ -r /etc/os-release ]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    case "${ID:-}:${VERSION_ID:-}" in
+        ubuntu:18.04)            OSNICK="bionic"          ;;
+        ubuntu:20.04)            OSNICK="focal"           ;;
+        ubuntu:22.04)            OSNICK="jammy"           ;;
+        ubuntu:24.04)            OSNICK="noble"           ;;
+        ubuntu:25.*|ubuntu:26.*) OSNICK="resolute"        ;;
+        debian:11*)              OSNICK="bullseye"        ;;
+        debian:12*)              OSNICK="bookworm"        ;;
+        debian:13*|debian:trixie) OSNICK="trixie"         ;;
+        alpine:*)                OSNICK="alpine"          ;;
+        amzn:2)                  OSNICK="amazonlinux2"    ;;
+        amzn:2023)               OSNICK="amazonlinux2023" ;;
+        rocky:8*)                OSNICK="rocky8"          ;;
+        rocky:9*)                OSNICK="rocky9"          ;;
+        rocky:10*)               OSNICK="rocky10"         ;;
+        almalinux:8*)            OSNICK="alma8"           ;;
+        almalinux:9*)            OSNICK="alma9"           ;;
+        almalinux:10*)           OSNICK="alma10"          ;;
+        mariner:2*)              OSNICK="mariner2"        ;;
+        azurelinux:3*)           OSNICK="azurelinux3"     ;;
+    esac
+fi
 
-git config --global --add safe.directory '*'
+if [ -z "$OSNICK" ]; then
+    echo "install_script.sh: cannot determine OSNICK (uname=$(uname -s))" >&2
+    exit 1
+fi
+
+echo "OSNICK=$OSNICK"
+
+# ----------------------------------------------------------------------------
+# Detect package manager
+# ----------------------------------------------------------------------------
+
+if   [ "$OSNICK" = "macos" ];                  then PM="brew"
+elif command -v apt-get >/dev/null 2>&1;       then PM="apt"
+elif command -v dnf     >/dev/null 2>&1;       then PM="dnf"
+elif command -v tdnf    >/dev/null 2>&1;       then PM="tdnf"
+elif command -v yum     >/dev/null 2>&1;       then PM="yum"
+elif command -v apk     >/dev/null 2>&1;       then PM="apk"
+else
+    echo "install_script.sh: no supported package manager found" >&2
+    exit 1
+fi
+
+echo "PM=$PM"
+
+# ----------------------------------------------------------------------------
+# Bootstrap awk
+# ----------------------------------------------------------------------------
+#
+# We use awk to parse dependencies.yaml. Most base images ship one (busybox
+# awk on alpine, mawk on debian/ubuntu, gawk on RHEL-likes), but a few
+# minimal images (CBL-Mariner 2 base, AzureLinux 3 base) don't, so install
+# it here before is_migrated runs. Without this we'd silently fall through
+# to the legacy path and confuse later steps.
+
+if ! command -v awk >/dev/null 2>&1; then
+    case "$PM" in
+        apt)  $MODE apt-get update -qq && $MODE apt-get install -yqq --no-install-recommends gawk ;;
+        dnf)  $MODE dnf -y install gawk ;;
+        yum)  $MODE yum -y install gawk ;;
+        tdnf) $MODE tdnf -y install gawk ;;
+        apk)  $MODE apk add --no-cache gawk ;;
+        brew) $MODE brew install gawk ;;
+    esac
+fi
+
+# ----------------------------------------------------------------------------
+# Decide between legacy and abstract paths
+# ----------------------------------------------------------------------------
+
+# Read `migrated_osnicks` from dependencies.yaml. If the YAML is missing
+# (because someone copied this script into a tree without it), or this OSNICK
+# isn't in the migrated list, fall back to the legacy <distro>_<ver>.sh flow.
+
+is_migrated() {
+    [ -f "$DEPS_YAML" ] || return 1
+    awk -v want="$1" '
+        /^migrated_osnicks:/ { in_section=1; next }
+        in_section {
+            # A line that does NOT start with whitespace is a new top-level
+            # key, so we leave the section (unless it is a comment).
+            if (/^[^ \t]/) {
+                if ($0 !~ /^#/) in_section=0
+                next
+            }
+            if (match($0, /^[ \t]*-[ \t]*/)) {
+                v = substr($0, RLENGTH + 1)
+                sub(/[ \t#].*$/, "", v)
+                if (v == want) { found=1; exit }
+            }
+        }
+        END { exit (found ? 0 : 1) }
+    ' "$DEPS_YAML"
+}
+
+if ! is_migrated "$OSNICK"; then
+    # Legacy path: same behaviour install_script.sh has had since forever.
+    # Reproduces the lower-cased "<distro_name>_<version>" filename scheme
+    # from before this refactor.
+    if [ "$(uname -s)" = "Darwin" ]; then
+        legacy_os="macos"
+    else
+        legacy_version=$(grep '^VERSION_ID=' /etc/os-release | sed 's/"//g')
+        legacy_version=${legacy_version#"VERSION_ID="}
+        legacy_name=$(grep '^NAME=' /etc/os-release | sed 's/"//g')
+        legacy_name=${legacy_name#"NAME="}
+        # Rocky uses major version only (matches pre-refactor behaviour).
+        case "$legacy_name" in "Rocky Linux") legacy_version=${legacy_version%.*} ;; esac
+        legacy_os=$(echo "$legacy_name" | tr '[:upper:]' '[:lower:]')_${legacy_version}
+        legacy_os=$(echo "$legacy_os" | sed 's/[/ ]/_/g')
+    fi
+    echo "install_script.sh: using legacy installer .install/${legacy_os}.sh"
+    # shellcheck disable=SC1090
+    . "$HERE/${legacy_os}.sh" "$MODE"
+    git config --global --add safe.directory '*' || true
+    exit 0
+fi
+
+# ----------------------------------------------------------------------------
+# Abstract path
+# ----------------------------------------------------------------------------
+
+echo "install_script.sh: installing abstract deps for $OSNICK via $PM"
+
+# Pure-awk YAML extraction. Handles the (limited) shape of dependencies.yaml:
+#
+#   system:
+#     - foo
+#     - bar
+#   python:
+#     - path/req.txt
+#   package_map:
+#     <abstract>:
+#       <pm>: [pkg1, pkg2]
+#       <pm>: skip
+#       <pm>: []
+
+# extract_flat_list <yaml> <key>  -> prints one entry per line.
+extract_flat_list() {
+    awk -v key="$1" '
+        $0 ~ "^"key":" { in_section=1; next }
+        in_section {
+            # A line that does NOT start with whitespace is a new top-level
+            # key, so we leave the section (unless it is a comment).
+            if (/^[^ \t]/) {
+                if ($0 !~ /^#/) in_section=0
+                next
+            }
+            if (/^[ \t]*#/)              { next }
+            if (match($0, /^[ \t]*-[ \t]*/)) {
+                v = substr($0, RLENGTH + 1)
+                sub(/[ \t]*#.*$/, "", v)
+                gsub(/^[ \t]+|[ \t]+$/, "", v)
+                if (v != "") print v
+            }
+        }
+    ' "$2"
+}
+
+# resolve_abstract <abstract> <pm> <yaml>  -> prints concrete packages,
+# space-separated. Empty if no entry / explicit skip.
+resolve_abstract() {
+    awk -v abs="$1" -v pm="$2" '
+        BEGIN { in_map=0; in_abs=0 }
+        /^package_map:/ { in_map=1; next }
+        in_map {
+            # Top-level key (no leading whitespace) closes the section unless
+            # it is a comment.
+            if (/^[^ \t]/) {
+                if ($0 !~ /^#/) { in_map=0; in_abs=0 }
+                next
+            }
+            # Abstract entry: 2 spaces indent, "<name>:"
+            if (match($0, /^  [a-zA-Z0-9_]+:/)) {
+                name = $0
+                gsub(/^[ \t]+|[ \t:]+$/, "", name)
+                in_abs = (name == abs)
+                next
+            }
+            if (in_abs) {
+                # Per-PM line: 4 spaces indent, "<pm>: <value>"
+                if (match($0, /^    [a-zA-Z0-9_+]+:/)) {
+                    line = $0
+                    sub(/^    /, "", line)
+                    split(line, parts, ":")
+                    cur_pm = parts[1]
+                    val = substr(line, length(parts[1]) + 2)
+                    # Strip trailing "  # comment".
+                    sub(/[ \t]+#.*$/, "", val)
+                    gsub(/^[ \t]+|[ \t]+$/, "", val)
+                    if (cur_pm != pm) next
+                    if (val == "skip" || val == "[]" || val == "") { exit }
+                    # Strip [ ], split on commas.
+                    gsub(/^\[|\]$/, "", val)
+                    n = split(val, items, ",")
+                    out = ""
+                    for (i=1; i<=n; i++) {
+                        gsub(/^[ \t]+|[ \t]+$/, "", items[i])
+                        if (items[i] != "") out = out (out ? " " : "") items[i]
+                    }
+                    print out
+                    exit
+                }
+            }
+        }
+    ' "$3"
+}
+
+# Bootstrap: ensure awk and a package-manager refresh are ready.
+case "$PM" in
+    apt)
+        export DEBIAN_FRONTEND=noninteractive
+        $MODE apt-get update -qq
+        ;;
+    dnf|yum|tdnf)
+        $MODE $PM -y makecache 2>/dev/null || true
+        ;;
+    apk)
+        $MODE apk update -q
+        ;;
+esac
+
+# Resolve every abstract dep -> concatenate -> single install call.
+all_pkgs=""
+while IFS= read -r abs; do
+    [ -z "$abs" ] && continue
+    pkgs=$(resolve_abstract "$abs" "$PM" "$DEPS_YAML")
+    [ -z "$pkgs" ] && continue
+    all_pkgs="$all_pkgs $pkgs"
+done <<EOF_DEPS
+$(extract_flat_list system "$DEPS_YAML")
+EOF_DEPS
+
+if [ -n "${all_pkgs# }" ]; then
+    echo "install_script.sh: installing: $all_pkgs"
+    case "$PM" in
+        apt)  $MODE apt-get install -yqq --no-install-recommends $all_pkgs ;;
+        dnf)  $MODE dnf -y install --allowerasing $all_pkgs ;;
+        yum)  $MODE yum -y install $all_pkgs ;;
+        apk)  $MODE apk add --no-cache $all_pkgs ;;
+        brew) $MODE brew install $all_pkgs ;;
+        tdnf)
+            # tdnf has no --skip-broken and aborts the whole transaction if
+            # any one package is missing from the repos (CBL-Mariner /
+            # AzureLinux ship a small subset compared to apt/dnf). Install
+            # one at a time so an individual missing package is just a
+            # warning, not a build failure.
+            for pkg in $all_pkgs; do
+                if ! $MODE tdnf -y install "$pkg" >/dev/null 2>&1; then
+                    echo "  (tdnf: skipped unavailable package '$pkg')"
+                fi
+            done
+            ;;
+    esac
+fi
+
+# OS-specific extras that don't fit the abstract->concrete mapping
+# (e.g. AmazonLinux2 needs openssl11 + devtoolset, Mariner2 needs awscli, ...).
+QUIRK="$HERE/quirks/${OSNICK}.sh"
+if [ -f "$QUIRK" ]; then
+    echo "install_script.sh: running quirk $QUIRK"
+    # shellcheck disable=SC1090
+    . "$QUIRK" "$MODE"
+fi
+
+git config --global --add safe.directory '*' || true
+
+# Note: Python requirement files are listed under `python:` in
+# dependencies.yaml but are installed by `make setup` (via
+# .install/common_installations.sh) inside its venv, not from here. This keeps
+# install_script.sh focused on system packages and lets Docker images that
+# manage their own Python environment (uv, venv) skip the duplicate work.
+
+echo "install_script.sh: done"

--- a/.install/macos.sh
+++ b/.install/macos.sh
@@ -16,6 +16,12 @@ brew install jq
 brew install openssl
 brew install llvm@$LLVM_VERSION
 brew install libblocksruntime
+# autoconf/automake/libtool are needed for some C deps that ship configure.ac
+# (matches the explicit `brew install ... autoconf automake libtool` step in
+# .github/workflows/flow-macos.yml so local `make setup` is self-sufficient).
+brew install autoconf
+brew install automake
+brew install libtool
 
 BREW_PREFIX=$(brew --prefix)
 GNUBIN=$BREW_PREFIX/opt/make/libexec/gnubin

--- a/.install/quirks/alma8.sh
+++ b/.install/quirks/alma8.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# AlmaLinux 8 extras: the abstract list installs a base gcc, but our build
+# really wants gcc-11 from gcc-toolset. Mirrors Dockerfile.alma8's setup.
+# After this quirk runs, the Dockerfile is responsible for exposing the
+# toolset on PATH/LD_LIBRARY_PATH (see Dockerfile.alma8 for the env lines).
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+
+MODE="${1:-}"
+
+$MODE dnf -y groupinstall "Development Tools"
+$MODE dnf config-manager --set-enabled powertools
+$MODE dnf -y install epel-release
+$MODE dnf -y install \
+    bzip2-devel \
+    gcc-toolset-11-gcc \
+    gcc-toolset-11-gcc-c++ \
+    gcc-toolset-11-libatomic-devel \
+    libffi-devel \
+    python3.11-devel \
+    xz \
+    zlib-devel
+
+# Drop a profile snippet so subsequent shells (including Dockerfile RUNs that
+# don't `source enable` themselves) get the toolset on PATH.
+$MODE cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh

--- a/.install/quirks/alma9.sh
+++ b/.install/quirks/alma9.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# AlmaLinux 9 extras: pulls gcc-13 from gcc-toolset to match Dockerfile.alma9.
+# After this quirk runs, the Dockerfile is responsible for exposing the
+# toolset on PATH/LD_LIBRARY_PATH.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+
+MODE="${1:-}"
+
+$MODE dnf -y install \
+    gcc-toolset-13-gcc \
+    gcc-toolset-13-gcc-c++ \
+    gcc-toolset-13-libatomic-devel
+
+$MODE cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh

--- a/.install/quirks/alpine.sh
+++ b/.install/quirks/alpine.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Alpine-only extras that don't fit the cross-distro abstract package map in
+# ../../dependencies.yaml. Run after the standard `apk add` of the abstract
+# system list.
+#
+# Why these are here and not in dependencies.yaml:
+#   - musl/Alpine specific runtime/headers (musl-dev, linux-headers, gcompat,
+#     libstdc++, libgcc, bsd-compat-headers): only meaningful on Alpine.
+#   - py3-* prebuilt wheels (cryptography, numpy, psutil) avoid building the
+#     C extensions against musl from source during pip install.
+#   - openblas-dev / xsimd: math/SIMD libs used by some test deps.
+#   - openssh, xz, py-virtualenv: kept verbatim from the legacy
+#     .install/alpine.sh script for parity.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+
+MODE="${1:-}"
+
+$MODE apk add --no-cache \
+    bash \
+    musl-dev \
+    linux-headers \
+    libffi-dev \
+    bsd-compat-headers \
+    gcompat \
+    libstdc++ \
+    libgcc \
+    openblas-dev \
+    xsimd \
+    xz \
+    openssh \
+    py3-cryptography \
+    py3-numpy \
+    py3-psutil \
+    py-virtualenv

--- a/.install/quirks/amazonlinux2.sh
+++ b/.install/quirks/amazonlinux2.sh
@@ -37,7 +37,9 @@ $MODE yum -y install --nogpgcheck --skip-broken \
     devtoolset-11-gcc-c++ \
     devtoolset-11-make || true
 
-# Make `cmake` point at cmake3 for callers that don't know about cmake3.
-if ! command -v cmake >/dev/null 2>&1; then
-    $MODE ln -sf "$(command -v cmake3)" /usr/bin/cmake
-fi
+# Force `cmake` -> cmake3. AL2's base repo also ships an ancient `cmake`
+# (2.8.12) which `yum install cmake` (from the abstract path) pulls in;
+# leaving that on PATH breaks anything needing cmake>=3 (e.g. cpu_features).
+# This symlink is unconditional on purpose to override the 2.8 binary —
+# the legacy Dockerfile.amazonlinux2 did exactly the same thing.
+$MODE ln -sf "$(command -v cmake3)" /usr/bin/cmake

--- a/.install/quirks/amazonlinux2.sh
+++ b/.install/quirks/amazonlinux2.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Amazon Linux 2 extras: AL2 ships ancient gcc/cmake. The standard abstract
+# install only does the easy packages; this quirk:
+#   * Enables EPEL and the (deprecated, served from CentOS Vault) SCL repo
+#   * Installs devtoolset-11 (gcc-11/g++-11) so we have a modern toolchain
+#   * Installs cmake3 and symlinks it as /usr/bin/cmake
+#
+# This mirrors the legacy .install/amazon_linux_2.sh / Dockerfile.amazonlinux2
+# behaviour. It does NOT (re)build Python from source: callers that need a
+# newer Python should layer that step in their Dockerfile.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+
+MODE="${1:-}"
+
+$MODE amazon-linux-extras install epel -y
+$MODE yum -y install epel-release yum-utils
+$MODE yum-config-manager --add-repo http://vault.centos.org/centos/7/sclo/x86_64/rh/
+
+$MODE yum -y install \
+    autogen \
+    centos-release-scl \
+    cmake3 \
+    scl-utils
+
+# devtoolset-11 lives in the CentOS Vault SCL repo and is x86_64-only there;
+# aarch64 hosts (e.g. Apple Silicon dev laptops) will see "No package
+# devtoolset-11-* available" and that's expected. --skip-broken makes that a
+# warning instead of a hard build failure so dependencies.yaml-driven builds
+# can at least exercise the abstract path on aarch64 even if the produced
+# image isn't usable for actual compilation.
+$MODE yum -y install --nogpgcheck --skip-broken \
+    devtoolset-11-gcc \
+    devtoolset-11-gcc-c++ \
+    devtoolset-11-make || true
+
+# Make `cmake` point at cmake3 for callers that don't know about cmake3.
+if ! command -v cmake >/dev/null 2>&1; then
+    $MODE ln -sf "$(command -v cmake3)" /usr/bin/cmake
+fi

--- a/.install/quirks/bionic.sh
+++ b/.install/quirks/bionic.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Ubuntu 18.04 (bionic) extras: pulls a newer gcc-10 from the toolchain test
+# PPA (bionic only ships gcc-7) and builds cmake 3.28 from source because
+# bionic's apt cmake is too old for our CMakeLists. Mirrors the legacy
+# Dockerfile.bionic logic.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+
+MODE="${1:-}"
+
+$MODE apt-get install -yqq --no-install-recommends \
+    software-properties-common lsb-core binfmt-support cargo zlib1g-dev
+$MODE add-apt-repository ppa:ubuntu-toolchain-r/test -y
+$MODE apt-get update -qq
+$MODE apt-get install -yqq --no-install-recommends gcc-10 g++-10
+$MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-10
+
+# bionic's cmake is too old; build the version pack.sh expects.
+cd /tmp
+wget -q https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz
+tar -xzf cmake-3.28.0.tar.gz
+cd cmake-3.28.0
+./configure
+make -j"$(nproc)"
+$MODE make install
+cd /
+rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz
+$MODE ln -sf /usr/local/bin/cmake /usr/bin/cmake

--- a/.install/quirks/focal.sh
+++ b/.install/quirks/focal.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Ubuntu 20.04 (focal) extras: pin gcc/g++ to the gcc-10 toolchain via
+# update-alternatives, matching the legacy .install/ubuntu_20.04.sh behaviour.
+# Run after the standard apt install of the abstract list.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+
+MODE="${1:-}"
+
+$MODE apt-get install -yqq --no-install-recommends gcc-10 g++-10 lcov
+$MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-10

--- a/.install/quirks/macos.sh
+++ b/.install/quirks/macos.sh
@@ -22,6 +22,21 @@ if ! command -v brew >/dev/null 2>&1; then
     exit 1
 fi
 
+# Conditional python install: only when python3 is genuinely absent.
+#
+# We deliberately don't list `python@3.11` in dependencies.yaml's brew
+# mapping because most macOS hosts already provide a python3 (Apple's
+# /usr/bin/python3, Xcode Command Line Tools, GitHub Actions runners' bundled
+# Python.framework, etc.) and `brew install python@3.11` would fail at
+# linking time when those framework symlinks already own /usr/local/bin/
+# python3.11. So only fall back to a brew install here on hosts where there
+# is genuinely no python3 (in which case nothing owns those symlinks and
+# the install is conflict-free).
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "quirks/macos.sh: python3 not on PATH; installing brew python@3.11"
+    brew install python@3.11
+fi
+
 LLVM_VERSION="18"
 BREW_PREFIX="$(brew --prefix)"
 GNUBIN="$BREW_PREFIX/opt/make/libexec/gnubin"

--- a/.install/quirks/macos.sh
+++ b/.install/quirks/macos.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# macOS-only post-install steps. Run after the abstract `brew install` of the
+# package list in ../../dependencies.yaml. Mirrors the PATH-munging that the
+# legacy .install/macos.sh did, but no longer duplicates the package
+# installation (the abstract installer already ran `brew install make jq
+# openssl@3 llvm@18 libblocksruntime autoconf automake libtool coreutils`).
+#
+# What the abstract installer cannot express:
+#   * Persisting a PATH that prefers GNU coreutils, llvm@18, and GNU make
+#     over their BSD/Apple counterparts (so `make`, `clang`, `tar`, `realpath`
+#     etc. behave the same as on Linux when developers run `make build`).
+#   * Writing the same PATH to $GITHUB_PATH inside GitHub Actions.
+#
+# Sourced by install_script.sh; receives MODE as $1 (unused on macOS, brew
+# refuses to run as root).
+
+set -eu
+
+if ! command -v brew >/dev/null 2>&1; then
+    echo "quirks/macos.sh: brew is not installed; install it from https://brew.sh" >&2
+    exit 1
+fi
+
+LLVM_VERSION="18"
+BREW_PREFIX="$(brew --prefix)"
+GNUBIN="$BREW_PREFIX/opt/make/libexec/gnubin"
+LLVM="$BREW_PREFIX/opt/llvm@$LLVM_VERSION/bin"
+COREUTILS="$BREW_PREFIX/opt/coreutils/libexec/gnubin"
+
+update_profile() {
+    local profile_path=$1
+    local newpath="export PATH=$COREUTILS:$LLVM:$GNUBIN:\$PATH"
+    grep -qxF "$newpath" "$profile_path" || echo "$newpath" >> "$profile_path"
+    echo "$newpath"
+    # NB: we deliberately do NOT `. "$profile_path"` here. The legacy
+    # macos.sh used to, but install_script.sh runs under `set -eu` and
+    # sourcing a .zshrc from bash often trips `set -u` on zsh-specific
+    # variables (e.g. $ZSH_VERSION). The PATH update is meant for the user's
+    # next shell anyway; the Makefile's next step (python3 -m venv) finds
+    # python3 via brew's existing /opt/homebrew/bin entry.
+    if [ -n "${GITHUB_PATH:-}" ]; then
+        echo "$newpath" >> "$GITHUB_PATH"
+    fi
+}
+
+# Use if/fi instead of `&&` chains: under `set -e`, a `[ ... ] && cmd` line
+# whose test fails returns 1 from the line itself and aborts the script.
+if [ -f "$HOME/.bash_profile" ]; then update_profile "$HOME/.bash_profile"; fi
+if [ -f "$HOME/.zshrc" ];        then update_profile "$HOME/.zshrc";        fi

--- a/.install/quirks/rocky8.sh
+++ b/.install/quirks/rocky8.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# Rocky Linux 8 extras: identical to alma8 (both are RHEL 8 rebuilds).
+# See quirks/alma8.sh for rationale.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+. "$(dirname "${BASH_SOURCE[0]:-$0}")/alma8.sh" "${1:-}"

--- a/.install/quirks/rocky9.sh
+++ b/.install/quirks/rocky9.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# Rocky Linux 9 extras: identical to alma9 (both are RHEL 9 rebuilds).
+# See quirks/alma9.sh for rationale.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+. "$(dirname "${BASH_SOURCE[0]:-$0}")/alma9.sh" "${1:-}"

--- a/Dockerfile.alma10
+++ b/Dockerfile.alma10
@@ -2,13 +2,12 @@
 FROM almalinux:10
 
 WORKDIR /workspace
-
 ENV DEBIAN_FRONTEND=noninteractive
-RUN dnf -y update
-RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync unzip clang jq \
-    autoconf automake libtool python3-devel
 
+# Install build/test deps via the unified abstract installer.
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 ARG REDIS_REF=unstable

--- a/Dockerfile.alma8
+++ b/Dockerfile.alma8
@@ -3,21 +3,17 @@ FROM almalinux:8
 
 WORKDIR /workspace
 
-RUN dnf update -y
+# Install build/test deps via the unified abstract installer; quirks/alma8.sh
+# pulls gcc-toolset-11 and drops a /etc/profile.d snippet enabling it.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-RUN dnf groupinstall "Development Tools" -yqq
-RUN dnf config-manager --set-enabled powertools
-RUN dnf install epel-release -yqq
-RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync clang curl jq python3.11-devel \
-    autoconf automake libtool
-
-RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
+# Expose the toolset on PATH for subsequent RUNs (the profile.d snippet only
+# fires for login shells).
 ENV PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
-
-COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 ARG REDIS_REF=unstable
 ARG SANITIZER=

--- a/Dockerfile.alma9
+++ b/Dockerfile.alma9
@@ -2,17 +2,17 @@
 FROM almalinux:9
 
 WORKDIR /workspace
-
 ENV DEBIAN_FRONTEND=noninteractive
-RUN dnf -y update
-RUN dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ gcc-toolset-13-libatomic-devel make wget git openssl openssl-devel which rsync unzip clang jq \
-    autoconf automake libtool python3-devel
-RUN cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh
+
+# Install build/test deps via the unified abstract installer; quirks/alma9.sh
+# pulls gcc-toolset-13 and drops a /etc/profile.d snippet enabling it.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+
 ENV PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH}"
-
-COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 ARG REDIS_REF=unstable
 ARG SANITIZER=

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -2,42 +2,17 @@ FROM alpine:3
 
 WORKDIR /workspace
 
-# Install dependencies
-RUN apk add --no-cache \
-    bash \
-    make \
-    libtool \
-    tar \
-    cmake \
-    python3 \
-    python3-dev \
-    py3-pip \
-    gcc \
-    git \
-    curl \
-    build-base \
-    autoconf \
-    automake \
-    py3-cryptography \
-    linux-headers \
-    musl-dev \
-    libffi-dev \
-    openssl-dev \
-    openssh \
-    py-virtualenv \
-    clang18-libclang \
-    gcompat \
-    libstdc++ \
-    libgcc \
-    g++ \
-    openblas-dev \
-    xsimd \
-    xz \
-    bsd-compat-headers \
-    clang18 \
-    jq
+# Bootstrap bash so install_script.sh (bash shebang) can run; apk and awk are
+# already provided by busybox.
+RUN apk add --no-cache bash
 
+# Install build/test deps via the unified abstract installer (see
+# dependencies.yaml). Alpine is in `migrated_osnicks`, so this resolves the
+# abstract list against apk and then runs .install/quirks/alpine.sh for the
+# musl/openblas extras that don't fit a cross-distro abstract mapping.
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable

--- a/Dockerfile.amazonlinux2
+++ b/Dockerfile.amazonlinux2
@@ -2,26 +2,21 @@ FROM amazonlinux:2
 
 WORKDIR /workspace
 
-RUN amazon-linux-extras install epel -y && \
-    yum -y install epel-release yum-utils && \
-    yum-config-manager --add-repo http://vault.centos.org/centos/7/sclo/x86_64/rh/ && \
-    yum -y install gcc make autogen automake libtool cmake3 git openssl-devel bzip2-devel libffi-devel zlib-devel wget centos-release-scl scl-utils which tar unzip jq && \
-    yum -y install devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-make --nogpgcheck
+# Install build/test deps via the unified abstract installer;
+# quirks/amazonlinux2.sh enables EPEL + the CentOS Vault SCL repo, installs
+# devtoolset-11 (gcc-11) and cmake3, and symlinks cmake3 as cmake.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 
-RUN ln -s `which cmake3` /usr/bin/cmake
-# Enable devtoolset-11 for all subsequent commands
+# Enable devtoolset-11 for all subsequent commands.
 ENV PATH="/opt/rh/devtoolset-11/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/devtoolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
 
-COPY .install /workspace/.install
-
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh
-
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv

--- a/Dockerfile.amazonlinux2023
+++ b/Dockerfile.amazonlinux2023
@@ -2,31 +2,12 @@ FROM amazonlinux:2023
 
 WORKDIR /workspace
 
-# Install dependencies
-# Use --allowerasing to replace curl-minimal with full curl
-RUN dnf -y update && dnf -y install --allowerasing \
-    git \
-    gcc \
-    gcc-c++ \
-    make \
-    cmake \
-    automake \
-    autoconf \
-    libtool \
-    openssl-devel \
-    zlib-devel \
-    bzip2-devel \
-    libffi-devel \
-    wget \
-    curl \
-    which \
-    tar \
-    unzip \
-    jq \
-    clang \
-    && dnf clean all
-
+# Install build/test deps via the unified abstract installer (see
+# dependencies.yaml). amazonlinux2023 is in `migrated_osnicks`, so this
+# resolves the abstract list against dnf in a single dnf install.
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh && dnf clean all
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable

--- a/Dockerfile.azurelinux3
+++ b/Dockerfile.azurelinux3
@@ -2,37 +2,15 @@ FROM mcr.microsoft.com/azurelinux/base/core:3.0
 
 WORKDIR /workspace
 
-# Install dependencies
-RUN tdnf -y update && \
-    tdnf install -y \
-    git \
-    wget \
-    curl \
-    gcc \
-    g++ \
-    make \
-    cmake \
-    libffi-devel \
-    openssl-devel \
-    build-essential \
-    zlib-devel \
-    bzip2-devel \
-    readline-devel \
-    which \
-    unzip \
-    jq \
-    ca-certificates \
-    tar
-
+# Install build/test deps via the unified abstract installer (uses tdnf).
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh
-
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv

--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -8,34 +8,17 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
     > /etc/apt/apt.conf.d/80-retries
 
-RUN apt update -qq \
-    && apt upgrade -yqq \
-    && apt dist-upgrade -yqq \
-    && apt install -yqq software-properties-common unzip rsync \
-    && add-apt-repository ppa:ubuntu-toolchain-r/test -y \
-    && apt update \
-    && apt install -yqq build-essential wget curl make gcc-10 g++-10 openssl libssl-dev cargo binfmt-support \
-    lsb-core libclang-dev clang zlib1g-dev jq automake libtool git \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
-
-RUN wget https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz \
-    && tar -xzvf cmake-3.28.0.tar.gz \
-    && cd cmake-3.28.0 \
-    && ./configure \
-    && make -j$(nproc) \
-    && make install \
-    && cd .. \
-    && rm -rf cmake-3.28.0 cmake-3.28.0.tar.gz \
-    && ln -sf /usr/local/bin/cmake /usr/bin/cmake
+# Install build/test deps via the unified abstract installer; quirks/bionic.sh
+# enables the toolchain-r/test PPA, installs gcc-10, and builds cmake 3.28
+# from source (bionic's apt cmake is too old).
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh
-
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -8,13 +8,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
     > /etc/apt/apt.conf.d/80-retries
 
-RUN apt update -qq \
-    && apt upgrade -yqq \
-    && apt-get update \
-    && apt install -yqq git wget curl build-essential lcov openssl libssl-dev \
-    rsync unzip libclang-dev clang autoconf automake libtool python3-dev
-
+# Install build/test deps via the unified abstract installer. install_cmake.sh
+# upgrades cmake afterwards (debian's apt cmake is older than what we need).
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 ARG REDIS_REF=unstable

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -8,36 +8,15 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
     > /etc/apt/apt.conf.d/80-retries
 
-RUN apt-get update && apt-get install -y build-essential \
-    make \
-    cmake \
-    autoconf \
-    automake \
-    libtool \
-    lcov \
-    git \
-    wget \
-    zlib1g-dev \
-    lsb-release \
-    libssl-dev \
-    openssl \
-    ca-certificates \
-    curl \
-    unzip \
-    rsync \
-    libclang-dev \
-    clang
-
-
+# Install build/test deps via the unified abstract installer.
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh
-
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -8,21 +8,16 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
     > /etc/apt/apt.conf.d/80-retries
 
-RUN apt update -qq \
-    && apt upgrade -yqq \
-    && apt install -yqq wget make clang-format gcc lcov git openssl libssl-dev \
-    unzip rsync build-essential gcc-10 g++-10 cargo libclang-dev clang curl cmake jq automake libtool \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
-
+# Install build/test deps via the unified abstract installer. focal's
+# quirks/focal.sh installs gcc-10 and switches /usr/bin/{gcc,g++} to it.
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh
-
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv

--- a/Dockerfile.jammy
+++ b/Dockerfile.jammy
@@ -8,25 +8,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
     > /etc/apt/apt.conf.d/80-retries
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    make \
-    gcc \
-    g++ \
-    gdb \
-    clang \
-    valgrind \
-    git \
-    jq \
-    libssl-dev \
-    autoconf \
-    automake \
-    libtool \
-    cmake \
-    curl \
-    libblocksruntime-dev
-
+# Install build/test deps via the unified abstract installer (see
+# dependencies.yaml). Ubuntu jammy is in `migrated_osnicks`, so this resolves
+# the abstract list against apt and runs a single apt-get install.
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable

--- a/Dockerfile.mariner2
+++ b/Dockerfile.mariner2
@@ -2,19 +2,15 @@ FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
 WORKDIR /workspace
 
-RUN tdnf makecache
-RUN tdnf install -y git ca-certificates build-essential wget tar openssl-devel cmake which unzip jq \
-    gcc g++ curl libffi-devel zlib-devel bzip2-devel
-
+# Install build/test deps via the unified abstract installer (uses tdnf).
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh
-
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv

--- a/Dockerfile.noble
+++ b/Dockerfile.noble
@@ -9,31 +9,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
     > /etc/apt/apt.conf.d/80-retries
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    make \
-    gcc \
-    g++ \
-    gdb \
-    clang \
-    valgrind \
-    git \
-    jq \
-    libssl-dev \
-    autoconf \
-    automake \
-    libtool \
-    cmake \
-    curl \
-    wget \
-    libblocksruntime-dev \
-    unzip \
-    rsync \
-    python3-dev
+# Install build/test deps via the unified abstract installer.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 
 ARG REDIS_REF=unstable
 ARG SANITIZER=
-COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.resolute
+++ b/Dockerfile.resolute
@@ -4,31 +4,13 @@ FROM ubuntu:26.04
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    make \
-    gcc \
-    g++ \
-    gdb \
-    clang \
-    valgrind \
-    git \
-    jq \
-    libssl-dev \
-    autoconf \
-    automake \
-    libtool \
-    cmake \
-    curl \
-    wget \
-    libblocksruntime-dev \
-    unzip \
-    rsync \
-    python3-dev
+# Install build/test deps via the unified abstract installer.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 
 ARG REDIS_REF=unstable
 ARG SANITIZER=
-COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -2,13 +2,12 @@
 FROM quay.io/rockylinux/rockylinux:10
 
 WORKDIR /workspace
-
 ENV DEBIAN_FRONTEND=noninteractive
-RUN dnf update -y
-RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync unzip clang jq \
-    autoconf automake libtool python3-devel
 
+# Install build/test deps via the unified abstract installer.
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 ARG REDIS_REF=unstable

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -2,21 +2,15 @@ FROM rockylinux:8
 
 WORKDIR /workspace
 
-RUN dnf update -y
+# Install build/test deps via the unified abstract installer; quirks/rocky8.sh
+# is a thin wrapper over alma8.sh that pulls gcc-toolset-11.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-RUN dnf groupinstall "Development Tools" -yqq
-RUN dnf config-manager --set-enabled powertools
-RUN dnf install epel-release -yqq
-RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync clang curl python3.11-devel \
-    autoconf automake libtool jq
-
-RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
 ENV PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
-
-COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 ARG REDIS_REF=unstable
 ARG SANITIZER=

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -2,35 +2,20 @@ FROM rockylinux:9
 
 WORKDIR /workspace
 
-RUN yum -y update --nobest
-RUN yum -y install --nobest --skip-broken gcc gcc-c++ \
-    git \
-    make \
-    cmake3 \
-    wget \
-    openssl-devel \
-    bzip2-devel \
-    libffi-devel \
-    zlib-devel \
-    scl-utils \
-    which \
-    jq \
-    unzip \
-    gcc-toolset-13-gcc \
-    gcc-toolset-13-gcc-c++ \
-    gcc-toolset-13-libatomic-devel \
-    automake \ 
-    libtool
-
+# Install build/test deps via the unified abstract installer; quirks/rocky9.sh
+# pulls gcc-toolset-13.
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ENV PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH}"
+
 ARG REDIS_REF=unstable
 ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh
-
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv

--- a/Dockerfile.trixie
+++ b/Dockerfile.trixie
@@ -8,13 +8,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
     > /etc/apt/apt.conf.d/80-retries
 
-RUN apt update -qq \
-    && apt upgrade -yqq \
-    && apt-get update \
-    && apt install -yqq git wget curl build-essential lcov openssl libssl-dev \
-    rsync unzip libclang-dev clang autoconf automake libtool python3-dev
-
+# Install build/test deps via the unified abstract installer. install_cmake.sh
+# upgrades cmake afterwards.
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 ARG REDIS_REF=unstable

--- a/Makefile
+++ b/Makefile
@@ -560,9 +560,8 @@ endif
 #----------------------------------------------------------------------------------------------
 
 setup:
-	$(SHOW)./sbin/setup
-	$(SHOW)pip3 install --user gevent 2>/dev/null \
-		|| pip3 install --user --break-system-packages gevent 2>/dev/null \
-		|| pip3 install --break-system-packages gevent
+	$(SHOW)cd .install && ./install_script.sh
+	$(SHOW)test -d venv || python3 -m venv venv
+	$(SHOW). ./venv/bin/activate && ./.install/common_installations.sh && pip install gevent
 
 .PHONY: setup

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,13 @@ MK_ALL_TARGETS=bindirs deps build pack
 
 include $(ROOT)/deps/readies/mk/main
 
+# readies `platform.cfg` skips exporting ARCH when __NO_PYTHON=1 (e.g. `make setup`
+# before python3 is installed). Uname keeps setup/build usable in that state.
+ifeq ($(ARCH),)
+ARCH:=$(shell uname -m | tr '[:upper:]' '[:lower:]' | sed -e 's/^x86_64$$/x64/' -e 's/^amd64$$/x64/' -e 's/^aarch64$$/arm64v8/' -e 's/^arm64$$/arm64v8/')
+export ARCH
+endif
+
 # RedisTimeSeries only supports 64-bit architectures
 ifneq ($(ARCH),x64)
 ifneq ($(ARCH),arm64v8)
@@ -557,10 +564,16 @@ endif
 #      RLTest, etc.).
 #   2. `gevent`     -> imported by tests/flow/test_short_read.py but
 #      commented out in tests/flow/requirements.txt, so install it here.
+#
+# install_script.sh MODE: on Linux, default `sudo` so apt works for non-root
+# users; on macOS, empty (brew must not run under sudo). Override with
+# `make setup INSTALL_SCRIPT_MODE=` when already root (e.g. some containers).
 #----------------------------------------------------------------------------------------------
 
+INSTALL_SCRIPT_MODE ?= $(if $(filter Linux,$(shell uname -s)),sudo,)
+
 setup:
-	$(SHOW)cd .install && ./install_script.sh
+	$(SHOW)cd .install && ./install_script.sh $(INSTALL_SCRIPT_MODE)
 	$(SHOW)test -d venv || python3 -m venv venv
 	$(SHOW). ./venv/bin/activate && ./.install/common_installations.sh && pip install gevent
 

--- a/Makefile
+++ b/Makefile
@@ -547,3 +547,22 @@ gen-compile-commands:
 endif
 
 .PHONY: pack upload-release upload-artifacts
+
+#----------------------------------------------------------------------------------------------
+# `make setup` — install build & test prereqs for RedisTimeSeries.
+#
+# Standalone-friendly. Steps:
+#   1. `sbin/setup`  -> getpy3 + system-setup.py + readies (autoconf,
+#      libtool, m4, automake, openssl, gnu-utils on macOS, cmake, RAMP,
+#      RLTest, etc.).
+#   2. `gevent`     -> imported by tests/flow/test_short_read.py but
+#      commented out in tests/flow/requirements.txt, so install it here.
+#----------------------------------------------------------------------------------------------
+
+setup:
+	$(SHOW)./sbin/setup
+	$(SHOW)pip3 install --user gevent 2>/dev/null \
+		|| pip3 install --user --break-system-packages gevent 2>/dev/null \
+		|| pip3 install --break-system-packages gevent
+
+.PHONY: setup

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -224,12 +224,18 @@ package_map:
 
   # ---- Python ------------------------------------------------------------
   python3:
+    # macOS: deliberately skip. GH Actions runners (and most dev Macs) ship a
+    # Python.framework whose `/usr/local/bin/python3.11` symlink collides
+    # with brew's `python@3.11`, making `brew install python@3.11` fail at
+    # the link step. We rely on whatever python3 is already on PATH; the
+    # legacy `.install/macos.sh` did the same for years. If a user has no
+    # python3, `make setup`'s `python3 -m venv` will give a clear error.
     apt:  [python3, python3-pip, python3-venv, python3-dev]
     dnf:  [python3, python3-pip, python3-devel]
     yum:  [python3, python3-pip, python3-devel]
     tdnf: [python3, python3-pip, python3-devel]
     apk:  [python3, python3-dev, py3-pip, py-virtualenv]
-    brew: [python@3.11]
+    brew: skip
 
   # ---- networking / misc tools ------------------------------------------
   git:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,0 +1,284 @@
+# RedisTimeSeries dependencies.
+#
+# This is the source of truth for what the module needs in order to build and
+# test. It is consumed by .install/install_script.sh (and indirectly by `make
+# setup` and by Dockerfile.<osnick> images). When you add or remove a
+# build-time dependency, edit this file --- not the per-OS shell scripts.
+#
+# The script picks the right concrete package per OS using `package_map`
+# below. OSes listed under `migrated_osnicks` go through this YAML pipeline;
+# any OS not listed continues to use its legacy .install/<distro>_<ver>.sh
+# script unchanged, so migration is incremental.
+#
+# OS-specific extras that don't fit the abstract->concrete table go in
+# .install/quirks/<osnick>.sh (run after the standard package install).
+
+# ----------------------------------------------------------------------------
+# Abstract system packages required to build redistimeseries.
+# Names here are looked up in `package_map` below.
+# ----------------------------------------------------------------------------
+system:
+  - gcc
+  - clang
+  - gdb
+  - make
+  - cmake
+  - autoconf
+  - automake
+  - libtool
+  - openssl_dev
+  - zlib_dev
+  - bzip2_dev
+  - libffi_dev
+  - libclang_dev
+  - python3
+  - git
+  - curl
+  - wget
+  - jq
+  - tar
+  - unzip
+  - rsync
+  - which
+  - valgrind
+  - lcov
+  - blocksruntime_dev
+  - readline_dev
+
+# Python requirement files to install via pip after system deps are present.
+# Paths are relative to the module src root.
+python:
+  - tests/flow/requirements.txt
+  - .install/build_package_requirements.txt
+
+# OSes that go through the abstract YAML pipeline.
+# OSes not listed here keep using the legacy .install/<distro>_<ver>.sh
+# script during migration; remove the legacy script and add the osnick here
+# to migrate that OS.
+migrated_osnicks:
+  # Ubuntu / Debian
+  - bionic       # 18.04  (needs quirks/bionic.sh: PPA + cmake-from-source)
+  - focal        # 20.04  (needs quirks/focal.sh:  gcc-10 update-alternatives)
+  - jammy        # 22.04
+  - noble        # 24.04
+  - resolute     # 26.04
+  - bullseye     # debian 11
+  - bookworm     # debian 12  (Dockerfile runs install_cmake.sh post-install)
+  - trixie       # debian 13  (Dockerfile runs install_cmake.sh post-install)
+  # Alpine
+  - alpine
+  # Red Hat family
+  - alma8        # AlmaLinux 8   (needs quirks/alma8.sh:  gcc-toolset-11)
+  - alma9        # AlmaLinux 9   (needs quirks/alma9.sh:  gcc-toolset-13)
+  - alma10       # AlmaLinux 10
+  - rocky8       # Rocky Linux 8 (needs quirks/rocky8.sh: gcc-toolset-11)
+  - rocky9       # Rocky Linux 9 (needs quirks/rocky9.sh: gcc-toolset-13)
+  - rocky10      # Rocky Linux 10
+  - amazonlinux2       # AmazonLinux 2 (needs quirks/amazonlinux2.sh: devtoolset-11 + cmake3 + epel)
+  - amazonlinux2023
+  # Microsoft
+  - mariner2     # CBL-Mariner 2  (tdnf)
+  - azurelinux3  # Azure Linux 3  (tdnf)
+
+# ----------------------------------------------------------------------------
+# Map of abstract dependency names to concrete packages per package manager.
+# An empty list (or the value `skip`) means "no install needed for this PM"
+# (already provided by the base image, or no equivalent package).
+# ----------------------------------------------------------------------------
+package_map:
+  # ---- compilers / build essentials --------------------------------------
+  gcc:
+    apt:  [build-essential]
+    dnf:  [gcc, gcc-c++, make]
+    yum:  [gcc, gcc-c++, make]
+    tdnf: [build-essential, make]
+    apk:  [build-base, g++]
+    brew: [gcc]
+  clang:
+    apt:  [clang]
+    dnf:  [clang]
+    yum:  [clang]
+    tdnf: [clang]
+    apk:  [clang18, clang18-libclang]
+    brew: [llvm]
+  make:
+    apt:  [make]
+    dnf:  [make]
+    yum:  [make]
+    tdnf: [make]
+    apk:  [make]
+    brew: [make]
+  gdb:
+    apt:  [gdb]
+    dnf:  [gdb]
+    yum:  [gdb]
+    tdnf: [gdb]
+    apk:  [gdb]
+    brew: skip
+  cmake:
+    apt:  [cmake]
+    dnf:  [cmake]
+    yum:  [cmake]
+    tdnf: [cmake]
+    apk:  [cmake]
+    brew: [cmake]
+  autoconf:
+    apt:  [autoconf]
+    dnf:  [autoconf]
+    yum:  [autoconf]
+    tdnf: [autoconf]
+    apk:  [autoconf]
+    brew: [autoconf]
+  automake:
+    apt:  [automake]
+    dnf:  [automake]
+    yum:  [automake]
+    tdnf: [automake]
+    apk:  [automake]
+    brew: [automake]
+  libtool:
+    apt:  [libtool]
+    dnf:  [libtool]
+    yum:  [libtool]
+    tdnf: [libtool]
+    apk:  [libtool]
+    brew: [libtool]
+
+  # ---- libraries ---------------------------------------------------------
+  openssl_dev:
+    apt:  [openssl, libssl-dev]
+    dnf:  [openssl, openssl-devel]
+    yum:  [openssl, openssl-devel]
+    tdnf: [openssl, openssl-devel]
+    apk:  [openssl, openssl-dev]
+    brew: [openssl@3]
+  zlib_dev:
+    apt:  [zlib1g-dev]
+    dnf:  [zlib-devel]
+    yum:  [zlib-devel]
+    tdnf: [zlib-devel]
+    apk:  [zlib-dev]
+    brew: [zlib]
+  bzip2_dev:
+    apt:  [libbz2-dev]
+    dnf:  [bzip2-devel]
+    yum:  [bzip2-devel]
+    tdnf: [bzip2-devel]
+    apk:  [bzip2-dev]
+    brew: [bzip2]
+  libffi_dev:
+    apt:  [libffi-dev]
+    dnf:  [libffi-devel]
+    yum:  [libffi-devel]
+    tdnf: [libffi-devel]
+    apk:  [libffi-dev]
+    brew: [libffi]
+  libclang_dev:
+    apt:  [libclang-dev]
+    dnf:  [clang-devel]
+    yum:  [clang-devel]
+    tdnf: [clang-devel]
+    apk:  [clang18-libclang]
+    brew: [llvm]
+  blocksruntime_dev:
+    apt:  [libblocksruntime-dev]
+    dnf:  []   # not packaged on RHEL-likes; clang -fblocks works without it
+    yum:  []
+    tdnf: []
+    apk:  []
+    brew: []
+  readline_dev:
+    # Only Azure Linux 3's Python build setup currently asks for it; cheap
+    # extra elsewhere if it's available.
+    apt:  []
+    dnf:  []
+    yum:  []
+    tdnf: [readline-devel]
+    apk:  []
+    brew: skip
+
+  # ---- Python ------------------------------------------------------------
+  python3:
+    apt:  [python3, python3-pip, python3-venv, python3-dev]
+    dnf:  [python3, python3-pip, python3-devel]
+    yum:  [python3, python3-pip, python3-devel]
+    tdnf: [python3, python3-pip, python3-devel]
+    apk:  [python3, python3-dev, py3-pip, py-virtualenv]
+    brew: [python@3.11]
+
+  # ---- networking / misc tools ------------------------------------------
+  git:
+    apt:  [git]
+    dnf:  [git]
+    yum:  [git]
+    tdnf: [git]
+    apk:  [git]
+    brew: [git]
+  curl:
+    apt:  [curl, ca-certificates]
+    dnf:  [curl, ca-certificates]
+    yum:  [curl, ca-certificates]
+    tdnf: [curl, ca-certificates]
+    apk:  [curl, ca-certificates]
+    brew: [curl]
+  wget:
+    apt:  [wget]
+    dnf:  [wget]
+    yum:  [wget]
+    tdnf: [wget]
+    apk:  [wget]
+    brew: [wget]
+  jq:
+    apt:  [jq]
+    dnf:  [jq]
+    yum:  [jq]
+    tdnf: [jq]
+    apk:  [jq]
+    brew: [jq]
+  tar:
+    apt:  [tar]
+    dnf:  [tar]
+    yum:  [tar]
+    tdnf: [tar]
+    apk:  [tar]
+    brew: skip
+  unzip:
+    apt:  [unzip]
+    dnf:  [unzip]
+    yum:  [unzip]
+    tdnf: [unzip]
+    apk:  [unzip]
+    brew: skip
+  rsync:
+    apt:  [rsync]
+    dnf:  [rsync]
+    yum:  [rsync]
+    tdnf: [rsync]
+    apk:  [rsync]
+    brew: [rsync]
+  which:
+    apt:  []   # debianutils ships /usr/bin/which by default
+    dnf:  [which]
+    yum:  [which]
+    tdnf: [which]
+    apk:  []   # busybox provides `which`
+    brew: skip
+
+  # ---- testing / coverage ------------------------------------------------
+  valgrind:
+    apt:  [valgrind]
+    dnf:  [valgrind]
+    yum:  [valgrind]
+    tdnf: [valgrind]
+    apk:  []
+    brew: skip
+  lcov:
+    # lcov isn't packaged on RHEL10/AlmaLinux10/RockyLinux10 base repos and we
+    # don't want to require EPEL just for coverage. Drop it on dnf/yum/tdnf;
+    # CI lanes that actually need lcov can install it explicitly.
+    apt:  [lcov]
+    dnf:  []
+    yum:  []
+    tdnf: []
+    apk:  [lcov]
+    brew: [lcov]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -44,6 +44,7 @@ system:
   - lcov
   - blocksruntime_dev
   - readline_dev
+  - coreutils
 
 # Python requirement files to install via pip after system deps are present.
 # Paths are relative to the module src root.
@@ -79,6 +80,9 @@ migrated_osnicks:
   # Microsoft
   - mariner2     # CBL-Mariner 2  (tdnf)
   - azurelinux3  # Azure Linux 3  (tdnf)
+  # macOS (homebrew). Needs quirks/macos.sh for the PATH/profile updates the
+  # abstract installer can't express.
+  - macos
 
 # ----------------------------------------------------------------------------
 # Map of abstract dependency names to concrete packages per package manager.
@@ -88,20 +92,26 @@ migrated_osnicks:
 package_map:
   # ---- compilers / build essentials --------------------------------------
   gcc:
+    # macOS already ships Apple clang (/usr/bin/cc); installing GNU gcc via
+    # brew shadows nothing useful and breaks builds that hard-code cc.
     apt:  [build-essential]
     dnf:  [gcc, gcc-c++, make]
     yum:  [gcc, gcc-c++, make]
     tdnf: [build-essential, make]
     apk:  [build-base, g++]
-    brew: [gcc]
+    brew: skip
   clang:
+    # Pin to llvm@18 so PATH munging in quirks/macos.sh keeps finding
+    # $(brew --prefix)/opt/llvm@18/bin (matches the legacy macos.sh).
     apt:  [clang]
     dnf:  [clang]
     yum:  [clang]
     tdnf: [clang]
     apk:  [clang18, clang18-libclang]
-    brew: [llvm]
+    brew: [llvm@18]
   make:
+    # On macOS replaces BSD make with GNU make at
+    # $(brew --prefix)/opt/make/libexec/gnubin/make.
     apt:  [make]
     dnf:  [make]
     yum:  [make]
@@ -174,19 +184,25 @@ package_map:
     apk:  [libffi-dev]
     brew: [libffi]
   libclang_dev:
+    # llvm@18 (resolved by `clang` above) already ships libclang on macOS;
+    # don't install plain `llvm` too or brew installs two side-by-side LLVMs.
     apt:  [libclang-dev]
     dnf:  [clang-devel]
     yum:  [clang-devel]
     tdnf: [clang-devel]
     apk:  [clang18-libclang]
-    brew: [llvm]
+    brew: skip
   blocksruntime_dev:
+    # macOS: Apple clang ships BlocksRuntime + Block.h inside the Xcode SDK,
+    # so no brew formula is needed (and `libblocksruntime` doesn't exist in
+    # homebrew core anyway). The legacy .install/macos.sh tried to install it
+    # and silently failed.
     apt:  [libblocksruntime-dev]
     dnf:  []   # not packaged on RHEL-likes; clang -fblocks works without it
     yum:  []
     tdnf: []
     apk:  []
-    brew: []
+    brew: skip
   readline_dev:
     # Only Azure Linux 3's Python build setup currently asks for it; cheap
     # extra elsewhere if it's available.
@@ -196,6 +212,15 @@ package_map:
     tdnf: [readline-devel]
     apk:  []
     brew: skip
+  coreutils:
+    # macOS-only: GNU coreutils replacement so build scripts that expect
+    # gnu-flavoured ls/sed/etc. work. Linux ships these by default.
+    apt:  []
+    dnf:  []
+    yum:  []
+    tdnf: []
+    apk:  []
+    brew: [coreutils]
 
   # ---- Python ------------------------------------------------------------
   python3:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches build/install tooling across many OS Dockerfiles and introduces new YAML-driven package resolution plus OS-specific quirks, so CI and developer environment setup may break if mappings are incomplete. Runtime/module code is unaffected.
> 
> **Overview**
> **Unifies system dependency installation across platforms.** `install_script.sh` is refactored to detect `OSNICK`/package manager, read `dependencies.yaml`, resolve abstract deps to concrete packages, skip already-installed packages, and run optional `.install/quirks/<osnick>.sh` scripts; it retains a legacy fallback for non-migrated OSes.
> 
> **Adds a single source of truth for deps and migrates Docker images.** New `dependencies.yaml` defines the abstract dependency list, per-package-manager mappings, and the set of migrated OS nicks; most `Dockerfile.*` images now copy this YAML and invoke the unified installer instead of embedding long `apt/dnf/yum/apk/tdnf` install commands.
> 
> **Introduces OS-specific quirk installers and a new local setup target.** Adds quirk scripts for Alpine/Ubuntu/Alma/Rocky/AmazonLinux2/macOS to handle toolset upgrades, cmake-from-source, PATH/profile tweaks, and repo enablement; `Makefile` adds `setup` (defaults to `sudo` on Linux) and ensures `ARCH` is set even before Python/readies export it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b3f7b19f4729eef7ec7d079bbb504d65b2a79d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->