### PR TITLE
[8.6] Cherry-pick: skip Event CI for src/version.h-only PRs (#1984)

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -6,6 +6,8 @@ permissions:
 
 on:
   pull_request:
+    paths-ignore:
+      - 'src/version.h'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Cherry-pick of #1984 from `master`: skip Event CI when a PR only changes `src/version.h` (paths-ignore).

Upstream commit: `2c371e15`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow change that only alters when the Event CI pipeline triggers; main risk is accidentally skipping CI for PRs that should have run when `src/version.h` is modified alongside other files.
> 
> **Overview**
> Updates the `Event CI` GitHub Actions workflow to *not run on pull requests that only touch* `src/version.h` by adding `pull_request.paths-ignore` for that file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c390424701592d29579fc8f574ca0d125ce6d7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->