### PR TITLE
MOD-15105 make one generic getUser function

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -28,20 +28,6 @@ int (*RedisModule_DisablePostponeClients)(void);
                              "TSDB: current user doesn't have read permission to one or more "     \
                              "keys that match the specified filter")
 
-// Returns the current user of the context.
-static inline struct RedisModuleUser *GetCurrentUser(struct RedisModuleCtx *ctx) {
-    struct RedisModuleString *username = RedisModule_GetCurrentUserName(ctx);
-
-    if (!username) {
-        return NULL;
-    }
-
-    struct RedisModuleUser *user = RedisModule_GetModuleUserFromUserName(username);
-    RedisModule_FreeString(ctx, username);
-
-    return user;
-}
-
 static inline int stringEqualsC(const RedisModuleString *s1, const char *s2) {
     size_t len;
     const char *s1Str = RedisModule_StringPtrLen(s1, &len);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -445,6 +445,13 @@ RedisModuleDict *QueryIndex(RedisModuleCtx *ctx,
     size_t dicts_size = 0;
     GetPredicateKeysDicts(ctx, &index_predicate[0], &dicts, &dicts_size);
 
+    // Resolve the user once for the whole multi-dict scan so ACL checks
+    // below don't alloc/free a RedisModuleUser per candidate key.
+    User_Ctx_t userCtx = { .user = NULL, .is_owned = false };
+    if (hasPermissionError) {
+        userCtx = GetUserFromContext(ctx);
+    }
+
     for (size_t i = 0; i < dicts_size; i++) {
         RedisModuleDict *dict = dicts[i];
         if (dict == NULL) {
@@ -456,7 +463,7 @@ RedisModuleDict *QueryIndex(RedisModuleCtx *ctx,
         size_t currentKeyLen = 0;
         while ((currentKey = RedisModule_DictNextC(iter, &currentKeyLen, NULL)) != NULL) {
             if (hasPermissionError) {
-                if (!CheckKeyIsAllowedToReadC(ctx, currentKey, currentKeyLen)) {
+                if (!CheckKeyIsAllowedToReadC(ctx, userCtx.user, currentKey, currentKeyLen)) {
                     *hasPermissionError = true;
                     continue;
                 }
@@ -469,6 +476,7 @@ RedisModuleDict *QueryIndex(RedisModuleCtx *ctx,
         RedisModule_DictIteratorStop(iter);
     }
 
+    FreeUser(&userCtx);
     free(dicts);
 
     if (unlikely(isReshardTrimming || isAsmTrimming || isAsmImporting)) {

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -436,7 +436,8 @@ Record *ListWithSeriesLastDatapoint(const Series *series, bool latest, bool resp
     }
 }
 
-void FreeContextUser(RedisModuleCtx *ctx) {
+
+static void ReleaseCtxUser(RedisModuleCtx *ctx) {
     if (!API_USER_CONTEXT_SUPPORTED)
         return;
     RedisModuleUser *user = (RedisModuleUser *)RedisModule_GetContextUser(ctx);
@@ -450,6 +451,7 @@ void FreeContextUser(RedisModuleCtx *ctx) {
 // already has the same user set, to avoid redundant alloc+free cycles.
 static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
     RedisModuleString *currentName = NULL;
+    User_Ctx_t currentUserCtx = { .user = NULL, .is_owned = false };
     if (!API_USER_CONTEXT_SUPPORTED)
         return;
 
@@ -459,14 +461,14 @@ static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
     RedisModule_StringPtrLen(userName, &len);
     RedisModule_Assert(len > 0);
 
-    // Check if the requested user is already set on the context
-    const RedisModuleUser *currentUser = GetUserFromContext(ctx);
-    if (currentUser) {
-        currentName = RedisModule_GetUserUsername(ctx, currentUser);
+    // Check if the requested user is already set on the context.
+    currentUserCtx = GetUserFromContext(ctx);
+    if (currentUserCtx.user) {
+        currentName = RedisModule_GetUserUsername(ctx, currentUserCtx.user);
         if (currentName && RedisModule_StringCompare(currentName, userName) == 0) {
             goto _cleanup;
         }
-        RedisModule_SetContextUser(ctx, NULL);
+        ReleaseCtxUser(ctx);
     }
 
     // Allocate and set the new user on the context
@@ -475,21 +477,9 @@ static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
         RedisModule_SetContextUser(ctx, user);
     }
 _cleanup:
-if(currentUser){
-    RedisModule_FreeModuleUser((RedisModuleUser *)currentUser);
-}
-if(currentName){
-    RedisModule_FreeString(ctx, currentName);
-}
-}
-
-static void ReleaseCtxUser(RedisModuleCtx *ctx) {
-    if (!API_USER_CONTEXT_SUPPORTED)
-        return;
-    RedisModuleUser *user = (RedisModuleUser *)RedisModule_GetContextUser(ctx);
-    if (user) {
-        RedisModule_FreeModuleUser(user);
-        RedisModule_SetContextUser(ctx, NULL);
+    FreeUser(&currentUserCtx);
+    if (currentName) {
+        RedisModule_FreeString(ctx, currentName);
     }
 }
 

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -455,7 +455,7 @@ static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
     RedisModule_Assert(len > 0);
 
     // Check if the requested user is already set on the context
-    const RedisModuleUser *currentUser = RedisModule_GetContextUser(ctx);
+    const RedisModuleUser *currentUser = GetUserFromContext(ctx);
     if (currentUser) {
         RedisModuleString *currentName = RedisModule_GetUserUsername(ctx, currentUser);
         if (currentName) {

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -436,7 +436,6 @@ Record *ListWithSeriesLastDatapoint(const Series *series, bool latest, bool resp
     }
 }
 
-
 static void ReleaseCtxUser(RedisModuleCtx *ctx) {
     if (!API_USER_CONTEXT_SUPPORTED)
         return;

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -19,12 +19,6 @@
 
 #define SeriesRecordName "SeriesRecord"
 
-/* All four must be present: Apply sets user from name; Release reads and clears via the same API
- * set. */
-#define API_USER_CONTEXT_SUPPORTED                                                                 \
-    (RedisModule_SetContextUser && RedisModule_GetContextUser &&                                   \
-     RedisModule_GetModuleUserFromUserName && RedisModule_GetUserUsername)
-
 static Record NullRecord;
 static MRRecordType *NullRecordType = NULL;
 static MRRecordType *StringRecordType = NULL;

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -436,9 +436,20 @@ Record *ListWithSeriesLastDatapoint(const Series *series, bool latest, bool resp
     }
 }
 
+void FreeContextUser(RedisModuleCtx *ctx) {
+    if (!API_USER_CONTEXT_SUPPORTED)
+        return;
+    RedisModuleUser *user = (RedisModuleUser *)RedisModule_GetContextUser(ctx);
+    if (user) {
+        RedisModule_FreeModuleUser(user);
+        RedisModule_SetContextUser(ctx, NULL);
+    }
+}
+
 // Set the context user for ACL checks. Skips allocation if the context
 // already has the same user set, to avoid redundant alloc+free cycles.
 static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
+    RedisModuleString *currentName = NULL;
     if (!API_USER_CONTEXT_SUPPORTED)
         return;
 
@@ -451,15 +462,10 @@ static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
     // Check if the requested user is already set on the context
     const RedisModuleUser *currentUser = GetUserFromContext(ctx);
     if (currentUser) {
-        RedisModuleString *currentName = RedisModule_GetUserUsername(ctx, currentUser);
-        if (currentName) {
-            const int cmp = RedisModule_StringCompare(currentName, userName);
-            RedisModule_FreeString(ctx, currentName);
-            if (cmp == 0) {
-                return; // Same user already set, nothing to do
-            }
+        currentName = RedisModule_GetUserUsername(ctx, currentUser);
+        if (currentName && RedisModule_StringCompare(currentName, userName) == 0) {
+            goto _cleanup;
         }
-        RedisModule_FreeModuleUser((RedisModuleUser *)currentUser);
         RedisModule_SetContextUser(ctx, NULL);
     }
 
@@ -468,6 +474,13 @@ static void ApplyCtxUser(RedisModuleCtx *ctx, RedisModuleString *userName) {
     if (user) {
         RedisModule_SetContextUser(ctx, user);
     }
+_cleanup:
+if(currentUser){
+    RedisModule_FreeModuleUser((RedisModuleUser *)currentUser);
+}
+if(currentName){
+    RedisModule_FreeString(ctx, currentName);
+}
 }
 
 static void ReleaseCtxUser(RedisModuleCtx *ctx) {

--- a/src/module.c
+++ b/src/module.c
@@ -122,13 +122,13 @@ static void FreeConfigAndStaticCtx(void) {
     }
 }
 
-RedisModuleString *GetUserFromContext(RedisModuleCtx *ctx) {
-    RedisModuleUser *user = NULL;
+RedisModuleUser *GetUserFromContext(RedisModuleCtx *ctx) {
+    const RedisModuleUser *ctxUser = NULL;
     RedisModuleString *userName = NULL;
     if (!API_USER_CONTEXT_SUPPORTED)
         return NULL;
-    user = RedisModule_GetContextUser(ctx);
-    userName = user ? RedisModule_GetUserUsername(user) : RedisModule_GetCurrentUserName(ctx);
+    ctxUser = RedisModule_GetContextUser(ctx);
+    userName = ctxUser ? RedisModule_GetUserUsername(ctxUser) : RedisModule_GetCurrentUserName(ctx);
     return RedisModule_GetModuleUserFromUserName(userName);
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -122,14 +122,32 @@ static void FreeConfigAndStaticCtx(void) {
     }
 }
 
-RedisModuleUser *GetUserFromContext(RedisModuleCtx *ctx) {
-    const RedisModuleUser *ctxUser = NULL;
-    RedisModuleString *userName = NULL;
+User_Ctx_t GetUserFromContext(RedisModuleCtx *ctx) {
+    const User_Ctx_t empty = { .user = NULL, .is_owned = false };
+
     if (!API_USER_CONTEXT_SUPPORTED)
-        return NULL;
-    ctxUser = RedisModule_GetContextUser(ctx);
-    userName = ctxUser ? RedisModule_GetUserUsername(ctxUser) : RedisModule_GetCurrentUserName(ctx);
-    return RedisModule_GetModuleUserFromUserName(userName);
+        return empty;
+
+    /* Fast path: ctx already has a user attached. Return it borrowed (is_owned=false): the ctx
+     * (or whoever attached it via SetContextUser) is responsible for its lifetime, so the caller
+     * MUST NOT free it. const is cast away to match the non-const RedisModuleUser* expected by
+     * the ACL/free APIs; this mirrors the existing pattern in libmr_integration.c. */
+    const RedisModuleUser *ctxUser = RedisModule_GetContextUser(ctx);
+    if (ctxUser) {
+        return (User_Ctx_t){ .user = (RedisModuleUser *)ctxUser, .is_owned = false };
+    }
+
+    /* Slow path: no user on the ctx. Look one up by current username. GetCurrentUserName returns
+     * a string registered on the ctx's auto-memory; we free it explicitly so it doesn't linger
+     * until the ctx is destroyed (effectively a slow leak on long-lived ctxs like rts_staticCtx).
+     * The resulting RedisModuleUser is freshly allocated and owned by the caller. */
+    RedisModuleString *userName = RedisModule_GetCurrentUserName(ctx);
+    if (!userName)
+        return empty;
+
+    RedisModuleUser *user = RedisModule_GetModuleUserFromUserName(userName);
+    RedisModule_FreeString(ctx, userName);
+    return (User_Ctx_t){ .user = user, .is_owned = (user != NULL) };
 }
 
 int TSDB_info(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {

--- a/src/module.c
+++ b/src/module.c
@@ -424,9 +424,8 @@ GetSeriesResult CheckDictSeriesPermissions(RedisModuleCtx *ctx,
 
     while ((currentKey = RedisModule_DictNext(ctx, iter, NULL)) != NULL) {
         if (checkAcls && !CheckKeyIsAllowedToRead(userCtx.user, currentKey)) {
-            RedisModule_Log(ctx,
-                            "warning",
-                            "The user lacks the required permissions for the key, stopping.");
+            RedisModule_Log(
+                ctx, "warning", "The user lacks the required permissions for the key, stopping.");
             RedisModule_FreeString(ctx, currentKey);
             ret = GetSeriesResult_PermissionError;
             break;

--- a/src/module.c
+++ b/src/module.c
@@ -407,33 +407,42 @@ exit:
 GetSeriesResult CheckDictSeriesPermissions(RedisModuleCtx *ctx,
                                            RedisModuleDict *dict,
                                            const GetSeriesFlags flags) {
+    // Resolve the user once for the whole dict scan; ACL is checked inline
+    // per key below so GetSeries is called without CheckForAcls and doesn't
+    // re-resolve the user per key.
+    const bool checkAcls = flags & GetSeriesFlags_CheckForAcls;
+    User_Ctx_t userCtx = { .user = NULL, .is_owned = false };
+    if (checkAcls) {
+        userCtx = GetUserFromContext(ctx);
+    }
+    const GetSeriesFlags childFlags = flags & ~GetSeriesFlags_CheckForAcls;
+
     RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(dict, "^", NULL, 0);
     RedisModuleString *currentKey;
     Series *series;
+    GetSeriesResult ret = GetSeriesResult_Success;
 
     while ((currentKey = RedisModule_DictNext(ctx, iter, NULL)) != NULL) {
+        if (checkAcls && !CheckKeyIsAllowedToRead(userCtx.user, currentKey)) {
+            RedisModule_Log(ctx,
+                            "warning",
+                            "The user lacks the required permissions for the key, stopping.");
+            RedisModule_FreeString(ctx, currentKey);
+            ret = GetSeriesResult_PermissionError;
+            break;
+        }
         RedisModuleKey *key;
         const GetSeriesResult status =
-            GetSeries(ctx, currentKey, &key, &series, REDISMODULE_READ, flags);
+            GetSeries(ctx, currentKey, &key, &series, REDISMODULE_READ, childFlags);
         RedisModule_FreeString(ctx, currentKey);
-
-        switch (status) {
-            case GetSeriesResult_Success:
-                RedisModule_CloseKey(key);
-                break;
-            case GetSeriesResult_GenericError:
-                break;
-            case GetSeriesResult_PermissionError:
-                RedisModule_Log(ctx,
-                                "warning",
-                                "The user lacks the required permissions for the key, stopping.");
-                RedisModule_DictIteratorStop(iter);
-                return GetSeriesResult_PermissionError;
+        if (status == GetSeriesResult_Success) {
+            RedisModule_CloseKey(key);
         }
     }
 
     RedisModule_DictIteratorStop(iter);
-    return GetSeriesResult_Success;
+    FreeUser(&userCtx);
+    return ret;
 }
 
 int replyUngroupedMultiRange(RedisModuleCtx *ctx, RedisModuleDict *result, const MRangeArgs *args) {

--- a/src/module.c
+++ b/src/module.c
@@ -122,6 +122,16 @@ static void FreeConfigAndStaticCtx(void) {
     }
 }
 
+RedisModuleString *GetUserFromContext(RedisModuleCtx *ctx) {
+    RedisModuleUser *user = NULL;
+    RedisModuleString *userName = NULL;
+    if (!API_USER_CONTEXT_SUPPORTED)
+        return NULL;
+    user = RedisModule_GetContextUser(ctx);
+    userName = user ? RedisModule_GetUserUsername(user) : RedisModule_GetCurrentUserName(ctx);
+    return RedisModule_GetModuleUserFromUserName(userName);
+}
+
 int TSDB_info(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_AutoMemory(ctx);
 

--- a/src/module.h
+++ b/src/module.h
@@ -24,7 +24,30 @@
     (RedisModule_SetContextUser && RedisModule_GetContextUser &&                                   \
      RedisModule_GetModuleUserFromUserName && RedisModule_GetUserUsername)
 
-RedisModuleUser *GetUserFromContext(RedisModuleCtx *ctx);
+/* Thin wrapper around RedisModuleUser*. `is_owned` tells the caller whether the user must be
+ * released with RedisModule_FreeModuleUser when done:
+ *   - is_owned == true  : the user was freshly allocated for this call; caller must release.
+ *   - is_owned == false : borrowed reference (e.g. attached to the ctx); caller MUST NOT release.
+ * Always release via FreeUser(), which makes the decision based on the flag. */
+typedef struct {
+    RedisModuleUser *user;
+    bool is_owned;
+} User_Ctx_t;
+
+User_Ctx_t GetUserFromContext(RedisModuleCtx *ctx);
+
+/* Release a User_Ctx_t. Frees the underlying RedisModuleUser iff the wrapper actually owns it
+ * (i.e. user != NULL && is_owned). Always clears the wrapper to a safe empty state afterwards,
+ * making double-FreeUser calls a no-op. */
+static inline void FreeUser(User_Ctx_t *userCtx) {
+    if (userCtx == NULL)
+        return;
+    if (userCtx->user != NULL && userCtx->is_owned) {
+        RedisModule_FreeModuleUser(userCtx->user);
+    }
+    userCtx->user = NULL;
+    userCtx->is_owned = false;
+}
 
 static inline bool is_nan_string(const char *str, size_t len) {
     if (len == 3 && strncasecmp(str, "nan", 3) == 0) {
@@ -73,13 +96,12 @@ static inline bool CheckKeyIsAllowedByAcls(RedisModuleCtx *ctx,
                                            RedisModuleString *keyName,
                                            const int permissionFlags) {
     bool allowed = true;
-    RedisModuleUser *user = NULL;
     if (ctx != NULL) {
-        if ((user = GetUserFromContext(ctx)) != NULL) {
-            allowed = RedisModule_ACLCheckKeyPermissions(user, keyName, permissionFlags) ==
-                      REDISMODULE_OK;
-
-            RedisModule_FreeModuleUser(user);
+        User_Ctx_t userCtx = GetUserFromContext(ctx);
+        if (userCtx.user) {
+            allowed = RedisModule_ACLCheckKeyPermissions(
+                          userCtx.user, keyName, permissionFlags) == REDISMODULE_OK;
+            FreeUser(&userCtx);
         }
     }
 
@@ -153,15 +175,15 @@ static inline bool IsUserAllowedToReadAllTheKeys(struct RedisModuleCtx *ctx,
 }
 
 static inline bool IsCurrentUserAllowedToReadAllTheKeys(struct RedisModuleCtx *ctx) {
-    struct RedisModuleUser *user = GetCurrentUser(ctx);
+    User_Ctx_t userCtx = GetUserFromContext(ctx);
 
-    if (!user) {
+    if (!userCtx.user) {
         return false;
     }
 
-    const bool ret = IsUserAllowedToReadAllTheKeys(ctx, user);
+    const bool ret = IsUserAllowedToReadAllTheKeys(ctx, userCtx.user);
 
-    RedisModule_FreeModuleUser(user);
+    FreeUser(&userCtx);
 
     return ret;
 }

--- a/src/module.h
+++ b/src/module.h
@@ -18,8 +18,11 @@
 
 #include "fast_double_parser_c/fast_double_parser_c.h"
 
-/* All four must be present: Apply sets user from name; Release reads and clears via the same API
- * set. */
+/* A RedisModuleCtx carries the connection's authenticated "client user" plus an
+ * optional "attached user" set by the module: SetContextUser attaches one,
+ * GetContextUser reads it back (borrowed), GetModuleUserFromUserName allocates
+ * one by name (owned), GetUserUsername returns a user's name. GetUserFromContext()
+ * below picks the attached user if present, else allocates the client user. */
 #define API_USER_CONTEXT_SUPPORTED                                                                 \
     (RedisModule_SetContextUser && RedisModule_GetContextUser &&                                   \
      RedisModule_GetModuleUserFromUserName && RedisModule_GetUserUsername)
@@ -87,74 +90,74 @@ static inline bool parse_double(const RedisModuleString *valueStr, double *outVa
     return parse_double_cstr(valueCStr, len, outValue);
 }
 
-/// @brief Check if the key is allowed by the ACLs for the current user.
-/// @param ctx The redis module context.
+/// @brief Check if the key is allowed by the ACLs for the given user.
+/// @param user The user to check against. Callers should hoist
+///             GetUserFromContext() once per request and pass userCtx.user
+///             here so multi-key loops don't pay per-key alloc/free.
+///             user==NULL means "no user resolvable" and default-allows.
 /// @param keyName The name of the key to check the ACLs for.
 /// @param permissionFlags The permissions to check for.
 /// @return true if the key is allowed by the ACLs, false otherwise.
-static inline bool CheckKeyIsAllowedByAcls(RedisModuleCtx *ctx,
+static inline bool CheckKeyIsAllowedByAcls(RedisModuleUser *user,
                                            RedisModuleString *keyName,
                                            const int permissionFlags) {
-    bool allowed = true;
-    if (ctx != NULL) {
-        User_Ctx_t userCtx = GetUserFromContext(ctx);
-        if (userCtx.user) {
-            allowed = RedisModule_ACLCheckKeyPermissions(
-                          userCtx.user, keyName, permissionFlags) == REDISMODULE_OK;
-            FreeUser(&userCtx);
-        }
+    if (user == NULL) {
+        return true;
     }
-
-    return allowed;
+    return RedisModule_ACLCheckKeyPermissions(user, keyName, permissionFlags) == REDISMODULE_OK;
 }
 
-/// @brief Check if the key is allowed by the ACLs for the current user.
-/// @param ctx The redis module context.
-/// @param keyName The name of the key to check the ACLs for (C String).
-/// @param permissionFlags The permissions to check for.
-/// @return true if the key is allowed by the ACLs, false otherwise.
+/// @brief Same as CheckKeyIsAllowedByAcls but with a C-string key. The
+///        RedisModuleString is allocated/freed internally; the user is
+///        taken as-is so loops can hoist it once.
 static inline bool CheckKeyIsAllowedByAclsC(RedisModuleCtx *ctx,
+                                            RedisModuleUser *user,
                                             const char *keyName,
                                             const size_t keyNameLength,
                                             const int permissionFlags) {
+    if (user == NULL) {
+        return true;
+    }
     RedisModuleString *key = RedisModule_CreateString(ctx, keyName, keyNameLength);
-    const bool isAllowed = CheckKeyIsAllowedByAcls(ctx, key, permissionFlags);
-
+    const bool isAllowed = CheckKeyIsAllowedByAcls(user, key, permissionFlags);
     RedisModule_FreeString(ctx, key);
-
     return isAllowed;
 }
 
-static inline bool CheckKeyIsAllowedToRead(RedisModuleCtx *ctx, RedisModuleString *keyName) {
-    return CheckKeyIsAllowedByAcls(ctx, keyName, REDISMODULE_CMD_KEY_ACCESS);
+static inline bool CheckKeyIsAllowedToRead(RedisModuleUser *user, RedisModuleString *keyName) {
+    return CheckKeyIsAllowedByAcls(user, keyName, REDISMODULE_CMD_KEY_ACCESS);
 }
 
 static inline bool CheckKeyIsAllowedToReadC(RedisModuleCtx *ctx,
+                                            RedisModuleUser *user,
                                             const char *keyName,
                                             const size_t keyNameLength) {
-    return CheckKeyIsAllowedByAclsC(ctx, keyName, keyNameLength, REDISMODULE_CMD_KEY_ACCESS);
+    return CheckKeyIsAllowedByAclsC(ctx, user, keyName, keyNameLength, REDISMODULE_CMD_KEY_ACCESS);
 }
 
-static inline bool CheckKeyIsAllowedToWrite(RedisModuleCtx *ctx, RedisModuleString *keyName) {
-    return CheckKeyIsAllowedByAcls(ctx, keyName, REDISMODULE_CMD_KEY_UPDATE);
+static inline bool CheckKeyIsAllowedToWrite(RedisModuleUser *user, RedisModuleString *keyName) {
+    return CheckKeyIsAllowedByAcls(user, keyName, REDISMODULE_CMD_KEY_UPDATE);
 }
 
 static inline bool CheckKeyIsAllowedToWriteC(RedisModuleCtx *ctx,
+                                             RedisModuleUser *user,
                                              const char *keyName,
                                              const size_t keyNameLength) {
-    return CheckKeyIsAllowedByAclsC(ctx, keyName, keyNameLength, REDISMODULE_CMD_KEY_UPDATE);
+    return CheckKeyIsAllowedByAclsC(ctx, user, keyName, keyNameLength, REDISMODULE_CMD_KEY_UPDATE);
 }
 
-static inline bool CheckKeyIsAllowedToReadWrite(RedisModuleCtx *ctx, RedisModuleString *keyName) {
+static inline bool CheckKeyIsAllowedToReadWrite(RedisModuleUser *user,
+                                                RedisModuleString *keyName) {
     return CheckKeyIsAllowedByAcls(
-        ctx, keyName, REDISMODULE_CMD_KEY_ACCESS | REDISMODULE_CMD_KEY_UPDATE);
+        user, keyName, REDISMODULE_CMD_KEY_ACCESS | REDISMODULE_CMD_KEY_UPDATE);
 }
 
 static inline bool CheckKeyIsAllowedToReadWriteC(RedisModuleCtx *ctx,
+                                                 RedisModuleUser *user,
                                                  const char *keyName,
                                                  const size_t keyNameLength) {
     return CheckKeyIsAllowedByAclsC(
-        ctx, keyName, keyNameLength, REDISMODULE_CMD_KEY_ACCESS | REDISMODULE_CMD_KEY_UPDATE);
+        ctx, user, keyName, keyNameLength, REDISMODULE_CMD_KEY_ACCESS | REDISMODULE_CMD_KEY_UPDATE);
 }
 
 // Returns true if the user is allowed to read all the keys.

--- a/src/module.h
+++ b/src/module.h
@@ -32,7 +32,8 @@
  *   - is_owned == true  : the user was freshly allocated for this call; caller must release.
  *   - is_owned == false : borrowed reference (e.g. attached to the ctx); caller MUST NOT release.
  * Always release via FreeUser(), which makes the decision based on the flag. */
-typedef struct {
+typedef struct
+{
     RedisModuleUser *user;
     bool is_owned;
 } User_Ctx_t;
@@ -146,8 +147,7 @@ static inline bool CheckKeyIsAllowedToWriteC(RedisModuleCtx *ctx,
     return CheckKeyIsAllowedByAclsC(ctx, user, keyName, keyNameLength, REDISMODULE_CMD_KEY_UPDATE);
 }
 
-static inline bool CheckKeyIsAllowedToReadWrite(RedisModuleUser *user,
-                                                RedisModuleString *keyName) {
+static inline bool CheckKeyIsAllowedToReadWrite(RedisModuleUser *user, RedisModuleString *keyName) {
     return CheckKeyIsAllowedByAcls(
         user, keyName, REDISMODULE_CMD_KEY_ACCESS | REDISMODULE_CMD_KEY_UPDATE);
 }

--- a/src/module.h
+++ b/src/module.h
@@ -18,6 +18,14 @@
 
 #include "fast_double_parser_c/fast_double_parser_c.h"
 
+/* All four must be present: Apply sets user from name; Release reads and clears via the same API
+ * set. */
+#define API_USER_CONTEXT_SUPPORTED                                                                 \
+    (RedisModule_SetContextUser && RedisModule_GetContextUser &&                                   \
+     RedisModule_GetModuleUserFromUserName && RedisModule_GetUserUsername)
+
+RedisModuleUser *GetUserFromContext(RedisModuleCtx *ctx);
+
 static inline bool is_nan_string(const char *str, size_t len) {
     if (len == 3 && strncasecmp(str, "nan", 3) == 0) {
         return true;
@@ -68,9 +76,8 @@ static inline bool CheckKeyIsAllowedByAcls(RedisModuleCtx *ctx,
     RedisModuleUser *user = NULL;
     if (ctx != NULL) {
         if ((user = GetUserFromContext(ctx)) != NULL) {
-            allowed = RedisModule_ACLCheckKeyPermissions((RedisModuleUser *)contextUser,
-                                                         keyName,
-                                                         permissionFlags) == REDISMODULE_OK;
+            allowed = RedisModule_ACLCheckKeyPermissions(user, keyName, permissionFlags) ==
+                      REDISMODULE_OK;
 
             RedisModule_FreeModuleUser(user);
         }
@@ -177,7 +184,6 @@ GetSeriesResult CheckDictSeriesPermissions(RedisModuleCtx *ctx,
                                            const GetSeriesFlags flags);
 
 int replyUngroupedMultiRange(RedisModuleCtx *ctx, RedisModuleDict *result, const MRangeArgs *args);
-RedisModuleString *GetUserFromContext(RedisModuleCtx *ctx);
 
 extern int persistence_in_progress;
 

--- a/src/module.h
+++ b/src/module.h
@@ -64,33 +64,19 @@ static inline bool parse_double(const RedisModuleString *valueStr, double *outVa
 static inline bool CheckKeyIsAllowedByAcls(RedisModuleCtx *ctx,
                                            RedisModuleString *keyName,
                                            const int permissionFlags) {
+    bool allowed = true;
+    RedisModuleUser *user = NULL;
     if (ctx != NULL) {
-        RedisModuleUser *user = GetCurrentUser(ctx);
+        if ((user = GetUserFromContext(ctx)) != NULL) {
+            allowed = RedisModule_ACLCheckKeyPermissions((RedisModuleUser *)contextUser,
+                                                         keyName,
+                                                         permissionFlags) == REDISMODULE_OK;
 
-        if (!user) {
-            const RedisModuleUser *contextUser =
-                RedisModule_GetContextUser ? RedisModule_GetContextUser(ctx) : NULL;
-            if (contextUser) {
-                return RedisModule_ACLCheckKeyPermissions((RedisModuleUser *)contextUser,
-                                                          keyName,
-                                                          permissionFlags) == REDISMODULE_OK;
-            }
-            return true;
+            RedisModule_FreeModuleUser(user);
         }
-
-        const int allowed = RedisModule_ACLCheckKeyPermissions(user, keyName, permissionFlags);
-
-        RedisModule_FreeModuleUser(user);
-
-        if (allowed != REDISMODULE_OK) {
-            return false;
-        }
-    } else {
-        RedisModule_Log(
-            NULL, "warning", "Can't check for the ACLs: redis module context is not set.");
     }
 
-    return true;
+    return allowed;
 }
 
 /// @brief Check if the key is allowed by the ACLs for the current user.
@@ -191,6 +177,7 @@ GetSeriesResult CheckDictSeriesPermissions(RedisModuleCtx *ctx,
                                            const GetSeriesFlags flags);
 
 int replyUngroupedMultiRange(RedisModuleCtx *ctx, RedisModuleDict *result, const MRangeArgs *args);
+RedisModuleString *GetUserFromContext(RedisModuleCtx *ctx);
 
 extern int persistence_in_progress;
 

--- a/src/module.h
+++ b/src/module.h
@@ -18,20 +18,19 @@
 
 #include "fast_double_parser_c/fast_double_parser_c.h"
 
-/* A RedisModuleCtx carries the connection's authenticated "client user" plus an
- * optional "attached user" set by the module: SetContextUser attaches one,
- * GetContextUser reads it back (borrowed), GetModuleUserFromUserName allocates
- * one by name (owned), GetUserUsername returns a user's name. GetUserFromContext()
- * below picks the attached user if present, else allocates the client user. */
+/* A RedisModuleCtx has a client user plus an optional attached user; when set,
+ * the attached user shadows the client for ACL on this ctx (used by libmr to
+ * run jobs under the originator's identity). SetContextUser attaches one;
+ * GetContextUser returns an internal pointer — caller MUST NOT free;
+ * GetModuleUserFromUserName allocates one — caller frees via FreeModuleUser;
+ * GetUserUsername returns a user's name. */
 #define API_USER_CONTEXT_SUPPORTED                                                                 \
     (RedisModule_SetContextUser && RedisModule_GetContextUser &&                                   \
      RedisModule_GetModuleUserFromUserName && RedisModule_GetUserUsername)
 
-/* Thin wrapper around RedisModuleUser*. `is_owned` tells the caller whether the user must be
- * released with RedisModule_FreeModuleUser when done:
- *   - is_owned == true  : the user was freshly allocated for this call; caller must release.
- *   - is_owned == false : borrowed reference (e.g. attached to the ctx); caller MUST NOT release.
- * Always release via FreeUser(), which makes the decision based on the flag. */
+/* RedisModuleUser* tagged with whether the caller owns it. If is_owned, the
+ * user was freshly allocated and must be freed; otherwise it's an internal ctx
+ * pointer and MUST NOT be freed. Always release via FreeUser(). */
 typedef struct
 {
     RedisModuleUser *user;
@@ -40,9 +39,8 @@ typedef struct
 
 User_Ctx_t GetUserFromContext(RedisModuleCtx *ctx);
 
-/* Release a User_Ctx_t. Frees the underlying RedisModuleUser iff the wrapper actually owns it
- * (i.e. user != NULL && is_owned). Always clears the wrapper to a safe empty state afterwards,
- * making double-FreeUser calls a no-op. */
+/* Release a User_Ctx_t: frees the underlying user only if owned, then clears
+ * the wrapper so double-FreeUser is a no-op. */
 static inline void FreeUser(User_Ctx_t *userCtx) {
     if (userCtx == NULL)
         return;
@@ -158,37 +156,6 @@ static inline bool CheckKeyIsAllowedToReadWriteC(RedisModuleCtx *ctx,
                                                  const size_t keyNameLength) {
     return CheckKeyIsAllowedByAclsC(
         ctx, user, keyName, keyNameLength, REDISMODULE_CMD_KEY_ACCESS | REDISMODULE_CMD_KEY_UPDATE);
-}
-
-// Returns true if the user is allowed to read all the keys.
-static inline bool IsUserAllowedToReadAllTheKeys(struct RedisModuleCtx *ctx,
-                                                 struct RedisModuleUser *user) {
-    struct RedisModuleString *prefix = RedisModule_CreateString(ctx, "*", 1);
-
-    if (!prefix) {
-        return false;
-    }
-
-    const bool ret = RedisModule_ACLCheckKeyPermissions(user, prefix, REDISMODULE_CMD_KEY_ACCESS) ==
-                     REDISMODULE_OK;
-
-    RedisModule_FreeString(ctx, prefix);
-
-    return ret;
-}
-
-static inline bool IsCurrentUserAllowedToReadAllTheKeys(struct RedisModuleCtx *ctx) {
-    User_Ctx_t userCtx = GetUserFromContext(ctx);
-
-    if (!userCtx.user) {
-        return false;
-    }
-
-    const bool ret = IsUserAllowedToReadAllTheKeys(ctx, userCtx.user);
-
-    FreeUser(&userCtx);
-
-    return ret;
 }
 
 extern RedisModuleType *SeriesType;

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -92,25 +92,31 @@ GetSeriesResult GetSeries(RedisModuleCtx *ctx,
     const char *currentKeyStr = RedisModule_StringPtrLen(keyName, &len);
 
     if (flags & GetSeriesFlags_CheckForAcls) {
-        if ((mode & REDISMODULE_READ) && !CheckKeyIsAllowedToRead(ctx, keyName)) {
+        // Resolve the user once for both Read and Write ACL checks below
+        // (previously each Check* call resolved + freed its own user).
+        User_Ctx_t userCtx = GetUserFromContext(ctx);
+
+        if ((mode & REDISMODULE_READ) && !CheckKeyIsAllowedToRead(userCtx.user, keyName)) {
+            FreeUser(&userCtx);
             if (!isSilent) {
                 RTS_ReplyPermissionError(ctx,
                                          "the current user doesn't have the read permission to "
                                          "one or more keys that match the specified filter");
             }
-
             return GetSeriesResult_PermissionError;
         }
 
-        if ((mode & REDISMODULE_WRITE) && !CheckKeyIsAllowedToWrite(ctx, keyName)) {
+        if ((mode & REDISMODULE_WRITE) && !CheckKeyIsAllowedToWrite(userCtx.user, keyName)) {
+            FreeUser(&userCtx);
             if (!isSilent) {
                 RTS_ReplyPermissionError(ctx,
                                          "the current user doesn't have the write permission "
                                          "to one or more keys that match the specified filter");
             }
-
             return GetSeriesResult_PermissionError;
         }
+
+        FreeUser(&userCtx);
     }
 
     RedisModuleKey *new_key = RedisModule_OpenKey(ctx, keyName, mode);

--- a/tests/flow/test_acls.py
+++ b/tests/flow/test_acls.py
@@ -316,9 +316,9 @@ def test_mrange_acl_partial_then_full_3shards(env):
     set_user_on_shard(conns[SHARD_1], user4, pw4, [NO_MATCH_KEY_PATTERN])
     set_user_on_shard(conns[SHARD_2], user4, pw4, [KEY_PATTERN_ALL])
 
-    # Run MRANGE using a connection where the user has full key access (~*), so
-    # IsCurrentUserAllowedToReadAllTheKeys passes on that connection's shard; stricter rules
-    # only apply on other shards (which then return empty).
+    # Run MRANGE using a connection where the user has full key access (~*), so the
+    # per-key ACL check passes on that connection's shard; stricter rules only apply
+    # on other shards (which then return empty).
     def run_mrange(connection, username, password):
         connection.execute_command('AUTH', username, password)
         try:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches ACL enforcement paths for multi-key reads and libmr context-user handling; mistakes could cause incorrect permission allow/deny behavior or user lifetime issues.
> 
> **Overview**
> Centralizes Redis ACL user resolution into a new `GetUserFromContext()`/`User_Ctx_t` API and updates key-permission helpers to accept a `RedisModuleUser*` instead of repeatedly resolving/freeing users.
> 
> Multi-key scans (`QueryIndex`, `CheckDictSeriesPermissions`, and `GetSeries` ACL checks) now hoist user lookup once per operation and reuse it across per-key ACL checks, reducing alloc/free churn and explicitly freeing username strings to avoid lingering auto-memory on long-lived contexts.
> 
> `libmr_integration.c` updates context-user apply/release logic to reuse the centralized user lookup and avoid redundant context user swaps; ACL-related test commentary is adjusted to reflect the new per-key checking approach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d15953ff94f03dcfe0f26b28050b1b44b9a5e749. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->