### PR TITLE
[8.4] Cherry-pick: skip Event CI for src/version.h-only PRs (#1984)

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -6,6 +6,8 @@ permissions:
 
 on:
   pull_request:
+    paths-ignore:
+      - 'src/version.h'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Cherry-pick of #1984 from `master`: skip Event CI when a PR only changes `src/version.h` (paths-ignore).

Upstream commit: `2c371e15`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts GitHub Actions trigger filtering and does not affect build logic or runtime code. The main risk is unintentionally skipping CI when `src/version.h` changes should have been validated alongside other files.
> 
> **Overview**
> Updates the `Event CI` GitHub Actions workflow to ignore pull requests that only modify `src/version.h` by adding `on.pull_request.paths-ignore` for that file, reducing unnecessary CI runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d92a69cb8adef3be0abad4482290113f7cb5036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->