### PR TITLE
ci: skip Event CI when PR only changes src/version.h

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -6,6 +6,8 @@ permissions:
 
 on:
   pull_request:
+    paths-ignore:
+      - 'src/version.h'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Adds `paths-ignore` for `src/version.h` on the Event CI `pull_request` trigger.

GitHub skips the workflow only when **all** changed files match ignored paths, so mixed PRs still run CI normally.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a GitHub Actions trigger tweak that only affects when the `Event CI` workflow runs, with no impact on build/test logic itself.
> 
> **Overview**
> Updates the `Event CI` GitHub Actions workflow to ignore PRs that only modify `src/version.h` by adding a `pull_request.paths-ignore` rule, reducing unnecessary CI runs while keeping CI enabled for mixed-file changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9ccc73beb5acd2664113b92c8143d1322edca9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->