### PR TITLE
[8.2] Cherry-pick: skip Event CI for src/version.h-only PRs (#1984)

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -7,6 +7,8 @@ permissions:
 
 on:
   pull_request:
+    paths-ignore:
+      - 'src/version.h'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Cherry-pick of #1984 from `master`: skip Event CI when a PR only changes `src/version.h` (paths-ignore).

Upstream commit: `2c371e15`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow tweak that only affects when the Event CI pipeline triggers on pull requests; the main risk is unintentionally skipping CI when `src/version.h` changes alongside other files if patterns are misinterpreted.
> 
> **Overview**
> Updates the `Event CI` GitHub Actions workflow to **not run on PRs that only modify** `src/version.h` by adding `pull_request.paths-ignore` for that file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34961ffee3d86d824480148fb1cbc74bfa3ae1c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->