### PR TITLE
Tal.ba/feat/agg wrong result

### DIFF
--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -684,18 +684,18 @@ static void twa_fillEmptyBuckets(size_t *write_index,
 #ifndef PREFIX_SUFFIX_IMPL
 
 /**
- * @brief TWA / PM edge rule: whether to skip filling a run of empty buckets (cases 6/7).
+ * @brief TWA: true if a run of empty buckets should be skipped (spec 6/7).
  *
- * At @p first_bucket_of_gap, uses @c twa_calc_ta and @c twa_get_samples_from_left/right. If there
- * is no neighbor sample on one side of the TWA window, empty interpolation is undefined — return
- * true so the caller omits the whole gap.
+ * At @p first_bucket_of_gap, uses @c twa_calc_ta and @c twa_get_samples_from_left/right. If a raw
+ * sample is missing on either side of the TWA window, interpolation is undefined — return true so
+ * the caller omits the whole gap.
  *
  * @param[in] self aggregation iterator.
  * @param[in] first_bucket_of_gap first empty bucket timestamp in the gap.
  * @param[in] aggregationTimeDelta bucket duration.
  * @return true to skip the gap (missing left or right neighbor); false if both neighbors exist.
  */
-static bool twa_empty_gap_skipped_by_pm_edge_rule(const AggregationIterator *self,
+static bool twa_should_skip_empty_gap(const AggregationIterator *self,
                                                   timestamp_t first_bucket_of_gap,
                                                   uint64_t aggregationTimeDelta) {
     Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
@@ -728,19 +728,13 @@ static int fillEmptyBuckets(Samples *samples,
     }
 
     // Check timestamp ordering
-    if (end_bucket_ts < first_bucket_ts) {
+    if (end_bucket_ts < first_bucket_ts || agg_time_delta == 0) {
         return 0; /* skip gap; -1 would abort the entire TS.RANGE */
     }
 
     // Check alignment with aggregation time delta
-    if (agg_time_delta == 0) {
+    if ((uint64_t)(end_bucket_ts - first_bucket_ts) % (uint64_t)agg_time_delta != 0) {
         return 0;
-    }
-    {
-        uint64_t span = end_bucket_ts - first_bucket_ts;
-        if (span % (uint64_t)agg_time_delta != 0) {
-            return 0; /* skip gap; -1 would abort the entire TS.RANGE */
-        }
     }
 
     size_t n_empty_buckets = ((end_bucket_ts - first_bucket_ts) / agg_time_delta) + 1;
@@ -753,7 +747,7 @@ static int fillEmptyBuckets(Samples *samples,
 #ifndef PREFIX_SUFFIX_IMPL // The PM decided to disable it, as it might cause OOM and complicates
                            // users
     if (self->hasTwa &&
-        twa_empty_gap_skipped_by_pm_edge_rule(self, cur_ts, self->aggregationTimeDelta)) {
+        twa_should_skip_empty_gap(self, cur_ts, self->aggregationTimeDelta)) {
         return 0;
     }
 #endif // PREFIX_SUFFIX_IMPL
@@ -818,8 +812,21 @@ static inline Samples *ensureOutputSamples(AggregationIterator *self,
     return &enrichedChunk->samples;
 }
 
-/* Prefix span: query start through bucket before first_sample_ts (shared by TWA / non-TWA EMPTY). */
-static void agg_iter_empty_prefix_span_bounds(const AggregationIterator *self,
+/**
+ * @brief Computes bucket bounds for `EMPTY` **prefix**: query edge through bucket before @p first_sample_ts.
+ *
+ * Forward: first bucket aligns to range start, last bucket is the one immediately before the bucket
+ * containing @p first_sample_ts. Reversed: uses range end and adjusts bounds symmetrically.
+ *
+ * @param[in] self iterator (range, alignment).
+ * @param[in] aggregationTimeDelta bucket width.
+ * @param[in] is_reversed forward vs reverse aggregation direction.
+ * @param[in] first_sample_ts timestamp of the first in-range raw sample (chunk start).
+ * @param[out] out_first_bucket first empty-prefix bucket start.
+ * @param[out] out_last_bucket last empty-prefix bucket start.
+ * @param[out] out_has_span false if there is no non-empty span to fill (degenerate / no gap).
+ */
+static void agg_iter_compute_empty_prefix_bounds(const AggregationIterator *self,
                                               uint64_t aggregationTimeDelta,
                                               bool is_reversed,
                                               timestamp_t first_sample_ts,
@@ -847,6 +854,23 @@ static void agg_iter_empty_prefix_span_bounds(const AggregationIterator *self,
     }
 }
 
+/**
+ * @brief Emits `EMPTY` buckets for aligned span [@p first_bucket, @p last_bucket] into the output chunk.
+ *
+ * Delegates to `fillEmptyBuckets`. Single-aggregation path appends into @p enrichedChunk and advances
+ * @p si past the filled span on success. Multi-aggregation path appends after existing prefix samples
+ * in `aux_chunk` (via `ensureOutputSamples`) and returns `fillEmptyBuckets`'s status unchanged.
+ *
+ * @param[in,out] self aggregation iterator (contexts, `EMPTY` policy).
+ * @param[in,out] enrichedChunk chunk being built; single-agg writes `samples`, multi-agg uses aux buffer.
+ * @param[in] first_bucket first bucket start in the span (inclusive).
+ * @param[in] last_bucket last bucket start in the span (inclusive).
+ * @param[in] is_reversed forward vs reverse bucket order for `fillEmptyBuckets`.
+ * @param[in] multiAgg if true, write into scratch samples; if false, write into @p enrichedChunk.
+ * @param[in,out] agg_n_samples sample count: prefix length for multi-agg; updated by `fillEmptyBuckets`.
+ * @param[in,out] si read index for `fillEmptyBuckets` on single-agg path; reset to `-1`, then incremented on success.
+ * @return `0` on success (single-agg), or `-1` on failure; multi-agg returns `fillEmptyBuckets`'s return code.
+ */
 static int agg_iter_fill_empty_span_in_chunk(AggregationIterator *self,
                                              EnrichedChunk *enrichedChunk,
                                              timestamp_t first_bucket,
@@ -994,7 +1018,7 @@ static int agg_iter_apply_empty_prefix(AggregationIterator *self,
     }
     timestamp_t first_bucket, last_bucket;
     bool has_span;
-    agg_iter_empty_prefix_span_bounds(self,
+    agg_iter_compute_empty_prefix_bounds(self,
                                       aggregationTimeDelta,
                                       is_reversed,
                                       enrichedChunk->samples.timestamps[0],
@@ -1640,7 +1664,7 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
                     __SWAP(fb, lb);
                 }
                 timestamp_t gap_cur_ts = is_reversed ? lb : fb;
-                if (twa_empty_gap_skipped_by_pm_edge_rule(self, gap_cur_ts, aggregationTimeDelta)) {
+                if (twa_should_skip_empty_gap(self, gap_cur_ts, aggregationTimeDelta)) {
                     skip_trailing_empty_fill = true;
                 }
             }

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -16,13 +16,6 @@
 #include <math.h> /* ceil */
 #include <string.h>
 
-static void agg_iter_load_last_pre_window(AggregationIterator *self, Sample *sample);
-static EnrichedChunk *agg_iter_empty_range_no_samples(AggregationIterator *self,
-                                                        uint64_t aggregationTimeDelta,
-                                                        bool is_reversed,
-                                                        size_t *agg_n_samples,
-                                                        int64_t *si);
-
 /**
  * @brief True if @p agg uses LOCF for `EMPTY` (last context / `finalize_empty_last_value`; @c LAST).
  * @param[in] agg aggregation class.
@@ -326,21 +319,73 @@ AggregationIterator *AggregationIterator_New(struct AbstractIterator *input,
     return iter;
 }
 
+/**
+ * @brief Return up to two nearest non-NaN samples on one side of @p cur_ts.
+ *
+ * Unifies the previous `..._from_left` / `..._from_right` pair. NaN samples are skipped
+ * because they can't serve as interpolation/carry sources.
+ *
+ * @param[in]  cur_ts    pivot timestamp.
+ * @param[in]  from_left true: scan `[0, cur_ts - 1]` newest-first (samples strictly before).
+ *                       false: scan `[cur_ts, UINT64_MAX]` oldest-first (samples at or after).
+ * @param[out] sample_1  closest sample to @p cur_ts on the chosen side.
+ * @param[out] sample_2  second-closest sample on the chosen side (written only when 2 found).
+ * @return number of samples written (0, 1, or 2).
+ */
 static size_t get_samples_from_side(timestamp_t cur_ts,
                                     bool from_left,
                                     const AggregationIterator *self,
                                     Sample *sample_1,
-                                    Sample *sample_2);
-static timestamp_t calc_ta(bool reverse,
+                                    Sample *sample_2) {
+    if (from_left ? (cur_ts == 0) : (cur_ts == UINT64_MAX)) {
+        return 0;
+    }
+    RangeArgs args = {
+        .aggregationArgs = { 0 },
+        .filterByValueArgs = { 0 },
+        .filterByTSArgs = { 0 },
+        .startTimestamp = from_left ? 0 : cur_ts,
+        .endTimestamp = from_left ? cur_ts - 1 : UINT64_MAX,
+        .latest = false,
+    };
+    AbstractSampleIterator *sample_iterator =
+        SeriesCreateSampleIterator(self->series, &args, from_left, true);
+    Sample sample;
+    size_t n = 0;
+    while (sample_iterator->GetNext(sample_iterator, &sample) == CR_OK) {
+        if (isnan(sample.value)) {
+            continue;
+        }
+        if (n == 0) {
+            *sample_1 = sample;
+            n = 1;
+        } else {
+            *sample_2 = sample;
+            n = 2;
+            break;
+        }
+    }
+    sample_iterator->Close(sample_iterator);
+    return n;
+}
+
+/** @brief Clipped leading edge of a bucket in iteration order (forward: start, reverse: end). */
+static timestamp_t get_bucket_start_in_query_window(bool reverse,
                            timestamp_t bucketStartTS,
                            timestamp_t bucketEndTS,
                            timestamp_t rangeStart,
-                           timestamp_t rangeEnd);
-static timestamp_t calc_tb(bool reverse,
+                           timestamp_t rangeEnd) {
+    return reverse ? min(bucketEndTS, rangeEnd) : max(bucketStartTS, rangeStart);
+}
+
+/** @brief Clipped trailing edge of a bucket in iteration order (forward: end, reverse: start). */
+static timestamp_t get_bucket_end_in_query_window(bool reverse,
                            timestamp_t bucketStartTS,
                            timestamp_t bucketEndTS,
                            timestamp_t rangeStart,
-                           timestamp_t rangeEnd);
+                           timestamp_t rangeEnd) {
+    return reverse ? max(bucketStartTS, rangeStart) : min(bucketEndTS, rangeEnd);
+}
 
 static void twa_calc_empty_bucket_val(timestamp_t ta,
                                       timestamp_t tb,
@@ -403,9 +448,9 @@ static void twa_compute_empty_bucket_value(const AggregationIterator *self,
     Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
     int64_t agg_time_delta = self->aggregationTimeDelta;
 
-    timestamp_t ta = calc_ta(
+    timestamp_t ta = get_bucket_start_in_query_window(
         false, bucket_ts, bucket_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
-    timestamp_t tb = calc_tb(
+    timestamp_t tb = get_bucket_end_in_query_window(
         false, bucket_ts, bucket_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
 
     size_t n_samples_before =
@@ -531,74 +576,6 @@ static void fillEmptyBucketsWithDefaultVals(size_t *write_index,
     }
 }
 
-/**
- * @brief Return up to two nearest non-NaN samples on one side of @p cur_ts.
- *
- * Unifies the previous `..._from_left` / `..._from_right` pair. NaN samples are skipped
- * because they can't serve as interpolation/carry sources.
- *
- * @param[in]  cur_ts    pivot timestamp.
- * @param[in]  from_left true: scan `[0, cur_ts - 1]` newest-first (samples strictly before).
- *                       false: scan `[cur_ts, UINT64_MAX]` oldest-first (samples at or after).
- * @param[out] sample_1  closest sample to @p cur_ts on the chosen side.
- * @param[out] sample_2  second-closest sample on the chosen side (written only when 2 found).
- * @return number of samples written (0, 1, or 2).
- */
-static size_t get_samples_from_side(timestamp_t cur_ts,
-                                    bool from_left,
-                                    const AggregationIterator *self,
-                                    Sample *sample_1,
-                                    Sample *sample_2) {
-    if (from_left ? (cur_ts == 0) : (cur_ts == UINT64_MAX)) {
-        return 0;
-    }
-    RangeArgs args = {
-        .aggregationArgs = { 0 },
-        .filterByValueArgs = { 0 },
-        .filterByTSArgs = { 0 },
-        .startTimestamp = from_left ? 0 : cur_ts,
-        .endTimestamp = from_left ? cur_ts - 1 : UINT64_MAX,
-        .latest = false,
-    };
-    AbstractSampleIterator *sample_iterator =
-        SeriesCreateSampleIterator(self->series, &args, from_left, true);
-    Sample sample;
-    size_t n = 0;
-    while (sample_iterator->GetNext(sample_iterator, &sample) == CR_OK) {
-        if (isnan(sample.value)) {
-            continue;
-        }
-        if (n == 0) {
-            *sample_1 = sample;
-            n = 1;
-        } else {
-            *sample_2 = sample;
-            n = 2;
-            break;
-        }
-    }
-    sample_iterator->Close(sample_iterator);
-    return n;
-}
-
-/** @brief Clipped leading edge of a bucket in iteration order (forward: start, reverse: end). */
-static timestamp_t calc_ta(bool reverse,
-                           timestamp_t bucketStartTS,
-                           timestamp_t bucketEndTS,
-                           timestamp_t rangeStart,
-                           timestamp_t rangeEnd) {
-    return reverse ? min(bucketEndTS, rangeEnd) : max(bucketStartTS, rangeStart);
-}
-
-/** @brief Clipped trailing edge of a bucket in iteration order (forward: end, reverse: start). */
-static timestamp_t calc_tb(bool reverse,
-                           timestamp_t bucketStartTS,
-                           timestamp_t bucketEndTS,
-                           timestamp_t rangeStart,
-                           timestamp_t rangeEnd) {
-    return reverse ? max(bucketStartTS, rangeStart) : min(bucketEndTS, rangeEnd);
-}
-
 static void twa_fillEmptyBuckets(size_t *write_index,
                                  timestamp_t cur_ts,
                                  Samples *samples,
@@ -609,15 +586,15 @@ static void twa_fillEmptyBuckets(size_t *write_index,
     size_t n_samples_before = 0, n_samples_after = 0;
     timestamp_t ta, tb;
     int64_t agg_time_delta = self->aggregationTimeDelta;
-    ta = calc_ta(
+    ta = get_bucket_start_in_query_window(
         false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
     n_samples_before = get_samples_from_side(ta, true, self, &sample_before, &sample_befBefore);
     n_samples_after = get_samples_from_side(ta, false, self, &sample_after, &sample_afAfter);
 
     for (size_t i = 0; i < n_empty_buckets; ++i) {
-        ta = calc_ta(
+        ta = get_bucket_start_in_query_window(
             false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
-        tb = calc_tb(
+        tb = get_bucket_end_in_query_window(
             false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
 
         timestamp_t ts = calc_bucket_ts(self->bucketTS, cur_ts, self->aggregationTimeDelta);
@@ -654,20 +631,24 @@ static void twa_fillEmptyBuckets(size_t *write_index,
 #ifndef PREFIX_SUFFIX_IMPL
 
 /**
- * @brief True if a run of empty buckets lies outside the data span and should be skipped.
+ * @brief Should an `EMPTY` bucket gap be dropped because it sits outside the data?
  *
- * Aggregation-agnostic: at @p first_bucket_of_gap, asks the series whether raw samples exist on
- * both sides of the bucket's leading edge. If either side has no samples, the gap is outside the
- * data span and the caller omits it. Used identically by:
- *   - TWA  : interpolation is undefined without left/right neighbors.
- *   - LOCF (e.g. `LAST + EMPTY`) : no carrier value exists outside the data span.
- *   - Plain `EMPTY` (`SUM`, `COUNT`, ...) : avoid synthesizing values past the data.
+ * Looks at the leading edge of @p first_bucket_of_gap and checks the series for raw samples on
+ * **both** sides. If either side has no sample, the gap lies outside the data span and the
+ * caller drops it. Aggregation-agnostic — applied uniformly to TWA, LOCF (`LAST + EMPTY`), and
+ * plain `EMPTY` (`SUM`, `COUNT`, ...) so that `TS.RANGE` and `TS.REVRANGE` produce the same
+ * set of buckets.
+ *
+ * @param[in] self                  aggregation iterator (provides series + query window).
+ * @param[in] first_bucket_of_gap   timestamp of the first empty bucket in the gap.
+ * @param[in] aggregationTimeDelta  bucket width.
+ * @return true → caller should drop the whole gap; false → emit empty buckets normally.
  */
 static bool should_skip_empty_gap(const AggregationIterator *self,
                                   timestamp_t first_bucket_of_gap,
                                   uint64_t aggregationTimeDelta) {
     Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
-    timestamp_t ta = calc_ta(
+    timestamp_t ta = get_bucket_start_in_query_window(
         false,
         first_bucket_of_gap,
         first_bucket_of_gap + aggregationTimeDelta,
@@ -884,7 +865,7 @@ static int agg_iter_append_empty_buckets(AggregationIterator *self,
  * @param[out] agg_n_samples emitted row count; @p si set to `-1` then passed to `fillEmptyBuckets`.
  * @return `fillEmptyBuckets` return value.
  */
-static int agg_iter_fill_aux_query_window(AggregationIterator *self,
+static int agg_iter_fill_window_when_empty(AggregationIterator *self,
                                           uint64_t aggregationTimeDelta,
                                           bool is_reversed,
                                           size_t *agg_n_samples,
@@ -905,6 +886,184 @@ static int agg_iter_fill_aux_query_window(AggregationIterator *self,
                             self,
                             is_reversed,
                             si);
+}
+
+/**
+ * @brief Hand a single out-of-region "neighbor" `sample` to every aggregation that wants it.
+ *
+ * "Out-of-region" = chronologically just outside the bucket (TWA) or just outside the query
+ * window (LOCF). Three mutually-exclusive modes, picked by the two flags:
+ *
+ * - `as_prev_bucket_neighbor` ⇒ TWA `addPrevBucketLastSample`: the sample anchors the
+ *   *left* endpoint of the time-weighted integral for the current bucket.
+ * - `as_next_bucket_neighbor` ⇒ TWA `addNextBucketFirstSample`: the sample anchors the
+ *   *right* endpoint of the integral.
+ * - both false ⇒ LOCF `appendValue` for aggs reported by `agg_class_needs_locf_empty_seed`
+ *   (today only `LAST`): stores the value as the agg's "latest", which becomes the carry
+ *   for empty buckets in `finalize_empty_last_value`.
+ *
+ * Aggs are skipped silently when the relevant hook is absent or `isValueValid(sample->value)`
+ * is false (e.g. `NaN` cannot anchor an integral or be carried forward).
+ *
+ * @return true if at least one aggregation accepted the sample.
+ */
+static bool agg_iter_apply_neighbor_sample(AggregationIterator *self,
+                                           const Sample *sample,
+                                           bool as_prev_bucket_neighbor,
+                                           bool as_next_bucket_neighbor) {
+    bool applied = false;
+    for (size_t a = 0; a < self->numAggregations; a++) {
+        AggregationClass *agg = &self->aggregations[a];
+        bool applies;
+        if (as_prev_bucket_neighbor) {
+            applies = (agg->addPrevBucketLastSample != NULL);
+        } else if (as_next_bucket_neighbor) {
+            applies = (agg->addNextBucketFirstSample != NULL);
+        } else {
+            applies = agg_class_needs_locf_empty_seed(agg);
+        }
+        if (!applies || !agg->isValueValid(sample->value)) {
+            continue;
+        }
+        if (as_prev_bucket_neighbor) {
+            agg->addPrevBucketLastSample(
+                self->aggregationContexts[a], sample->value, sample->timestamp);
+        } else if (as_next_bucket_neighbor) {
+            agg->addNextBucketFirstSample(
+                self->aggregationContexts[a], sample->value, sample->timestamp);
+        } else {
+            agg->appendValue(self->aggregationContexts[a], sample->value, sample->timestamp);
+        }
+        applied = true;
+    }
+    return applied;
+}
+
+/**
+ * @brief Seeds aggregation contexts from a raw sample in `[range_start, range_end]`.
+ *
+ * Iterates the series via `SeriesCreateSampleIterator` and stops at the first sample that
+ * successfully seeds at least one aggregation. Modes (mutually exclusive):
+ * - `as_prev_bucket_neighbor`: TWA `addPrevBucketLastSample`.
+ * - `as_next_bucket_neighbor`: TWA `addNextBucketFirstSample`.
+ * - `seed_last_locf`: LOCF `appendValue` for aggs needing LOCF empty seeding (e.g. `LAST`);
+ *   on success also sets `self->last_locf_seed_ok`.
+ */
+static void agg_iter_neighbor_sample_scan(AggregationIterator *self,
+                                          Sample *sample,
+                                          timestamp_t range_start,
+                                          timestamp_t range_end,
+                                          bool reverse_iteration,
+                                          bool as_prev_bucket_neighbor,
+                                          bool as_next_bucket_neighbor,
+                                          bool seed_last_locf) {
+    RangeArgs args = {
+        .aggregationArgs = { 0 },
+        .filterByValueArgs = { 0 },
+        .filterByTSArgs = { 0 },
+        .startTimestamp = range_start,
+        .endTimestamp = range_end,
+        .latest = false,
+    };
+    AbstractSampleIterator *sample_iterator =
+        SeriesCreateSampleIterator(self->series, &args, reverse_iteration, true);
+    while (sample_iterator->GetNext(sample_iterator, sample) == CR_OK) {
+        if (as_prev_bucket_neighbor &&
+            agg_iter_apply_neighbor_sample(self, sample, true, false)) {
+            sample_iterator->Close(sample_iterator);
+            return;
+        }
+        if (as_next_bucket_neighbor &&
+            agg_iter_apply_neighbor_sample(self, sample, false, true)) {
+            sample_iterator->Close(sample_iterator);
+            return;
+        }
+        if (seed_last_locf && agg_iter_apply_neighbor_sample(self, sample, false, false)) {
+            self->last_locf_seed_ok = true;
+            sample_iterator->Close(sample_iterator);
+            return;
+        }
+    }
+    sample_iterator->Close(sample_iterator);
+}
+
+/**
+ * @brief Pre-loads LOCF empty seed from the latest raw sample chronologically just outside the
+ *        query window in the iteration direction (forward: before `startTimestamp`; reverse:
+ *        after `endTimestamp`).
+ *
+ * Used by `TS.RANGE`/`TS.REVRANGE ... AGGREGATION LAST ... EMPTY` so empty buckets at the
+ * leading edge of the window (in iteration order) can produce a value via
+ * `finalize_empty_last_value`. No-ops if `EMPTY` is inactive, the relevant edge is at the
+ * timestamp domain boundary, or no aggregation needs an LOCF empty seed. Resets
+ * `last_locf_seed_ok` and delegates the scan to `agg_iter_neighbor_sample_scan`, which sets
+ * the flag on success.
+ */
+static void agg_iter_load_last_pre_window(AggregationIterator *self, Sample *sample) {
+    if (!self->empty) {
+        return;
+    }
+    if (!self->reverse && self->startTimestamp == 0) {
+        return;
+    }
+    if (self->reverse && self->endTimestamp == UINT64_MAX) {
+        return;
+    }
+    // LOCF carry via appendValue is only safe for LAST: any other agg (SUM/COUNT/AVG/MIN/MAX/
+    // FIRST/STD/VAR/TWA) would silently corrupt its in-window result by treating the
+    // out-of-window carry sample as in-window data.
+    if (!agg_iter_any_locf_empty_agg(self)) {
+        return;
+    }
+    self->last_locf_seed_ok = false;
+    agg_iter_neighbor_sample_scan(self,
+                                  sample,
+                                  self->reverse ? self->endTimestamp + 1 : 0,
+                                  self->reverse ? UINT64_MAX : self->startTimestamp - 1,
+                                  !self->reverse,
+                                  false,
+                                  false,
+                                  true);
+}
+
+/**
+ * @brief Fills `[startTimestamp, endTimestamp]` with empty buckets when no in-range samples exist (non-TWA `EMPTY`).
+ *
+ * Marks the full empty range as handled, pre-loads an LOCF seed, then writes empty buckets into
+ * the aux chunk via `agg_iter_fill_window_when_empty`. Returns @c NULL when forward LOCF has no
+ * pre-window seed, the fill fails, or no buckets were written. Caller must ensure `self->empty`,
+ * `!initialized`, `!handled_non_twa_empty_full_range`, and `!TWA_EMPTY_RANGE(self)`.
+ *
+ * @param[in,out] self                 aggregation iterator (`handled_non_twa_empty_full_range`, aux chunk).
+ * @param[in]     aggregationTimeDelta bucket duration.
+ * @param[in]     is_reversed          forward vs reverse direction.
+ * @param[out]    agg_n_samples        number of samples written to the aux chunk.
+ * @param[in,out] si                   current sample index into the aux chunk.
+ * @return The aux `EnrichedChunk` populated with empty buckets, or @c NULL on failure / no output.
+ */
+static EnrichedChunk *agg_iter_empty_range_no_samples(AggregationIterator *self,
+                                                        uint64_t aggregationTimeDelta,
+                                                        bool is_reversed,
+                                                        size_t *agg_n_samples,
+                                                        int64_t *si) {
+    self->handled_non_twa_empty_full_range = true;
+    *agg_n_samples = 0;
+    Sample locf;
+    agg_iter_load_last_pre_window(self, &locf);
+    if (!is_reversed && self->startTimestamp > 0 && !self->last_locf_seed_ok) {
+        return NULL;
+    }
+    int err = agg_iter_fill_window_when_empty(
+        self, aggregationTimeDelta, is_reversed, agg_n_samples, si);
+    if (err != 0) {
+        return NULL;
+    }
+    if (*agg_n_samples == 0) {
+        return NULL;
+    }
+    (*si)++;
+    self->aux_chunk->samples.num_samples = *agg_n_samples;
+    return self->aux_chunk;
 }
 
 /**
@@ -945,7 +1104,7 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
         if (!self->handled_twa_empty_prefix) {
             self->handled_twa_empty_prefix = true;
             self->handled_twa_empty_suffix = true; // The prefix in this case is also the suffix
-            int err = agg_iter_fill_aux_query_window(
+            int err = agg_iter_fill_window_when_empty(
                 self, aggregationTimeDelta, is_reversed, agg_n_samples, si);
             if (err != 0) {
                 return NULL;
@@ -1058,174 +1217,6 @@ static int agg_iter_apply_empty_prefix(AggregationIterator *self,
                                              si);
 }
 
-/**
- * @brief Seeds all applicable aggregations from a single raw `sample`.
- *
- * Three mutually-exclusive seed modes (the first true flag wins):
- * - `seed_prev_bucket_neighbors`: TWA prev-bucket seeding via `addPrevBucketLastSample`.
- * - `seed_next_bucket_neighbors`: TWA next-bucket seeding via `addNextBucketFirstSample`.
- * - otherwise: LOCF empty-bucket seeding via `appendValue` for aggs reported by
- *   `agg_class_needs_locf_empty_seed` (e.g. `TS_AGG_LAST`).
- *
- * Aggs are skipped when the relevant hook is absent or `isValueValid(sample->value)` is false.
- *
- * @return true if at least one aggregation was seeded.
- */
-static bool agg_iter_try_seed_sample(AggregationIterator *self,
-                                     const Sample *sample,
-                                     bool seed_prev_bucket_neighbors,
-                                     bool seed_next_bucket_neighbors) {
-    bool seeded = false;
-    for (size_t a = 0; a < self->numAggregations; a++) {
-        AggregationClass *agg = &self->aggregations[a];
-        bool applies;
-        if (seed_prev_bucket_neighbors) {
-            applies = (agg->addPrevBucketLastSample != NULL);
-        } else if (seed_next_bucket_neighbors) {
-            applies = (agg->addNextBucketFirstSample != NULL);
-        } else {
-            applies = agg_class_needs_locf_empty_seed(agg);
-        }
-        if (!applies || !agg->isValueValid(sample->value)) {
-            continue;
-        }
-        if (seed_prev_bucket_neighbors) {
-            agg->addPrevBucketLastSample(
-                self->aggregationContexts[a], sample->value, sample->timestamp);
-        } else if (seed_next_bucket_neighbors) {
-            agg->addNextBucketFirstSample(
-                self->aggregationContexts[a], sample->value, sample->timestamp);
-        } else {
-            agg->appendValue(self->aggregationContexts[a], sample->value, sample->timestamp);
-        }
-        seeded = true;
-    }
-    return seeded;
-}
-
-/**
- * @brief Seeds aggregation contexts from a raw sample in `[range_start, range_end]`.
- *
- * Iterates the series via `SeriesCreateSampleIterator` and stops at the first sample that
- * successfully seeds at least one aggregation. Modes (mutually exclusive):
- * - `seed_prev_bucket_neighbors`: TWA `addPrevBucketLastSample`.
- * - `seed_next_bucket_neighbors`: TWA `addNextBucketFirstSample`.
- * - `seed_last_locf`: LOCF `appendValue` for aggs needing LOCF empty seeding (e.g. `LAST`);
- *   on success also sets `self->last_locf_seed_ok`.
- */
-static void agg_iter_neighbor_sample_scan(AggregationIterator *self,
-                                          Sample *sample,
-                                          timestamp_t range_start,
-                                          timestamp_t range_end,
-                                          bool reverse_iteration,
-                                          bool seed_prev_bucket_neighbors,
-                                          bool seed_next_bucket_neighbors,
-                                          bool seed_last_locf) {
-    RangeArgs args = {
-        .aggregationArgs = { 0 },
-        .filterByValueArgs = { 0 },
-        .filterByTSArgs = { 0 },
-        .startTimestamp = range_start,
-        .endTimestamp = range_end,
-        .latest = false,
-    };
-    AbstractSampleIterator *sample_iterator =
-        SeriesCreateSampleIterator(self->series, &args, reverse_iteration, true);
-    while (sample_iterator->GetNext(sample_iterator, sample) == CR_OK) {
-        if (seed_prev_bucket_neighbors &&
-            agg_iter_try_seed_sample(self, sample, true, false)) {
-            sample_iterator->Close(sample_iterator);
-            return;
-        }
-        if (seed_next_bucket_neighbors &&
-            agg_iter_try_seed_sample(self, sample, false, true)) {
-            sample_iterator->Close(sample_iterator);
-            return;
-        }
-        if (seed_last_locf && agg_iter_try_seed_sample(self, sample, false, false)) {
-            self->last_locf_seed_ok = true;
-            sample_iterator->Close(sample_iterator);
-            return;
-        }
-    }
-    sample_iterator->Close(sample_iterator);
-}
-
-/**
- * @brief Pre-loads LOCF empty seed from the latest raw sample chronologically just outside the
- *        query window in the iteration direction (forward: before `startTimestamp`; reverse:
- *        after `endTimestamp`).
- *
- * Used by `TS.RANGE`/`TS.REVRANGE ... AGGREGATION LAST ... EMPTY` so empty buckets at the
- * leading edge of the window (in iteration order) can produce a value via
- * `finalize_empty_last_value`. No-ops if `EMPTY` is inactive, the relevant edge is at the
- * timestamp domain boundary, or no aggregation needs an LOCF empty seed. Resets
- * `last_locf_seed_ok` and delegates the scan to `agg_iter_neighbor_sample_scan`, which sets
- * the flag on success.
- */
-static void agg_iter_load_last_pre_window(AggregationIterator *self, Sample *sample) {
-    if (!self->empty) {
-        return;
-    }
-    if (!self->reverse && self->startTimestamp == 0) {
-        return;
-    }
-    if (self->reverse && self->endTimestamp == UINT64_MAX) {
-        return;
-    }
-    if (!agg_iter_any_locf_empty_agg(self)) {
-        return;
-    }
-    self->last_locf_seed_ok = false;
-    agg_iter_neighbor_sample_scan(self,
-                                  sample,
-                                  self->reverse ? self->endTimestamp + 1 : 0,
-                                  self->reverse ? UINT64_MAX : self->startTimestamp - 1,
-                                  !self->reverse,
-                                  false,
-                                  false,
-                                  true);
-}
-
-/**
- * @brief Fills `[startTimestamp, endTimestamp]` with empty buckets when no in-range samples exist (non-TWA `EMPTY`).
- *
- * Marks the full empty range as handled, pre-loads an LOCF seed, then writes empty buckets into
- * the aux chunk via `agg_iter_fill_aux_query_window`. Returns @c NULL when forward LOCF has no
- * pre-window seed, the fill fails, or no buckets were written. Caller must ensure `self->empty`,
- * `!initialized`, `!handled_non_twa_empty_full_range`, and `!TWA_EMPTY_RANGE(self)`.
- *
- * @param[in,out] self                 aggregation iterator (`handled_non_twa_empty_full_range`, aux chunk).
- * @param[in]     aggregationTimeDelta bucket duration.
- * @param[in]     is_reversed          forward vs reverse direction.
- * @param[out]    agg_n_samples        number of samples written to the aux chunk.
- * @param[in,out] si                   current sample index into the aux chunk.
- * @return The aux `EnrichedChunk` populated with empty buckets, or @c NULL on failure / no output.
- */
-static EnrichedChunk *agg_iter_empty_range_no_samples(AggregationIterator *self,
-                                                        uint64_t aggregationTimeDelta,
-                                                        bool is_reversed,
-                                                        size_t *agg_n_samples,
-                                                        int64_t *si) {
-    self->handled_non_twa_empty_full_range = true;
-    *agg_n_samples = 0;
-    Sample locf;
-    agg_iter_load_last_pre_window(self, &locf);
-    if (!is_reversed && self->startTimestamp > 0 && !self->last_locf_seed_ok) {
-        return NULL;
-    }
-    int err = agg_iter_fill_aux_query_window(
-        self, aggregationTimeDelta, is_reversed, agg_n_samples, si);
-    if (err != 0) {
-        return NULL;
-    }
-    if (*agg_n_samples == 0) {
-        return NULL;
-    }
-    (*si)++;
-    self->aux_chunk->samples.num_samples = *agg_n_samples;
-    return self->aux_chunk;
-}
 
 // First chunk only: bucket start from first sample, TWA params, optional prior sample for TWA.
 static void agg_iter_init_if_needed(AggregationIterator *self,
@@ -1243,12 +1234,12 @@ static void agg_iter_init_if_needed(AggregationIterator *self,
     self->initialized = true;
 
     if (self->hasTwa) {
-        timestamp_t ta = calc_ta(self->reverse,
+        timestamp_t ta = get_bucket_start_in_query_window(self->reverse,
                                      BucketStartNormalize(self->aggregationLastTimestamp),
                                      self->aggregationLastTimestamp + aggregationTimeDelta,
                                      self->startTimestamp,
                                      self->endTimestamp);
-        timestamp_t tb = calc_tb(self->reverse,
+        timestamp_t tb = get_bucket_end_in_query_window(self->reverse,
                                      BucketStartNormalize(self->aggregationLastTimestamp),
                                      self->aggregationLastTimestamp + aggregationTimeDelta,
                                      self->startTimestamp,
@@ -1485,7 +1476,7 @@ static int agg_iter_general_on_bucket_boundary(AggregationIterator *self,
         // correct value during fillEmptyBuckets. The subsequent appendValue for the same
         // sample (in process_chunk_general) is idempotent for LOCF aggs (e.g. LAST).
         if (is_reversed) {
-            agg_iter_try_seed_sample(self, sample, false, false);
+            agg_iter_apply_neighbor_sample(self, sample, false, false);
         }
         timestamp_t first_bucket, last_bucket;
         if (agg_iter_empty_gap_after_finalize(*contextScope,
@@ -1515,7 +1506,7 @@ static int agg_iter_general_on_bucket_boundary(AggregationIterator *self,
     agg_iter_advance_context_scope(self, aggregationTimeDelta, contextScope);
 
     if (self->hasTwa) {
-        timestamp_t tb = calc_tb(self->reverse,
+        timestamp_t tb = get_bucket_end_in_query_window(self->reverse,
                                      self->aggregationLastTimestamp,
                                      *contextScope,
                                      self->startTimestamp,

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -855,7 +855,7 @@ static void agg_iter_compute_empty_prefix_bounds(const AggregationIterator *self
 }
 
 /**
- * @brief Emits `EMPTY` buckets for aligned span [@p first_bucket, @p last_bucket] into the output chunk.
+ * @brief Appends `EMPTY` buckets for aligned span [@p first_bucket, @p last_bucket] into the output chunk.
  *
  * Delegates to `fillEmptyBuckets`. Single-aggregation path appends into @p enrichedChunk and advances
  * @p si past the filled span on success. Multi-aggregation path appends after existing prefix samples
@@ -871,7 +871,7 @@ static void agg_iter_compute_empty_prefix_bounds(const AggregationIterator *self
  * @param[in,out] si read index for `fillEmptyBuckets` on single-agg path; reset to `-1`, then incremented on success.
  * @return `0` on success (single-agg), or `-1` on failure; multi-agg returns `fillEmptyBuckets`'s return code.
  */
-static int agg_iter_fill_empty_span_in_chunk(AggregationIterator *self,
+static int agg_iter_append_empty_buckets(AggregationIterator *self,
                                              EnrichedChunk *enrichedChunk,
                                              timestamp_t first_bucket,
                                              timestamp_t last_bucket,
@@ -901,7 +901,19 @@ static int agg_iter_fill_empty_span_in_chunk(AggregationIterator *self,
     return 0;
 }
 
-/* aux_chunk: fill aligned span for whole query window [startTimestamp,endTimestamp]. */
+/**
+ * @brief Emit `EMPTY` buckets for the full query range into `aux_chunk` via `fillEmptyBuckets`.
+ *
+ * Used when there is no in-range data to merge into an `EnrichedChunk` but `EMPTY` still needs
+ * every bucket (TWA empty range; non-TWA empty full range after LOCF). `aux_chunk` is the scratch
+ * buffer because there is no upstream chunk to extend.
+ *
+ * @param[in,out] self iterator (range, alignment, contexts).
+ * @param[in] aggregationTimeDelta bucket width.
+ * @param[in] is_reversed forward vs reverse (`fillEmptyBuckets`; may swap aligned bounds).
+ * @param[out] agg_n_samples emitted row count; @p si set to `-1` then passed to `fillEmptyBuckets`.
+ * @return `fillEmptyBuckets` return value.
+ */
 static int agg_iter_fill_aux_query_window(AggregationIterator *self,
                                           uint64_t aggregationTimeDelta,
                                           bool is_reversed,
@@ -988,9 +1000,7 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
             return self->aux_chunk;
         }
         return NULL;
-    }
-    if (self->empty && !self->initialized && !self->handled_non_twa_empty_full_range &&
-        !TWA_EMPTY_RANGE(self)) {
+    } else if (self->empty && !self->initialized && !self->handled_non_twa_empty_full_range) {
         return agg_iter_empty_range_no_samples(
             self, aggregationTimeDelta, is_reversed, agg_n_samples, si);
     }
@@ -1032,7 +1042,7 @@ static int agg_iter_apply_empty_prefix(AggregationIterator *self,
         !self->last_locf_seed_ok) {
         return 0;
     }
-    return agg_iter_fill_empty_span_in_chunk(self,
+    return agg_iter_append_empty_buckets(self,
                                              enrichedChunk,
                                              first_bucket,
                                              last_bucket,

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -9,25 +9,53 @@
 #include "filter_iterator.h"
 
 #include "abstract_iterator.h"
+#include "compaction.h"
 #include "series_iterator.h"
 #include "utils/arr.h"
 #include <assert.h>
 #include <math.h> /* ceil */
 #include <string.h>
 
-static void agg_iter_seed_last_empty_before_query(AggregationIterator *self, Sample *sample);
-static EnrichedChunk *agg_iter_non_twa_empty_full_range(AggregationIterator *self,
+static void agg_iter_load_last_pre_window(AggregationIterator *self, Sample *sample);
+static EnrichedChunk *agg_iter_empty_range_no_samples(AggregationIterator *self,
                                                         uint64_t aggregationTimeDelta,
                                                         bool is_reversed,
                                                         size_t *agg_n_samples,
                                                         int64_t *si);
-static int agg_iter_apply_non_twa_empty_prefix(AggregationIterator *self,
-                                               EnrichedChunk *enrichedChunk,
-                                               uint64_t aggregationTimeDelta,
-                                               bool is_reversed,
-                                               bool multiAgg,
-                                               size_t *agg_n_samples,
-                                               int64_t *si);
+
+/**
+ * @brief True if @p agg uses LOCF for `EMPTY` (last context / `finalize_empty_last_value`; @c LAST).
+ * @param[in] agg aggregation class.
+ */
+static inline bool agg_class_needs_locf_empty_seed(const AggregationClass *agg) {
+    return agg->type == TS_AGG_LAST;
+}
+
+/**
+ * @brief True if @p self needs a sample before the first bucket (`addPrevBucketLastSample` on any agg).
+ * @param[in] self aggregation iterator (e.g. TWA).
+ */
+static bool agg_iter_needs_prev_bucket_sample(const AggregationIterator *self) {
+    for (size_t a = 0; a < self->numAggregations; a++) {
+        if (self->aggregations[a].addPrevBucketLastSample) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * @brief True if any aggregation in @p self uses LOCF for `EMPTY` (see agg_class_needs_locf_empty_seed).
+ * @param[in] self aggregation iterator.
+ */
+static bool agg_iter_any_locf_empty_agg(const AggregationIterator *self) {
+    for (size_t a = 0; a < self->numAggregations; a++) {
+        if (agg_class_needs_locf_empty_seed(&self->aggregations[a])) {
+            return true;
+        }
+    }
+    return false;
+}
 
 static inline bool check_sample_value(double value, FilterByValueArgs *byValueArgs) {
     if (value >= byValueArgs->min && value <= byValueArgs->max) {
@@ -654,11 +682,22 @@ static void twa_fillEmptyBuckets(size_t *write_index,
 }
 
 #ifndef PREFIX_SUFFIX_IMPL
-/* PM "canceled" cases 6/7: skip the entire gap when the first bucket has no sample on one side.
- * Shared by fillEmptyBuckets (TWA) and agg_iter_finalize suffix (LAST+EMPTY to match TWA row count). */
-static bool empty_gap_skipped_by_pm_edge_rule(const AggregationIterator *self,
-                                              timestamp_t first_bucket_of_gap,
-                                              uint64_t aggregationTimeDelta) {
+
+/**
+ * @brief TWA / PM edge rule: whether to skip filling a run of empty buckets (cases 6/7).
+ *
+ * At @p first_bucket_of_gap, uses @c twa_calc_ta and @c twa_get_samples_from_left/right. If there
+ * is no neighbor sample on one side of the TWA window, empty interpolation is undefined — return
+ * true so the caller omits the whole gap.
+ *
+ * @param[in] self aggregation iterator.
+ * @param[in] first_bucket_of_gap first empty bucket timestamp in the gap.
+ * @param[in] aggregationTimeDelta bucket duration.
+ * @return true to skip the gap (missing left or right neighbor); false if both neighbors exist.
+ */
+static bool twa_empty_gap_skipped_by_pm_edge_rule(const AggregationIterator *self,
+                                                  timestamp_t first_bucket_of_gap,
+                                                  uint64_t aggregationTimeDelta) {
     Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
     timestamp_t ta = twa_calc_ta(
         false,
@@ -714,7 +753,7 @@ static int fillEmptyBuckets(Samples *samples,
 #ifndef PREFIX_SUFFIX_IMPL // The PM decided to disable it, as it might cause OOM and complicates
                            // users
     if (self->hasTwa &&
-        empty_gap_skipped_by_pm_edge_rule(self, cur_ts, self->aggregationTimeDelta)) {
+        twa_empty_gap_skipped_by_pm_edge_rule(self, cur_ts, self->aggregationTimeDelta)) {
         return 0;
     }
 #endif // PREFIX_SUFFIX_IMPL
@@ -779,6 +818,89 @@ static inline Samples *ensureOutputSamples(AggregationIterator *self,
     return &enrichedChunk->samples;
 }
 
+/* Prefix span: query start through bucket before first_sample_ts (shared by TWA / non-TWA EMPTY). */
+static void agg_iter_empty_prefix_span_bounds(const AggregationIterator *self,
+                                              uint64_t aggregationTimeDelta,
+                                              bool is_reversed,
+                                              timestamp_t first_sample_ts,
+                                              timestamp_t *out_first_bucket,
+                                              timestamp_t *out_last_bucket,
+                                              bool *out_has_span) {
+    *out_first_bucket =
+        CalcBucketStart(is_reversed ? self->endTimestamp : self->startTimestamp,
+                        aggregationTimeDelta,
+                        self->timestampAlignment);
+    *out_last_bucket =
+        CalcBucketStart(first_sample_ts, aggregationTimeDelta, self->timestampAlignment);
+    *out_has_span = true;
+    if (!is_reversed) {
+        if (*out_first_bucket >= *out_last_bucket) {
+            *out_has_span = false;
+        }
+        *out_last_bucket =
+            max(0, (int64_t)((int64_t)*out_last_bucket - (int64_t)aggregationTimeDelta));
+    } else {
+        *out_last_bucket += aggregationTimeDelta;
+        if (*out_first_bucket < *out_last_bucket) {
+            *out_has_span = false;
+        }
+    }
+}
+
+static int agg_iter_fill_empty_span_in_chunk(AggregationIterator *self,
+                                             EnrichedChunk *enrichedChunk,
+                                             timestamp_t first_bucket,
+                                             timestamp_t last_bucket,
+                                             bool is_reversed,
+                                             bool multiAgg,
+                                             size_t *agg_n_samples,
+                                             int64_t *si) {
+    if (multiAgg) {
+        Samples *prefixSamples = ensureOutputSamples(self, enrichedChunk, *agg_n_samples + 256);
+        prefixSamples->num_samples = *agg_n_samples;
+        int64_t read_idx = -1;
+        return fillEmptyBuckets(
+            prefixSamples, agg_n_samples, first_bucket, last_bucket, self, is_reversed, &read_idx);
+    }
+    *si = -1;
+    int err = fillEmptyBuckets(&enrichedChunk->samples,
+                               agg_n_samples,
+                               first_bucket,
+                               last_bucket,
+                               self,
+                               is_reversed,
+                               si);
+    if (err != 0) {
+        return -1;
+    }
+    (*si)++;
+    return 0;
+}
+
+/* aux_chunk: fill aligned span for whole query window [startTimestamp,endTimestamp]. */
+static int agg_iter_fill_aux_query_window(AggregationIterator *self,
+                                          uint64_t aggregationTimeDelta,
+                                          bool is_reversed,
+                                          size_t *agg_n_samples,
+                                          int64_t *si) {
+    timestamp_t fb =
+        CalcBucketStart(self->startTimestamp, aggregationTimeDelta, self->timestampAlignment);
+    timestamp_t lb =
+        CalcBucketStart(self->endTimestamp, aggregationTimeDelta, self->timestampAlignment);
+    if (is_reversed) {
+        __SWAP(fb, lb);
+    }
+    *si = -1;
+    self->aux_chunk->samples.num_samples = 0;
+    return fillEmptyBuckets(&self->aux_chunk->samples,
+                            agg_n_samples,
+                            fb,
+                            lb,
+                            self,
+                            is_reversed,
+                            si);
+}
+
 // No samples from upstream: finalize, TWA-only empty range, or end stream.
 // Sets *enter_finalize when caller must run agg_iter_finalize().
 static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
@@ -796,22 +918,8 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
         if (!self->handled_twa_empty_prefix) {
             self->handled_twa_empty_prefix = true;
             self->handled_twa_empty_suffix = true; // The prefix in this case is also the suffix
-            timestamp_t first_bucket = CalcBucketStart(
-                self->startTimestamp, aggregationTimeDelta, self->timestampAlignment);
-            timestamp_t last_bucket =
-                CalcBucketStart(self->endTimestamp, aggregationTimeDelta, self->timestampAlignment);
-            if (is_reversed) {
-                __SWAP(first_bucket, last_bucket);
-            }
-            *si = -1;
-            self->aux_chunk->samples.num_samples = 0;
-            int err = fillEmptyBuckets(&self->aux_chunk->samples,
-                                       agg_n_samples,
-                                       first_bucket,
-                                       last_bucket,
-                                       self,
-                                       is_reversed,
-                                       si);
+            int err = agg_iter_fill_aux_query_window(
+                self, aggregationTimeDelta, is_reversed, agg_n_samples, si);
             if (err != 0) {
                 return NULL;
             }
@@ -859,216 +967,161 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
     }
     if (self->empty && !self->initialized && !self->handled_non_twa_empty_full_range &&
         !TWA_EMPTY_RANGE(self)) {
-        return agg_iter_non_twa_empty_full_range(
+        return agg_iter_empty_range_no_samples(
             self, aggregationTimeDelta, is_reversed, agg_n_samples, si);
     }
     return NULL;
 }
 
-// TWA empty range: fill buckets from query start to first raw sample. Returns 0 or -1 on error.
-static int agg_iter_apply_twa_empty_prefix(AggregationIterator *self,
-                                           EnrichedChunk *enrichedChunk,
-                                           uint64_t aggregationTimeDelta,
-                                           bool is_reversed,
-                                           bool multiAgg,
-                                           size_t *agg_n_samples,
-                                           int64_t *si) {
-    if (!TWA_EMPTY_RANGE(self) || self->handled_twa_empty_prefix) {
+/* EMPTY prefix before first in-range sample: TWA_EMPTY_RANGE vs non-TWA EMPTY (LAST LOCF gate). */
+static int agg_iter_apply_empty_prefix(AggregationIterator *self,
+                                       EnrichedChunk *enrichedChunk,
+                                       uint64_t aggregationTimeDelta,
+                                       bool is_reversed,
+                                       bool multiAgg,
+                                       size_t *agg_n_samples,
+                                       int64_t *si) {
+    if (TWA_EMPTY_RANGE(self)) {
+        if (self->handled_twa_empty_prefix) {
+            return 0;
+        }
+        self->handled_twa_empty_prefix = true;
+    } else {
+        if (!self->empty || self->handled_non_twa_empty_prefix) {
+            return 0;
+        }
+        self->handled_non_twa_empty_prefix = true;
+    }
+    timestamp_t first_bucket, last_bucket;
+    bool has_span;
+    agg_iter_empty_prefix_span_bounds(self,
+                                      aggregationTimeDelta,
+                                      is_reversed,
+                                      enrichedChunk->samples.timestamps[0],
+                                      &first_bucket,
+                                      &last_bucket,
+                                      &has_span);
+    if (!has_span) {
         return 0;
     }
-    self->handled_twa_empty_prefix = true;
-    timestamp_t first_bucket =
-        CalcBucketStart(is_reversed ? self->endTimestamp : self->startTimestamp,
-                        aggregationTimeDelta,
-                        self->timestampAlignment);
-    timestamp_t first_sample_ts = enrichedChunk->samples.timestamps[0];
-    timestamp_t last_bucket =
-        CalcBucketStart(first_sample_ts, aggregationTimeDelta, self->timestampAlignment);
-    bool has_empty_buckets = true;
-    if (!is_reversed) {
-        if (first_bucket >= last_bucket) {
-            has_empty_buckets = false;
-        }
-        last_bucket = max(0, (int64_t)((int64_t)last_bucket - (int64_t)aggregationTimeDelta));
-    } else {
-        last_bucket += aggregationTimeDelta;
-        if (first_bucket < last_bucket) {
-            has_empty_buckets = false;
-        }
-    }
-    if (!has_empty_buckets) {
+    if (!TWA_EMPTY_RANGE(self) && !is_reversed && self->startTimestamp > 0 &&
+        !self->last_locf_seed_ok) {
         return 0;
     }
-    if (multiAgg) {
-        Samples *prefixSamples = ensureOutputSamples(self, enrichedChunk, *agg_n_samples + 256);
-        prefixSamples->num_samples = *agg_n_samples;
-        int64_t read_idx = -1;
-        int err = fillEmptyBuckets(
-            prefixSamples, agg_n_samples, first_bucket, last_bucket, self, is_reversed, &read_idx);
-        if (err != 0) {
-            return -1;
-        }
-    } else {
-        *si = -1;
-        int err = fillEmptyBuckets(&enrichedChunk->samples,
-                                   agg_n_samples,
-                                   first_bucket,
-                                   last_bucket,
-                                   self,
-                                   is_reversed,
-                                   si);
-        if (err != 0) {
-            return -1;
-        }
-        (*si)++;
-    }
-    return 0;
+    return agg_iter_fill_empty_span_in_chunk(self,
+                                             enrichedChunk,
+                                             first_bucket,
+                                             last_bucket,
+                                             is_reversed,
+                                             multiAgg,
+                                             agg_n_samples,
+                                             si);
 }
 
-/* EMPTY without TWA (e.g. LAST): emit buckets from query start through the bucket before the first
- * raw sample — same geometry as agg_iter_apply_twa_empty_prefix; requires LOCF seed first. */
-static int agg_iter_apply_non_twa_empty_prefix(AggregationIterator *self,
-                                               EnrichedChunk *enrichedChunk,
-                                               uint64_t aggregationTimeDelta,
-                                               bool is_reversed,
-                                               bool multiAgg,
-                                               size_t *agg_n_samples,
-                                               int64_t *si) {
-    if (!self->empty || self->handled_non_twa_empty_prefix || TWA_EMPTY_RANGE(self)) {
-        return 0;
-    }
-    self->handled_non_twa_empty_prefix = true;
-    timestamp_t first_bucket =
-        CalcBucketStart(is_reversed ? self->endTimestamp : self->startTimestamp,
-                        aggregationTimeDelta,
-                        self->timestampAlignment);
-    timestamp_t first_sample_ts = enrichedChunk->samples.timestamps[0];
-    timestamp_t last_bucket =
-        CalcBucketStart(first_sample_ts, aggregationTimeDelta, self->timestampAlignment);
-    bool has_empty_buckets = true;
-    if (!is_reversed) {
-        if (first_bucket >= last_bucket) {
-            has_empty_buckets = false;
-        }
-        last_bucket = max(0, (int64_t)((int64_t)last_bucket - (int64_t)aggregationTimeDelta));
-    } else {
-        last_bucket += aggregationTimeDelta;
-        if (first_bucket < last_bucket) {
-            has_empty_buckets = false;
-        }
-    }
-    if (!has_empty_buckets) {
-        return 0;
-    }
-    /* Mirror TWA empty-bucket neighbor rule (fillEmptyBuckets PREFIX block): do not emit prefix
-     * buckets for LAST+EMPTY when there is no sample strictly before the query start to LOCF from. */
-    if (!is_reversed && self->startTimestamp > 0 && !self->last_locf_seed_ok) {
-        return 0;
-    }
-    if (multiAgg) {
-        Samples *prefixSamples = ensureOutputSamples(self, enrichedChunk, *agg_n_samples + 256);
-        prefixSamples->num_samples = *agg_n_samples;
-        int64_t read_idx = -1;
-        int err = fillEmptyBuckets(
-            prefixSamples, agg_n_samples, first_bucket, last_bucket, self, is_reversed, &read_idx);
-        if (err != 0) {
-            return -1;
-        }
-    } else {
-        *si = -1;
-        int err = fillEmptyBuckets(&enrichedChunk->samples,
-                                   agg_n_samples,
-                                   first_bucket,
-                                   last_bucket,
-                                   self,
-                                   is_reversed,
-                                   si);
-        if (err != 0) {
-            return -1;
-        }
-        (*si)++;
-    }
-    return 0;
-}
-
-/* TS.RANGE … AGGREGATION LAST … EMPTY: empty buckets use finalize_empty_last_value (context value).
- * Seed LAST context from the latest raw sample strictly before the query start (LOCF), mirroring
- * how TWA pulls a neighbor sample (reverse scan of [0, startTimestamp - 1]). */
-static void agg_iter_seed_last_empty_before_query(AggregationIterator *self, Sample *sample) {
-    if (!self->empty || self->reverse || self->startTimestamp == 0) {
-        return;
-    }
-    bool any_last = false;
-    for (size_t a = 0; a < self->numAggregations; a++) {
-        if (self->aggregations[a].type == TS_AGG_LAST) {
-            any_last = true;
-            break;
-        }
-    }
-    if (!any_last) {
-        return;
-    }
-    self->last_locf_seed_ok = false;
+/* Scan raw samples in [range_start, range_end] using SeriesCreateSampleIterator(reverse_iteration).
+ *
+ * Prev-bucket padding: any aggregation with addPrevBucketLastSample (TWA today; same hook drives
+ * future neighbor sampling) — first iterator sample where at least one hook accepts isValueValid
+ * seeds all applicable hooks, then return.
+ *
+ * LOCF empty padding: types where agg_class_needs_locf_empty_seed (TS_AGG_LAST today) — appendValue
+ * for each applicable agg where isValueValid; if any seeded, set last_locf_seed_ok and return.
+ */
+static void agg_iter_neighbor_sample_scan(AggregationIterator *self,
+                                          Sample *sample,
+                                          timestamp_t range_start,
+                                          timestamp_t range_end,
+                                          bool reverse_iteration,
+                                          bool seed_prev_bucket_neighbors,
+                                          bool seed_last_locf) {
     RangeArgs args = {
         .aggregationArgs = { 0 },
         .filterByValueArgs = { 0 },
         .filterByTSArgs = { 0 },
-        .startTimestamp = 0,
-        .endTimestamp = self->startTimestamp - 1,
+        .startTimestamp = range_start,
+        .endTimestamp = range_end,
         .latest = false,
     };
     AbstractSampleIterator *sample_iterator =
-        SeriesCreateSampleIterator(self->series, &args, true, true);
+        SeriesCreateSampleIterator(self->series, &args, reverse_iteration, true);
     while (sample_iterator->GetNext(sample_iterator, sample) == CR_OK) {
-        bool seeded = false;
-        for (size_t a = 0; a < self->numAggregations; a++) {
-            if (self->aggregations[a].type != TS_AGG_LAST) {
-                continue;
-            }
-            if (self->aggregations[a].isValueValid(sample->value)) {
-                self->aggregations[a].appendValue(
+        if (seed_prev_bucket_neighbors) {
+            bool any_prev = false;
+            for (size_t a = 0; a < self->numAggregations; a++) {
+                AggregationClass *agg = &self->aggregations[a];
+                if (!agg->addPrevBucketLastSample) {
+                    continue;
+                }
+                if (!agg->isValueValid(sample->value)) {
+                    continue;
+                }
+                agg->addPrevBucketLastSample(
                     self->aggregationContexts[a], sample->value, sample->timestamp);
-                seeded = true;
+                any_prev = true;
+            }
+            if (any_prev) {
+                sample_iterator->Close(sample_iterator);
+                return;
             }
         }
-        if (seeded) {
-            self->last_locf_seed_ok = true;
-            break;
+        if (seed_last_locf) {
+            bool seeded = false;
+            for (size_t a = 0; a < self->numAggregations; a++) {
+                AggregationClass *agg = &self->aggregations[a];
+                if (!agg_class_needs_locf_empty_seed(agg)) {
+                    continue;
+                }
+                if (!agg->isValueValid(sample->value)) {
+                    continue;
+                }
+                agg->appendValue(self->aggregationContexts[a], sample->value, sample->timestamp);
+                seeded = true;
+            }
+            if (seeded) {
+                self->last_locf_seed_ok = true;
+                sample_iterator->Close(sample_iterator);
+                return;
+            }
         }
     }
     sample_iterator->Close(sample_iterator);
 }
 
-/* EMPTY without TWA (e.g. LAST): upstream never produced samples — fill [start,end] with finalizeEmpty.
+/* TS.RANGE … AGGREGATION LAST … EMPTY: empty buckets use finalize_empty_last_value (context value).
+ * Load LAST context from the latest raw sample strictly before the query start (LOCF). */
+static void agg_iter_load_last_pre_window(AggregationIterator *self, Sample *sample) {
+    if (!self->empty || self->reverse || self->startTimestamp == 0) {
+        return;
+    }
+    if (!agg_iter_any_locf_empty_agg(self)) {
+        return;
+    }
+    self->last_locf_seed_ok = false;
+    agg_iter_neighbor_sample_scan(self,
+                                  sample,
+                                  0,
+                                  self->startTimestamp - 1,
+                                  true,
+                                  false,
+                                  true);
+}
+
+/* EMPTY without TWA: no in-range samples — fill [start,end] with finalizeEmpty.
  * Caller must ensure empty, !initialized, !handled_non_twa_empty_full_range, and !TWA_EMPTY_RANGE. */
-static EnrichedChunk *agg_iter_non_twa_empty_full_range(AggregationIterator *self,
+static EnrichedChunk *agg_iter_empty_range_no_samples(AggregationIterator *self,
                                                         uint64_t aggregationTimeDelta,
                                                         bool is_reversed,
                                                         size_t *agg_n_samples,
                                                         int64_t *si) {
     self->handled_non_twa_empty_full_range = true;
-    timestamp_t first_bucket =
-        CalcBucketStart(self->startTimestamp, aggregationTimeDelta, self->timestampAlignment);
-    timestamp_t last_bucket =
-        CalcBucketStart(self->endTimestamp, aggregationTimeDelta, self->timestampAlignment);
-    if (is_reversed) {
-        __SWAP(first_bucket, last_bucket);
-    }
-    *si = -1;
     *agg_n_samples = 0;
-    self->aux_chunk->samples.num_samples = 0;
     Sample locf;
-    agg_iter_seed_last_empty_before_query(self, &locf);
+    agg_iter_load_last_pre_window(self, &locf);
     if (!is_reversed && self->startTimestamp > 0 && !self->last_locf_seed_ok) {
         return NULL;
     }
-    int err = fillEmptyBuckets(&self->aux_chunk->samples,
-                               agg_n_samples,
-                               first_bucket,
-                               last_bucket,
-                               self,
-                               is_reversed,
-                               si);
+    int err = agg_iter_fill_aux_query_window(
+        self, aggregationTimeDelta, is_reversed, agg_n_samples, si);
     if (err != 0) {
         return NULL;
     }
@@ -1115,30 +1168,14 @@ static void agg_iter_init_if_needed(AggregationIterator *self,
         }
     }
 
-    if (self->hasTwa && !((!is_reversed) && init_ts == 0)) {
-        RangeArgs args = {
-            .aggregationArgs = { 0 },
-            .filterByValueArgs = { 0 },
-            .filterByTSArgs = { 0 },
-            .startTimestamp = is_reversed ? init_ts + 1 : 0,
-            .endTimestamp = is_reversed ? UINT64_MAX : init_ts - 1,
-            .latest = false,
-        };
-        AbstractSampleIterator *sample_iterator =
-            SeriesCreateSampleIterator(self->series, &args, !is_reversed, true);
-        // Skip NaN samples - they shouldn't be used for TWA interpolation
-        while (sample_iterator->GetNext(sample_iterator, sample) == CR_OK) {
-            if (!isnan(sample->value)) {
-                for (size_t a = 0; a < self->numAggregations; a++) {
-                    if (self->aggregations[a].type == TS_AGG_TWA) {
-                        self->aggregations[a].addPrevBucketLastSample(
-                            self->aggregationContexts[a], sample->value, sample->timestamp);
-                    }
-                }
-                break;
-            }
-        }
-        sample_iterator->Close(sample_iterator);
+    if (agg_iter_needs_prev_bucket_sample(self) && !((!is_reversed) && init_ts == 0)) {
+        agg_iter_neighbor_sample_scan(self,
+                                      sample,
+                                      is_reversed ? init_ts + 1 : 0,
+                                      is_reversed ? UINT64_MAX : init_ts - 1,
+                                      !is_reversed,
+                                      true,
+                                      false);
     }
 }
 
@@ -1603,7 +1640,7 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
                     __SWAP(fb, lb);
                 }
                 timestamp_t gap_cur_ts = is_reversed ? lb : fb;
-                if (empty_gap_skipped_by_pm_edge_rule(self, gap_cur_ts, aggregationTimeDelta)) {
+                if (twa_empty_gap_skipped_by_pm_edge_rule(self, gap_cur_ts, aggregationTimeDelta)) {
                     skip_trailing_empty_fill = true;
                 }
             }
@@ -1653,25 +1690,16 @@ EnrichedChunk *AggregationIterator_GetNextChunk(struct AbstractIterator *iter) {
     }
 
     if (self->empty && !self->initialized) {
-        agg_iter_seed_last_empty_before_query(self, &sample);
+        agg_iter_load_last_pre_window(self, &sample);
     }
 
-    if (agg_iter_apply_twa_empty_prefix(self,
-                                        enrichedChunk,
-                                        aggregationTimeDelta,
-                                        is_reversed,
-                                        multiAgg,
-                                        &agg_n_samples,
-                                        &si) != 0) {
-        return NULL;
-    }
-    if (agg_iter_apply_non_twa_empty_prefix(self,
-                                            enrichedChunk,
-                                            aggregationTimeDelta,
-                                            is_reversed,
-                                            multiAgg,
-                                            &agg_n_samples,
-                                            &si) != 0) {
+    if (agg_iter_apply_empty_prefix(self,
+                                      enrichedChunk,
+                                      aggregationTimeDelta,
+                                      is_reversed,
+                                      multiAgg,
+                                      &agg_n_samples,
+                                      &si) != 0) {
         return NULL;
     }
     self->hasUnFinalizedContext = true;

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -15,6 +15,20 @@
 #include <math.h> /* ceil */
 #include <string.h>
 
+static void agg_iter_seed_last_empty_before_query(AggregationIterator *self, Sample *sample);
+static EnrichedChunk *agg_iter_non_twa_empty_full_range(AggregationIterator *self,
+                                                        uint64_t aggregationTimeDelta,
+                                                        bool is_reversed,
+                                                        size_t *agg_n_samples,
+                                                        int64_t *si);
+static int agg_iter_apply_non_twa_empty_prefix(AggregationIterator *self,
+                                               EnrichedChunk *enrichedChunk,
+                                               uint64_t aggregationTimeDelta,
+                                               bool is_reversed,
+                                               bool multiAgg,
+                                               size_t *agg_n_samples,
+                                               int64_t *si);
+
 static inline bool check_sample_value(double value, FilterByValueArgs *byValueArgs) {
     if (value >= byValueArgs->min && value <= byValueArgs->max) {
         return true;
@@ -273,6 +287,9 @@ AggregationIterator *AggregationIterator_New(struct AbstractIterator *input,
     }
     iter->handled_twa_empty_prefix = false;
     iter->handled_twa_empty_suffix = false;
+    iter->handled_non_twa_empty_full_range = false;
+    iter->handled_non_twa_empty_prefix = false;
+    iter->last_locf_seed_ok = true;
     iter->prev_ts = DC;
     iter->validSamplesInBucket = false;
     memset(iter->validPerAgg, 0, sizeof(iter->validPerAgg));
@@ -636,6 +653,27 @@ static void twa_fillEmptyBuckets(size_t *write_index,
     }
 }
 
+#ifndef PREFIX_SUFFIX_IMPL
+/* PM "canceled" cases 6/7: skip the entire gap when the first bucket has no sample on one side.
+ * Shared by fillEmptyBuckets (TWA) and agg_iter_finalize suffix (LAST+EMPTY to match TWA row count). */
+static bool empty_gap_skipped_by_pm_edge_rule(const AggregationIterator *self,
+                                              timestamp_t first_bucket_of_gap,
+                                              uint64_t aggregationTimeDelta) {
+    Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
+    timestamp_t ta = twa_calc_ta(
+        false,
+        first_bucket_of_gap,
+        first_bucket_of_gap + aggregationTimeDelta,
+        self->startTimestamp,
+        self->endTimestamp);
+    size_t n_samples_before =
+        twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore);
+    size_t n_samples_after =
+        twa_get_samples_from_right(ta, self, &sample_after, &sample_afAfter);
+    return n_samples_before == 0 || n_samples_after == 0;
+}
+#endif // PREFIX_SUFFIX_IMPL
+
 static int fillEmptyBuckets(Samples *samples,
                             size_t *write_index,
                             timestamp_t first_bucket_ts,
@@ -652,36 +690,32 @@ static int fillEmptyBuckets(Samples *samples,
 
     // Check timestamp ordering
     if (end_bucket_ts < first_bucket_ts) {
-        return -1;
+        return 0; /* skip gap; -1 would abort the entire TS.RANGE */
     }
 
     // Check alignment with aggregation time delta
-    if ((end_bucket_ts - first_bucket_ts) % agg_time_delta != 0) {
-        return -1;
+    if (agg_time_delta == 0) {
+        return 0;
+    }
+    {
+        uint64_t span = end_bucket_ts - first_bucket_ts;
+        if (span % (uint64_t)agg_time_delta != 0) {
+            return 0; /* skip gap; -1 would abort the entire TS.RANGE */
+        }
     }
 
     size_t n_empty_buckets = ((end_bucket_ts - first_bucket_ts) / agg_time_delta) + 1;
     if (n_empty_buckets == 0) {
-        return -1;
+        return 0;
     }
 
     timestamp_t cur_ts = (reversed) ? end_bucket_ts : first_bucket_ts;
 
 #ifndef PREFIX_SUFFIX_IMPL // The PM decided to disable it, as it might cause OOM and complicates
                            // users
-    if (self->hasTwa) {
-        Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
-        timestamp_t ta;
-        int64_t agg_time_delta = self->aggregationTimeDelta;
-        ta = twa_calc_ta(
-            false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
-        size_t n_samples_before =
-            twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore);
-        size_t n_samples_after =
-            twa_get_samples_from_right(ta, self, &sample_after, &sample_afAfter);
-        if (n_samples_before == 0 || n_samples_after == 0) { // the PM canceled cases 6 and 7
-            return 0;
-        }
+    if (self->hasTwa &&
+        empty_gap_skipped_by_pm_edge_rule(self, cur_ts, self->aggregationTimeDelta)) {
+        return 0;
     }
 #endif // PREFIX_SUFFIX_IMPL
 
@@ -823,6 +857,11 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
         }
         return NULL;
     }
+    if (self->empty && !self->initialized && !self->handled_non_twa_empty_full_range &&
+        !TWA_EMPTY_RANGE(self)) {
+        return agg_iter_non_twa_empty_full_range(
+            self, aggregationTimeDelta, is_reversed, agg_n_samples, si);
+    }
     return NULL;
 }
 
@@ -884,6 +923,161 @@ static int agg_iter_apply_twa_empty_prefix(AggregationIterator *self,
         (*si)++;
     }
     return 0;
+}
+
+/* EMPTY without TWA (e.g. LAST): emit buckets from query start through the bucket before the first
+ * raw sample — same geometry as agg_iter_apply_twa_empty_prefix; requires LOCF seed first. */
+static int agg_iter_apply_non_twa_empty_prefix(AggregationIterator *self,
+                                               EnrichedChunk *enrichedChunk,
+                                               uint64_t aggregationTimeDelta,
+                                               bool is_reversed,
+                                               bool multiAgg,
+                                               size_t *agg_n_samples,
+                                               int64_t *si) {
+    if (!self->empty || self->handled_non_twa_empty_prefix || TWA_EMPTY_RANGE(self)) {
+        return 0;
+    }
+    self->handled_non_twa_empty_prefix = true;
+    timestamp_t first_bucket =
+        CalcBucketStart(is_reversed ? self->endTimestamp : self->startTimestamp,
+                        aggregationTimeDelta,
+                        self->timestampAlignment);
+    timestamp_t first_sample_ts = enrichedChunk->samples.timestamps[0];
+    timestamp_t last_bucket =
+        CalcBucketStart(first_sample_ts, aggregationTimeDelta, self->timestampAlignment);
+    bool has_empty_buckets = true;
+    if (!is_reversed) {
+        if (first_bucket >= last_bucket) {
+            has_empty_buckets = false;
+        }
+        last_bucket = max(0, (int64_t)((int64_t)last_bucket - (int64_t)aggregationTimeDelta));
+    } else {
+        last_bucket += aggregationTimeDelta;
+        if (first_bucket < last_bucket) {
+            has_empty_buckets = false;
+        }
+    }
+    if (!has_empty_buckets) {
+        return 0;
+    }
+    /* Mirror TWA empty-bucket neighbor rule (fillEmptyBuckets PREFIX block): do not emit prefix
+     * buckets for LAST+EMPTY when there is no sample strictly before the query start to LOCF from. */
+    if (!is_reversed && self->startTimestamp > 0 && !self->last_locf_seed_ok) {
+        return 0;
+    }
+    if (multiAgg) {
+        Samples *prefixSamples = ensureOutputSamples(self, enrichedChunk, *agg_n_samples + 256);
+        prefixSamples->num_samples = *agg_n_samples;
+        int64_t read_idx = -1;
+        int err = fillEmptyBuckets(
+            prefixSamples, agg_n_samples, first_bucket, last_bucket, self, is_reversed, &read_idx);
+        if (err != 0) {
+            return -1;
+        }
+    } else {
+        *si = -1;
+        int err = fillEmptyBuckets(&enrichedChunk->samples,
+                                   agg_n_samples,
+                                   first_bucket,
+                                   last_bucket,
+                                   self,
+                                   is_reversed,
+                                   si);
+        if (err != 0) {
+            return -1;
+        }
+        (*si)++;
+    }
+    return 0;
+}
+
+/* TS.RANGE … AGGREGATION LAST … EMPTY: empty buckets use finalize_empty_last_value (context value).
+ * Seed LAST context from the latest raw sample strictly before the query start (LOCF), mirroring
+ * how TWA pulls a neighbor sample (reverse scan of [0, startTimestamp - 1]). */
+static void agg_iter_seed_last_empty_before_query(AggregationIterator *self, Sample *sample) {
+    if (!self->empty || self->reverse || self->startTimestamp == 0) {
+        return;
+    }
+    bool any_last = false;
+    for (size_t a = 0; a < self->numAggregations; a++) {
+        if (self->aggregations[a].type == TS_AGG_LAST) {
+            any_last = true;
+            break;
+        }
+    }
+    if (!any_last) {
+        return;
+    }
+    self->last_locf_seed_ok = false;
+    RangeArgs args = {
+        .aggregationArgs = { 0 },
+        .filterByValueArgs = { 0 },
+        .filterByTSArgs = { 0 },
+        .startTimestamp = 0,
+        .endTimestamp = self->startTimestamp - 1,
+        .latest = false,
+    };
+    AbstractSampleIterator *sample_iterator =
+        SeriesCreateSampleIterator(self->series, &args, true, true);
+    while (sample_iterator->GetNext(sample_iterator, sample) == CR_OK) {
+        bool seeded = false;
+        for (size_t a = 0; a < self->numAggregations; a++) {
+            if (self->aggregations[a].type != TS_AGG_LAST) {
+                continue;
+            }
+            if (self->aggregations[a].isValueValid(sample->value)) {
+                self->aggregations[a].appendValue(
+                    self->aggregationContexts[a], sample->value, sample->timestamp);
+                seeded = true;
+            }
+        }
+        if (seeded) {
+            self->last_locf_seed_ok = true;
+            break;
+        }
+    }
+    sample_iterator->Close(sample_iterator);
+}
+
+/* EMPTY without TWA (e.g. LAST): upstream never produced samples — fill [start,end] with finalizeEmpty.
+ * Caller must ensure empty, !initialized, !handled_non_twa_empty_full_range, and !TWA_EMPTY_RANGE. */
+static EnrichedChunk *agg_iter_non_twa_empty_full_range(AggregationIterator *self,
+                                                        uint64_t aggregationTimeDelta,
+                                                        bool is_reversed,
+                                                        size_t *agg_n_samples,
+                                                        int64_t *si) {
+    self->handled_non_twa_empty_full_range = true;
+    timestamp_t first_bucket =
+        CalcBucketStart(self->startTimestamp, aggregationTimeDelta, self->timestampAlignment);
+    timestamp_t last_bucket =
+        CalcBucketStart(self->endTimestamp, aggregationTimeDelta, self->timestampAlignment);
+    if (is_reversed) {
+        __SWAP(first_bucket, last_bucket);
+    }
+    *si = -1;
+    *agg_n_samples = 0;
+    self->aux_chunk->samples.num_samples = 0;
+    Sample locf;
+    agg_iter_seed_last_empty_before_query(self, &locf);
+    if (!is_reversed && self->startTimestamp > 0 && !self->last_locf_seed_ok) {
+        return NULL;
+    }
+    int err = fillEmptyBuckets(&self->aux_chunk->samples,
+                               agg_n_samples,
+                               first_bucket,
+                               last_bucket,
+                               self,
+                               is_reversed,
+                               si);
+    if (err != 0) {
+        return NULL;
+    }
+    if (*agg_n_samples == 0) {
+        return NULL;
+    }
+    (*si)++;
+    self->aux_chunk->samples.num_samples = *agg_n_samples;
+    return self->aux_chunk;
 }
 
 // First chunk only: bucket start from first sample, TWA params, optional prior sample for TWA.
@@ -980,6 +1174,18 @@ static bool agg_iter_empty_gap_after_finalize(uint64_t contextScope,
         }
         *out_last_bucket =
             max(0, (int64_t)((int64_t)aggregationLastTimestamp - (int64_t)aggregationTimeDelta));
+        /* fillEmptyBuckets rejects end < first or (end-first) % delta != 0 with -1, which aborts
+         * the whole range query. Skip synthetic gaps that would fail those checks. */
+        if (has_empty_buckets) {
+            if (*out_last_bucket < *out_first_bucket) {
+                has_empty_buckets = false;
+            } else if (aggregationTimeDelta != 0) {
+                uint64_t span = *out_last_bucket - *out_first_bucket;
+                if (span % aggregationTimeDelta != 0) {
+                    has_empty_buckets = false;
+                }
+            }
+        }
     }
     return has_empty_buckets;
 }
@@ -1362,7 +1568,10 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
     self->aux_chunk->samples.timestamps[0] =
         calc_bucket_ts(self->bucketTS, self->aggregationLastTimestamp, self->aggregationTimeDelta);
     size_t n_samples = 1;
-    if (TWA_EMPTY_RANGE(self) && !self->handled_twa_empty_suffix) {
+    /* Emit trailing empty buckets from the last output bucket through endTimestamp. TWA fillEmptyBuckets
+     * may insert nothing for a gap (PM edge rule); LAST+EMPTY uses the same rule for the suffix so
+     * bucket counts match TWA+EMPTY. */
+    if (self->empty && !self->handled_twa_empty_suffix) {
         self->handled_twa_empty_suffix = true;
         timestamp_t last_bucket =
             CalcBucketStart(is_reversed ? self->startTimestamp : self->endTimestamp,
@@ -1385,16 +1594,34 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
         int64_t read_index = 0;
         if (has_empty_buckets) {
             self->aux_chunk->samples.num_samples = 1;
-            int err = fillEmptyBuckets(&self->aux_chunk->samples,
-                                       &n_samples,
-                                       first_bucket,
-                                       last_bucket,
-                                       self,
-                                       is_reversed,
-                                       &read_index);
-            if (err != 0) {
-                return NULL;
+#ifndef PREFIX_SUFFIX_IMPL
+            bool skip_trailing_empty_fill = false;
+            if (!self->hasTwa) {
+                timestamp_t fb = first_bucket;
+                timestamp_t lb = last_bucket;
+                if (is_reversed) {
+                    __SWAP(fb, lb);
+                }
+                timestamp_t gap_cur_ts = is_reversed ? lb : fb;
+                if (empty_gap_skipped_by_pm_edge_rule(self, gap_cur_ts, aggregationTimeDelta)) {
+                    skip_trailing_empty_fill = true;
+                }
             }
+            if (!skip_trailing_empty_fill) {
+#endif // PREFIX_SUFFIX_IMPL
+                int err = fillEmptyBuckets(&self->aux_chunk->samples,
+                                           &n_samples,
+                                           first_bucket,
+                                           last_bucket,
+                                           self,
+                                           is_reversed,
+                                           &read_index);
+                if (err != 0) {
+                    return NULL;
+                }
+#ifndef PREFIX_SUFFIX_IMPL
+            }
+#endif // PREFIX_SUFFIX_IMPL
         }
     }
     self->aux_chunk->samples.num_samples = n_samples;
@@ -1425,6 +1652,10 @@ EnrichedChunk *AggregationIterator_GetNextChunk(struct AbstractIterator *iter) {
         return r;
     }
 
+    if (self->empty && !self->initialized) {
+        agg_iter_seed_last_empty_before_query(self, &sample);
+    }
+
     if (agg_iter_apply_twa_empty_prefix(self,
                                         enrichedChunk,
                                         aggregationTimeDelta,
@@ -1432,6 +1663,15 @@ EnrichedChunk *AggregationIterator_GetNextChunk(struct AbstractIterator *iter) {
                                         multiAgg,
                                         &agg_n_samples,
                                         &si) != 0) {
+        return NULL;
+    }
+    if (agg_iter_apply_non_twa_empty_prefix(self,
+                                            enrichedChunk,
+                                            aggregationTimeDelta,
+                                            is_reversed,
+                                            multiAgg,
+                                            &agg_n_samples,
+                                            &si) != 0) {
         return NULL;
     }
     self->hasUnFinalizedContext = true;

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -326,24 +326,21 @@ AggregationIterator *AggregationIterator_New(struct AbstractIterator *input,
     return iter;
 }
 
-static size_t twa_get_samples_from_left(timestamp_t cur_ts,
-                                        const AggregationIterator *self,
-                                        Sample *sample_left,
-                                        Sample *sample_leftLeft);
-static size_t twa_get_samples_from_right(timestamp_t cur_ts,
-                                         const AggregationIterator *self,
-                                         Sample *sample_right,
-                                         Sample *sample_rightRight);
-timestamp_t twa_calc_ta(bool reverse,
-                        timestamp_t bucketStartTS,
-                        timestamp_t bucketEndTS,
-                        timestamp_t rangeStart,
-                        timestamp_t rangeEnd);
-timestamp_t twa_calc_tb(bool reverse,
-                        timestamp_t bucketStartTS,
-                        timestamp_t bucketEndTS,
-                        timestamp_t rangeStart,
-                        timestamp_t rangeEnd);
+static size_t get_samples_from_side(timestamp_t cur_ts,
+                                    bool from_left,
+                                    const AggregationIterator *self,
+                                    Sample *sample_1,
+                                    Sample *sample_2);
+static timestamp_t calc_ta(bool reverse,
+                           timestamp_t bucketStartTS,
+                           timestamp_t bucketEndTS,
+                           timestamp_t rangeStart,
+                           timestamp_t rangeEnd);
+static timestamp_t calc_tb(bool reverse,
+                           timestamp_t bucketStartTS,
+                           timestamp_t bucketEndTS,
+                           timestamp_t rangeStart,
+                           timestamp_t rangeEnd);
 
 static void twa_calc_empty_bucket_val(timestamp_t ta,
                                       timestamp_t tb,
@@ -406,14 +403,14 @@ static void twa_compute_empty_bucket_value(const AggregationIterator *self,
     Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
     int64_t agg_time_delta = self->aggregationTimeDelta;
 
-    timestamp_t ta = twa_calc_ta(
+    timestamp_t ta = calc_ta(
         false, bucket_ts, bucket_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
-    timestamp_t tb = twa_calc_tb(
+    timestamp_t tb = calc_tb(
         false, bucket_ts, bucket_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
 
     size_t n_samples_before =
-        twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore);
-    size_t n_samples_after = twa_get_samples_from_right(tb, self, &sample_after, &sample_afAfter);
+        get_samples_from_side(ta, true, self, &sample_before, &sample_befBefore);
+    size_t n_samples_after = get_samples_from_side(tb, false, self, &sample_after, &sample_afAfter);
 
     twa_calc_empty_bucket_val(ta,
                               tb,
@@ -534,99 +531,72 @@ static void fillEmptyBucketsWithDefaultVals(size_t *write_index,
     }
 }
 
-static size_t twa_get_samples_from_right(timestamp_t cur_ts,
-                                         const AggregationIterator *self,
-                                         Sample *sample_right,
-                                         Sample *sample_rightRight) {
-    size_t n_samples_right = 0;
-    if (cur_ts < UINT64_MAX) {
-        RangeArgs args = {
-            .aggregationArgs = { 0 },
-            .filterByValueArgs = { 0 },
-            .filterByTSArgs = { 0 },
-            .startTimestamp = cur_ts,
-            .endTimestamp = UINT64_MAX,
-            .latest = false,
-        };
-        AbstractSampleIterator *sample_iterator =
-            SeriesCreateSampleIterator(self->series, &args, false, true);
-        Sample sample;
-        // Skip NaN samples - they shouldn't be used for interpolation
-        while (sample_iterator->GetNext(sample_iterator, &sample) == CR_OK) {
-            if (!isnan(sample.value)) {
-                if (n_samples_right == 0) {
-                    *sample_right = sample;
-                    n_samples_right++;
-                } else if (n_samples_right == 1) {
-                    *sample_rightRight = sample;
-                    n_samples_right++;
-                    break;
-                }
-            }
+/**
+ * @brief Return up to two nearest non-NaN samples on one side of @p cur_ts.
+ *
+ * Unifies the previous `..._from_left` / `..._from_right` pair. NaN samples are skipped
+ * because they can't serve as interpolation/carry sources.
+ *
+ * @param[in]  cur_ts    pivot timestamp.
+ * @param[in]  from_left true: scan `[0, cur_ts - 1]` newest-first (samples strictly before).
+ *                       false: scan `[cur_ts, UINT64_MAX]` oldest-first (samples at or after).
+ * @param[out] sample_1  closest sample to @p cur_ts on the chosen side.
+ * @param[out] sample_2  second-closest sample on the chosen side (written only when 2 found).
+ * @return number of samples written (0, 1, or 2).
+ */
+static size_t get_samples_from_side(timestamp_t cur_ts,
+                                    bool from_left,
+                                    const AggregationIterator *self,
+                                    Sample *sample_1,
+                                    Sample *sample_2) {
+    if (from_left ? (cur_ts == 0) : (cur_ts == UINT64_MAX)) {
+        return 0;
+    }
+    RangeArgs args = {
+        .aggregationArgs = { 0 },
+        .filterByValueArgs = { 0 },
+        .filterByTSArgs = { 0 },
+        .startTimestamp = from_left ? 0 : cur_ts,
+        .endTimestamp = from_left ? cur_ts - 1 : UINT64_MAX,
+        .latest = false,
+    };
+    AbstractSampleIterator *sample_iterator =
+        SeriesCreateSampleIterator(self->series, &args, from_left, true);
+    Sample sample;
+    size_t n = 0;
+    while (sample_iterator->GetNext(sample_iterator, &sample) == CR_OK) {
+        if (isnan(sample.value)) {
+            continue;
         }
-        sample_iterator->Close(sample_iterator);
-    }
-    return n_samples_right;
-}
-
-static size_t twa_get_samples_from_left(timestamp_t cur_ts,
-                                        const AggregationIterator *self,
-                                        Sample *sample_left,
-                                        Sample *sample_leftLeft) {
-    size_t n_samples_left = 0;
-    if (cur_ts > 0) {
-        RangeArgs args = {
-            .aggregationArgs = { 0 },
-            .filterByValueArgs = { 0 },
-            .filterByTSArgs = { 0 },
-            .startTimestamp = 0,
-            .endTimestamp = cur_ts - 1,
-            .latest = false,
-        };
-        AbstractSampleIterator *sample_iterator =
-            SeriesCreateSampleIterator(self->series, &args, true, true);
-        Sample sample;
-        // Skip NaN samples - they shouldn't be used for interpolation
-        // Note: iterator is reversed, so we get samples in descending timestamp order
-        while (sample_iterator->GetNext(sample_iterator, &sample) == CR_OK) {
-            if (!isnan(sample.value)) {
-                if (n_samples_left == 0) {
-                    *sample_left = sample;
-                    n_samples_left++;
-                } else if (n_samples_left == 1) {
-                    *sample_leftLeft = sample;
-                    n_samples_left++;
-                    break;
-                }
-            }
+        if (n == 0) {
+            *sample_1 = sample;
+            n = 1;
+        } else {
+            *sample_2 = sample;
+            n = 2;
+            break;
         }
-        sample_iterator->Close(sample_iterator);
     }
-    return n_samples_left;
+    sample_iterator->Close(sample_iterator);
+    return n;
 }
 
-timestamp_t twa_calc_ta(bool reverse,
-                        timestamp_t bucketStartTS,
-                        timestamp_t bucketEndTS,
-                        timestamp_t rangeStart,
-                        timestamp_t rangeEnd) {
-    if (!reverse) {
-        return max(bucketStartTS, rangeStart);
-    } else {
-        return min(bucketEndTS, rangeEnd);
-    }
+/** @brief Clipped leading edge of a bucket in iteration order (forward: start, reverse: end). */
+static timestamp_t calc_ta(bool reverse,
+                           timestamp_t bucketStartTS,
+                           timestamp_t bucketEndTS,
+                           timestamp_t rangeStart,
+                           timestamp_t rangeEnd) {
+    return reverse ? min(bucketEndTS, rangeEnd) : max(bucketStartTS, rangeStart);
 }
 
-timestamp_t twa_calc_tb(bool reverse,
-                        timestamp_t bucketStartTS,
-                        timestamp_t bucketEndTS,
-                        timestamp_t rangeStart,
-                        timestamp_t rangeEnd) {
-    if (!reverse) {
-        return min(bucketEndTS, rangeEnd);
-    } else {
-        return max(bucketStartTS, rangeStart);
-    }
+/** @brief Clipped trailing edge of a bucket in iteration order (forward: end, reverse: start). */
+static timestamp_t calc_tb(bool reverse,
+                           timestamp_t bucketStartTS,
+                           timestamp_t bucketEndTS,
+                           timestamp_t rangeStart,
+                           timestamp_t rangeEnd) {
+    return reverse ? max(bucketStartTS, rangeStart) : min(bucketEndTS, rangeEnd);
 }
 
 static void twa_fillEmptyBuckets(size_t *write_index,
@@ -639,15 +609,15 @@ static void twa_fillEmptyBuckets(size_t *write_index,
     size_t n_samples_before = 0, n_samples_after = 0;
     timestamp_t ta, tb;
     int64_t agg_time_delta = self->aggregationTimeDelta;
-    ta = twa_calc_ta(
+    ta = calc_ta(
         false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
-    n_samples_before = twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore);
-    n_samples_after = twa_get_samples_from_right(ta, self, &sample_after, &sample_afAfter);
+    n_samples_before = get_samples_from_side(ta, true, self, &sample_before, &sample_befBefore);
+    n_samples_after = get_samples_from_side(ta, false, self, &sample_after, &sample_afAfter);
 
     for (size_t i = 0; i < n_empty_buckets; ++i) {
-        ta = twa_calc_ta(
+        ta = calc_ta(
             false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
-        tb = twa_calc_tb(
+        tb = calc_tb(
             false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
 
         timestamp_t ts = calc_bucket_ts(self->bucketTS, cur_ts, self->aggregationTimeDelta);
@@ -684,33 +654,32 @@ static void twa_fillEmptyBuckets(size_t *write_index,
 #ifndef PREFIX_SUFFIX_IMPL
 
 /**
- * @brief TWA: true if a run of empty buckets should be skipped (spec 6/7).
+ * @brief True if a run of empty buckets lies outside the data span and should be skipped.
  *
- * At @p first_bucket_of_gap, uses @c twa_calc_ta and @c twa_get_samples_from_left/right. If a raw
- * sample is missing on either side of the TWA window, interpolation is undefined — return true so
- * the caller omits the whole gap.
- *
- * @param[in] self aggregation iterator.
- * @param[in] first_bucket_of_gap first empty bucket timestamp in the gap.
- * @param[in] aggregationTimeDelta bucket duration.
- * @return true to skip the gap (missing left or right neighbor); false if both neighbors exist.
+ * Aggregation-agnostic: at @p first_bucket_of_gap, asks the series whether raw samples exist on
+ * both sides of the bucket's leading edge. If either side has no samples, the gap is outside the
+ * data span and the caller omits it. Used identically by:
+ *   - TWA  : interpolation is undefined without left/right neighbors.
+ *   - LOCF (e.g. `LAST + EMPTY`) : no carrier value exists outside the data span.
+ *   - Plain `EMPTY` (`SUM`, `COUNT`, ...) : avoid synthesizing values past the data.
  */
-static bool twa_should_skip_empty_gap(const AggregationIterator *self,
-                                                  timestamp_t first_bucket_of_gap,
-                                                  uint64_t aggregationTimeDelta) {
+static bool should_skip_empty_gap(const AggregationIterator *self,
+                                  timestamp_t first_bucket_of_gap,
+                                  uint64_t aggregationTimeDelta) {
     Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
-    timestamp_t ta = twa_calc_ta(
+    timestamp_t ta = calc_ta(
         false,
         first_bucket_of_gap,
         first_bucket_of_gap + aggregationTimeDelta,
         self->startTimestamp,
         self->endTimestamp);
     size_t n_samples_before =
-        twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore);
+        get_samples_from_side(ta, true, self, &sample_before, &sample_befBefore);
     size_t n_samples_after =
-        twa_get_samples_from_right(ta, self, &sample_after, &sample_afAfter);
+        get_samples_from_side(ta, false, self, &sample_after, &sample_afAfter);
     return n_samples_before == 0 || n_samples_after == 0;
 }
+
 #endif // PREFIX_SUFFIX_IMPL
 
 static int fillEmptyBuckets(Samples *samples,
@@ -746,8 +715,9 @@ static int fillEmptyBuckets(Samples *samples,
 
 #ifndef PREFIX_SUFFIX_IMPL // The PM decided to disable it, as it might cause OOM and complicates
                            // users
-    if (self->hasTwa &&
-        twa_should_skip_empty_gap(self, cur_ts, self->aggregationTimeDelta)) {
+    // Skip empty buckets that lie outside the data span (no raw sample on one side). Applies
+    // uniformly to TWA, LOCF, and plain EMPTY so forward and reverse return the same buckets.
+    if (should_skip_empty_gap(self, cur_ts, self->aggregationTimeDelta)) {
         return 0;
     }
 #endif // PREFIX_SUFFIX_IMPL
@@ -937,8 +907,29 @@ static int agg_iter_fill_aux_query_window(AggregationIterator *self,
                             si);
 }
 
-// No samples from upstream: finalize, TWA-only empty range, or end stream.
-// Sets *enter_finalize when caller must run agg_iter_finalize().
+/**
+ * @brief Handles the "no more samples from upstream" case for an aggregation iterator.
+ *
+ * Decides between three terminal paths and signals the caller via @p enter_finalize:
+ * - If a partially-built bucket is still pending (`hasUnFinalizedContext`), sets
+ *   @p enter_finalize to @c true so the caller runs `agg_iter_finalize()`.
+ * - If TWA `EMPTY` range mode is active, emits the empty prefix on the first call and
+ *   the empty suffix on the second call (each via the aux chunk), then ends the stream.
+ * - If a non-TWA `EMPTY` policy has a fully-empty range that hasn't been emitted yet,
+ *   delegates to `agg_iter_empty_range_no_samples()`.
+ * - Otherwise returns @c NULL to signal end of stream.
+ *
+ * @param[in,out] self            aggregation iterator (TWA flags, aux chunk, prev_ts).
+ * @param[in]     aggregationTimeDelta bucket duration.
+ * @param[in]     is_reversed     forward vs reverse aggregation direction.
+ * @param[in,out] agg_n_samples   running count of samples written to the aux chunk.
+ * @param[in,out] si              current sample index into the aux chunk; reset to -1
+ *                                before filling and post-incremented after.
+ * @param[out]    enter_finalize  set to @c true iff the caller must run `agg_iter_finalize()`;
+ *                                @c false otherwise.
+ * @return The aux `EnrichedChunk` populated with empty buckets, or @c NULL when the stream
+ *         has ended or the caller must finalize first.
+ */
 static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
                                               uint64_t aggregationTimeDelta,
                                               bool is_reversed,
@@ -1007,7 +998,22 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
     return NULL;
 }
 
-/* EMPTY prefix before first in-range sample: TWA_EMPTY_RANGE vs non-TWA EMPTY (LAST LOCF gate). */
+
+/**
+ * @brief Emits the `EMPTY` prefix once per range, before the first non-empty bucket.
+ *
+ * Gated by the per-range `handled_*_empty_prefix` flags; no-ops if `EMPTY` is inactive,
+ * the span is degenerate, or (non-TWA forward LOCF) no valid pre-range seed exists.
+ *
+ * @param[in,out] self                 aggregation iterator (`EMPTY` flags, range bounds).
+ * @param[in,out] enrichedChunk        output chunk receiving prefix buckets.
+ * @param[in]     aggregationTimeDelta bucket duration.
+ * @param[in]     is_reversed          forward vs reverse direction.
+ * @param[in]     multiAgg             true if more than one aggregation is active.
+ * @param[in,out] agg_n_samples        running count of samples written.
+ * @param[in,out] si                   current sample index into the output buffer.
+ * @return 0 on success/no-op; error code propagated from `agg_iter_append_empty_buckets()`.
+ */
 static int agg_iter_apply_empty_prefix(AggregationIterator *self,
                                        EnrichedChunk *enrichedChunk,
                                        uint64_t aggregationTimeDelta,
@@ -1052,14 +1058,60 @@ static int agg_iter_apply_empty_prefix(AggregationIterator *self,
                                              si);
 }
 
-/* Scan raw samples in [range_start, range_end] using SeriesCreateSampleIterator(reverse_iteration).
+/**
+ * @brief Seeds all applicable aggregations from a single raw `sample`.
  *
- * Prev-bucket padding: any aggregation with addPrevBucketLastSample (TWA today; same hook drives
- * future neighbor sampling) — first iterator sample where at least one hook accepts isValueValid
- * seeds all applicable hooks, then return.
+ * Three mutually-exclusive seed modes (the first true flag wins):
+ * - `seed_prev_bucket_neighbors`: TWA prev-bucket seeding via `addPrevBucketLastSample`.
+ * - `seed_next_bucket_neighbors`: TWA next-bucket seeding via `addNextBucketFirstSample`.
+ * - otherwise: LOCF empty-bucket seeding via `appendValue` for aggs reported by
+ *   `agg_class_needs_locf_empty_seed` (e.g. `TS_AGG_LAST`).
  *
- * LOCF empty padding: types where agg_class_needs_locf_empty_seed (TS_AGG_LAST today) — appendValue
- * for each applicable agg where isValueValid; if any seeded, set last_locf_seed_ok and return.
+ * Aggs are skipped when the relevant hook is absent or `isValueValid(sample->value)` is false.
+ *
+ * @return true if at least one aggregation was seeded.
+ */
+static bool agg_iter_try_seed_sample(AggregationIterator *self,
+                                     const Sample *sample,
+                                     bool seed_prev_bucket_neighbors,
+                                     bool seed_next_bucket_neighbors) {
+    bool seeded = false;
+    for (size_t a = 0; a < self->numAggregations; a++) {
+        AggregationClass *agg = &self->aggregations[a];
+        bool applies;
+        if (seed_prev_bucket_neighbors) {
+            applies = (agg->addPrevBucketLastSample != NULL);
+        } else if (seed_next_bucket_neighbors) {
+            applies = (agg->addNextBucketFirstSample != NULL);
+        } else {
+            applies = agg_class_needs_locf_empty_seed(agg);
+        }
+        if (!applies || !agg->isValueValid(sample->value)) {
+            continue;
+        }
+        if (seed_prev_bucket_neighbors) {
+            agg->addPrevBucketLastSample(
+                self->aggregationContexts[a], sample->value, sample->timestamp);
+        } else if (seed_next_bucket_neighbors) {
+            agg->addNextBucketFirstSample(
+                self->aggregationContexts[a], sample->value, sample->timestamp);
+        } else {
+            agg->appendValue(self->aggregationContexts[a], sample->value, sample->timestamp);
+        }
+        seeded = true;
+    }
+    return seeded;
+}
+
+/**
+ * @brief Seeds aggregation contexts from a raw sample in `[range_start, range_end]`.
+ *
+ * Iterates the series via `SeriesCreateSampleIterator` and stops at the first sample that
+ * successfully seeds at least one aggregation. Modes (mutually exclusive):
+ * - `seed_prev_bucket_neighbors`: TWA `addPrevBucketLastSample`.
+ * - `seed_next_bucket_neighbors`: TWA `addNextBucketFirstSample`.
+ * - `seed_last_locf`: LOCF `appendValue` for aggs needing LOCF empty seeding (e.g. `LAST`);
+ *   on success also sets `self->last_locf_seed_ok`.
  */
 static void agg_iter_neighbor_sample_scan(AggregationIterator *self,
                                           Sample *sample,
@@ -1067,6 +1119,7 @@ static void agg_iter_neighbor_sample_scan(AggregationIterator *self,
                                           timestamp_t range_end,
                                           bool reverse_iteration,
                                           bool seed_prev_bucket_neighbors,
+                                          bool seed_next_bucket_neighbors,
                                           bool seed_last_locf) {
     RangeArgs args = {
         .aggregationArgs = { 0 },
@@ -1079,52 +1132,45 @@ static void agg_iter_neighbor_sample_scan(AggregationIterator *self,
     AbstractSampleIterator *sample_iterator =
         SeriesCreateSampleIterator(self->series, &args, reverse_iteration, true);
     while (sample_iterator->GetNext(sample_iterator, sample) == CR_OK) {
-        if (seed_prev_bucket_neighbors) {
-            bool any_prev = false;
-            for (size_t a = 0; a < self->numAggregations; a++) {
-                AggregationClass *agg = &self->aggregations[a];
-                if (!agg->addPrevBucketLastSample) {
-                    continue;
-                }
-                if (!agg->isValueValid(sample->value)) {
-                    continue;
-                }
-                agg->addPrevBucketLastSample(
-                    self->aggregationContexts[a], sample->value, sample->timestamp);
-                any_prev = true;
-            }
-            if (any_prev) {
-                sample_iterator->Close(sample_iterator);
-                return;
-            }
+        if (seed_prev_bucket_neighbors &&
+            agg_iter_try_seed_sample(self, sample, true, false)) {
+            sample_iterator->Close(sample_iterator);
+            return;
         }
-        if (seed_last_locf) {
-            bool seeded = false;
-            for (size_t a = 0; a < self->numAggregations; a++) {
-                AggregationClass *agg = &self->aggregations[a];
-                if (!agg_class_needs_locf_empty_seed(agg)) {
-                    continue;
-                }
-                if (!agg->isValueValid(sample->value)) {
-                    continue;
-                }
-                agg->appendValue(self->aggregationContexts[a], sample->value, sample->timestamp);
-                seeded = true;
-            }
-            if (seeded) {
-                self->last_locf_seed_ok = true;
-                sample_iterator->Close(sample_iterator);
-                return;
-            }
+        if (seed_next_bucket_neighbors &&
+            agg_iter_try_seed_sample(self, sample, false, true)) {
+            sample_iterator->Close(sample_iterator);
+            return;
+        }
+        if (seed_last_locf && agg_iter_try_seed_sample(self, sample, false, false)) {
+            self->last_locf_seed_ok = true;
+            sample_iterator->Close(sample_iterator);
+            return;
         }
     }
     sample_iterator->Close(sample_iterator);
 }
 
-/* TS.RANGE … AGGREGATION LAST … EMPTY: empty buckets use finalize_empty_last_value (context value).
- * Load LAST context from the latest raw sample strictly before the query start (LOCF). */
+/**
+ * @brief Pre-loads LOCF empty seed from the latest raw sample chronologically just outside the
+ *        query window in the iteration direction (forward: before `startTimestamp`; reverse:
+ *        after `endTimestamp`).
+ *
+ * Used by `TS.RANGE`/`TS.REVRANGE ... AGGREGATION LAST ... EMPTY` so empty buckets at the
+ * leading edge of the window (in iteration order) can produce a value via
+ * `finalize_empty_last_value`. No-ops if `EMPTY` is inactive, the relevant edge is at the
+ * timestamp domain boundary, or no aggregation needs an LOCF empty seed. Resets
+ * `last_locf_seed_ok` and delegates the scan to `agg_iter_neighbor_sample_scan`, which sets
+ * the flag on success.
+ */
 static void agg_iter_load_last_pre_window(AggregationIterator *self, Sample *sample) {
-    if (!self->empty || self->reverse || self->startTimestamp == 0) {
+    if (!self->empty) {
+        return;
+    }
+    if (!self->reverse && self->startTimestamp == 0) {
+        return;
+    }
+    if (self->reverse && self->endTimestamp == UINT64_MAX) {
         return;
     }
     if (!agg_iter_any_locf_empty_agg(self)) {
@@ -1133,15 +1179,29 @@ static void agg_iter_load_last_pre_window(AggregationIterator *self, Sample *sam
     self->last_locf_seed_ok = false;
     agg_iter_neighbor_sample_scan(self,
                                   sample,
-                                  0,
-                                  self->startTimestamp - 1,
-                                  true,
+                                  self->reverse ? self->endTimestamp + 1 : 0,
+                                  self->reverse ? UINT64_MAX : self->startTimestamp - 1,
+                                  !self->reverse,
+                                  false,
                                   false,
                                   true);
 }
 
-/* EMPTY without TWA: no in-range samples — fill [start,end] with finalizeEmpty.
- * Caller must ensure empty, !initialized, !handled_non_twa_empty_full_range, and !TWA_EMPTY_RANGE. */
+/**
+ * @brief Fills `[startTimestamp, endTimestamp]` with empty buckets when no in-range samples exist (non-TWA `EMPTY`).
+ *
+ * Marks the full empty range as handled, pre-loads an LOCF seed, then writes empty buckets into
+ * the aux chunk via `agg_iter_fill_aux_query_window`. Returns @c NULL when forward LOCF has no
+ * pre-window seed, the fill fails, or no buckets were written. Caller must ensure `self->empty`,
+ * `!initialized`, `!handled_non_twa_empty_full_range`, and `!TWA_EMPTY_RANGE(self)`.
+ *
+ * @param[in,out] self                 aggregation iterator (`handled_non_twa_empty_full_range`, aux chunk).
+ * @param[in]     aggregationTimeDelta bucket duration.
+ * @param[in]     is_reversed          forward vs reverse direction.
+ * @param[out]    agg_n_samples        number of samples written to the aux chunk.
+ * @param[in,out] si                   current sample index into the aux chunk.
+ * @return The aux `EnrichedChunk` populated with empty buckets, or @c NULL on failure / no output.
+ */
 static EnrichedChunk *agg_iter_empty_range_no_samples(AggregationIterator *self,
                                                         uint64_t aggregationTimeDelta,
                                                         bool is_reversed,
@@ -1183,12 +1243,12 @@ static void agg_iter_init_if_needed(AggregationIterator *self,
     self->initialized = true;
 
     if (self->hasTwa) {
-        timestamp_t ta = twa_calc_ta(self->reverse,
+        timestamp_t ta = calc_ta(self->reverse,
                                      BucketStartNormalize(self->aggregationLastTimestamp),
                                      self->aggregationLastTimestamp + aggregationTimeDelta,
                                      self->startTimestamp,
                                      self->endTimestamp);
-        timestamp_t tb = twa_calc_tb(self->reverse,
+        timestamp_t tb = calc_tb(self->reverse,
                                      BucketStartNormalize(self->aggregationLastTimestamp),
                                      self->aggregationLastTimestamp + aggregationTimeDelta,
                                      self->startTimestamp,
@@ -1202,6 +1262,8 @@ static void agg_iter_init_if_needed(AggregationIterator *self,
         }
     }
 
+    // Guard against `init_ts - 1` underflow in forward direction when init_ts == 0
+    // (no samples can exist before timestamp 0, so nothing to scan).
     if (agg_iter_needs_prev_bucket_sample(self) && !((!is_reversed) && init_ts == 0)) {
         agg_iter_neighbor_sample_scan(self,
                                       sample,
@@ -1209,6 +1271,7 @@ static void agg_iter_init_if_needed(AggregationIterator *self,
                                       is_reversed ? UINT64_MAX : init_ts - 1,
                                       !is_reversed,
                                       true,
+                                      false,
                                       false);
     }
 }
@@ -1416,6 +1479,14 @@ static int agg_iter_general_on_bucket_boundary(AggregationIterator *self,
     self->aggregationLastTimestamp =
         CalcBucketStart(sample->timestamp, aggregationTimeDelta, self->timestampAlignment);
     if (self->empty) {
+        // In reverse iteration, the chronologically-previous-in-time sample relative to the
+        // empty gap is the upcoming one (sample arg here), not the bucket we just finalized.
+        // Pre-load LOCF aggregations' contexts with it so finalize_empty_*_value emits the
+        // correct value during fillEmptyBuckets. The subsequent appendValue for the same
+        // sample (in process_chunk_general) is idempotent for LOCF aggs (e.g. LAST).
+        if (is_reversed) {
+            agg_iter_try_seed_sample(self, sample, false, false);
+        }
         timestamp_t first_bucket, last_bucket;
         if (agg_iter_empty_gap_after_finalize(*contextScope,
                                               self->aggregationLastTimestamp,
@@ -1444,7 +1515,7 @@ static int agg_iter_general_on_bucket_boundary(AggregationIterator *self,
     agg_iter_advance_context_scope(self, aggregationTimeDelta, contextScope);
 
     if (self->hasTwa) {
-        timestamp_t tb = twa_calc_tb(self->reverse,
+        timestamp_t tb = calc_tb(self->reverse,
                                      self->aggregationLastTimestamp,
                                      *contextScope,
                                      self->startTimestamp,
@@ -1555,31 +1626,27 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
                                         bool is_reversed,
                                         Sample *sample) {
     self->hasUnFinalizedContext = false;
-    for (size_t a = 0; a < self->numAggregations; a++) {
-        if (self->aggregations[a].type == TS_AGG_TWA) {
-            Sample last_sample;
-            self->aggregations[a].getLastSample(self->aggregationContexts[a], &last_sample);
-            if (!(is_reversed && last_sample.timestamp == 0)) {
-                RangeArgs args = {
-                    .aggregationArgs = { 0 },
-                    .filterByValueArgs = { 0 },
-                    .filterByTSArgs = { 0 },
-                    .startTimestamp = is_reversed ? 0 : last_sample.timestamp + 1,
-                    .endTimestamp = is_reversed ? last_sample.timestamp - 1 : UINT64_MAX,
-                    .latest = false,
-                };
-                AbstractSampleIterator *sample_iterator =
-                    SeriesCreateSampleIterator(self->series, &args, is_reversed, true);
-                // Skip non valid samples - they shouldn't be used for interpolation
-                while (sample_iterator->GetNext(sample_iterator, sample) == CR_OK) {
-                    if (self->aggregations[a].isValueValid(sample->value)) {
-                        self->aggregations[a].addNextBucketFirstSample(
-                            self->aggregationContexts[a], sample->value, sample->timestamp);
-                        break;
-                    }
-                }
-                sample_iterator->Close(sample_iterator);
+    if (self->hasTwa) {
+        // All TWA aggs in a single query share the same chronology, so use any TWA agg's
+        // last sample to compute the scan range and seed all TWA aggs with one series scan.
+        Sample last_sample;
+        bool found = false;
+        for (size_t a = 0; a < self->numAggregations && !found; a++) {
+            if (self->aggregations[a].type == TS_AGG_TWA) {
+                self->aggregations[a].getLastSample(self->aggregationContexts[a], &last_sample);
+                found = true;
             }
+        }
+        if (found && !(is_reversed && last_sample.timestamp == 0)) {
+            agg_iter_neighbor_sample_scan(
+                self,
+                sample,
+                is_reversed ? 0 : last_sample.timestamp + 1,
+                is_reversed ? last_sample.timestamp - 1 : UINT64_MAX,
+                is_reversed,
+                false,
+                true,
+                false);
         }
     }
 
@@ -1665,34 +1732,16 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
         int64_t read_index = 0;
         if (has_empty_buckets) {
             self->aux_chunk->samples.num_samples = 1;
-#ifndef PREFIX_SUFFIX_IMPL
-            bool skip_trailing_empty_fill = false;
-            if (!self->hasTwa) {
-                timestamp_t fb = first_bucket;
-                timestamp_t lb = last_bucket;
-                if (is_reversed) {
-                    __SWAP(fb, lb);
-                }
-                timestamp_t gap_cur_ts = is_reversed ? lb : fb;
-                if (twa_should_skip_empty_gap(self, gap_cur_ts, aggregationTimeDelta)) {
-                    skip_trailing_empty_fill = true;
-                }
+            int err = fillEmptyBuckets(&self->aux_chunk->samples,
+                                       &n_samples,
+                                       first_bucket,
+                                       last_bucket,
+                                       self,
+                                       is_reversed,
+                                       &read_index);
+            if (err != 0) {
+                return NULL;
             }
-            if (!skip_trailing_empty_fill) {
-#endif // PREFIX_SUFFIX_IMPL
-                int err = fillEmptyBuckets(&self->aux_chunk->samples,
-                                           &n_samples,
-                                           first_bucket,
-                                           last_bucket,
-                                           self,
-                                           is_reversed,
-                                           &read_index);
-                if (err != 0) {
-                    return NULL;
-                }
-#ifndef PREFIX_SUFFIX_IMPL
-            }
-#endif // PREFIX_SUFFIX_IMPL
         }
     }
     self->aux_chunk->samples.num_samples = n_samples;

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -311,6 +311,7 @@ AggregationIterator *AggregationIterator_New(struct AbstractIterator *input,
     iter->handled_non_twa_empty_full_range = false;
     iter->handled_non_twa_empty_prefix = false;
     iter->last_locf_seed_ok = true;
+    iter->last_bucket_sample_count = 0;
     iter->prev_ts = DC;
     iter->validSamplesInBucket = false;
     memset(iter->validPerAgg, 0, sizeof(iter->validPerAgg));
@@ -1445,6 +1446,9 @@ static int agg_iter_general_on_bucket_boundary(AggregationIterator *self,
                                                int64_t *si,
                                                Sample *twa_last_samples,
                                                bool *twaHadValid) {
+    const size_t samples_in_bucket_being_closed = self->last_bucket_sample_count;
+    self->last_bucket_sample_count = 0;
+
     for (size_t a = 0; a < self->numAggregations; a++) {
         if (self->aggregations[a].type == TS_AGG_TWA &&
             self->aggregations[a].isValueValid(sample->value)) {
@@ -1470,22 +1474,22 @@ static int agg_iter_general_on_bucket_boundary(AggregationIterator *self,
     self->aggregationLastTimestamp =
         CalcBucketStart(sample->timestamp, aggregationTimeDelta, self->timestampAlignment);
     if (self->empty) {
-        // In reverse iteration, the chronologically-previous-in-time sample relative to the
-        // empty gap is the upcoming one (sample arg here), not the bucket we just finalized.
-        // Pre-load LOCF aggregations' contexts with it so finalize_empty_*_value emits the
-        // correct value during fillEmptyBuckets. The subsequent appendValue for the same
-        // sample (in process_chunk_general) is idempotent for LOCF aggs (e.g. LAST).
-        if (is_reversed) {
+        timestamp_t first_bucket, last_bucket;
+        const bool has_gap = agg_iter_empty_gap_after_finalize(*contextScope,
+                                                               self->aggregationLastTimestamp,
+                                                               aggregationTimeDelta,
+                                                               is_reversed,
+                                                               false,
+                                                               &first_bucket,
+                                                               &last_bucket);
+        /* Blind reverse LOCF seeding breaks (a) multi-sample buckets and (b) multi-bucket empty
+         * spans. Seed only for a *single* empty bucket between two populated buckets where the
+         * bucket we closed had one raw sample (reverse iteration order bug). */
+        if (has_gap && is_reversed && agg_iter_any_locf_empty_agg(self) &&
+            samples_in_bucket_being_closed == 1 && first_bucket == last_bucket) {
             agg_iter_apply_neighbor_sample(self, sample, false, false);
         }
-        timestamp_t first_bucket, last_bucket;
-        if (agg_iter_empty_gap_after_finalize(*contextScope,
-                                              self->aggregationLastTimestamp,
-                                              aggregationTimeDelta,
-                                              is_reversed,
-                                              false,
-                                              &first_bucket,
-                                              &last_bucket)) {
+        if (has_gap) {
             Samples *emptySamples = ensureOutputSamples(self, enrichedChunk, *agg_n_samples + 256);
             if (multiAgg) {
                 emptySamples->num_samples = *agg_n_samples;
@@ -1537,6 +1541,9 @@ static void agg_iter_append_sample_to_all_aggs(AggregationIterator *self,
     if (self->numAggregations == 1) {
         if (aggregation->isValueValid(sample->value)) {
             appendValue(aggregationContext, sample->value, sample->timestamp);
+            if (aggregation->type == TS_AGG_LAST) {
+                self->last_bucket_sample_count++;
+            }
             self->validSamplesInBucket = true;
             self->validPerAgg[0] = true;
         }
@@ -1545,6 +1552,9 @@ static void agg_iter_append_sample_to_all_aggs(AggregationIterator *self,
             if (self->aggregations[a].isValueValid(sample->value)) {
                 self->aggregations[a].appendValue(
                     self->aggregationContexts[a], sample->value, sample->timestamp);
+                if (self->aggregations[a].type == TS_AGG_LAST) {
+                    self->last_bucket_sample_count++;
+                }
                 self->validSamplesInBucket = true;
                 self->validPerAgg[a] = true;
             }

--- a/src/filter_iterator.h
+++ b/src/filter_iterator.h
@@ -61,6 +61,10 @@ typedef struct AggregationIterator
     bool hasTwa; // precomputed: any aggregation is TWA
     bool handled_twa_empty_prefix;
     bool handled_twa_empty_suffix;
+    bool handled_non_twa_empty_full_range; // EMPTY without TWA: synthetic range when no raw chunk
+    bool handled_non_twa_empty_prefix; // EMPTY without TWA: buckets before first in-range sample
+    /* LAST+EMPTY: true if prior sample before range was applied (LOCF) or LOCF is not required. */
+    bool last_locf_seed_ok;
     timestamp_t prev_ts;
     bool validSamplesInBucket; // are there any valid samples in current bucket (any aggregation)
     bool validPerAgg[TS_AGG_TYPES_MAX]; // per-aggregation validity tracking for current bucket

--- a/src/filter_iterator.h
+++ b/src/filter_iterator.h
@@ -67,6 +67,8 @@ typedef struct AggregationIterator
     bool handled_non_twa_empty_prefix;
     // LAST+EMPTY: we already copied the last raw value from before `startTimestamp` into LAST (or LAST not used).
     bool last_locf_seed_ok;
+    /** Single-agg LAST: valid raw samples counted for the in-memory bucket being filled (cleared on boundary). */
+    size_t last_bucket_sample_count;
     timestamp_t prev_ts;
     bool validSamplesInBucket; // are there any valid samples in current bucket (any aggregation)
     bool validPerAgg[TS_AGG_TYPES_MAX]; // per-aggregation validity tracking for current bucket

--- a/src/filter_iterator.h
+++ b/src/filter_iterator.h
@@ -61,9 +61,11 @@ typedef struct AggregationIterator
     bool hasTwa; // precomputed: any aggregation is TWA
     bool handled_twa_empty_prefix;
     bool handled_twa_empty_suffix;
-    bool handled_non_twa_empty_full_range; // EMPTY without TWA: synthetic range when no raw chunk
-    bool handled_non_twa_empty_prefix; // EMPTY without TWA: buckets before first in-range sample
-    /* LAST+EMPTY: true if prior sample before range was applied (LOCF) or LOCF is not required. */
+    // No points in [start,end] but EMPTY is on: we already returned the "all buckets empty" result once.
+    bool handled_non_twa_empty_full_range;
+    // We already inserted EMPTY buckets between range start and the first real point; do not repeat.
+    bool handled_non_twa_empty_prefix;
+    // LAST+EMPTY: we already copied the last raw value from before `startTimestamp` into LAST (or LAST not used).
     bool last_locf_seed_ok;
     timestamp_t prev_ts;
     bool validSamplesInBucket; // are there any valid samples in current bucket (any aggregation)

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -1934,3 +1934,235 @@ def test_ts_range_countAll():
             assert float(result[2][1]) == 1.0
             assert float(result[3][1]) == 1.0
             assert float(result[4][1]) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Regression: TS.RANGE / TS.REVRANGE with AGGREGATION ... EMPTY must produce
+# the same set of bucket timestamps in both directions (one is the reverse of
+# the other), and carry the chronologically-correct value for LOCF-style
+# aggregations such as LAST.
+#
+# This guards against two bugs that previously affected reverse iteration:
+#   Bug A) extra empty buckets emitted past the data span.
+#   Bug B) wrong carry-forward value for empty buckets between samples.
+#
+# To extend coverage to a new aggregation, just add it to AGGREGATIONS below.
+# To additionally check exact values for that aggregation, add an entry to
+# PER_AGG_VALUE_CHECKS. Without an entry, only timestamp-symmetry is verified.
+# ---------------------------------------------------------------------------
+
+# Aggregations to validate. Add more here with zero other code changes
+# (provided the aggregation behaves like one of the cases handled by
+# _agg_sample_value / _agg_empty_value below).
+AGGREGATIONS = ['last', 'max', 'count']
+
+
+def _agg_sample_value(agg, v):
+    """Value the aggregation produces for a bucket that contains exactly one sample."""
+    if agg == 'count':
+        return '1'
+    # last, max, min, sum, avg, first, range, ... — single sample → that value
+    return str(v)
+
+
+def _agg_empty_value(agg, prev_v, next_v):
+    """Value the aggregation produces for an empty bucket that lies BETWEEN two samples
+    (i.e. has both a left and a right neighbor — should_skip_empty_gap keeps it)."""
+    if agg == 'last':
+        return str(prev_v)            # LOCF: carry forward chronologically previous value
+    if agg == 'count':
+        return '0'                    # no samples in bucket
+    return 'NaN'                      # max, min, sum, avg, ... default empty fill
+
+
+def _build_expected_forward(samples, bucket_size, window, agg):
+    """
+    Build the expected forward TS.RANGE result for `agg` over `samples`,
+    `window` and `bucket_size`. Each sample at t produces:
+        - bucket t                   → _agg_sample_value(agg, v)
+        - bucket (t + bucket_size)   → _agg_empty_value(agg, v, next_v)
+    The trailing carry bucket is dropped when there is no next sample
+    (matches should_skip_empty_gap).
+    """
+    win_lo, win_hi = window
+    out = []
+    for i, (t, v) in enumerate(samples):
+        if win_lo <= t <= win_hi:
+            out.append((t, _agg_sample_value(agg, v)))
+        carry_t = t + bucket_size
+        if carry_t <= win_hi and i + 1 < len(samples):
+            next_v = samples[i + 1][1]
+            out.append((carry_t, _agg_empty_value(agg, v, next_v)))
+    return out
+
+
+def _decode_pair(row):
+    ts = int(row[0])
+    val = row[1].decode() if isinstance(row[1], bytes) else row[1]
+    return ts, val
+
+
+def _format_redis_cli(pairs):
+    """Format a list of (ts, value) pairs the way redis-cli prints them."""
+    if not pairs:
+        return '(empty array)'
+    lines = []
+    for i, (ts, val) in enumerate(pairs, start=1):
+        lines.append(f'{i}) 1) (integer) {ts}')
+        lines.append(f'   2) {val}')
+    return '\n'.join(lines)
+
+
+def _print_block(title, pairs):
+    print(f'\n--- {title} ---')
+    print(_format_redis_cli(pairs))
+
+
+def _format_samples(samples):
+    """Format input samples like ([t=10, v=100], [t=20, v=110], ...)."""
+    inner = ', '.join(f'[t={t}, v={v}]' for t, v in samples)
+    return f'({inner})'
+
+
+def _print_samples(title, samples):
+    print(f'\n--- {title} ({len(samples)} samples) ---')
+    print(_format_samples(samples))
+
+
+def test_range_revrange_empty_symmetry():
+    """
+    Forward and reverse aggregated EMPTY queries must be mirror images of
+    each other (same bucket timestamps, reversed order). For aggregations
+    listed in PER_AGG_VALUE_CHECKS the bucket values are also asserted.
+    """
+    samples = [(18, 100), (20, 110)]
+    window  = (18, 22)
+    bucket  = 1
+    with Env().getClusterConnectionIfNeeded() as r:
+        for agg in AGGREGATIONS:
+            key = 'ts_sym_' + agg + '{a}'
+            r.execute_command('DEL', key)
+            r.execute_command('TS.CREATE', key)
+            for t, v in samples:
+                r.execute_command('TS.ADD', key, t, v)
+
+            _print_samples(f'{agg} input samples', samples)
+
+            win_lo, win_hi = window
+            fwd = r.execute_command('TS.RANGE',    key, win_lo, win_hi,
+                                    'AGGREGATION', agg, bucket, 'EMPTY')
+            rev = r.execute_command('TS.REVRANGE', key, win_lo, win_hi,
+                                    'AGGREGATION', agg, bucket, 'EMPTY')
+
+            got_fwd = [_decode_pair(row) for row in fwd]
+            got_rev = [_decode_pair(row) for row in rev]
+
+            exp_fwd = _build_expected_forward(samples, bucket, window, agg)
+            exp_rev = list(reversed(exp_fwd))
+
+            _print_block(f'{agg} TS.RANGE actual',      got_fwd)
+            _print_block(f'{agg} TS.REVRANGE actual',   got_rev)
+            _print_block(f'{agg} TS.RANGE expected',    exp_fwd)
+            _print_block(f'{agg} TS.REVRANGE expected', exp_rev)
+
+            assert len(fwd) == len(rev), (
+                f'{agg}: bucket count mismatch; '
+                f'fwd={len(fwd)} ({fwd}), rev={len(rev)} ({rev})')
+
+            fwd_ts = [ts for ts, _ in got_fwd]
+            rev_ts = [ts for ts, _ in got_rev]
+            assert fwd_ts == list(reversed(rev_ts)), (
+                f'{agg}: timestamps not mirrored; '
+                f'fwd={fwd_ts}, rev={rev_ts}')
+
+            assert got_fwd == exp_fwd, (
+                f'{agg} forward values mismatch.\n'
+                f'expected:\n{_format_redis_cli(exp_fwd)}\n'
+                f'actual:\n{_format_redis_cli(got_fwd)}')
+            assert got_rev == exp_rev, (
+                f'{agg} reverse values mismatch.\n'
+                f'expected:\n{_format_redis_cli(exp_rev)}\n'
+                f'actual:\n{_format_redis_cli(got_rev)}')
+
+
+# ---------------------------------------------------------------------------
+# Regression: same EMPTY-aggregation symmetry, but on a series whose samples
+# span MANY chunks. The aggregation iterator's GetNext() loop must walk
+# multiple chunks while still emitting the correct empty buckets in both
+# directions and with correct carry values.
+#
+# We force tiny chunks (CHUNK_SIZE=48 bytes, uncompressed → 3 samples / chunk)
+# and sparse samples so the empty buckets between samples land on chunk
+# boundaries.
+#
+# Generic over AGGREGATIONS like the previous test; LAST also gets exact
+# value-level assertions via MULTICHUNK_VALUE_CHECKS.
+# ---------------------------------------------------------------------------
+
+# Sample layout:  t in {10, 20, 30, ..., 300}, value = ts * 10.
+# 30 samples / 3-per-chunk = 10 chunks.
+_MC_SAMPLE_TS    = list(range(10, 301, 10))
+_MC_SAMPLES      = [(t, t * 10) for t in _MC_SAMPLE_TS]
+_MC_WINDOW       = (10, 300)
+_MC_BUCKET_SIZE  = 5
+_MC_CHUNK_BYTES  = 48     # uncompressed: 16 B/sample → 3 samples / chunk
+
+def test_range_revrange_empty_symmetry_multichunk():
+    """
+    Same forward/reverse EMPTY-aggregation symmetry as the previous test,
+    but the underlying series is split across ~10 chunks so the
+    AggregationIterator GetNext loop is exercised across chunk boundaries.
+    """
+    with Env().getClusterConnectionIfNeeded() as r:
+        for agg in AGGREGATIONS:
+            key = 'ts_sym_mc_' + agg + '{a}'
+            r.execute_command('DEL', key)
+            r.execute_command('TS.CREATE', key,
+                              'ENCODING', 'UNCOMPRESSED',
+                              'CHUNK_SIZE', _MC_CHUNK_BYTES)
+            for t, v in _MC_SAMPLES:
+                r.execute_command('TS.ADD', key, t, v)
+
+            # Sanity-check that we really got multiple chunks.
+            info = r.execute_command('TS.INFO', key)
+            info_dict = {info[i]: info[i + 1] for i in range(0, len(info), 2)}
+            chunk_count_key = b'chunkCount' if b'chunkCount' in info_dict else 'chunkCount'
+            chunk_count = int(info_dict[chunk_count_key])
+            assert chunk_count > 1, (
+                f'expected the series to span multiple chunks, got '
+                f'chunkCount={chunk_count}; sample/chunk math may have changed')
+
+            win_lo, win_hi = _MC_WINDOW
+            fwd = r.execute_command('TS.RANGE',    key, win_lo, win_hi,
+                                    'AGGREGATION', agg, _MC_BUCKET_SIZE, 'EMPTY')
+            rev = r.execute_command('TS.REVRANGE', key, win_lo, win_hi,
+                                    'AGGREGATION', agg, _MC_BUCKET_SIZE, 'EMPTY')
+
+            got_fwd = [_decode_pair(row) for row in fwd]
+            got_rev = [_decode_pair(row) for row in rev]
+
+            exp_fwd = _build_expected_forward(
+                _MC_SAMPLES, _MC_BUCKET_SIZE, _MC_WINDOW, agg)
+            exp_rev = list(reversed(exp_fwd))
+
+            print(f'\n--- {agg} multichunk: chunkCount={chunk_count}, '
+                  f'samples={len(_MC_SAMPLES)}, buckets={len(exp_fwd)} ---')
+
+            assert len(fwd) == len(rev), (
+                f'{agg}: bucket count mismatch; '
+                f'fwd={len(fwd)}, rev={len(rev)}')
+
+            fwd_ts = [ts for ts, _ in got_fwd]
+            rev_ts = [ts for ts, _ in got_rev]
+            assert fwd_ts == list(reversed(rev_ts)), (
+                f'{agg}: timestamps not mirrored across chunks; '
+                f'fwd={fwd_ts}, rev={rev_ts}')
+
+            assert got_fwd == exp_fwd, (
+                f'{agg} forward values mismatch (multichunk).\n'
+                f'expected:\n{_format_redis_cli(exp_fwd)}\n'
+                f'actual:\n{_format_redis_cli(got_fwd)}')
+            assert got_rev == exp_rev, (
+                f'{agg} reverse values mismatch (multichunk).\n'
+                f'expected:\n{_format_redis_cli(exp_rev)}\n'
+                f'actual:\n{_format_redis_cli(got_rev)}')


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core aggregation iterator logic for `EMPTY` bucket generation and LOCF behavior, which can affect query results across multiple aggregations and reverse iteration. Changes are localized but subtle (gap skipping, boundary seeding, finalize behavior), so regressions in bucket emission/value carry are possible.
> 
> **Overview**
> Aligns `EMPTY` handling so forward and reverse aggregated queries emit the **same bucket set** (mirrored), by skipping empty gaps that fall outside the series’ data span and by treating invalid/degenerate gaps as non-fatal skips instead of aborting the range.
> 
> Adds explicit LOCF seeding for `LAST + EMPTY` from the nearest raw sample just outside the query window, tightens reverse-iteration seeding to avoid incorrect carries, and refactors/centralizes neighbor-sample scans and bucket-bound calculations (including safer edge handling like `init_ts==0`).
> 
> Extends iterator state to avoid double-emitting prefixes/full-empty ranges and adds regression tests that assert forward/reverse symmetry and correct values for `last`/`max`/`count`, including a multi-chunk scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff6e9ffb99f8eb55c1eac751da8e9c55701dc635. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->