### PR TITLE
Cherry-pick: MOD-14420 fix count reducers return wrong NaN (#2013)

### DIFF
--- a/src/multiseries_agg_dup_sample_iterator.c
+++ b/src/multiseries_agg_dup_sample_iterator.c
@@ -24,30 +24,40 @@ ChunkResult MultiSeriesAggDupSampleIterator_GetNext(
         return CR_END;
     }
 
-    bool is_nan = isnan(iter->next_sample.value);
-    if (!is_nan) {
+    bool is_valid = iter->aggregation->isValueValid(iter->next_sample.value);
+    if (is_valid) {
         iter->aggregation->appendValue(
             aggContext, iter->next_sample.value, iter->next_sample.timestamp);
     }
 
+    bool any_valid = is_valid;
     Sample _sample;
     ChunkResult ret;
     while ((ret = iter->base.input->GetNext(iter->base.input, &_sample)) == CR_OK &&
            _sample.timestamp == iter->next_sample.timestamp) {
-        bool _is_nan = isnan(_sample.value);
-        if (!_is_nan) {
+        bool _is_valid = iter->aggregation->isValueValid(_sample.value);
+        if (_is_valid) {
             iter->aggregation->appendValue(aggContext, _sample.value, _sample.timestamp);
         }
-        is_nan = is_nan && _is_nan;
+        any_valid = any_valid || _is_valid;
     }
 
     sample->timestamp = iter->next_sample.timestamp;
-    if (likely(!is_nan)) {
+    if (likely(any_valid)) {
         iter->aggregation->finalize(aggContext, &sample->value);
-        iter->aggregation->resetContext(aggContext);
     } else {
-        sample->value = NAN;
+        // In the reduce context, NaN inputs represent "no data" from source series.
+        // Count-type reducers (count, countnan, countall) should return 0 when no
+        // valid inputs exist. All other value-type reducers (sum, min, max, avg, etc.)
+        // must propagate NaN to signal "no data" for this timestamp bucket.
+        TS_AGG_TYPES_T type = iter->aggregation->type;
+        if (type == TS_AGG_COUNT || type == TS_AGG_COUNT_NAN || type == TS_AGG_COUNT_ALL) {
+            iter->aggregation->finalizeEmpty(aggContext, &sample->value);
+        } else {
+            sample->value = NAN;
+        }
     }
+    iter->aggregation->resetContext(aggContext);
     iter->next_sample = _sample;
     if (ret == CR_END) {
         iter->has_next_sample = false;

--- a/tests/flow/test_ts_mrange_groupby.py
+++ b/tests/flow/test_ts_mrange_groupby.py
@@ -308,3 +308,62 @@ def test_bucket_timestamp():
         expected_data = [['metric_name=user', [], exp_samples]]
         assert expected_data == \
         decode_if_needed(r1.execute_command('TS.MREVRANGE', "0", "73", "AGGREGATION", "max", agg_size, 'BUCKETTIMESTAMP', '+', "filter", "metric_family=cpu", "groupby", "metric_name", "reduce", "sum"))
+
+
+def test_groupby_reduce_count_with_nan():
+    env = Env()
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', 'stock:A', 'LABELS', 'type', 'stock', 'name', 'A')
+        r.execute_command('TS.CREATE', 'stock:B', 'LABELS', 'type', 'stock', 'name', 'B')
+        r.execute_command('TS.MADD',
+                          'stock:A', 1000, 100,
+                          'stock:A', 1010, 110,
+                          'stock:A', 1020, 120,
+                          'stock:A', 1030, 'NaN')
+        r.execute_command('TS.MADD',
+                          'stock:B', 1000, 120,
+                          'stock:B', 1010, 110,
+                          'stock:B', 1020, 'NaN',
+                          'stock:B', 1030, 'NaN')
+
+        # REDUCE count: counts non-NaN values per timestamp.
+        # At ts=1020: stock:B is NaN, stock:A is 120  -> count=1
+        # At ts=1030: both are NaN                    -> count=0 (not NaN)
+        result = decode_if_needed(r1.execute_command(
+            'TS.MRANGE', '-', '+', 'WITHLABELS',
+            'FILTER', 'type=stock',
+            'GROUPBY', 'type', 'REDUCE', 'count'))
+        samples = result[0][2]
+        sample_map = {ts: val for ts, val in samples}
+        assert sample_map[1000] == '2', f"count at ts=1000 expected 2, got {sample_map[1000]}"
+        assert sample_map[1010] == '2', f"count at ts=1010 expected 2, got {sample_map[1010]}"
+        assert sample_map[1020] == '1', f"count at ts=1020 expected 1, got {sample_map[1020]}"
+        assert sample_map[1030] == '0', f"count at ts=1030 expected 0, got {sample_map[1030]}"
+
+        # REDUCE countnan: counts NaN values per timestamp.
+        # At ts=1020: stock:B is NaN, stock:A is 120  -> countnan=1
+        # At ts=1030: both are NaN                    -> countnan=2
+        result = decode_if_needed(r1.execute_command(
+            'TS.MRANGE', '-', '+', 'WITHLABELS',
+            'FILTER', 'type=stock',
+            'GROUPBY', 'type', 'REDUCE', 'countnan'))
+        samples = result[0][2]
+        sample_map = {ts: val for ts, val in samples}
+        assert sample_map[1000] == '0', f"countnan at ts=1000 expected 0, got {sample_map[1000]}"
+        assert sample_map[1010] == '0', f"countnan at ts=1010 expected 0, got {sample_map[1010]}"
+        assert sample_map[1020] == '1', f"countnan at ts=1020 expected 1, got {sample_map[1020]}"
+        assert sample_map[1030] == '2', f"countnan at ts=1030 expected 2, got {sample_map[1030]}"
+
+        # REDUCE countall: counts all values (NaN or not) per timestamp.
+        # At ts=1020: one NaN + one non-NaN           -> countall=2
+        # At ts=1030: both are NaN                    -> countall=2
+        result = decode_if_needed(r1.execute_command(
+            'TS.MRANGE', '-', '+', 'WITHLABELS',
+            'FILTER', 'type=stock',
+            'GROUPBY', 'type', 'REDUCE', 'countall'))
+        samples = result[0][2]
+        sample_map = {ts: val for ts, val in samples}
+        assert sample_map[1000] == '2', f"countall at ts=1000 expected 2, got {sample_map[1000]}"
+        assert sample_map[1010] == '2', f"countall at ts=1010 expected 2, got {sample_map[1010]}"
+        assert sample_map[1020] == '2', f"countall at ts=1020 expected 2, got {sample_map[1020]}"
+        assert sample_map[1030] == '2', f"countall at ts=1030 expected 2, got {sample_map[1030]}"


### PR DESCRIPTION
MOD-14420 fix count reducers return wrong NaN (#2013)

Cherry-pick of 9b1827c2 onto 8.8

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reducer semantics for GROUPBY/REDUCE when all input series provide NaN at a timestamp, which can affect query results for count-based reducers and downstream dashboards. Scope is limited to multi-series reduce path and is covered by new flow tests.
> 
> **Overview**
> Fixes `GROUPBY ... REDUCE` behavior when all source series return NaN for a given timestamp: the iterator now tracks *any valid input* via `aggregation->isValueValid()` rather than treating NaN uniformly.
> 
> When no valid inputs exist, **count-type reducers** (`count`, `countnan`, `countall`) now return **0** via `finalizeEmpty`, while other reducers continue to **propagate NaN**; aggregation context reset is also moved to occur after both paths. Adds a new flow test covering these NaN/empty semantics across the three count reducers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77917161c28ab66f136ca49e9e3d7bb84621cc65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->