### PR TITLE
MOD-15020 - remove bionic os support (#1983)

### DIFF
--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -18,7 +18,7 @@ runs:
         echo "name=$(echo "${{ inputs.image }} x86-64, Redis unstable" | \
           sed -e 's/[":\/\\<>\|*?]/_/g' -e 's/__*/_/g' -e 's/^_//' -e 's/_$//')" >> $GITHUB_OUTPUT
     - name: Upload test artifacts
-      if: inputs.image != 'amazonlinux:2' && inputs.image != 'ubuntu:bionic'
+      if: inputs.image != 'amazonlinux:2'
       uses: actions/upload-artifact@v4
       with:
         name: Test logs ${{ steps.artifact-names.outputs.name }}

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -97,7 +97,7 @@ jobs:
     needs: [prepare-values]
     with:
       arch: x64
-      os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie
+      os: focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       beta-version: ${{needs.prepare-values.outputs.beta-version}}
       quick: false
@@ -107,7 +107,7 @@ jobs:
     needs: [prepare-values]
     with:
       arch: arm64
-      os: bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2
+      os: focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       beta-version: ${{needs.prepare-values.outputs.beta-version}}
       quick: false

--- a/.github/workflows/event-tag.yml
+++ b/.github/workflows/event-tag.yml
@@ -33,7 +33,7 @@ jobs:
     needs: [prepare-values]
     with:
       arch: x64
-      os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie
+      os: focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
     secrets: inherit
   build-linux-arm64:
@@ -41,7 +41,7 @@ jobs:
     needs: [prepare-values]
     with:
       arch: arm64
-      os: bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2
+      os: focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
     secrets: inherit
   macos:

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -105,9 +105,9 @@ jobs:
           OS="${{ inputs.os }}"
           if [ -z "${OS}" ]; then
             if [ "${{ inputs.arch }}" == "arm64" ]; then
-              OS="bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2"
+              OS="focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2"
             else
-              OS="bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie"
+              OS="focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie"
             fi
           fi
           # Convert space-separated list to JSON array

--- a/.github/workflows/flow-random-traffic.yml
+++ b/.github/workflows/flow-random-traffic.yml
@@ -43,7 +43,7 @@ jobs:
             echo "os=${INPUT_OS}" >> $GITHUB_OUTPUT
             echo "Using specified OS: ${INPUT_OS}"
           else
-            OS_LIST=(bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie)
+            OS_LIST=(focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie)
             RANDOM_INDEX=$((RANDOM % ${#OS_LIST[@]}))
             SELECTED=${OS_LIST[$RANDOM_INDEX]}
             echo "os=${SELECTED}" >> $GITHUB_OUTPUT

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -74,7 +74,6 @@ if [[ -r /etc/os-release ]]; then
 fi
 [[ $OSNICK == trusty ]]  && OSNICK=ubuntu14.04
 [[ $OSNICK == xenial ]]  && OSNICK=ubuntu16.04
-[[ $OSNICK == bionic ]]  && OSNICK=ubuntu18.04
 [[ $OSNICK == focal ]]   && OSNICK=ubuntu20.04
 [[ $OSNICK == jammy ]]   && OSNICK=ubuntu22.04
 [[ $OSNICK == noble ]]   && OSNICK=ubuntu24.04

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -48,7 +48,6 @@ if [[ -r /etc/os-release ]]; then
 fi
 [[ $OSNICK == trusty ]]  && OSNICK=ubuntu14.04
 [[ $OSNICK == xenial ]]  && OSNICK=ubuntu16.04
-[[ $OSNICK == bionic ]]  && OSNICK=ubuntu18.04
 [[ $OSNICK == focal ]]   && OSNICK=ubuntu20.04
 [[ $OSNICK == jammy ]]   && OSNICK=ubuntu22.04
 [[ $OSNICK == noble ]]   && OSNICK=ubuntu24.04

--- a/tests/qa/adhoc.json
+++ b/tests/qa/adhoc.json
@@ -13,9 +13,9 @@
     "cycle_environments_setup": [
       {
         "teardown": true,
-        "name": "bionic-amd64-aws",
+        "name": "focal-amd64-aws",
         "concurrency": 1,
-        "module_url": "http://redismodules.s3.amazonaws.com/{{RS_MODULE_FILE_PREFIX}}/snapshots/{{RS_MODULE_FILE_PREFIX}}.Linux-ubuntu18.04-x86_64.{{MODULE_VERSION}}.zip"
+        "module_url": "http://redismodules.s3.amazonaws.com/{{RS_MODULE_FILE_PREFIX}}/snapshots/{{RS_MODULE_FILE_PREFIX}}.Linux-ubuntu20.04-x86_64.{{MODULE_VERSION}}.zip"
       }
     ]
   }

--- a/tests/qa/nightly.json
+++ b/tests/qa/nightly.json
@@ -13,9 +13,9 @@
     "cycle_environments_setup": [
       {
         "teardown": true,
-        "name": "bionic-amd64-aws",
+        "name": "focal-amd64-aws",
         "concurrency": 1,
-        "module_url": "http://redismodules.s3.amazonaws.com/{{RS_MODULE_FILE_PREFIX}}/snapshots/{{RS_MODULE_FILE_PREFIX}}.Linux-ubuntu18.04-x86_64.master.zip"
+        "module_url": "http://redismodules.s3.amazonaws.com/{{RS_MODULE_FILE_PREFIX}}/snapshots/{{RS_MODULE_FILE_PREFIX}}.Linux-ubuntu20.04-x86_64.master.zip"
       }
     ]
   }

--- a/tests/qa/qatests
+++ b/tests/qa/qatests
@@ -27,9 +27,13 @@ RLEC_PLATFORMS = {
     'xenial': { 
         'os':  'Linux-ubuntu16.04',
         'env': 'xenial-amd64-aws' },
+    # Legacy RS trains still list osnick 'bionic' below; required for lookup in run().
     'bionic': {
         'os': 'Linux-ubuntu18.04',
         'env': 'bionic-amd64-aws' },
+    'focal': {
+        'os': 'Linux-ubuntu20.04',
+        'env': 'focal-amd64-aws' },
     'centos7': {
         'os': 'Linux-rhel7',
         'env': 'rhel7.7-x86_64-aws' },
@@ -49,16 +53,20 @@ RLEC_PLATFORMS = {
 }
 
 RLEC_VER_ENVS = {
-    '6.0.8': ['xenial', 'bionic', 'centos7'],
-    '6.0.12': ['xenial', 'bionic', 'centos7'],
-    '6.0.20': ['xenial', 'bionic', 'centos7'],
-    '6.2.4': ['xenial', 'bionic', 'centos7'],
-    '6.2.8': ['xenial', 'bionic', 'centos7', 'rocky8'],
-    '6.2.10': ['xenial', 'bionic', 'centos7', 'rocky8'],
-    '6.2.12': ['xenial', 'bionic', 'centos7', 'rocky8'],
-    '6.2.18': ['xenial', 'bionic', 'centos7', 'rocky8'],
-    '100.0.0': ['xenial', 'bionic', 'centos7', 'rocky8'],
-    '100.0.21-26142': ['xenial', 'bionic', 'centos7', 'rocky8', 'rocky9', 'rocky9-arm']
+    # Older RS: keep legacy Ubuntu/RHEL OS nicks (incl. bionic); xenial/focal ages noted in reviews.
+    '6.0.8': ['xenial', 'bionic', 'focal', 'centos7'],
+    '6.0.12': ['xenial', 'bionic', 'focal', 'centos7'],
+    '6.0.20': ['xenial', 'bionic', 'focal', 'centos7'],
+    '6.2.4': ['xenial', 'bionic', 'focal', 'centos7'],
+    '6.2.8': ['xenial', 'bionic', 'focal', 'centos7', 'rocky8'],
+    '6.2.10': ['xenial', 'bionic', 'focal', 'centos7', 'rocky8'],
+    '6.2.12': ['xenial', 'bionic', 'focal', 'centos7', 'rocky8'],
+    '6.2.18': ['xenial', 'bionic', 'focal', 'centos7', 'rocky8'],
+    '6.4.0': ['xenial', 'bionic', 'focal', 'centos7', 'rocky8'],
+    '6.4.2': ['xenial', 'bionic', 'focal', 'centos7', 'rocky8'],
+    # Tip / modern RS: no bionic (rlecver_base is major.minor.patch before first '-').
+    '100.0.0': ['xenial', 'focal', 'centos7', 'rocky8'],
+    '100.0.21': ['xenial', 'focal', 'centos7', 'rocky8', 'rocky9', 'rocky9-arm'],
 }
 
 class Command1(click.Command):
@@ -116,9 +124,9 @@ class Test:
         else:
             mod_sem_ver = modver
             try:
-                bionic_os = RLEC_PLATFORMS['bionic']['os']
-                mod_url_bionic = f"http://redismodules.s3.amazonaws.com/{mod_dir}/{mod_prefix}.{bionic_os}.{modver}.zip"
-                mod_zip = paella.wget(mod_url_bionic, tempdir=True)
+                probe_os = RLEC_PLATFORMS['focal']['os']
+                mod_url_probe = f"http://redismodules.s3.amazonaws.com/{mod_dir}/{mod_prefix}.{probe_os}.{modver}.zip"
+                mod_zip = paella.wget(mod_url_probe, tempdir=True)
                 with ZipFile(mod_zip) as zip:
                     with zip.open('module.json') as jf:
                         j = json.loads(jf.read())
@@ -150,6 +158,8 @@ class Test:
         rlec_envs = ""
         if self.rlecver_base in RLEC_VER_ENVS:
             envs = RLEC_VER_ENVS[self.rlecver_base]
+        elif self.rlecver_base.startswith('8.8.'):
+            envs = ['xenial', 'focal', 'centos7', 'rocky8']
         else:
             envs = RLEC_PLATFORMS.keys()
         found_osnick = False

--- a/tests/qa/release.json
+++ b/tests/qa/release.json
@@ -20,12 +20,6 @@
       },
       {
         "teardown": true,
-        "name": "bionic-amd64-aws",
-        "concurrency": 1,
-        "module_url": "http://redismodules.s3.amazonaws.com/{{RS_MODULE_FILE_PREFIX}}/{{RS_MODULE_FILE_PREFIX}}.Linux-ubuntu18.04-x86_64.{{MODULE_VERSION}}.zip"
-      },
-      {
-        "teardown": true,
         "name": "rhel7.7-x86_64-aws",
         "concurrency": 1,
         "module_url": "http://redismodules.s3.amazonaws.com/{{RS_MODULE_FILE_PREFIX}}/{{RS_MODULE_FILE_PREFIX}}.Linux-rhel7-x86_64.{{MODULE_VERSION}}.zip"


### PR DESCRIPTION
* remove bionic os support

* remive bionic for 8.8 & master only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are confined to CI/packaging and QA configuration, but may reduce coverage or break legacy release-test assumptions if any pipelines still expect `bionic` artifacts/environments.
> 
> **Overview**
> Removes Ubuntu `bionic` (18.04) from GitHub Actions build matrices (nightly/tagged/linux flows and random-traffic) and stops special-casing it for artifact uploads.
> 
> Updates packaging/upload scripts and QA configs to prefer `focal` (20.04) artifacts/environments: drops `bionic` OS mapping in `sbin/pack.sh`/`sbin/upload-artifacts`, switches QA `adhoc`/`nightly` env+module URLs to `focal`, removes `bionic` from `release.json`, and adjusts `tests/qa/qatests` to add `focal`, probe semantic versions via `focal`, and avoid `bionic` for modern RS/`8.8.*` runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f310f9670f062054b582ea5c6b2b09c2b771dc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->