### PR TITLE
[1.10] Cherry-pick: skip Event CI for src/version.h-only PRs (#1984)

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -7,6 +7,8 @@ permissions:
 
 on:
   pull_request:
+    paths-ignore:
+      - 'src/version.h'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Cherry-pick of #1984 from `master`: skip Event CI when a PR only changes `src/version.h` (paths-ignore).

Upstream commit: `2c371e15`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts the GitHub Actions trigger to avoid running CI on PRs that touch `src/version.h` alone, without changing build or test behavior otherwise.
> 
> **Overview**
> Updates the `Event CI` GitHub Actions workflow to **not trigger on pull requests that only modify** `src/version.h` by adding `paths-ignore` under `pull_request`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12c8b35c6c5a9de2146c72954c29f2c8b1e4e85a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->