### PR TITLE
[8.8] Cherry-pick: skip Event CI for src/version.h-only PRs (#1984)

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -6,6 +6,8 @@ permissions:
 
 on:
   pull_request:
+    paths-ignore:
+      - 'src/version.h'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Cherry-pick of #1984 from `master`: skip Event CI when a PR only changes `src/version.h` (paths-ignore).

Upstream commit: `2c371e15`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just prevents `Event CI` from running when a PR only touches `src/version.h`; main risk is reduced CI coverage if other relevant changes are bundled into that file.
> 
> **Overview**
> Updates the `Event CI` GitHub Actions workflow to ignore pull requests that only change `src/version.h` by adding `paths-ignore` under the `pull_request` trigger, reducing unnecessary CI runs for version-bump-only PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 182746581407b894b4dedfa6dd42c050ec732242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->