### PR TITLE
MOD-15020 - fix bionic image installation by pulling gcc 8 from ununtu

### DIFF
--- a/.install/ubuntu_18.04.sh
+++ b/.install/ubuntu_18.04.sh
@@ -6,10 +6,11 @@ MODE=$1 # whether to install using sudo or not
 $MODE apt update -qq
 $MODE apt upgrade -yqq
 
-add-apt-repository ppa:ubuntu-toolchain-r/test -y
-apt update
-apt-get install -y build-essential make autoconf automake libtool lcov git wget zlib1g-dev lsb-release libssl-dev openssl ca-certificates curl unzip gcc-10 g++-10 binfmt-support lsb-core awscli libclang-dev clang libffi-dev jq
-update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+$MODE apt-get install -yqq software-properties-common
+$MODE add-apt-repository universe -y
+$MODE apt update
+$MODE apt-get install -y build-essential make autoconf automake libtool lcov git wget zlib1g-dev lsb-release libssl-dev openssl ca-certificates curl unzip gcc-8 g++-8 binfmt-support lsb-core awscli libclang-dev clang libffi-dev jq
+$MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 --slave /usr/bin/g++ g++ /usr/bin/g++-8
 
 wget https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz
 tar -xzvf cmake-3.28.0.tar.gz

--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -12,11 +12,11 @@ RUN apt update -qq \
     && apt upgrade -yqq \
     && apt dist-upgrade -yqq \
     && apt install -yqq software-properties-common unzip rsync \
-    && add-apt-repository ppa:ubuntu-toolchain-r/test -y \
+    && add-apt-repository universe -y \
     && apt update \
-    && apt install -yqq build-essential wget curl make gcc-10 g++-10 openssl libssl-dev cargo binfmt-support \
+    && apt install -yqq build-essential wget curl make gcc-8 g++-8 openssl libssl-dev cargo binfmt-support \
     lsb-core libclang-dev clang zlib1g-dev jq automake libtool git \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 --slave /usr/bin/g++ g++ /usr/bin/g++-8
 
 RUN wget https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz \
     && tar -xzvf cmake-3.28.0.tar.gz \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Build environment changes in the Ubuntu 18.04 installer and Docker image (compiler toolchain and apt repos) could affect native compilation results and dependency compatibility.
> 
> **Overview**
> Updates the Ubuntu 18.04 install script and `Dockerfile.bionic` to stop using the `ubuntu-toolchain-r/test` PPA and instead enable the `universe` repository.
> 
> Switches the toolchain from `gcc-10/g++-10` to `gcc-8/g++-8` and updates `update-alternatives` accordingly, adding `software-properties-common` where needed to manage apt repositories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66b3731abd4fc762e4f904879f56d996f7f73b03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->