### PR TITLE
[8.0] Cherry-pick: skip Event CI for src/version.h-only PRs (#1984)

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -7,6 +7,8 @@ permissions:
 
 on:
   pull_request:
+    paths-ignore:
+      - 'src/version.h'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Cherry-pick of #1984 from `master`: skip Event CI when a PR only changes `src/version.h` (paths-ignore).

Upstream commit: `2c371e15`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow change that only affects when the `Event CI` GitHub Actions workflow triggers; no product code is modified.
> 
> **Overview**
> Updates the `Event CI` GitHub Actions workflow to **not run on pull requests that only touch** `src/version.h` by adding `paths-ignore` under the `pull_request` trigger, reducing unnecessary CI runs for version-bump-only changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4247e5515f0f3f28e503c5f8ac2ea728f497f535. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->