### PR TITLE
MOD-8187 - Time Series - All aggregators except TWA - wrong results

### DIFF
--- a/src/compaction.c
+++ b/src/compaction.c
@@ -55,7 +55,6 @@ typedef struct TwaContext
     timestamp_t first_ts;
     timestamp_t last_ts;
     bool is_first_bucket;
-    bool reverse;
     int64_t iteration;
 } TwaContext;
 
@@ -79,7 +78,7 @@ void finalize_empty_last_value(void *contextPtr, double *value) {
     *value = context->value;
 }
 
-void *SingleValueCreateContext(__unused bool reverse) {
+void *SingleValueCreateContext(void) {
     SingleValueContext *context = (SingleValueContext *)malloc(sizeof(SingleValueContext));
     context->value = 0;
     return context;
@@ -96,7 +95,7 @@ void SingleValueReset(void *contextPtr) {
     context->value = 0;
 }
 
-void *LastValueCreateContext(__unused bool reverse) {
+void *LastValueCreateContext(void) {
     SingleValueContext *context = malloc(sizeof *context);
     context->value = NAN;
     return context;
@@ -129,7 +128,7 @@ int SingleValueReadContext(void *contextPtr, RedisModuleIO *io, int encver) {
     return TSDB_OK;
 }
 
-void *FirstValueCreateContext(__unused bool reverse) {
+void *FirstValueCreateContext(void) {
     FirstValueContext *context = (FirstValueContext *)malloc(sizeof(FirstValueContext));
     context->value = 0;
     context->isResetted = true;
@@ -176,7 +175,7 @@ static inline void _AvgInitContext(AvgContext *context) {
     context->isOverflow = false;
 }
 
-void *AvgCreateContext(__unused bool reverse) {
+void *AvgCreateContext(void) {
     AvgContext *context = (AvgContext *)malloc(sizeof(AvgContext));
     _AvgInitContext(context);
     return context;
@@ -265,7 +264,7 @@ int AvgReadContext(void *contextPtr, RedisModuleIO *io, int encver) {
     return TSDB_OK;
 }
 
-static inline void _TwainitContext(TwaContext *context, bool reverse) {
+static inline void _TwainitContext(TwaContext *context) {
     context->res = 0;
     context->prevTS = DC;        // arbitrary value
     context->prevValue = DC;     // arbitrary value
@@ -275,7 +274,6 @@ static inline void _TwainitContext(TwaContext *context, bool reverse) {
     context->last_ts = DC;
     context->is_first_bucket = true;
     context->iteration = 0;
-    context->reverse = reverse;
 }
 
 void *TwaCloneContext(void *contextPtr) {
@@ -284,9 +282,9 @@ void *TwaCloneContext(void *contextPtr) {
     return buf;
 }
 
-void *TwaCreateContext(bool reverse) {
+void *TwaCreateContext(void) {
     TwaContext *context = (TwaContext *)malloc(sizeof(TwaContext));
-    _TwainitContext(context, reverse);
+    _TwainitContext(context);
     return context;
 }
 
@@ -299,9 +297,6 @@ static inline void _update_twaContext(TwaContext *wcontext,
 
 void TwaAddBucketParams(void *contextPtr, timestamp_t bucketStartTS, timestamp_t bucketEndTS) {
     TwaContext *context = (TwaContext *)contextPtr;
-    if (context->reverse) {
-        __SWAP(bucketStartTS, bucketEndTS);
-    }
     context->bucketStartTS = bucketStartTS;
     context->bucketEndTS = bucketEndTS;
 }
@@ -315,12 +310,8 @@ void TwaAddPrevBucketLastSample(void *contextPtr, double value, timestamp_t ts) 
 void TwaAddValue(void *contextPtr, double value, timestamp_t ts) {
     TwaContext *context = (TwaContext *)contextPtr;
     int64_t *iter = &context->iteration;
-    timestamp_t t1 = context->prevTS, t2 = ts;
-    double v1 = context->prevValue, v2 = value;
-    if (context->reverse) {
-        __SWAP(t1, t2);
-        __SWAP(v1, v2);
-    }
+    const timestamp_t t1 = context->prevTS, t2 = ts;
+    const double v1 = context->prevValue, v2 = value;
     const double delta_time = t2 - t1;
     const double delta_val = v2 - v1;
     const bool *is_first_bucket = &context->is_first_bucket;
@@ -330,11 +321,7 @@ void TwaAddValue(void *contextPtr, double value, timestamp_t ts) {
         if (!(*is_first_bucket)) {
             context->first_ts = ta;
             double vab = v1 + ((double)((ta - t1) * delta_val)) / delta_time;
-            if (!context->reverse) {
-                context->res += ((vab + v2) * (t2 - ta)) / 2.0;
-            } else {
-                context->res += ((vab + v1) * (ta - t1)) / 2.0;
-            }
+            context->res += ((vab + v2) * (t2 - ta)) / 2.0;
         } else {
             // else: cur sample is the first in the series, so just store it
             context->first_ts = ts;
@@ -351,22 +338,14 @@ void TwaAddValue(void *contextPtr, double value, timestamp_t ts) {
 
 void TwaAddNextBucketFirstSample(void *contextPtr, double value, timestamp_t ts) {
     TwaContext *context = (TwaContext *)contextPtr;
-    timestamp_t t1 = context->prevTS, t2 = ts;
-    double v1 = context->prevValue, v2 = value;
-    if (context->reverse) {
-        __SWAP(t1, t2);
-        __SWAP(v1, v2);
-    }
+    const timestamp_t t1 = context->prevTS, t2 = ts;
+    const double v1 = context->prevValue, v2 = value;
     const double delta_time = t2 - t1;
     const double delta_val = v2 - v1;
     const timestamp_t tb = context->bucketEndTS;
 
     double vab = v1 + ((double)((tb - t1) * delta_val)) / delta_time;
-    if (!context->reverse) {
-        context->res += ((vab + v1) * (tb - t1)) / 2.0;
-    } else {
-        context->res += ((vab + v2) * (t2 - tb)) / 2.0;
-    }
+    context->res += ((vab + v1) * (tb - t1)) / 2.0;
 
     context->last_ts = tb;
 }
@@ -390,10 +369,11 @@ void TwaGetLastSample(void *contextPtr, Sample *sample) {
 }
 
 void TwaReset(void *contextPtr) {
-    TwaContext *wcontext = (TwaContext *)contextPtr;
-    _TwainitContext(contextPtr, wcontext->reverse);
+    _TwainitContext(contextPtr);
 }
 
+/* The trailing zero preserves the on-disk layout (TWA always operated forward; the legacy
+ * `reverse` field on disk was never set for compaction-rule contexts). */
 void TwaWriteContext(void *contextPtr, RedisModuleIO *io) {
     TwaContext *context = (TwaContext *)contextPtr;
     RedisModule_SaveDouble(io, context->res);
@@ -405,7 +385,7 @@ void TwaWriteContext(void *contextPtr, RedisModuleIO *io) {
     RedisModule_SaveUnsigned(io, context->last_ts);
     RedisModule_SaveUnsigned(io, context->is_first_bucket);
     RedisModule_SaveUnsigned(io, context->iteration);
-    RedisModule_SaveUnsigned(io, context->reverse);
+    RedisModule_SaveUnsigned(io, 0);
 }
 
 int TwaReadContext(void *contextPtr, RedisModuleIO *io, int encver) {
@@ -420,11 +400,11 @@ int TwaReadContext(void *contextPtr, RedisModuleIO *io, int encver) {
     context->last_ts = LoadUnsigned_IOError(io, err, TSDB_ERROR);
     context->is_first_bucket = LoadUnsigned_IOError(io, err, TSDB_ERROR);
     context->iteration = LoadUnsigned_IOError(io, err, TSDB_ERROR);
-    context->reverse = LoadUnsigned_IOError(io, err, TSDB_ERROR);
+    (void)LoadUnsigned_IOError(io, err, TSDB_ERROR); /* legacy reverse flag, ignored */
     return TSDB_OK;
 }
 
-void *StdCreateContext(__unused bool reverse) {
+void *StdCreateContext(void) {
     StdContext *context = (StdContext *)malloc(sizeof(StdContext));
     context->cnt = 0;
     context->sum = 0;
@@ -648,7 +628,7 @@ static AggregationClass aggVarS = {
     .isValueValid = nonNaNValueValid,
 };
 
-void *MaxMinCreateContext(__unused bool reverse) {
+void *MaxMinCreateContext(void) {
     MaxMinContext *context = (MaxMinContext *)malloc(sizeof(MaxMinContext));
     context->minValue = DBL_MAX;
     context->maxValue = _DOUBLE_MIN;

--- a/src/compaction.c
+++ b/src/compaction.c
@@ -27,6 +27,12 @@
 #include "valgrind/valgrind.h"
 #endif
 
+/* Placeholder written in place of the removed `reverse` field on the TwaContext.
+ * Preserves the on-disk RDB layout so older binaries can still parse new RDBs and
+ * vice versa without bumping the encoding version. TWA always operates forward now,
+ * and the legacy flag was never set for compaction-rule contexts anyway. */
+ #define TWA_LEGACY_REVERSE_FLAG 0
+ 
 typedef struct FirstValueContext
 {
     double value;
@@ -385,7 +391,7 @@ void TwaWriteContext(void *contextPtr, RedisModuleIO *io) {
     RedisModule_SaveUnsigned(io, context->last_ts);
     RedisModule_SaveUnsigned(io, context->is_first_bucket);
     RedisModule_SaveUnsigned(io, context->iteration);
-    RedisModule_SaveUnsigned(io, 0);
+    RedisModule_SaveUnsigned(io, TWA_LEGACY_REVERSE_FLAG);
 }
 
 int TwaReadContext(void *contextPtr, RedisModuleIO *io, int encver) {

--- a/src/compaction.c
+++ b/src/compaction.c
@@ -27,12 +27,6 @@
 #include "valgrind/valgrind.h"
 #endif
 
-/* Placeholder written in place of the removed `reverse` field on the TwaContext.
- * Preserves the on-disk RDB layout so older binaries can still parse new RDBs and
- * vice versa without bumping the encoding version. TWA always operates forward now,
- * and the legacy flag was never set for compaction-rule contexts anyway. */
- #define TWA_LEGACY_REVERSE_FLAG 0
- 
 typedef struct FirstValueContext
 {
     double value;
@@ -378,8 +372,6 @@ void TwaReset(void *contextPtr) {
     _TwainitContext(contextPtr);
 }
 
-/* The trailing zero preserves the on-disk layout (TWA always operated forward; the legacy
- * `reverse` field on disk was never set for compaction-rule contexts). */
 void TwaWriteContext(void *contextPtr, RedisModuleIO *io) {
     TwaContext *context = (TwaContext *)contextPtr;
     RedisModule_SaveDouble(io, context->res);
@@ -391,7 +383,6 @@ void TwaWriteContext(void *contextPtr, RedisModuleIO *io) {
     RedisModule_SaveUnsigned(io, context->last_ts);
     RedisModule_SaveUnsigned(io, context->is_first_bucket);
     RedisModule_SaveUnsigned(io, context->iteration);
-    RedisModule_SaveUnsigned(io, TWA_LEGACY_REVERSE_FLAG);
 }
 
 int TwaReadContext(void *contextPtr, RedisModuleIO *io, int encver) {
@@ -406,7 +397,10 @@ int TwaReadContext(void *contextPtr, RedisModuleIO *io, int encver) {
     context->last_ts = LoadUnsigned_IOError(io, err, TSDB_ERROR);
     context->is_first_bucket = LoadUnsigned_IOError(io, err, TSDB_ERROR);
     context->iteration = LoadUnsigned_IOError(io, err, TSDB_ERROR);
-    (void)LoadUnsigned_IOError(io, err, TSDB_ERROR); /* legacy reverse flag, ignored */
+    if (encver < TS_TWA_DROP_REVERSE_VER) {
+        // Pre-v10 RDBs carry a dead `reverse` byte after `iteration`. Consume and discard.
+        (void)LoadUnsigned_IOError(io, err, TSDB_ERROR);
+    }
     return TSDB_OK;
 }
 

--- a/src/compaction.h
+++ b/src/compaction.h
@@ -21,7 +21,7 @@
 typedef struct AggregationClass
 {
     TS_AGG_TYPES_T type;
-    void *(*createContext)(bool reverse);
+    void *(*createContext)(void);
     void (*freeContext)(void *context);
     void (*appendValue)(void *context, double value, timestamp_t ts);
     void (*appendValueVec)(void *__restrict__ context,

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -360,18 +360,6 @@ static size_t get_samples_from_side(timestamp_t cur_ts,
     return n;
 }
 
-/** @brief Bucket leading edge clipped to the query window (forward iteration). */
-static timestamp_t get_bucket_start_in_query_window(timestamp_t bucketStartTS,
-                                                    timestamp_t rangeStart) {
-    return max(bucketStartTS, rangeStart);
-}
-
-/** @brief Bucket trailing edge clipped to the query window (forward iteration). */
-static timestamp_t get_bucket_end_in_query_window(timestamp_t bucketEndTS,
-                                                  timestamp_t rangeEnd) {
-    return min(bucketEndTS, rangeEnd);
-}
-
 static void twa_calc_empty_bucket_val(timestamp_t ta,
                                       timestamp_t tb,
                                       const Sample *sample_before,
@@ -433,8 +421,8 @@ static void twa_compute_empty_bucket_value(const AggregationIterator *self,
     Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
     int64_t agg_time_delta = self->aggregationTimeDelta;
 
-    timestamp_t ta = get_bucket_start_in_query_window(bucket_ts, self->startTimestamp);
-    timestamp_t tb = get_bucket_end_in_query_window(bucket_ts + agg_time_delta, self->endTimestamp);
+    timestamp_t ta = max(bucket_ts, self->startTimestamp);
+    timestamp_t tb = min(bucket_ts + agg_time_delta, self->endTimestamp);
 
     size_t n_samples_before =
         get_samples_from_side(ta, true, self, &sample_before, &sample_befBefore);
@@ -563,13 +551,13 @@ static void twa_fillEmptyBuckets(size_t *write_index,
     size_t n_samples_before = 0, n_samples_after = 0;
     timestamp_t ta, tb;
     int64_t agg_time_delta = self->aggregationTimeDelta;
-    ta = get_bucket_start_in_query_window(cur_ts, self->startTimestamp);
+    ta = max(cur_ts, self->startTimestamp);
     n_samples_before = get_samples_from_side(ta, true, self, &sample_before, &sample_befBefore);
     n_samples_after = get_samples_from_side(ta, false, self, &sample_after, &sample_afAfter);
 
     for (size_t i = 0; i < n_empty_buckets; ++i) {
-        ta = get_bucket_start_in_query_window(cur_ts, self->startTimestamp);
-        tb = get_bucket_end_in_query_window(cur_ts + agg_time_delta, self->endTimestamp);
+        ta = max(cur_ts, self->startTimestamp);
+        tb = min(cur_ts + agg_time_delta, self->endTimestamp);
 
         timestamp_t ts = calc_bucket_ts(self->bucketTS, cur_ts, self->aggregationTimeDelta);
         double twa_val = 0;
@@ -615,7 +603,7 @@ static void twa_fillEmptyBuckets(size_t *write_index,
 static bool should_skip_empty_gap(const AggregationIterator *self,
                                   timestamp_t first_bucket_of_gap) {
     Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
-    timestamp_t ta = get_bucket_start_in_query_window(first_bucket_of_gap, self->startTimestamp);
+    timestamp_t ta = max(first_bucket_of_gap, self->startTimestamp);
     size_t n_samples_before =
         get_samples_from_side(ta, true, self, &sample_before, &sample_befBefore);
     size_t n_samples_after =
@@ -1099,8 +1087,8 @@ static void agg_iter_init_if_needed(AggregationIterator *self,
     if (self->hasTwa) {
         timestamp_t bucket_start = BucketStartNormalize(self->aggregationLastTimestamp);
         timestamp_t bucket_end = self->aggregationLastTimestamp + aggregationTimeDelta;
-        timestamp_t ta = get_bucket_start_in_query_window(bucket_start, self->startTimestamp);
-        timestamp_t tb = get_bucket_end_in_query_window(bucket_end, self->endTimestamp);
+        timestamp_t ta = max(bucket_start, self->startTimestamp);
+        timestamp_t tb = min(bucket_end, self->endTimestamp);
         for (size_t a = 0; a < self->numAggregations; a++) {
             if (self->aggregations[a].type == TS_AGG_TWA) {
                 self->aggregations[a].addBucketParams(self->aggregationContexts[a], ta, tb);
@@ -1328,7 +1316,7 @@ static int agg_iter_general_on_bucket_boundary(AggregationIterator *self,
     agg_iter_advance_context_scope(self, aggregationTimeDelta, contextScope);
 
     if (self->hasTwa) {
-        timestamp_t tb = get_bucket_end_in_query_window(*contextScope, self->endTimestamp);
+        timestamp_t tb = min(*contextScope, self->endTimestamp);
         for (size_t a = 0; a < self->numAggregations; a++) {
             if (self->aggregations[a].type == TS_AGG_TWA) {
                 if (twaHadValid[a] &&

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -9,11 +9,46 @@
 #include "filter_iterator.h"
 
 #include "abstract_iterator.h"
+#include "compaction.h"
 #include "series_iterator.h"
 #include "utils/arr.h"
 #include <assert.h>
 #include <math.h> /* ceil */
 #include <string.h>
+
+/**
+ * @brief True if @p agg uses LOCF for `EMPTY` (last context / `finalize_empty_last_value`; @c LAST).
+ * @param[in] agg aggregation class.
+ */
+static inline bool agg_class_needs_locf_empty_seed(const AggregationClass *agg) {
+    return agg->type == TS_AGG_LAST;
+}
+
+/**
+ * @brief True if @p self needs a sample before the first bucket (`addPrevBucketLastSample` on any agg).
+ * @param[in] self aggregation iterator (e.g. TWA).
+ */
+static bool agg_iter_needs_prev_bucket_sample(const AggregationIterator *self) {
+    for (size_t a = 0; a < self->numAggregations; a++) {
+        if (self->aggregations[a].addPrevBucketLastSample) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * @brief True if any aggregation in @p self uses LOCF for `EMPTY` (see agg_class_needs_locf_empty_seed).
+ * @param[in] self aggregation iterator.
+ */
+static bool agg_iter_any_locf_empty_agg(const AggregationIterator *self) {
+    for (size_t a = 0; a < self->numAggregations; a++) {
+        if (agg_class_needs_locf_empty_seed(&self->aggregations[a])) {
+            return true;
+        }
+    }
+    return false;
+}
 
 static inline bool check_sample_value(double value, FilterByValueArgs *byValueArgs) {
     if (value >= byValueArgs->min && value <= byValueArgs->max) {
@@ -273,6 +308,9 @@ AggregationIterator *AggregationIterator_New(struct AbstractIterator *input,
     }
     iter->handled_twa_empty_prefix = false;
     iter->handled_twa_empty_suffix = false;
+    iter->handled_non_twa_empty_full_range = false;
+    iter->handled_non_twa_empty_prefix = false;
+    iter->last_locf_seed_ok = true;
     iter->prev_ts = DC;
     iter->validSamplesInBucket = false;
     memset(iter->validPerAgg, 0, sizeof(iter->validPerAgg));
@@ -281,24 +319,73 @@ AggregationIterator *AggregationIterator_New(struct AbstractIterator *input,
     return iter;
 }
 
-static size_t twa_get_samples_from_left(timestamp_t cur_ts,
-                                        const AggregationIterator *self,
-                                        Sample *sample_left,
-                                        Sample *sample_leftLeft);
-static size_t twa_get_samples_from_right(timestamp_t cur_ts,
-                                         const AggregationIterator *self,
-                                         Sample *sample_right,
-                                         Sample *sample_rightRight);
-timestamp_t twa_calc_ta(bool reverse,
-                        timestamp_t bucketStartTS,
-                        timestamp_t bucketEndTS,
-                        timestamp_t rangeStart,
-                        timestamp_t rangeEnd);
-timestamp_t twa_calc_tb(bool reverse,
-                        timestamp_t bucketStartTS,
-                        timestamp_t bucketEndTS,
-                        timestamp_t rangeStart,
-                        timestamp_t rangeEnd);
+/**
+ * @brief Return up to two nearest non-NaN samples on one side of @p cur_ts.
+ *
+ * Unifies the previous `..._from_left` / `..._from_right` pair. NaN samples are skipped
+ * because they can't serve as interpolation/carry sources.
+ *
+ * @param[in]  cur_ts    pivot timestamp.
+ * @param[in]  from_left true: scan `[0, cur_ts - 1]` newest-first (samples strictly before).
+ *                       false: scan `[cur_ts, UINT64_MAX]` oldest-first (samples at or after).
+ * @param[out] sample_1  closest sample to @p cur_ts on the chosen side.
+ * @param[out] sample_2  second-closest sample on the chosen side (written only when 2 found).
+ * @return number of samples written (0, 1, or 2).
+ */
+static size_t get_samples_from_side(timestamp_t cur_ts,
+                                    bool from_left,
+                                    const AggregationIterator *self,
+                                    Sample *sample_1,
+                                    Sample *sample_2) {
+    if (from_left ? (cur_ts == 0) : (cur_ts == UINT64_MAX)) {
+        return 0;
+    }
+    RangeArgs args = {
+        .aggregationArgs = { 0 },
+        .filterByValueArgs = { 0 },
+        .filterByTSArgs = { 0 },
+        .startTimestamp = from_left ? 0 : cur_ts,
+        .endTimestamp = from_left ? cur_ts - 1 : UINT64_MAX,
+        .latest = false,
+    };
+    AbstractSampleIterator *sample_iterator =
+        SeriesCreateSampleIterator(self->series, &args, from_left, true);
+    Sample sample;
+    size_t n = 0;
+    while (sample_iterator->GetNext(sample_iterator, &sample) == CR_OK) {
+        if (isnan(sample.value)) {
+            continue;
+        }
+        if (n == 0) {
+            *sample_1 = sample;
+            n = 1;
+        } else {
+            *sample_2 = sample;
+            n = 2;
+            break;
+        }
+    }
+    sample_iterator->Close(sample_iterator);
+    return n;
+}
+
+/** @brief Clipped leading edge of a bucket in iteration order (forward: start, reverse: end). */
+static timestamp_t get_bucket_start_in_query_window(bool reverse,
+                           timestamp_t bucketStartTS,
+                           timestamp_t bucketEndTS,
+                           timestamp_t rangeStart,
+                           timestamp_t rangeEnd) {
+    return reverse ? min(bucketEndTS, rangeEnd) : max(bucketStartTS, rangeStart);
+}
+
+/** @brief Clipped trailing edge of a bucket in iteration order (forward: end, reverse: start). */
+static timestamp_t get_bucket_end_in_query_window(bool reverse,
+                           timestamp_t bucketStartTS,
+                           timestamp_t bucketEndTS,
+                           timestamp_t rangeStart,
+                           timestamp_t rangeEnd) {
+    return reverse ? max(bucketStartTS, rangeStart) : min(bucketEndTS, rangeEnd);
+}
 
 static void twa_calc_empty_bucket_val(timestamp_t ta,
                                       timestamp_t tb,
@@ -361,14 +448,14 @@ static void twa_compute_empty_bucket_value(const AggregationIterator *self,
     Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
     int64_t agg_time_delta = self->aggregationTimeDelta;
 
-    timestamp_t ta = twa_calc_ta(
+    timestamp_t ta = get_bucket_start_in_query_window(
         false, bucket_ts, bucket_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
-    timestamp_t tb = twa_calc_tb(
+    timestamp_t tb = get_bucket_end_in_query_window(
         false, bucket_ts, bucket_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
 
     size_t n_samples_before =
-        twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore);
-    size_t n_samples_after = twa_get_samples_from_right(tb, self, &sample_after, &sample_afAfter);
+        get_samples_from_side(ta, true, self, &sample_before, &sample_befBefore);
+    size_t n_samples_after = get_samples_from_side(tb, false, self, &sample_after, &sample_afAfter);
 
     twa_calc_empty_bucket_val(ta,
                               tb,
@@ -489,101 +576,6 @@ static void fillEmptyBucketsWithDefaultVals(size_t *write_index,
     }
 }
 
-static size_t twa_get_samples_from_right(timestamp_t cur_ts,
-                                         const AggregationIterator *self,
-                                         Sample *sample_right,
-                                         Sample *sample_rightRight) {
-    size_t n_samples_right = 0;
-    if (cur_ts < UINT64_MAX) {
-        RangeArgs args = {
-            .aggregationArgs = { 0 },
-            .filterByValueArgs = { 0 },
-            .filterByTSArgs = { 0 },
-            .startTimestamp = cur_ts,
-            .endTimestamp = UINT64_MAX,
-            .latest = false,
-        };
-        AbstractSampleIterator *sample_iterator =
-            SeriesCreateSampleIterator(self->series, &args, false, true);
-        Sample sample;
-        // Skip NaN samples - they shouldn't be used for interpolation
-        while (sample_iterator->GetNext(sample_iterator, &sample) == CR_OK) {
-            if (!isnan(sample.value)) {
-                if (n_samples_right == 0) {
-                    *sample_right = sample;
-                    n_samples_right++;
-                } else if (n_samples_right == 1) {
-                    *sample_rightRight = sample;
-                    n_samples_right++;
-                    break;
-                }
-            }
-        }
-        sample_iterator->Close(sample_iterator);
-    }
-    return n_samples_right;
-}
-
-static size_t twa_get_samples_from_left(timestamp_t cur_ts,
-                                        const AggregationIterator *self,
-                                        Sample *sample_left,
-                                        Sample *sample_leftLeft) {
-    size_t n_samples_left = 0;
-    if (cur_ts > 0) {
-        RangeArgs args = {
-            .aggregationArgs = { 0 },
-            .filterByValueArgs = { 0 },
-            .filterByTSArgs = { 0 },
-            .startTimestamp = 0,
-            .endTimestamp = cur_ts - 1,
-            .latest = false,
-        };
-        AbstractSampleIterator *sample_iterator =
-            SeriesCreateSampleIterator(self->series, &args, true, true);
-        Sample sample;
-        // Skip NaN samples - they shouldn't be used for interpolation
-        // Note: iterator is reversed, so we get samples in descending timestamp order
-        while (sample_iterator->GetNext(sample_iterator, &sample) == CR_OK) {
-            if (!isnan(sample.value)) {
-                if (n_samples_left == 0) {
-                    *sample_left = sample;
-                    n_samples_left++;
-                } else if (n_samples_left == 1) {
-                    *sample_leftLeft = sample;
-                    n_samples_left++;
-                    break;
-                }
-            }
-        }
-        sample_iterator->Close(sample_iterator);
-    }
-    return n_samples_left;
-}
-
-timestamp_t twa_calc_ta(bool reverse,
-                        timestamp_t bucketStartTS,
-                        timestamp_t bucketEndTS,
-                        timestamp_t rangeStart,
-                        timestamp_t rangeEnd) {
-    if (!reverse) {
-        return max(bucketStartTS, rangeStart);
-    } else {
-        return min(bucketEndTS, rangeEnd);
-    }
-}
-
-timestamp_t twa_calc_tb(bool reverse,
-                        timestamp_t bucketStartTS,
-                        timestamp_t bucketEndTS,
-                        timestamp_t rangeStart,
-                        timestamp_t rangeEnd) {
-    if (!reverse) {
-        return min(bucketEndTS, rangeEnd);
-    } else {
-        return max(bucketStartTS, rangeStart);
-    }
-}
-
 static void twa_fillEmptyBuckets(size_t *write_index,
                                  timestamp_t cur_ts,
                                  Samples *samples,
@@ -594,15 +586,15 @@ static void twa_fillEmptyBuckets(size_t *write_index,
     size_t n_samples_before = 0, n_samples_after = 0;
     timestamp_t ta, tb;
     int64_t agg_time_delta = self->aggregationTimeDelta;
-    ta = twa_calc_ta(
+    ta = get_bucket_start_in_query_window(
         false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
-    n_samples_before = twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore);
-    n_samples_after = twa_get_samples_from_right(ta, self, &sample_after, &sample_afAfter);
+    n_samples_before = get_samples_from_side(ta, true, self, &sample_before, &sample_befBefore);
+    n_samples_after = get_samples_from_side(ta, false, self, &sample_after, &sample_afAfter);
 
     for (size_t i = 0; i < n_empty_buckets; ++i) {
-        ta = twa_calc_ta(
+        ta = get_bucket_start_in_query_window(
             false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
-        tb = twa_calc_tb(
+        tb = get_bucket_end_in_query_window(
             false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
 
         timestamp_t ts = calc_bucket_ts(self->bucketTS, cur_ts, self->aggregationTimeDelta);
@@ -636,6 +628,41 @@ static void twa_fillEmptyBuckets(size_t *write_index,
     }
 }
 
+#ifndef PREFIX_SUFFIX_IMPL
+
+/**
+ * @brief Should an `EMPTY` bucket gap be dropped because it sits outside the data?
+ *
+ * Looks at the leading edge of @p first_bucket_of_gap and checks the series for raw samples on
+ * **both** sides. If either side has no sample, the gap lies outside the data span and the
+ * caller drops it. Aggregation-agnostic — applied uniformly to TWA, LOCF (`LAST + EMPTY`), and
+ * plain `EMPTY` (`SUM`, `COUNT`, ...) so that `TS.RANGE` and `TS.REVRANGE` produce the same
+ * set of buckets.
+ *
+ * @param[in] self                  aggregation iterator (provides series + query window).
+ * @param[in] first_bucket_of_gap   timestamp of the first empty bucket in the gap.
+ * @param[in] aggregationTimeDelta  bucket width.
+ * @return true → caller should drop the whole gap; false → emit empty buckets normally.
+ */
+static bool should_skip_empty_gap(const AggregationIterator *self,
+                                  timestamp_t first_bucket_of_gap,
+                                  uint64_t aggregationTimeDelta) {
+    Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
+    timestamp_t ta = get_bucket_start_in_query_window(
+        false,
+        first_bucket_of_gap,
+        first_bucket_of_gap + aggregationTimeDelta,
+        self->startTimestamp,
+        self->endTimestamp);
+    size_t n_samples_before =
+        get_samples_from_side(ta, true, self, &sample_before, &sample_befBefore);
+    size_t n_samples_after =
+        get_samples_from_side(ta, false, self, &sample_after, &sample_afAfter);
+    return n_samples_before == 0 || n_samples_after == 0;
+}
+
+#endif // PREFIX_SUFFIX_IMPL
+
 static int fillEmptyBuckets(Samples *samples,
                             size_t *write_index,
                             timestamp_t first_bucket_ts,
@@ -651,37 +678,28 @@ static int fillEmptyBuckets(Samples *samples,
     }
 
     // Check timestamp ordering
-    if (end_bucket_ts < first_bucket_ts) {
-        return -1;
+    if (end_bucket_ts < first_bucket_ts || agg_time_delta == 0) {
+        return 0; /* skip gap; -1 would abort the entire TS.RANGE */
     }
 
     // Check alignment with aggregation time delta
-    if ((end_bucket_ts - first_bucket_ts) % agg_time_delta != 0) {
-        return -1;
+    if ((uint64_t)(end_bucket_ts - first_bucket_ts) % (uint64_t)agg_time_delta != 0) {
+        return 0;
     }
 
     size_t n_empty_buckets = ((end_bucket_ts - first_bucket_ts) / agg_time_delta) + 1;
     if (n_empty_buckets == 0) {
-        return -1;
+        return 0;
     }
 
     timestamp_t cur_ts = (reversed) ? end_bucket_ts : first_bucket_ts;
 
 #ifndef PREFIX_SUFFIX_IMPL // The PM decided to disable it, as it might cause OOM and complicates
                            // users
-    if (self->hasTwa) {
-        Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
-        timestamp_t ta;
-        int64_t agg_time_delta = self->aggregationTimeDelta;
-        ta = twa_calc_ta(
-            false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
-        size_t n_samples_before =
-            twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore);
-        size_t n_samples_after =
-            twa_get_samples_from_right(ta, self, &sample_after, &sample_afAfter);
-        if (n_samples_before == 0 || n_samples_after == 0) { // the PM canceled cases 6 and 7
-            return 0;
-        }
+    // Skip empty buckets that lie outside the data span (no raw sample on one side). Applies
+    // uniformly to TWA, LOCF, and plain EMPTY so forward and reverse return the same buckets.
+    if (should_skip_empty_gap(self, cur_ts, self->aggregationTimeDelta)) {
+        return 0;
     }
 #endif // PREFIX_SUFFIX_IMPL
 
@@ -745,8 +763,332 @@ static inline Samples *ensureOutputSamples(AggregationIterator *self,
     return &enrichedChunk->samples;
 }
 
-// No samples from upstream: finalize, TWA-only empty range, or end stream.
-// Sets *enter_finalize when caller must run agg_iter_finalize().
+/**
+ * @brief Computes bucket bounds for `EMPTY` **prefix**: query edge through bucket before @p first_sample_ts.
+ *
+ * Forward: first bucket aligns to range start, last bucket is the one immediately before the bucket
+ * containing @p first_sample_ts. Reversed: uses range end and adjusts bounds symmetrically.
+ *
+ * @param[in] self iterator (range, alignment).
+ * @param[in] aggregationTimeDelta bucket width.
+ * @param[in] is_reversed forward vs reverse aggregation direction.
+ * @param[in] first_sample_ts timestamp of the first in-range raw sample (chunk start).
+ * @param[out] out_first_bucket first empty-prefix bucket start.
+ * @param[out] out_last_bucket last empty-prefix bucket start.
+ * @param[out] out_has_span false if there is no non-empty span to fill (degenerate / no gap).
+ */
+static void agg_iter_compute_empty_prefix_bounds(const AggregationIterator *self,
+                                              uint64_t aggregationTimeDelta,
+                                              bool is_reversed,
+                                              timestamp_t first_sample_ts,
+                                              timestamp_t *out_first_bucket,
+                                              timestamp_t *out_last_bucket,
+                                              bool *out_has_span) {
+    *out_first_bucket =
+        CalcBucketStart(is_reversed ? self->endTimestamp : self->startTimestamp,
+                        aggregationTimeDelta,
+                        self->timestampAlignment);
+    *out_last_bucket =
+        CalcBucketStart(first_sample_ts, aggregationTimeDelta, self->timestampAlignment);
+    *out_has_span = true;
+    if (!is_reversed) {
+        if (*out_first_bucket >= *out_last_bucket) {
+            *out_has_span = false;
+        }
+        *out_last_bucket =
+            max(0, (int64_t)((int64_t)*out_last_bucket - (int64_t)aggregationTimeDelta));
+    } else {
+        *out_last_bucket += aggregationTimeDelta;
+        if (*out_first_bucket < *out_last_bucket) {
+            *out_has_span = false;
+        }
+    }
+}
+
+/**
+ * @brief Appends `EMPTY` buckets for aligned span [@p first_bucket, @p last_bucket] into the output chunk.
+ *
+ * Delegates to `fillEmptyBuckets`. Single-aggregation path appends into @p enrichedChunk and advances
+ * @p si past the filled span on success. Multi-aggregation path appends after existing prefix samples
+ * in `aux_chunk` (via `ensureOutputSamples`) and returns `fillEmptyBuckets`'s status unchanged.
+ *
+ * @param[in,out] self aggregation iterator (contexts, `EMPTY` policy).
+ * @param[in,out] enrichedChunk chunk being built; single-agg writes `samples`, multi-agg uses aux buffer.
+ * @param[in] first_bucket first bucket start in the span (inclusive).
+ * @param[in] last_bucket last bucket start in the span (inclusive).
+ * @param[in] is_reversed forward vs reverse bucket order for `fillEmptyBuckets`.
+ * @param[in] multiAgg if true, write into scratch samples; if false, write into @p enrichedChunk.
+ * @param[in,out] agg_n_samples sample count: prefix length for multi-agg; updated by `fillEmptyBuckets`.
+ * @param[in,out] si read index for `fillEmptyBuckets` on single-agg path; reset to `-1`, then incremented on success.
+ * @return `0` on success (single-agg), or `-1` on failure; multi-agg returns `fillEmptyBuckets`'s return code.
+ */
+static int agg_iter_append_empty_buckets(AggregationIterator *self,
+                                             EnrichedChunk *enrichedChunk,
+                                             timestamp_t first_bucket,
+                                             timestamp_t last_bucket,
+                                             bool is_reversed,
+                                             bool multiAgg,
+                                             size_t *agg_n_samples,
+                                             int64_t *si) {
+    if (multiAgg) {
+        Samples *prefixSamples = ensureOutputSamples(self, enrichedChunk, *agg_n_samples + 256);
+        prefixSamples->num_samples = *agg_n_samples;
+        int64_t read_idx = -1;
+        return fillEmptyBuckets(
+            prefixSamples, agg_n_samples, first_bucket, last_bucket, self, is_reversed, &read_idx);
+    }
+    *si = -1;
+    int err = fillEmptyBuckets(&enrichedChunk->samples,
+                               agg_n_samples,
+                               first_bucket,
+                               last_bucket,
+                               self,
+                               is_reversed,
+                               si);
+    if (err != 0) {
+        return -1;
+    }
+    (*si)++;
+    return 0;
+}
+
+/**
+ * @brief Emit `EMPTY` buckets for the full query range into `aux_chunk` via `fillEmptyBuckets`.
+ *
+ * Used when there is no in-range data to merge into an `EnrichedChunk` but `EMPTY` still needs
+ * every bucket (TWA empty range; non-TWA empty full range after LOCF). `aux_chunk` is the scratch
+ * buffer because there is no upstream chunk to extend.
+ *
+ * @param[in,out] self iterator (range, alignment, contexts).
+ * @param[in] aggregationTimeDelta bucket width.
+ * @param[in] is_reversed forward vs reverse (`fillEmptyBuckets`; may swap aligned bounds).
+ * @param[out] agg_n_samples emitted row count; @p si set to `-1` then passed to `fillEmptyBuckets`.
+ * @return `fillEmptyBuckets` return value.
+ */
+static int agg_iter_fill_window_when_empty(AggregationIterator *self,
+                                          uint64_t aggregationTimeDelta,
+                                          bool is_reversed,
+                                          size_t *agg_n_samples,
+                                          int64_t *si) {
+    timestamp_t fb =
+        CalcBucketStart(self->startTimestamp, aggregationTimeDelta, self->timestampAlignment);
+    timestamp_t lb =
+        CalcBucketStart(self->endTimestamp, aggregationTimeDelta, self->timestampAlignment);
+    if (is_reversed) {
+        __SWAP(fb, lb);
+    }
+    *si = -1;
+    self->aux_chunk->samples.num_samples = 0;
+    return fillEmptyBuckets(&self->aux_chunk->samples,
+                            agg_n_samples,
+                            fb,
+                            lb,
+                            self,
+                            is_reversed,
+                            si);
+}
+
+/**
+ * @brief Hand a single out-of-region "neighbor" `sample` to every aggregation that wants it.
+ *
+ * "Out-of-region" = chronologically just outside the bucket (TWA) or just outside the query
+ * window (LOCF). Three mutually-exclusive modes, picked by the two flags:
+ *
+ * - `as_prev_bucket_neighbor` ⇒ TWA `addPrevBucketLastSample`: the sample anchors the
+ *   *left* endpoint of the time-weighted integral for the current bucket.
+ * - `as_next_bucket_neighbor` ⇒ TWA `addNextBucketFirstSample`: the sample anchors the
+ *   *right* endpoint of the integral.
+ * - both false ⇒ LOCF `appendValue` for aggs reported by `agg_class_needs_locf_empty_seed`
+ *   (today only `LAST`): stores the value as the agg's "latest", which becomes the carry
+ *   for empty buckets in `finalize_empty_last_value`.
+ *
+ * Aggs are skipped silently when the relevant hook is absent or `isValueValid(sample->value)`
+ * is false (e.g. `NaN` cannot anchor an integral or be carried forward).
+ *
+ * @return true if at least one aggregation accepted the sample.
+ */
+static bool agg_iter_apply_neighbor_sample(AggregationIterator *self,
+                                           const Sample *sample,
+                                           bool as_prev_bucket_neighbor,
+                                           bool as_next_bucket_neighbor) {
+    bool applied = false;
+    for (size_t a = 0; a < self->numAggregations; a++) {
+        AggregationClass *agg = &self->aggregations[a];
+        bool applies;
+        if (as_prev_bucket_neighbor) {
+            applies = (agg->addPrevBucketLastSample != NULL);
+        } else if (as_next_bucket_neighbor) {
+            applies = (agg->addNextBucketFirstSample != NULL);
+        } else {
+            applies = agg_class_needs_locf_empty_seed(agg);
+        }
+        if (!applies || !agg->isValueValid(sample->value)) {
+            continue;
+        }
+        if (as_prev_bucket_neighbor) {
+            agg->addPrevBucketLastSample(
+                self->aggregationContexts[a], sample->value, sample->timestamp);
+        } else if (as_next_bucket_neighbor) {
+            agg->addNextBucketFirstSample(
+                self->aggregationContexts[a], sample->value, sample->timestamp);
+        } else {
+            agg->appendValue(self->aggregationContexts[a], sample->value, sample->timestamp);
+        }
+        applied = true;
+    }
+    return applied;
+}
+
+/**
+ * @brief Seeds aggregation contexts from a raw sample in `[range_start, range_end]`.
+ *
+ * Iterates the series via `SeriesCreateSampleIterator` and stops at the first sample that
+ * successfully seeds at least one aggregation. Modes (mutually exclusive):
+ * - `as_prev_bucket_neighbor`: TWA `addPrevBucketLastSample`.
+ * - `as_next_bucket_neighbor`: TWA `addNextBucketFirstSample`.
+ * - `seed_last_locf`: LOCF `appendValue` for aggs needing LOCF empty seeding (e.g. `LAST`);
+ *   on success also sets `self->last_locf_seed_ok`.
+ */
+static void agg_iter_neighbor_sample_scan(AggregationIterator *self,
+                                          Sample *sample,
+                                          timestamp_t range_start,
+                                          timestamp_t range_end,
+                                          bool reverse_iteration,
+                                          bool as_prev_bucket_neighbor,
+                                          bool as_next_bucket_neighbor,
+                                          bool seed_last_locf) {
+    RangeArgs args = {
+        .aggregationArgs = { 0 },
+        .filterByValueArgs = { 0 },
+        .filterByTSArgs = { 0 },
+        .startTimestamp = range_start,
+        .endTimestamp = range_end,
+        .latest = false,
+    };
+    AbstractSampleIterator *sample_iterator =
+        SeriesCreateSampleIterator(self->series, &args, reverse_iteration, true);
+    while (sample_iterator->GetNext(sample_iterator, sample) == CR_OK) {
+        if (as_prev_bucket_neighbor &&
+            agg_iter_apply_neighbor_sample(self, sample, true, false)) {
+            sample_iterator->Close(sample_iterator);
+            return;
+        }
+        if (as_next_bucket_neighbor &&
+            agg_iter_apply_neighbor_sample(self, sample, false, true)) {
+            sample_iterator->Close(sample_iterator);
+            return;
+        }
+        if (seed_last_locf && agg_iter_apply_neighbor_sample(self, sample, false, false)) {
+            self->last_locf_seed_ok = true;
+            sample_iterator->Close(sample_iterator);
+            return;
+        }
+    }
+    sample_iterator->Close(sample_iterator);
+}
+
+/**
+ * @brief Pre-loads LOCF empty seed from the latest raw sample chronologically just outside the
+ *        query window in the iteration direction (forward: before `startTimestamp`; reverse:
+ *        after `endTimestamp`).
+ *
+ * Used by `TS.RANGE`/`TS.REVRANGE ... AGGREGATION LAST ... EMPTY` so empty buckets at the
+ * leading edge of the window (in iteration order) can produce a value via
+ * `finalize_empty_last_value`. No-ops if `EMPTY` is inactive, the relevant edge is at the
+ * timestamp domain boundary, or no aggregation needs an LOCF empty seed. Resets
+ * `last_locf_seed_ok` and delegates the scan to `agg_iter_neighbor_sample_scan`, which sets
+ * the flag on success.
+ */
+static void agg_iter_load_last_pre_window(AggregationIterator *self, Sample *sample) {
+    if (!self->empty) {
+        return;
+    }
+    if (!self->reverse && self->startTimestamp == 0) {
+        return;
+    }
+    if (self->reverse && self->endTimestamp == UINT64_MAX) {
+        return;
+    }
+    // LOCF carry via appendValue is only safe for LAST: any other agg (SUM/COUNT/AVG/MIN/MAX/
+    // FIRST/STD/VAR/TWA) would silently corrupt its in-window result by treating the
+    // out-of-window carry sample as in-window data.
+    if (!agg_iter_any_locf_empty_agg(self)) {
+        return;
+    }
+    self->last_locf_seed_ok = false;
+    agg_iter_neighbor_sample_scan(self,
+                                  sample,
+                                  self->reverse ? self->endTimestamp + 1 : 0,
+                                  self->reverse ? UINT64_MAX : self->startTimestamp - 1,
+                                  !self->reverse,
+                                  false,
+                                  false,
+                                  true);
+}
+
+/**
+ * @brief Fills `[startTimestamp, endTimestamp]` with empty buckets when no in-range samples exist (non-TWA `EMPTY`).
+ *
+ * Marks the full empty range as handled, pre-loads an LOCF seed, then writes empty buckets into
+ * the aux chunk via `agg_iter_fill_window_when_empty`. Returns @c NULL when forward LOCF has no
+ * pre-window seed, the fill fails, or no buckets were written. Caller must ensure `self->empty`,
+ * `!initialized`, `!handled_non_twa_empty_full_range`, and `!TWA_EMPTY_RANGE(self)`.
+ *
+ * @param[in,out] self                 aggregation iterator (`handled_non_twa_empty_full_range`, aux chunk).
+ * @param[in]     aggregationTimeDelta bucket duration.
+ * @param[in]     is_reversed          forward vs reverse direction.
+ * @param[out]    agg_n_samples        number of samples written to the aux chunk.
+ * @param[in,out] si                   current sample index into the aux chunk.
+ * @return The aux `EnrichedChunk` populated with empty buckets, or @c NULL on failure / no output.
+ */
+static EnrichedChunk *agg_iter_empty_range_no_samples(AggregationIterator *self,
+                                                        uint64_t aggregationTimeDelta,
+                                                        bool is_reversed,
+                                                        size_t *agg_n_samples,
+                                                        int64_t *si) {
+    self->handled_non_twa_empty_full_range = true;
+    *agg_n_samples = 0;
+    Sample locf;
+    agg_iter_load_last_pre_window(self, &locf);
+    if (!is_reversed && self->startTimestamp > 0 && !self->last_locf_seed_ok) {
+        return NULL;
+    }
+    int err = agg_iter_fill_window_when_empty(
+        self, aggregationTimeDelta, is_reversed, agg_n_samples, si);
+    if (err != 0) {
+        return NULL;
+    }
+    if (*agg_n_samples == 0) {
+        return NULL;
+    }
+    (*si)++;
+    self->aux_chunk->samples.num_samples = *agg_n_samples;
+    return self->aux_chunk;
+}
+
+/**
+ * @brief Handles the "no more samples from upstream" case for an aggregation iterator.
+ *
+ * Decides between three terminal paths and signals the caller via @p enter_finalize:
+ * - If a partially-built bucket is still pending (`hasUnFinalizedContext`), sets
+ *   @p enter_finalize to @c true so the caller runs `agg_iter_finalize()`.
+ * - If TWA `EMPTY` range mode is active, emits the empty prefix on the first call and
+ *   the empty suffix on the second call (each via the aux chunk), then ends the stream.
+ * - If a non-TWA `EMPTY` policy has a fully-empty range that hasn't been emitted yet,
+ *   delegates to `agg_iter_empty_range_no_samples()`.
+ * - Otherwise returns @c NULL to signal end of stream.
+ *
+ * @param[in,out] self            aggregation iterator (TWA flags, aux chunk, prev_ts).
+ * @param[in]     aggregationTimeDelta bucket duration.
+ * @param[in]     is_reversed     forward vs reverse aggregation direction.
+ * @param[in,out] agg_n_samples   running count of samples written to the aux chunk.
+ * @param[in,out] si              current sample index into the aux chunk; reset to -1
+ *                                before filling and post-incremented after.
+ * @param[out]    enter_finalize  set to @c true iff the caller must run `agg_iter_finalize()`;
+ *                                @c false otherwise.
+ * @return The aux `EnrichedChunk` populated with empty buckets, or @c NULL when the stream
+ *         has ended or the caller must finalize first.
+ */
 static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
                                               uint64_t aggregationTimeDelta,
                                               bool is_reversed,
@@ -762,22 +1104,8 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
         if (!self->handled_twa_empty_prefix) {
             self->handled_twa_empty_prefix = true;
             self->handled_twa_empty_suffix = true; // The prefix in this case is also the suffix
-            timestamp_t first_bucket = CalcBucketStart(
-                self->startTimestamp, aggregationTimeDelta, self->timestampAlignment);
-            timestamp_t last_bucket =
-                CalcBucketStart(self->endTimestamp, aggregationTimeDelta, self->timestampAlignment);
-            if (is_reversed) {
-                __SWAP(first_bucket, last_bucket);
-            }
-            *si = -1;
-            self->aux_chunk->samples.num_samples = 0;
-            int err = fillEmptyBuckets(&self->aux_chunk->samples,
-                                       agg_n_samples,
-                                       first_bucket,
-                                       last_bucket,
-                                       self,
-                                       is_reversed,
-                                       si);
+            int err = agg_iter_fill_window_when_empty(
+                self, aggregationTimeDelta, is_reversed, agg_n_samples, si);
             if (err != 0) {
                 return NULL;
             }
@@ -822,69 +1150,73 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
             return self->aux_chunk;
         }
         return NULL;
+    } else if (self->empty && !self->initialized && !self->handled_non_twa_empty_full_range) {
+        return agg_iter_empty_range_no_samples(
+            self, aggregationTimeDelta, is_reversed, agg_n_samples, si);
     }
     return NULL;
 }
 
-// TWA empty range: fill buckets from query start to first raw sample. Returns 0 or -1 on error.
-static int agg_iter_apply_twa_empty_prefix(AggregationIterator *self,
-                                           EnrichedChunk *enrichedChunk,
-                                           uint64_t aggregationTimeDelta,
-                                           bool is_reversed,
-                                           bool multiAgg,
-                                           size_t *agg_n_samples,
-                                           int64_t *si) {
-    if (!TWA_EMPTY_RANGE(self) || self->handled_twa_empty_prefix) {
+
+/**
+ * @brief Emits the `EMPTY` prefix once per range, before the first non-empty bucket.
+ *
+ * Gated by the per-range `handled_*_empty_prefix` flags; no-ops if `EMPTY` is inactive,
+ * the span is degenerate, or (non-TWA forward LOCF) no valid pre-range seed exists.
+ *
+ * @param[in,out] self                 aggregation iterator (`EMPTY` flags, range bounds).
+ * @param[in,out] enrichedChunk        output chunk receiving prefix buckets.
+ * @param[in]     aggregationTimeDelta bucket duration.
+ * @param[in]     is_reversed          forward vs reverse direction.
+ * @param[in]     multiAgg             true if more than one aggregation is active.
+ * @param[in,out] agg_n_samples        running count of samples written.
+ * @param[in,out] si                   current sample index into the output buffer.
+ * @return 0 on success/no-op; error code propagated from `agg_iter_append_empty_buckets()`.
+ */
+static int agg_iter_apply_empty_prefix(AggregationIterator *self,
+                                       EnrichedChunk *enrichedChunk,
+                                       uint64_t aggregationTimeDelta,
+                                       bool is_reversed,
+                                       bool multiAgg,
+                                       size_t *agg_n_samples,
+                                       int64_t *si) {
+    if (TWA_EMPTY_RANGE(self)) {
+        if (self->handled_twa_empty_prefix) {
+            return 0;
+        }
+        self->handled_twa_empty_prefix = true;
+    } else {
+        if (!self->empty || self->handled_non_twa_empty_prefix) {
+            return 0;
+        }
+        self->handled_non_twa_empty_prefix = true;
+    }
+    timestamp_t first_bucket, last_bucket;
+    bool has_span;
+    agg_iter_compute_empty_prefix_bounds(self,
+                                      aggregationTimeDelta,
+                                      is_reversed,
+                                      enrichedChunk->samples.timestamps[0],
+                                      &first_bucket,
+                                      &last_bucket,
+                                      &has_span);
+    if (!has_span) {
         return 0;
     }
-    self->handled_twa_empty_prefix = true;
-    timestamp_t first_bucket =
-        CalcBucketStart(is_reversed ? self->endTimestamp : self->startTimestamp,
-                        aggregationTimeDelta,
-                        self->timestampAlignment);
-    timestamp_t first_sample_ts = enrichedChunk->samples.timestamps[0];
-    timestamp_t last_bucket =
-        CalcBucketStart(first_sample_ts, aggregationTimeDelta, self->timestampAlignment);
-    bool has_empty_buckets = true;
-    if (!is_reversed) {
-        if (first_bucket >= last_bucket) {
-            has_empty_buckets = false;
-        }
-        last_bucket = max(0, (int64_t)((int64_t)last_bucket - (int64_t)aggregationTimeDelta));
-    } else {
-        last_bucket += aggregationTimeDelta;
-        if (first_bucket < last_bucket) {
-            has_empty_buckets = false;
-        }
-    }
-    if (!has_empty_buckets) {
+    if (!TWA_EMPTY_RANGE(self) && !is_reversed && self->startTimestamp > 0 &&
+        !self->last_locf_seed_ok) {
         return 0;
     }
-    if (multiAgg) {
-        Samples *prefixSamples = ensureOutputSamples(self, enrichedChunk, *agg_n_samples + 256);
-        prefixSamples->num_samples = *agg_n_samples;
-        int64_t read_idx = -1;
-        int err = fillEmptyBuckets(
-            prefixSamples, agg_n_samples, first_bucket, last_bucket, self, is_reversed, &read_idx);
-        if (err != 0) {
-            return -1;
-        }
-    } else {
-        *si = -1;
-        int err = fillEmptyBuckets(&enrichedChunk->samples,
-                                   agg_n_samples,
-                                   first_bucket,
-                                   last_bucket,
-                                   self,
-                                   is_reversed,
-                                   si);
-        if (err != 0) {
-            return -1;
-        }
-        (*si)++;
-    }
-    return 0;
+    return agg_iter_append_empty_buckets(self,
+                                             enrichedChunk,
+                                             first_bucket,
+                                             last_bucket,
+                                             is_reversed,
+                                             multiAgg,
+                                             agg_n_samples,
+                                             si);
 }
+
 
 // First chunk only: bucket start from first sample, TWA params, optional prior sample for TWA.
 static void agg_iter_init_if_needed(AggregationIterator *self,
@@ -902,12 +1234,12 @@ static void agg_iter_init_if_needed(AggregationIterator *self,
     self->initialized = true;
 
     if (self->hasTwa) {
-        timestamp_t ta = twa_calc_ta(self->reverse,
+        timestamp_t ta = get_bucket_start_in_query_window(self->reverse,
                                      BucketStartNormalize(self->aggregationLastTimestamp),
                                      self->aggregationLastTimestamp + aggregationTimeDelta,
                                      self->startTimestamp,
                                      self->endTimestamp);
-        timestamp_t tb = twa_calc_tb(self->reverse,
+        timestamp_t tb = get_bucket_end_in_query_window(self->reverse,
                                      BucketStartNormalize(self->aggregationLastTimestamp),
                                      self->aggregationLastTimestamp + aggregationTimeDelta,
                                      self->startTimestamp,
@@ -921,30 +1253,17 @@ static void agg_iter_init_if_needed(AggregationIterator *self,
         }
     }
 
-    if (self->hasTwa && !((!is_reversed) && init_ts == 0)) {
-        RangeArgs args = {
-            .aggregationArgs = { 0 },
-            .filterByValueArgs = { 0 },
-            .filterByTSArgs = { 0 },
-            .startTimestamp = is_reversed ? init_ts + 1 : 0,
-            .endTimestamp = is_reversed ? UINT64_MAX : init_ts - 1,
-            .latest = false,
-        };
-        AbstractSampleIterator *sample_iterator =
-            SeriesCreateSampleIterator(self->series, &args, !is_reversed, true);
-        // Skip NaN samples - they shouldn't be used for TWA interpolation
-        while (sample_iterator->GetNext(sample_iterator, sample) == CR_OK) {
-            if (!isnan(sample->value)) {
-                for (size_t a = 0; a < self->numAggregations; a++) {
-                    if (self->aggregations[a].type == TS_AGG_TWA) {
-                        self->aggregations[a].addPrevBucketLastSample(
-                            self->aggregationContexts[a], sample->value, sample->timestamp);
-                    }
-                }
-                break;
-            }
-        }
-        sample_iterator->Close(sample_iterator);
+    // Guard against `init_ts - 1` underflow in forward direction when init_ts == 0
+    // (no samples can exist before timestamp 0, so nothing to scan).
+    if (agg_iter_needs_prev_bucket_sample(self) && !((!is_reversed) && init_ts == 0)) {
+        agg_iter_neighbor_sample_scan(self,
+                                      sample,
+                                      is_reversed ? init_ts + 1 : 0,
+                                      is_reversed ? UINT64_MAX : init_ts - 1,
+                                      !is_reversed,
+                                      true,
+                                      false,
+                                      false);
     }
 }
 
@@ -980,6 +1299,18 @@ static bool agg_iter_empty_gap_after_finalize(uint64_t contextScope,
         }
         *out_last_bucket =
             max(0, (int64_t)((int64_t)aggregationLastTimestamp - (int64_t)aggregationTimeDelta));
+        /* fillEmptyBuckets rejects end < first or (end-first) % delta != 0 with -1, which aborts
+         * the whole range query. Skip synthetic gaps that would fail those checks. */
+        if (has_empty_buckets) {
+            if (*out_last_bucket < *out_first_bucket) {
+                has_empty_buckets = false;
+            } else if (aggregationTimeDelta != 0) {
+                uint64_t span = *out_last_bucket - *out_first_bucket;
+                if (span % aggregationTimeDelta != 0) {
+                    has_empty_buckets = false;
+                }
+            }
+        }
     }
     return has_empty_buckets;
 }
@@ -1139,6 +1470,14 @@ static int agg_iter_general_on_bucket_boundary(AggregationIterator *self,
     self->aggregationLastTimestamp =
         CalcBucketStart(sample->timestamp, aggregationTimeDelta, self->timestampAlignment);
     if (self->empty) {
+        // In reverse iteration, the chronologically-previous-in-time sample relative to the
+        // empty gap is the upcoming one (sample arg here), not the bucket we just finalized.
+        // Pre-load LOCF aggregations' contexts with it so finalize_empty_*_value emits the
+        // correct value during fillEmptyBuckets. The subsequent appendValue for the same
+        // sample (in process_chunk_general) is idempotent for LOCF aggs (e.g. LAST).
+        if (is_reversed) {
+            agg_iter_apply_neighbor_sample(self, sample, false, false);
+        }
         timestamp_t first_bucket, last_bucket;
         if (agg_iter_empty_gap_after_finalize(*contextScope,
                                               self->aggregationLastTimestamp,
@@ -1167,7 +1506,7 @@ static int agg_iter_general_on_bucket_boundary(AggregationIterator *self,
     agg_iter_advance_context_scope(self, aggregationTimeDelta, contextScope);
 
     if (self->hasTwa) {
-        timestamp_t tb = twa_calc_tb(self->reverse,
+        timestamp_t tb = get_bucket_end_in_query_window(self->reverse,
                                      self->aggregationLastTimestamp,
                                      *contextScope,
                                      self->startTimestamp,
@@ -1278,31 +1617,27 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
                                         bool is_reversed,
                                         Sample *sample) {
     self->hasUnFinalizedContext = false;
-    for (size_t a = 0; a < self->numAggregations; a++) {
-        if (self->aggregations[a].type == TS_AGG_TWA) {
-            Sample last_sample;
-            self->aggregations[a].getLastSample(self->aggregationContexts[a], &last_sample);
-            if (!(is_reversed && last_sample.timestamp == 0)) {
-                RangeArgs args = {
-                    .aggregationArgs = { 0 },
-                    .filterByValueArgs = { 0 },
-                    .filterByTSArgs = { 0 },
-                    .startTimestamp = is_reversed ? 0 : last_sample.timestamp + 1,
-                    .endTimestamp = is_reversed ? last_sample.timestamp - 1 : UINT64_MAX,
-                    .latest = false,
-                };
-                AbstractSampleIterator *sample_iterator =
-                    SeriesCreateSampleIterator(self->series, &args, is_reversed, true);
-                // Skip non valid samples - they shouldn't be used for interpolation
-                while (sample_iterator->GetNext(sample_iterator, sample) == CR_OK) {
-                    if (self->aggregations[a].isValueValid(sample->value)) {
-                        self->aggregations[a].addNextBucketFirstSample(
-                            self->aggregationContexts[a], sample->value, sample->timestamp);
-                        break;
-                    }
-                }
-                sample_iterator->Close(sample_iterator);
+    if (self->hasTwa) {
+        // All TWA aggs in a single query share the same chronology, so use any TWA agg's
+        // last sample to compute the scan range and seed all TWA aggs with one series scan.
+        Sample last_sample;
+        bool found = false;
+        for (size_t a = 0; a < self->numAggregations && !found; a++) {
+            if (self->aggregations[a].type == TS_AGG_TWA) {
+                self->aggregations[a].getLastSample(self->aggregationContexts[a], &last_sample);
+                found = true;
             }
+        }
+        if (found && !(is_reversed && last_sample.timestamp == 0)) {
+            agg_iter_neighbor_sample_scan(
+                self,
+                sample,
+                is_reversed ? 0 : last_sample.timestamp + 1,
+                is_reversed ? last_sample.timestamp - 1 : UINT64_MAX,
+                is_reversed,
+                false,
+                true,
+                false);
         }
     }
 
@@ -1362,7 +1697,10 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
     self->aux_chunk->samples.timestamps[0] =
         calc_bucket_ts(self->bucketTS, self->aggregationLastTimestamp, self->aggregationTimeDelta);
     size_t n_samples = 1;
-    if (TWA_EMPTY_RANGE(self) && !self->handled_twa_empty_suffix) {
+    /* Emit trailing empty buckets from the last output bucket through endTimestamp. TWA fillEmptyBuckets
+     * may insert nothing for a gap (PM edge rule); LAST+EMPTY uses the same rule for the suffix so
+     * bucket counts match TWA+EMPTY. */
+    if (self->empty && !self->handled_twa_empty_suffix) {
         self->handled_twa_empty_suffix = true;
         timestamp_t last_bucket =
             CalcBucketStart(is_reversed ? self->startTimestamp : self->endTimestamp,
@@ -1425,13 +1763,17 @@ EnrichedChunk *AggregationIterator_GetNextChunk(struct AbstractIterator *iter) {
         return r;
     }
 
-    if (agg_iter_apply_twa_empty_prefix(self,
-                                        enrichedChunk,
-                                        aggregationTimeDelta,
-                                        is_reversed,
-                                        multiAgg,
-                                        &agg_n_samples,
-                                        &si) != 0) {
+    if (self->empty && !self->initialized) {
+        agg_iter_load_last_pre_window(self, &sample);
+    }
+
+    if (agg_iter_apply_empty_prefix(self,
+                                      enrichedChunk,
+                                      aggregationTimeDelta,
+                                      is_reversed,
+                                      multiAgg,
+                                      &agg_n_samples,
+                                      &si) != 0) {
         return NULL;
     }
     self->hasUnFinalizedContext = true;

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -196,12 +196,7 @@ EnrichedChunk *SeriesFilterTSIterator_GetNextChunk(struct AbstractIterator *base
                               self->ByTsArgs.count - 1);
         if (count > 0) {
             enrichedChunk->samples.num_samples = count;
-            if (unlikely(self->reverse)) {
-                reverseEnrichedChunk(enrichedChunk);
-                self->ByTsArgs.count -= count;
-            } else {
-                self->tsFilterIndex += count; // at least count samples consumed
-            }
+            self->tsFilterIndex += count; // at least count samples consumed
             return enrichedChunk;
         }
     }
@@ -210,15 +205,13 @@ EnrichedChunk *SeriesFilterTSIterator_GetNextChunk(struct AbstractIterator *base
 }
 
 SeriesFilterTSIterator *SeriesFilterTSIterator_New(AbstractIterator *input,
-                                                   FilterByTSArgs ByTsArgs,
-                                                   bool rev) {
+                                                   FilterByTSArgs ByTsArgs) {
     SeriesFilterTSIterator *newIter = malloc(sizeof(SeriesFilterTSIterator));
     newIter->base.input = input;
     newIter->base.GetNext = SeriesFilterTSIterator_GetNextChunk;
     newIter->base.Close = SeriesFilterIterator_Close;
     newIter->ByTsArgs = ByTsArgs;
     newIter->tsFilterIndex = 0;
-    newIter->reverse = rev;
     return newIter;
 }
 
@@ -271,7 +264,6 @@ AggregationIterator *AggregationIterator_New(struct AbstractIterator *input,
                                              AggregationClass **aggregations,
                                              int64_t aggregationTimeDelta,
                                              timestamp_t timestampAlignment,
-                                             bool reverse,
                                              bool empty,
                                              BucketTimestamp bucketTS,
                                              Series *series,
@@ -284,13 +276,12 @@ AggregationIterator *AggregationIterator_New(struct AbstractIterator *input,
     iter->numAggregations = numAggregations;
     for (size_t i = 0; i < numAggregations; i++) {
         iter->aggregations[i] = *aggregations[i];
-        iter->aggregationContexts[i] = iter->aggregations[i].createContext(reverse);
+        iter->aggregationContexts[i] = iter->aggregations[i].createContext();
     }
     iter->timestampAlignment = timestampAlignment;
     iter->aggregationTimeDelta = aggregationTimeDelta;
     iter->aggregationLastTimestamp = 0;
     iter->hasUnFinalizedContext = false;
-    iter->reverse = reverse;
     iter->series = series;
     iter->initialized = false;
     iter->empty = empty;
@@ -369,22 +360,16 @@ static size_t get_samples_from_side(timestamp_t cur_ts,
     return n;
 }
 
-/** @brief Clipped leading edge of a bucket in iteration order (forward: start, reverse: end). */
-static timestamp_t get_bucket_start_in_query_window(bool reverse,
-                           timestamp_t bucketStartTS,
-                           timestamp_t bucketEndTS,
-                           timestamp_t rangeStart,
-                           timestamp_t rangeEnd) {
-    return reverse ? min(bucketEndTS, rangeEnd) : max(bucketStartTS, rangeStart);
+/** @brief Bucket leading edge clipped to the query window (forward iteration). */
+static timestamp_t get_bucket_start_in_query_window(timestamp_t bucketStartTS,
+                                                    timestamp_t rangeStart) {
+    return max(bucketStartTS, rangeStart);
 }
 
-/** @brief Clipped trailing edge of a bucket in iteration order (forward: end, reverse: start). */
-static timestamp_t get_bucket_end_in_query_window(bool reverse,
-                           timestamp_t bucketStartTS,
-                           timestamp_t bucketEndTS,
-                           timestamp_t rangeStart,
-                           timestamp_t rangeEnd) {
-    return reverse ? max(bucketStartTS, rangeStart) : min(bucketEndTS, rangeEnd);
+/** @brief Bucket trailing edge clipped to the query window (forward iteration). */
+static timestamp_t get_bucket_end_in_query_window(timestamp_t bucketEndTS,
+                                                  timestamp_t rangeEnd) {
+    return min(bucketEndTS, rangeEnd);
 }
 
 static void twa_calc_empty_bucket_val(timestamp_t ta,
@@ -448,10 +433,8 @@ static void twa_compute_empty_bucket_value(const AggregationIterator *self,
     Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
     int64_t agg_time_delta = self->aggregationTimeDelta;
 
-    timestamp_t ta = get_bucket_start_in_query_window(
-        false, bucket_ts, bucket_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
-    timestamp_t tb = get_bucket_end_in_query_window(
-        false, bucket_ts, bucket_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
+    timestamp_t ta = get_bucket_start_in_query_window(bucket_ts, self->startTimestamp);
+    timestamp_t tb = get_bucket_end_in_query_window(bucket_ts + agg_time_delta, self->endTimestamp);
 
     size_t n_samples_before =
         get_samples_from_side(ta, true, self, &sample_before, &sample_befBefore);
@@ -558,8 +541,7 @@ static void fillEmptyBucketsWithDefaultVals(size_t *write_index,
                                             timestamp_t cur_ts,
                                             Samples *samples,
                                             const AggregationIterator *self,
-                                            size_t n_empty_buckets,
-                                            bool reversed) {
+                                            size_t n_empty_buckets) {
     for (size_t i = 0; i < n_empty_buckets; ++i) {
         timestamp_t ts = calc_bucket_ts(self->bucketTS, cur_ts, self->aggregationTimeDelta);
         for (size_t a = 0; a < self->numAggregations; a++) {
@@ -567,11 +549,7 @@ static void fillEmptyBucketsWithDefaultVals(size_t *write_index,
                                                 &Samples_value_at(samples, *write_index, a));
         }
         samples->timestamps[*write_index] = ts;
-        if (reversed) {
-            cur_ts -= self->aggregationTimeDelta;
-        } else {
-            cur_ts += self->aggregationTimeDelta;
-        }
+        cur_ts += self->aggregationTimeDelta;
         (*write_index)++;
     }
 }
@@ -580,22 +558,18 @@ static void twa_fillEmptyBuckets(size_t *write_index,
                                  timestamp_t cur_ts,
                                  Samples *samples,
                                  const AggregationIterator *self,
-                                 size_t n_empty_buckets,
-                                 bool reversed) {
+                                 size_t n_empty_buckets) {
     Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
     size_t n_samples_before = 0, n_samples_after = 0;
     timestamp_t ta, tb;
     int64_t agg_time_delta = self->aggregationTimeDelta;
-    ta = get_bucket_start_in_query_window(
-        false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
+    ta = get_bucket_start_in_query_window(cur_ts, self->startTimestamp);
     n_samples_before = get_samples_from_side(ta, true, self, &sample_before, &sample_befBefore);
     n_samples_after = get_samples_from_side(ta, false, self, &sample_after, &sample_afAfter);
 
     for (size_t i = 0; i < n_empty_buckets; ++i) {
-        ta = get_bucket_start_in_query_window(
-            false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
-        tb = get_bucket_end_in_query_window(
-            false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
+        ta = get_bucket_start_in_query_window(cur_ts, self->startTimestamp);
+        tb = get_bucket_end_in_query_window(cur_ts + agg_time_delta, self->endTimestamp);
 
         timestamp_t ts = calc_bucket_ts(self->bucketTS, cur_ts, self->aggregationTimeDelta);
         double twa_val = 0;
@@ -619,11 +593,7 @@ static void twa_fillEmptyBuckets(size_t *write_index,
             }
         }
         samples->timestamps[*write_index] = ts;
-        if (reversed) {
-            cur_ts -= self->aggregationTimeDelta;
-        } else {
-            cur_ts += self->aggregationTimeDelta;
-        }
+        cur_ts += self->aggregationTimeDelta;
         (*write_index)++;
     }
 }
@@ -636,24 +606,16 @@ static void twa_fillEmptyBuckets(size_t *write_index,
  * Looks at the leading edge of @p first_bucket_of_gap and checks the series for raw samples on
  * **both** sides. If either side has no sample, the gap lies outside the data span and the
  * caller drops it. Aggregation-agnostic — applied uniformly to TWA, LOCF (`LAST + EMPTY`), and
- * plain `EMPTY` (`SUM`, `COUNT`, ...) so that `TS.RANGE` and `TS.REVRANGE` produce the same
- * set of buckets.
+ * plain `EMPTY` (`SUM`, `COUNT`, ...).
  *
  * @param[in] self                  aggregation iterator (provides series + query window).
  * @param[in] first_bucket_of_gap   timestamp of the first empty bucket in the gap.
- * @param[in] aggregationTimeDelta  bucket width.
  * @return true → caller should drop the whole gap; false → emit empty buckets normally.
  */
 static bool should_skip_empty_gap(const AggregationIterator *self,
-                                  timestamp_t first_bucket_of_gap,
-                                  uint64_t aggregationTimeDelta) {
+                                  timestamp_t first_bucket_of_gap) {
     Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
-    timestamp_t ta = get_bucket_start_in_query_window(
-        false,
-        first_bucket_of_gap,
-        first_bucket_of_gap + aggregationTimeDelta,
-        self->startTimestamp,
-        self->endTimestamp);
+    timestamp_t ta = get_bucket_start_in_query_window(first_bucket_of_gap, self->startTimestamp);
     size_t n_samples_before =
         get_samples_from_side(ta, true, self, &sample_before, &sample_befBefore);
     size_t n_samples_after =
@@ -668,14 +630,10 @@ static int fillEmptyBuckets(Samples *samples,
                             timestamp_t first_bucket_ts,
                             timestamp_t end_bucket_ts,
                             const AggregationIterator *self,
-                            bool reversed,
                             int64_t *read_index) {
     int64_t agg_time_delta = self->aggregationTimeDelta;
     int64_t _read_index = *read_index + 1; // Cause we already stored the sample in read_index
     size_t vps = samples->values_per_sample;
-    if (reversed) {
-        __SWAP(end_bucket_ts, first_bucket_ts);
-    }
 
     // Check timestamp ordering
     if (end_bucket_ts < first_bucket_ts || agg_time_delta == 0) {
@@ -692,13 +650,11 @@ static int fillEmptyBuckets(Samples *samples,
         return 0;
     }
 
-    timestamp_t cur_ts = (reversed) ? end_bucket_ts : first_bucket_ts;
+    timestamp_t cur_ts = first_bucket_ts;
 
 #ifndef PREFIX_SUFFIX_IMPL // The PM decided to disable it, as it might cause OOM and complicates
                            // users
-    // Skip empty buckets that lie outside the data span (no raw sample on one side). Applies
-    // uniformly to TWA, LOCF, and plain EMPTY so forward and reverse return the same buckets.
-    if (should_skip_empty_gap(self, cur_ts, self->aggregationTimeDelta)) {
+    if (should_skip_empty_gap(self, cur_ts)) {
         return 0;
     }
 #endif // PREFIX_SUFFIX_IMPL
@@ -740,10 +696,9 @@ static int fillEmptyBuckets(Samples *samples,
     }
 
     if (self->hasTwa) {
-        twa_fillEmptyBuckets(write_index, cur_ts, samples, self, n_empty_buckets, reversed);
+        twa_fillEmptyBuckets(write_index, cur_ts, samples, self, n_empty_buckets);
     } else {
-        fillEmptyBucketsWithDefaultVals(
-            write_index, cur_ts, samples, self, n_empty_buckets, reversed);
+        fillEmptyBucketsWithDefaultVals(write_index, cur_ts, samples, self, n_empty_buckets);
     }
 
     return 0;
@@ -766,12 +721,11 @@ static inline Samples *ensureOutputSamples(AggregationIterator *self,
 /**
  * @brief Computes bucket bounds for `EMPTY` **prefix**: query edge through bucket before @p first_sample_ts.
  *
- * Forward: first bucket aligns to range start, last bucket is the one immediately before the bucket
- * containing @p first_sample_ts. Reversed: uses range end and adjusts bounds symmetrically.
+ * First bucket aligns to range start, last bucket is the one immediately before the bucket
+ * containing @p first_sample_ts.
  *
  * @param[in] self iterator (range, alignment).
  * @param[in] aggregationTimeDelta bucket width.
- * @param[in] is_reversed forward vs reverse aggregation direction.
  * @param[in] first_sample_ts timestamp of the first in-range raw sample (chunk start).
  * @param[out] out_first_bucket first empty-prefix bucket start.
  * @param[out] out_last_bucket last empty-prefix bucket start.
@@ -779,54 +733,30 @@ static inline Samples *ensureOutputSamples(AggregationIterator *self,
  */
 static void agg_iter_compute_empty_prefix_bounds(const AggregationIterator *self,
                                               uint64_t aggregationTimeDelta,
-                                              bool is_reversed,
                                               timestamp_t first_sample_ts,
                                               timestamp_t *out_first_bucket,
                                               timestamp_t *out_last_bucket,
                                               bool *out_has_span) {
     *out_first_bucket =
-        CalcBucketStart(is_reversed ? self->endTimestamp : self->startTimestamp,
-                        aggregationTimeDelta,
-                        self->timestampAlignment);
+        CalcBucketStart(self->startTimestamp, aggregationTimeDelta, self->timestampAlignment);
     *out_last_bucket =
         CalcBucketStart(first_sample_ts, aggregationTimeDelta, self->timestampAlignment);
-    *out_has_span = true;
-    if (!is_reversed) {
-        if (*out_first_bucket >= *out_last_bucket) {
-            *out_has_span = false;
-        }
-        *out_last_bucket =
-            max(0, (int64_t)((int64_t)*out_last_bucket - (int64_t)aggregationTimeDelta));
-    } else {
-        *out_last_bucket += aggregationTimeDelta;
-        if (*out_first_bucket < *out_last_bucket) {
-            *out_has_span = false;
-        }
-    }
+    *out_has_span = (*out_first_bucket < *out_last_bucket);
+    *out_last_bucket =
+        max(0, (int64_t)((int64_t)*out_last_bucket - (int64_t)aggregationTimeDelta));
 }
 
 /**
  * @brief Appends `EMPTY` buckets for aligned span [@p first_bucket, @p last_bucket] into the output chunk.
  *
- * Delegates to `fillEmptyBuckets`. Single-aggregation path appends into @p enrichedChunk and advances
- * @p si past the filled span on success. Multi-aggregation path appends after existing prefix samples
- * in `aux_chunk` (via `ensureOutputSamples`) and returns `fillEmptyBuckets`'s status unchanged.
- *
- * @param[in,out] self aggregation iterator (contexts, `EMPTY` policy).
- * @param[in,out] enrichedChunk chunk being built; single-agg writes `samples`, multi-agg uses aux buffer.
- * @param[in] first_bucket first bucket start in the span (inclusive).
- * @param[in] last_bucket last bucket start in the span (inclusive).
- * @param[in] is_reversed forward vs reverse bucket order for `fillEmptyBuckets`.
- * @param[in] multiAgg if true, write into scratch samples; if false, write into @p enrichedChunk.
- * @param[in,out] agg_n_samples sample count: prefix length for multi-agg; updated by `fillEmptyBuckets`.
- * @param[in,out] si read index for `fillEmptyBuckets` on single-agg path; reset to `-1`, then incremented on success.
- * @return `0` on success (single-agg), or `-1` on failure; multi-agg returns `fillEmptyBuckets`'s return code.
+ * Single-aggregation path appends into @p enrichedChunk and advances @p si past the filled span on
+ * success. Multi-aggregation path appends after existing prefix samples in `aux_chunk` (via
+ * `ensureOutputSamples`) and returns `fillEmptyBuckets`'s status unchanged.
  */
 static int agg_iter_append_empty_buckets(AggregationIterator *self,
                                              EnrichedChunk *enrichedChunk,
                                              timestamp_t first_bucket,
                                              timestamp_t last_bucket,
-                                             bool is_reversed,
                                              bool multiAgg,
                                              size_t *agg_n_samples,
                                              int64_t *si) {
@@ -835,7 +765,7 @@ static int agg_iter_append_empty_buckets(AggregationIterator *self,
         prefixSamples->num_samples = *agg_n_samples;
         int64_t read_idx = -1;
         return fillEmptyBuckets(
-            prefixSamples, agg_n_samples, first_bucket, last_bucket, self, is_reversed, &read_idx);
+            prefixSamples, agg_n_samples, first_bucket, last_bucket, self, &read_idx);
     }
     *si = -1;
     int err = fillEmptyBuckets(&enrichedChunk->samples,
@@ -843,7 +773,6 @@ static int agg_iter_append_empty_buckets(AggregationIterator *self,
                                first_bucket,
                                last_bucket,
                                self,
-                               is_reversed,
                                si);
     if (err != 0) {
         return -1;
@@ -858,34 +787,18 @@ static int agg_iter_append_empty_buckets(AggregationIterator *self,
  * Used when there is no in-range data to merge into an `EnrichedChunk` but `EMPTY` still needs
  * every bucket (TWA empty range; non-TWA empty full range after LOCF). `aux_chunk` is the scratch
  * buffer because there is no upstream chunk to extend.
- *
- * @param[in,out] self iterator (range, alignment, contexts).
- * @param[in] aggregationTimeDelta bucket width.
- * @param[in] is_reversed forward vs reverse (`fillEmptyBuckets`; may swap aligned bounds).
- * @param[out] agg_n_samples emitted row count; @p si set to `-1` then passed to `fillEmptyBuckets`.
- * @return `fillEmptyBuckets` return value.
  */
 static int agg_iter_fill_window_when_empty(AggregationIterator *self,
                                           uint64_t aggregationTimeDelta,
-                                          bool is_reversed,
                                           size_t *agg_n_samples,
                                           int64_t *si) {
     timestamp_t fb =
         CalcBucketStart(self->startTimestamp, aggregationTimeDelta, self->timestampAlignment);
     timestamp_t lb =
         CalcBucketStart(self->endTimestamp, aggregationTimeDelta, self->timestampAlignment);
-    if (is_reversed) {
-        __SWAP(fb, lb);
-    }
     *si = -1;
     self->aux_chunk->samples.num_samples = 0;
-    return fillEmptyBuckets(&self->aux_chunk->samples,
-                            agg_n_samples,
-                            fb,
-                            lb,
-                            self,
-                            is_reversed,
-                            si);
+    return fillEmptyBuckets(&self->aux_chunk->samples, agg_n_samples, fb, lb, self, si);
 }
 
 /**
@@ -988,25 +901,20 @@ static void agg_iter_neighbor_sample_scan(AggregationIterator *self,
 }
 
 /**
- * @brief Pre-loads LOCF empty seed from the latest raw sample chronologically just outside the
- *        query window in the iteration direction (forward: before `startTimestamp`; reverse:
- *        after `endTimestamp`).
+ * @brief Pre-loads LOCF empty seed from the latest raw sample chronologically just before
+ *        `startTimestamp`.
  *
- * Used by `TS.RANGE`/`TS.REVRANGE ... AGGREGATION LAST ... EMPTY` so empty buckets at the
- * leading edge of the window (in iteration order) can produce a value via
- * `finalize_empty_last_value`. No-ops if `EMPTY` is inactive, the relevant edge is at the
- * timestamp domain boundary, or no aggregation needs an LOCF empty seed. Resets
- * `last_locf_seed_ok` and delegates the scan to `agg_iter_neighbor_sample_scan`, which sets
- * the flag on success.
+ * Used by `TS.RANGE ... AGGREGATION LAST ... EMPTY` so empty buckets at the leading edge of the
+ * window can produce a value via `finalize_empty_last_value`. No-ops if `EMPTY` is inactive, the
+ * window starts at timestamp 0, or no aggregation needs an LOCF empty seed. Resets
+ * `last_locf_seed_ok` and delegates the scan to `agg_iter_neighbor_sample_scan`, which sets the
+ * flag on success.
  */
 static void agg_iter_load_last_pre_window(AggregationIterator *self, Sample *sample) {
     if (!self->empty) {
         return;
     }
-    if (!self->reverse && self->startTimestamp == 0) {
-        return;
-    }
-    if (self->reverse && self->endTimestamp == UINT64_MAX) {
+    if (self->startTimestamp == 0) {
         return;
     }
     // LOCF carry via appendValue is only safe for LAST: any other agg (SUM/COUNT/AVG/MIN/MAX/
@@ -1016,11 +924,13 @@ static void agg_iter_load_last_pre_window(AggregationIterator *self, Sample *sam
         return;
     }
     self->last_locf_seed_ok = false;
+    /* Walk the series backwards from startTimestamp-1 to find the latest sample before the
+     * query window. This is an internal seek - it does NOT affect the user-visible direction. */
     agg_iter_neighbor_sample_scan(self,
                                   sample,
-                                  self->reverse ? self->endTimestamp + 1 : 0,
-                                  self->reverse ? UINT64_MAX : self->startTimestamp - 1,
-                                  !self->reverse,
+                                  0,
+                                  self->startTimestamp - 1,
+                                  true,
                                   false,
                                   false,
                                   true);
@@ -1030,31 +940,21 @@ static void agg_iter_load_last_pre_window(AggregationIterator *self, Sample *sam
  * @brief Fills `[startTimestamp, endTimestamp]` with empty buckets when no in-range samples exist (non-TWA `EMPTY`).
  *
  * Marks the full empty range as handled, pre-loads an LOCF seed, then writes empty buckets into
- * the aux chunk via `agg_iter_fill_window_when_empty`. Returns @c NULL when forward LOCF has no
- * pre-window seed, the fill fails, or no buckets were written. Caller must ensure `self->empty`,
- * `!initialized`, `!handled_non_twa_empty_full_range`, and `!TWA_EMPTY_RANGE(self)`.
- *
- * @param[in,out] self                 aggregation iterator (`handled_non_twa_empty_full_range`, aux chunk).
- * @param[in]     aggregationTimeDelta bucket duration.
- * @param[in]     is_reversed          forward vs reverse direction.
- * @param[out]    agg_n_samples        number of samples written to the aux chunk.
- * @param[in,out] si                   current sample index into the aux chunk.
- * @return The aux `EnrichedChunk` populated with empty buckets, or @c NULL on failure / no output.
+ * the aux chunk via `agg_iter_fill_window_when_empty`. Returns @c NULL when LOCF has no
+ * pre-window seed, the fill fails, or no buckets were written.
  */
 static EnrichedChunk *agg_iter_empty_range_no_samples(AggregationIterator *self,
                                                         uint64_t aggregationTimeDelta,
-                                                        bool is_reversed,
                                                         size_t *agg_n_samples,
                                                         int64_t *si) {
     self->handled_non_twa_empty_full_range = true;
     *agg_n_samples = 0;
     Sample locf;
     agg_iter_load_last_pre_window(self, &locf);
-    if (!is_reversed && self->startTimestamp > 0 && !self->last_locf_seed_ok) {
+    if (self->startTimestamp > 0 && !self->last_locf_seed_ok) {
         return NULL;
     }
-    int err = agg_iter_fill_window_when_empty(
-        self, aggregationTimeDelta, is_reversed, agg_n_samples, si);
+    int err = agg_iter_fill_window_when_empty(self, aggregationTimeDelta, agg_n_samples, si);
     if (err != 0) {
         return NULL;
     }
@@ -1077,21 +977,9 @@ static EnrichedChunk *agg_iter_empty_range_no_samples(AggregationIterator *self,
  * - If a non-TWA `EMPTY` policy has a fully-empty range that hasn't been emitted yet,
  *   delegates to `agg_iter_empty_range_no_samples()`.
  * - Otherwise returns @c NULL to signal end of stream.
- *
- * @param[in,out] self            aggregation iterator (TWA flags, aux chunk, prev_ts).
- * @param[in]     aggregationTimeDelta bucket duration.
- * @param[in]     is_reversed     forward vs reverse aggregation direction.
- * @param[in,out] agg_n_samples   running count of samples written to the aux chunk.
- * @param[in,out] si              current sample index into the aux chunk; reset to -1
- *                                before filling and post-incremented after.
- * @param[out]    enter_finalize  set to @c true iff the caller must run `agg_iter_finalize()`;
- *                                @c false otherwise.
- * @return The aux `EnrichedChunk` populated with empty buckets, or @c NULL when the stream
- *         has ended or the caller must finalize first.
  */
 static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
                                               uint64_t aggregationTimeDelta,
-                                              bool is_reversed,
                                               size_t *agg_n_samples,
                                               int64_t *si,
                                               bool *enter_finalize) {
@@ -1104,8 +992,7 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
         if (!self->handled_twa_empty_prefix) {
             self->handled_twa_empty_prefix = true;
             self->handled_twa_empty_suffix = true; // The prefix in this case is also the suffix
-            int err = agg_iter_fill_window_when_empty(
-                self, aggregationTimeDelta, is_reversed, agg_n_samples, si);
+            int err = agg_iter_fill_window_when_empty(self, aggregationTimeDelta, agg_n_samples, si);
             if (err != 0) {
                 return NULL;
             }
@@ -1116,22 +1003,14 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
         if (!self->handled_twa_empty_suffix) {
             self->handled_twa_empty_suffix = true;
             timestamp_t last_bucket =
-                CalcBucketStart(is_reversed ? self->startTimestamp : self->endTimestamp,
+                CalcBucketStart(self->endTimestamp,
                                 aggregationTimeDelta,
                                 self->timestampAlignment);
             timestamp_t first_bucket =
                 CalcBucketStart(self->prev_ts, aggregationTimeDelta, self->timestampAlignment);
-            if (!is_reversed) {
-                first_bucket += aggregationTimeDelta;
-                if (first_bucket > last_bucket) {
-                    return NULL;
-                }
-            } else {
-                if (first_bucket <= last_bucket) {
-                    return NULL;
-                }
-                first_bucket =
-                    max(0, (int64_t)((int64_t)first_bucket - (int64_t)aggregationTimeDelta));
+            first_bucket += aggregationTimeDelta;
+            if (first_bucket > last_bucket) {
+                return NULL;
             }
             *si = -1;
             self->aux_chunk->samples.num_samples = 0;
@@ -1140,7 +1019,6 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
                                        first_bucket,
                                        last_bucket,
                                        self,
-                                       is_reversed,
                                        si);
             if (err != 0) {
                 return NULL;
@@ -1151,8 +1029,7 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
         }
         return NULL;
     } else if (self->empty && !self->initialized && !self->handled_non_twa_empty_full_range) {
-        return agg_iter_empty_range_no_samples(
-            self, aggregationTimeDelta, is_reversed, agg_n_samples, si);
+        return agg_iter_empty_range_no_samples(self, aggregationTimeDelta, agg_n_samples, si);
     }
     return NULL;
 }
@@ -1162,21 +1039,11 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
  * @brief Emits the `EMPTY` prefix once per range, before the first non-empty bucket.
  *
  * Gated by the per-range `handled_*_empty_prefix` flags; no-ops if `EMPTY` is inactive,
- * the span is degenerate, or (non-TWA forward LOCF) no valid pre-range seed exists.
- *
- * @param[in,out] self                 aggregation iterator (`EMPTY` flags, range bounds).
- * @param[in,out] enrichedChunk        output chunk receiving prefix buckets.
- * @param[in]     aggregationTimeDelta bucket duration.
- * @param[in]     is_reversed          forward vs reverse direction.
- * @param[in]     multiAgg             true if more than one aggregation is active.
- * @param[in,out] agg_n_samples        running count of samples written.
- * @param[in,out] si                   current sample index into the output buffer.
- * @return 0 on success/no-op; error code propagated from `agg_iter_append_empty_buckets()`.
+ * the span is degenerate, or (non-TWA LOCF) no valid pre-range seed exists.
  */
 static int agg_iter_apply_empty_prefix(AggregationIterator *self,
                                        EnrichedChunk *enrichedChunk,
                                        uint64_t aggregationTimeDelta,
-                                       bool is_reversed,
                                        bool multiAgg,
                                        size_t *agg_n_samples,
                                        int64_t *si) {
@@ -1195,7 +1062,6 @@ static int agg_iter_apply_empty_prefix(AggregationIterator *self,
     bool has_span;
     agg_iter_compute_empty_prefix_bounds(self,
                                       aggregationTimeDelta,
-                                      is_reversed,
                                       enrichedChunk->samples.timestamps[0],
                                       &first_bucket,
                                       &last_bucket,
@@ -1203,15 +1069,13 @@ static int agg_iter_apply_empty_prefix(AggregationIterator *self,
     if (!has_span) {
         return 0;
     }
-    if (!TWA_EMPTY_RANGE(self) && !is_reversed && self->startTimestamp > 0 &&
-        !self->last_locf_seed_ok) {
+    if (!TWA_EMPTY_RANGE(self) && self->startTimestamp > 0 && !self->last_locf_seed_ok) {
         return 0;
     }
     return agg_iter_append_empty_buckets(self,
                                              enrichedChunk,
                                              first_bucket,
                                              last_bucket,
-                                             is_reversed,
                                              multiAgg,
                                              agg_n_samples,
                                              si);
@@ -1223,7 +1087,6 @@ static void agg_iter_init_if_needed(AggregationIterator *self,
                                     EnrichedChunk *enrichedChunk,
                                     int64_t si,
                                     uint64_t aggregationTimeDelta,
-                                    bool is_reversed,
                                     Sample *sample) {
     if (self->initialized) {
         return;
@@ -1234,33 +1097,27 @@ static void agg_iter_init_if_needed(AggregationIterator *self,
     self->initialized = true;
 
     if (self->hasTwa) {
-        timestamp_t ta = get_bucket_start_in_query_window(self->reverse,
-                                     BucketStartNormalize(self->aggregationLastTimestamp),
-                                     self->aggregationLastTimestamp + aggregationTimeDelta,
-                                     self->startTimestamp,
-                                     self->endTimestamp);
-        timestamp_t tb = get_bucket_end_in_query_window(self->reverse,
-                                     BucketStartNormalize(self->aggregationLastTimestamp),
-                                     self->aggregationLastTimestamp + aggregationTimeDelta,
-                                     self->startTimestamp,
-                                     self->endTimestamp);
+        timestamp_t bucket_start = BucketStartNormalize(self->aggregationLastTimestamp);
+        timestamp_t bucket_end = self->aggregationLastTimestamp + aggregationTimeDelta;
+        timestamp_t ta = get_bucket_start_in_query_window(bucket_start, self->startTimestamp);
+        timestamp_t tb = get_bucket_end_in_query_window(bucket_end, self->endTimestamp);
         for (size_t a = 0; a < self->numAggregations; a++) {
             if (self->aggregations[a].type == TS_AGG_TWA) {
-                self->aggregations[a].addBucketParams(self->aggregationContexts[a],
-                                                      (!self->reverse) ? ta : tb,
-                                                      (!self->reverse) ? tb : ta);
+                self->aggregations[a].addBucketParams(self->aggregationContexts[a], ta, tb);
             }
         }
     }
 
-    // Guard against `init_ts - 1` underflow in forward direction when init_ts == 0
+    // Guard against `init_ts - 1` underflow when init_ts == 0
     // (no samples can exist before timestamp 0, so nothing to scan).
-    if (agg_iter_needs_prev_bucket_sample(self) && !((!is_reversed) && init_ts == 0)) {
+    /* Internal seek: walk the series backwards from init_ts-1 to find the closest sample
+     * that anchors the current bucket's TWA integral. */
+    if (agg_iter_needs_prev_bucket_sample(self) && init_ts != 0) {
         agg_iter_neighbor_sample_scan(self,
                                       sample,
-                                      is_reversed ? init_ts + 1 : 0,
-                                      is_reversed ? UINT64_MAX : init_ts - 1,
-                                      !is_reversed,
+                                      0,
+                                      init_ts - 1,
+                                      true,
                                       true,
                                       false,
                                       false);
@@ -1274,41 +1131,24 @@ static void agg_iter_init_if_needed(AggregationIterator *self,
 static bool agg_iter_empty_gap_after_finalize(uint64_t contextScope,
                                               timestamp_t aggregationLastTimestamp,
                                               uint64_t aggregationTimeDelta,
-                                              bool is_reversed,
-                                              bool reversed_gap_max_style,
                                               timestamp_t *out_first_bucket,
                                               timestamp_t *out_last_bucket) {
     bool has_empty_buckets = true;
-    if (is_reversed) {
-        *out_first_bucket =
-            max(0, (int64_t)((int64_t)contextScope - (int64_t)(2 * aggregationTimeDelta)));
-        *out_last_bucket = aggregationLastTimestamp + aggregationTimeDelta;
-        if (reversed_gap_max_style) {
-            if (contextScope > *out_last_bucket + (2 * aggregationTimeDelta)) {
-                has_empty_buckets = false;
-            }
-        } else {
-            if (contextScope < *out_last_bucket + (2 * aggregationTimeDelta)) {
-                has_empty_buckets = false;
-            }
-        }
-    } else {
-        *out_first_bucket = contextScope;
-        if (*out_first_bucket >= aggregationLastTimestamp) {
+    *out_first_bucket = contextScope;
+    if (*out_first_bucket >= aggregationLastTimestamp) {
+        has_empty_buckets = false;
+    }
+    *out_last_bucket =
+        max(0, (int64_t)((int64_t)aggregationLastTimestamp - (int64_t)aggregationTimeDelta));
+    /* fillEmptyBuckets rejects end < first or (end-first) % delta != 0 with -1, which aborts
+     * the whole range query. Skip synthetic gaps that would fail those checks. */
+    if (has_empty_buckets) {
+        if (*out_last_bucket < *out_first_bucket) {
             has_empty_buckets = false;
-        }
-        *out_last_bucket =
-            max(0, (int64_t)((int64_t)aggregationLastTimestamp - (int64_t)aggregationTimeDelta));
-        /* fillEmptyBuckets rejects end < first or (end-first) % delta != 0 with -1, which aborts
-         * the whole range query. Skip synthetic gaps that would fail those checks. */
-        if (has_empty_buckets) {
-            if (*out_last_bucket < *out_first_bucket) {
+        } else if (aggregationTimeDelta != 0) {
+            uint64_t span = *out_last_bucket - *out_first_bucket;
+            if (span % aggregationTimeDelta != 0) {
                 has_empty_buckets = false;
-            } else if (aggregationTimeDelta != 0) {
-                uint64_t span = *out_last_bucket - *out_first_bucket;
-                if (span % aggregationTimeDelta != 0) {
-                    has_empty_buckets = false;
-                }
             }
         }
     }
@@ -1351,7 +1191,6 @@ static int agg_iter_max_emit_opening_sample(AggregationIterator *self,
                                             AggregationClass *aggregation,
                                             void *aggregationContext,
                                             uint64_t aggregationTimeDelta,
-                                            bool is_reversed,
                                             void (*appendValue)(void *, double, timestamp_t),
                                             uint64_t *contextScope,
                                             size_t *agg_n_samples,
@@ -1370,8 +1209,6 @@ static int agg_iter_max_emit_opening_sample(AggregationIterator *self,
         if (agg_iter_empty_gap_after_finalize(*contextScope,
                                               self->aggregationLastTimestamp,
                                               aggregationTimeDelta,
-                                              is_reversed,
-                                              true,
                                               &first_bucket,
                                               &last_bucket)) {
             int err = fillEmptyBuckets(&enrichedChunk->samples,
@@ -1379,7 +1216,6 @@ static int agg_iter_max_emit_opening_sample(AggregationIterator *self,
                                        first_bucket,
                                        last_bucket,
                                        self,
-                                       is_reversed,
                                        si);
             if (err != 0) {
                 return -1;
@@ -1397,13 +1233,12 @@ static int agg_iter_max_emit_opening_sample(AggregationIterator *self,
     return 0;
 }
 
-// Single agg MAX forward: vectorized append per bucket. Returns 0 or -1 on fillEmptyBuckets error.
+// Single agg MAX: vectorized append per bucket. Returns 0 or -1 on fillEmptyBuckets error.
 static int agg_iter_process_chunk_max_fast_path(AggregationIterator *self,
                                                 EnrichedChunk *enrichedChunk,
                                                 AggregationClass *aggregation,
                                                 void *aggregationContext,
                                                 uint64_t aggregationTimeDelta,
-                                                bool is_reversed,
                                                 void (*appendValue)(void *, double, timestamp_t),
                                                 uint64_t *contextScope,
                                                 size_t *agg_n_samples,
@@ -1422,7 +1257,6 @@ static int agg_iter_process_chunk_max_fast_path(AggregationIterator *self,
                                              aggregation,
                                              aggregationContext,
                                              aggregationTimeDelta,
-                                             is_reversed,
                                              appendValue,
                                              contextScope,
                                              agg_n_samples,
@@ -1438,7 +1272,6 @@ static int agg_iter_general_on_bucket_boundary(AggregationIterator *self,
                                                EnrichedChunk *enrichedChunk,
                                                Sample *sample,
                                                uint64_t aggregationTimeDelta,
-                                               bool is_reversed,
                                                bool multiAgg,
                                                uint64_t *contextScope,
                                                size_t *agg_n_samples,
@@ -1470,20 +1303,10 @@ static int agg_iter_general_on_bucket_boundary(AggregationIterator *self,
     self->aggregationLastTimestamp =
         CalcBucketStart(sample->timestamp, aggregationTimeDelta, self->timestampAlignment);
     if (self->empty) {
-        // In reverse iteration, the chronologically-previous-in-time sample relative to the
-        // empty gap is the upcoming one (sample arg here), not the bucket we just finalized.
-        // Pre-load LOCF aggregations' contexts with it so finalize_empty_*_value emits the
-        // correct value during fillEmptyBuckets. The subsequent appendValue for the same
-        // sample (in process_chunk_general) is idempotent for LOCF aggs (e.g. LAST).
-        if (is_reversed) {
-            agg_iter_apply_neighbor_sample(self, sample, false, false);
-        }
         timestamp_t first_bucket, last_bucket;
         if (agg_iter_empty_gap_after_finalize(*contextScope,
                                               self->aggregationLastTimestamp,
                                               aggregationTimeDelta,
-                                              is_reversed,
-                                              false,
                                               &first_bucket,
                                               &last_bucket)) {
             Samples *emptySamples = ensureOutputSamples(self, enrichedChunk, *agg_n_samples + 256);
@@ -1496,7 +1319,6 @@ static int agg_iter_general_on_bucket_boundary(AggregationIterator *self,
                                        first_bucket,
                                        last_bucket,
                                        self,
-                                       is_reversed,
                                        multiAgg ? &read_idx : si);
             if (err != 0) {
                 return -1;
@@ -1506,11 +1328,7 @@ static int agg_iter_general_on_bucket_boundary(AggregationIterator *self,
     agg_iter_advance_context_scope(self, aggregationTimeDelta, contextScope);
 
     if (self->hasTwa) {
-        timestamp_t tb = get_bucket_end_in_query_window(self->reverse,
-                                     self->aggregationLastTimestamp,
-                                     *contextScope,
-                                     self->startTimestamp,
-                                     self->endTimestamp);
+        timestamp_t tb = get_bucket_end_in_query_window(*contextScope, self->endTimestamp);
         for (size_t a = 0; a < self->numAggregations; a++) {
             if (self->aggregations[a].type == TS_AGG_TWA) {
                 if (twaHadValid[a] &&
@@ -1519,10 +1337,9 @@ static int agg_iter_general_on_bucket_boundary(AggregationIterator *self,
                                                                   twa_last_samples[a].value,
                                                                   twa_last_samples[a].timestamp);
                 }
-                self->aggregations[a].addBucketParams(
-                    self->aggregationContexts[a],
-                    (!self->reverse) ? self->aggregationLastTimestamp : tb,
-                    (!self->reverse) ? tb : *contextScope);
+                self->aggregations[a].addBucketParams(self->aggregationContexts[a],
+                                                      self->aggregationLastTimestamp,
+                                                      tb);
             }
         }
     }
@@ -1557,7 +1374,6 @@ static int agg_iter_process_chunk_general(AggregationIterator *self,
                                           AggregationClass *aggregation,
                                           void *aggregationContext,
                                           uint64_t aggregationTimeDelta,
-                                          bool is_reversed,
                                           bool multiAgg,
                                           void (*appendValue)(void *, double, timestamp_t),
                                           uint64_t *contextScope,
@@ -1571,13 +1387,11 @@ static int agg_iter_process_chunk_general(AggregationIterator *self,
     while (*si < (int64_t)samples->num_samples) {
         sample->timestamp = enrichedChunk->samples.timestamps[*si];
         sample->value = Samples_value_at(&enrichedChunk->samples, *si, 0);
-        if ((!is_reversed && sample->timestamp >= *contextScope) ||
-            (is_reversed && sample->timestamp < self->aggregationLastTimestamp)) {
+        if (sample->timestamp >= *contextScope) {
             if (agg_iter_general_on_bucket_boundary(self,
                                                     enrichedChunk,
                                                     sample,
                                                     aggregationTimeDelta,
-                                                    is_reversed,
                                                     multiAgg,
                                                     contextScope,
                                                     agg_n_samples,
@@ -1614,7 +1428,6 @@ static EnrichedChunk *agg_iter_try_emit_partial(AggregationIterator *self,
 
 static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
                                         uint64_t aggregationTimeDelta,
-                                        bool is_reversed,
                                         Sample *sample) {
     self->hasUnFinalizedContext = false;
     if (self->hasTwa) {
@@ -1628,16 +1441,15 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
                 found = true;
             }
         }
-        if (found && !(is_reversed && last_sample.timestamp == 0)) {
-            agg_iter_neighbor_sample_scan(
-                self,
-                sample,
-                is_reversed ? 0 : last_sample.timestamp + 1,
-                is_reversed ? last_sample.timestamp - 1 : UINT64_MAX,
-                is_reversed,
-                false,
-                true,
-                false);
+        if (found) {
+            agg_iter_neighbor_sample_scan(self,
+                                          sample,
+                                          last_sample.timestamp + 1,
+                                          UINT64_MAX,
+                                          false,
+                                          false,
+                                          true,
+                                          false);
         }
     }
 
@@ -1697,29 +1509,19 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
     self->aux_chunk->samples.timestamps[0] =
         calc_bucket_ts(self->bucketTS, self->aggregationLastTimestamp, self->aggregationTimeDelta);
     size_t n_samples = 1;
-    /* Emit trailing empty buckets from the last output bucket through endTimestamp. TWA fillEmptyBuckets
-     * may insert nothing for a gap (PM edge rule); LAST+EMPTY uses the same rule for the suffix so
-     * bucket counts match TWA+EMPTY. */
+    /* Emit trailing empty buckets from the last output bucket through endTimestamp. TWA
+     * fillEmptyBuckets may insert nothing for a gap (PM edge rule); LAST+EMPTY uses the same
+     * rule for the suffix so bucket counts match TWA+EMPTY. */
     if (self->empty && !self->handled_twa_empty_suffix) {
         self->handled_twa_empty_suffix = true;
         timestamp_t last_bucket =
-            CalcBucketStart(is_reversed ? self->startTimestamp : self->endTimestamp,
+            CalcBucketStart(self->endTimestamp,
                             aggregationTimeDelta,
                             self->timestampAlignment);
         timestamp_t first_bucket = CalcBucketStart(
             self->aux_chunk->samples.timestamps[0], aggregationTimeDelta, self->timestampAlignment);
-        bool has_empty_buckets = true;
-        if (is_reversed) {
-            if (first_bucket <= last_bucket) {
-                has_empty_buckets = false;
-            }
-            first_bucket = (int64_t)((int64_t)first_bucket - (int64_t)aggregationTimeDelta);
-        } else {
-            if (first_bucket >= last_bucket) {
-                has_empty_buckets = false;
-            }
-            first_bucket += aggregationTimeDelta;
-        }
+        bool has_empty_buckets = (first_bucket < last_bucket);
+        first_bucket += aggregationTimeDelta;
         int64_t read_index = 0;
         if (has_empty_buckets) {
             self->aux_chunk->samples.num_samples = 1;
@@ -1728,7 +1530,6 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
                                        first_bucket,
                                        last_bucket,
                                        self,
-                                       is_reversed,
                                        &read_index);
             if (err != 0) {
                 return NULL;
@@ -1744,7 +1545,6 @@ EnrichedChunk *AggregationIterator_GetNextChunk(struct AbstractIterator *iter) {
     AggregationClass *aggregation = &self->aggregations[0];
     void *aggregationContext = self->aggregationContexts[0];
     uint64_t aggregationTimeDelta = self->aggregationTimeDelta;
-    bool is_reversed = self->reverse;
     bool multiAgg = self->numAggregations > 1;
     Sample sample;
 
@@ -1756,9 +1556,9 @@ EnrichedChunk *AggregationIterator_GetNextChunk(struct AbstractIterator *iter) {
     if (!enrichedChunk || enrichedChunk->samples.num_samples == 0) {
         bool enter_finalize;
         EnrichedChunk *r = agg_iter_on_empty_chunk(
-            self, aggregationTimeDelta, is_reversed, &agg_n_samples, &si, &enter_finalize);
+            self, aggregationTimeDelta, &agg_n_samples, &si, &enter_finalize);
         if (enter_finalize) {
-            return agg_iter_finalize(self, aggregationTimeDelta, is_reversed, &sample);
+            return agg_iter_finalize(self, aggregationTimeDelta, &sample);
         }
         return r;
     }
@@ -1770,7 +1570,6 @@ EnrichedChunk *AggregationIterator_GetNextChunk(struct AbstractIterator *iter) {
     if (agg_iter_apply_empty_prefix(self,
                                       enrichedChunk,
                                       aggregationTimeDelta,
-                                      is_reversed,
                                       multiAgg,
                                       &agg_n_samples,
                                       &si) != 0) {
@@ -1778,20 +1577,19 @@ EnrichedChunk *AggregationIterator_GetNextChunk(struct AbstractIterator *iter) {
     }
     self->hasUnFinalizedContext = true;
 
-    agg_iter_init_if_needed(self, enrichedChunk, si, aggregationTimeDelta, is_reversed, &sample);
+    agg_iter_init_if_needed(self, enrichedChunk, si, aggregationTimeDelta, &sample);
 
     void (*appendValue)(void *, double, timestamp_t) = aggregation->appendValue;
     uint64_t contextScope = self->aggregationLastTimestamp + aggregationTimeDelta;
     self->aggregationLastTimestamp = BucketStartNormalize(self->aggregationLastTimestamp);
     while (enrichedChunk) {
-        assert(self->reverse == enrichedChunk->rev || enrichedChunk->samples.num_samples == 0);
-        if (self->numAggregations == 1 && aggregation->type == TS_AGG_MAX && !is_reversed) {
+        assert(!enrichedChunk->rev || enrichedChunk->samples.num_samples == 0);
+        if (self->numAggregations == 1 && aggregation->type == TS_AGG_MAX) {
             if (agg_iter_process_chunk_max_fast_path(self,
                                                      enrichedChunk,
                                                      aggregation,
                                                      aggregationContext,
                                                      aggregationTimeDelta,
-                                                     is_reversed,
                                                      appendValue,
                                                      &contextScope,
                                                      &agg_n_samples,
@@ -1806,7 +1604,6 @@ EnrichedChunk *AggregationIterator_GetNextChunk(struct AbstractIterator *iter) {
                                                aggregation,
                                                aggregationContext,
                                                aggregationTimeDelta,
-                                               is_reversed,
                                                multiAgg,
                                                appendValue,
                                                &contextScope,
@@ -1826,7 +1623,7 @@ EnrichedChunk *AggregationIterator_GetNextChunk(struct AbstractIterator *iter) {
         si = 0;
     }
 
-    return agg_iter_finalize(self, aggregationTimeDelta, is_reversed, &sample);
+    return agg_iter_finalize(self, aggregationTimeDelta, &sample);
 }
 
 void AggregationIterator_Close(struct AbstractIterator *iterator) {

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -199,7 +199,12 @@ EnrichedChunk *SeriesFilterTSIterator_GetNextChunk(struct AbstractIterator *base
                               self->ByTsArgs.count - 1);
         if (count > 0) {
             enrichedChunk->samples.num_samples = count;
-            self->tsFilterIndex += count; // at least count samples consumed
+            if (unlikely(self->reverse)) {
+                reverseEnrichedChunk(enrichedChunk);
+                self->ByTsArgs.count -= count;
+            } else {
+                self->tsFilterIndex += count; // at least count samples consumed
+            }
             return enrichedChunk;
         }
     }
@@ -208,13 +213,15 @@ EnrichedChunk *SeriesFilterTSIterator_GetNextChunk(struct AbstractIterator *base
 }
 
 SeriesFilterTSIterator *SeriesFilterTSIterator_New(AbstractIterator *input,
-                                                   FilterByTSArgs ByTsArgs) {
+                                                   FilterByTSArgs ByTsArgs,
+                                                   bool rev) {
     SeriesFilterTSIterator *newIter = malloc(sizeof(SeriesFilterTSIterator));
     newIter->base.input = input;
     newIter->base.GetNext = SeriesFilterTSIterator_GetNextChunk;
     newIter->base.Close = SeriesFilterIterator_Close;
     newIter->ByTsArgs = ByTsArgs;
     newIter->tsFilterIndex = 0;
+    newIter->reverse = rev;
     return newIter;
 }
 

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -17,7 +17,8 @@
 #include <string.h>
 
 /**
- * @brief True if @p agg uses LOCF for `EMPTY` (last context / `finalize_empty_last_value`; @c LAST).
+ * @brief True if @p agg uses LOCF for `EMPTY` (last context / `finalize_empty_last_value`; @c
+ * LAST).
  * @param[in] agg aggregation class.
  */
 static inline bool agg_class_needs_locf_empty_seed(const AggregationClass *agg) {
@@ -25,7 +26,8 @@ static inline bool agg_class_needs_locf_empty_seed(const AggregationClass *agg) 
 }
 
 /**
- * @brief True if @p self needs a sample before the first bucket (`addPrevBucketLastSample` on any agg).
+ * @brief True if @p self needs a sample before the first bucket (`addPrevBucketLastSample` on any
+ * agg).
  * @param[in] self aggregation iterator (e.g. TWA).
  */
 static bool agg_iter_needs_prev_bucket_sample(const AggregationIterator *self) {
@@ -38,7 +40,8 @@ static bool agg_iter_needs_prev_bucket_sample(const AggregationIterator *self) {
 }
 
 /**
- * @brief True if any aggregation in @p self uses LOCF for `EMPTY` (see agg_class_needs_locf_empty_seed).
+ * @brief True if any aggregation in @p self uses LOCF for `EMPTY` (see
+ * agg_class_needs_locf_empty_seed).
  * @param[in] self aggregation iterator.
  */
 static bool agg_iter_any_locf_empty_agg(const AggregationIterator *self) {
@@ -606,8 +609,7 @@ static bool should_skip_empty_gap(const AggregationIterator *self,
     timestamp_t ta = max(first_bucket_of_gap, self->startTimestamp);
     size_t n_samples_before =
         get_samples_from_side(ta, true, self, &sample_before, &sample_befBefore);
-    size_t n_samples_after =
-        get_samples_from_side(ta, false, self, &sample_after, &sample_afAfter);
+    size_t n_samples_after = get_samples_from_side(ta, false, self, &sample_after, &sample_afAfter);
     return n_samples_before == 0 || n_samples_after == 0;
 }
 
@@ -707,7 +709,8 @@ static inline Samples *ensureOutputSamples(AggregationIterator *self,
 }
 
 /**
- * @brief Computes bucket bounds for `EMPTY` **prefix**: query edge through bucket before @p first_sample_ts.
+ * @brief Computes bucket bounds for `EMPTY` **prefix**: query edge through bucket before @p
+ * first_sample_ts.
  *
  * First bucket aligns to range start, last bucket is the one immediately before the bucket
  * containing @p first_sample_ts.
@@ -720,34 +723,34 @@ static inline Samples *ensureOutputSamples(AggregationIterator *self,
  * @param[out] out_has_span false if there is no non-empty span to fill (degenerate / no gap).
  */
 static void agg_iter_compute_empty_prefix_bounds(const AggregationIterator *self,
-                                              uint64_t aggregationTimeDelta,
-                                              timestamp_t first_sample_ts,
-                                              timestamp_t *out_first_bucket,
-                                              timestamp_t *out_last_bucket,
-                                              bool *out_has_span) {
+                                                 uint64_t aggregationTimeDelta,
+                                                 timestamp_t first_sample_ts,
+                                                 timestamp_t *out_first_bucket,
+                                                 timestamp_t *out_last_bucket,
+                                                 bool *out_has_span) {
     *out_first_bucket =
         CalcBucketStart(self->startTimestamp, aggregationTimeDelta, self->timestampAlignment);
     *out_last_bucket =
         CalcBucketStart(first_sample_ts, aggregationTimeDelta, self->timestampAlignment);
     *out_has_span = (*out_first_bucket < *out_last_bucket);
-    *out_last_bucket =
-        max(0, (int64_t)((int64_t)*out_last_bucket - (int64_t)aggregationTimeDelta));
+    *out_last_bucket = max(0, (int64_t)((int64_t)*out_last_bucket - (int64_t)aggregationTimeDelta));
 }
 
 /**
- * @brief Appends `EMPTY` buckets for aligned span [@p first_bucket, @p last_bucket] into the output chunk.
+ * @brief Appends `EMPTY` buckets for aligned span [@p first_bucket, @p last_bucket] into the output
+ * chunk.
  *
  * Single-aggregation path appends into @p enrichedChunk and advances @p si past the filled span on
  * success. Multi-aggregation path appends after existing prefix samples in `aux_chunk` (via
  * `ensureOutputSamples`) and returns `fillEmptyBuckets`'s status unchanged.
  */
 static int agg_iter_append_empty_buckets(AggregationIterator *self,
-                                             EnrichedChunk *enrichedChunk,
-                                             timestamp_t first_bucket,
-                                             timestamp_t last_bucket,
-                                             bool multiAgg,
-                                             size_t *agg_n_samples,
-                                             int64_t *si) {
+                                         EnrichedChunk *enrichedChunk,
+                                         timestamp_t first_bucket,
+                                         timestamp_t last_bucket,
+                                         bool multiAgg,
+                                         size_t *agg_n_samples,
+                                         int64_t *si) {
     if (multiAgg) {
         Samples *prefixSamples = ensureOutputSamples(self, enrichedChunk, *agg_n_samples + 256);
         prefixSamples->num_samples = *agg_n_samples;
@@ -756,12 +759,8 @@ static int agg_iter_append_empty_buckets(AggregationIterator *self,
             prefixSamples, agg_n_samples, first_bucket, last_bucket, self, &read_idx);
     }
     *si = -1;
-    int err = fillEmptyBuckets(&enrichedChunk->samples,
-                               agg_n_samples,
-                               first_bucket,
-                               last_bucket,
-                               self,
-                               si);
+    int err = fillEmptyBuckets(
+        &enrichedChunk->samples, agg_n_samples, first_bucket, last_bucket, self, si);
     if (err != 0) {
         return -1;
     }
@@ -777,9 +776,9 @@ static int agg_iter_append_empty_buckets(AggregationIterator *self,
  * buffer because there is no upstream chunk to extend.
  */
 static int agg_iter_fill_window_when_empty(AggregationIterator *self,
-                                          uint64_t aggregationTimeDelta,
-                                          size_t *agg_n_samples,
-                                          int64_t *si) {
+                                           uint64_t aggregationTimeDelta,
+                                           size_t *agg_n_samples,
+                                           int64_t *si) {
     timestamp_t fb =
         CalcBucketStart(self->startTimestamp, aggregationTimeDelta, self->timestampAlignment);
     timestamp_t lb =
@@ -869,13 +868,11 @@ static void agg_iter_neighbor_sample_scan(AggregationIterator *self,
     AbstractSampleIterator *sample_iterator =
         SeriesCreateSampleIterator(self->series, &args, reverse_iteration, true);
     while (sample_iterator->GetNext(sample_iterator, sample) == CR_OK) {
-        if (as_prev_bucket_neighbor &&
-            agg_iter_apply_neighbor_sample(self, sample, true, false)) {
+        if (as_prev_bucket_neighbor && agg_iter_apply_neighbor_sample(self, sample, true, false)) {
             sample_iterator->Close(sample_iterator);
             return;
         }
-        if (as_next_bucket_neighbor &&
-            agg_iter_apply_neighbor_sample(self, sample, false, true)) {
+        if (as_next_bucket_neighbor && agg_iter_apply_neighbor_sample(self, sample, false, true)) {
             sample_iterator->Close(sample_iterator);
             return;
         }
@@ -914,27 +911,22 @@ static void agg_iter_load_last_pre_window(AggregationIterator *self, Sample *sam
     self->last_locf_seed_ok = false;
     /* Walk the series backwards from startTimestamp-1 to find the latest sample before the
      * query window. This is an internal seek - it does NOT affect the user-visible direction. */
-    agg_iter_neighbor_sample_scan(self,
-                                  sample,
-                                  0,
-                                  self->startTimestamp - 1,
-                                  true,
-                                  false,
-                                  false,
-                                  true);
+    agg_iter_neighbor_sample_scan(
+        self, sample, 0, self->startTimestamp - 1, true, false, false, true);
 }
 
 /**
- * @brief Fills `[startTimestamp, endTimestamp]` with empty buckets when no in-range samples exist (non-TWA `EMPTY`).
+ * @brief Fills `[startTimestamp, endTimestamp]` with empty buckets when no in-range samples exist
+ * (non-TWA `EMPTY`).
  *
  * Marks the full empty range as handled, pre-loads an LOCF seed, then writes empty buckets into
  * the aux chunk via `agg_iter_fill_window_when_empty`. Returns @c NULL when LOCF has no
  * pre-window seed, the fill fails, or no buckets were written.
  */
 static EnrichedChunk *agg_iter_empty_range_no_samples(AggregationIterator *self,
-                                                        uint64_t aggregationTimeDelta,
-                                                        size_t *agg_n_samples,
-                                                        int64_t *si) {
+                                                      uint64_t aggregationTimeDelta,
+                                                      size_t *agg_n_samples,
+                                                      int64_t *si) {
     self->handled_non_twa_empty_full_range = true;
     *agg_n_samples = 0;
     Sample locf;
@@ -980,7 +972,8 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
         if (!self->handled_twa_empty_prefix) {
             self->handled_twa_empty_prefix = true;
             self->handled_twa_empty_suffix = true; // The prefix in this case is also the suffix
-            int err = agg_iter_fill_window_when_empty(self, aggregationTimeDelta, agg_n_samples, si);
+            int err =
+                agg_iter_fill_window_when_empty(self, aggregationTimeDelta, agg_n_samples, si);
             if (err != 0) {
                 return NULL;
             }
@@ -991,9 +984,7 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
         if (!self->handled_twa_empty_suffix) {
             self->handled_twa_empty_suffix = true;
             timestamp_t last_bucket =
-                CalcBucketStart(self->endTimestamp,
-                                aggregationTimeDelta,
-                                self->timestampAlignment);
+                CalcBucketStart(self->endTimestamp, aggregationTimeDelta, self->timestampAlignment);
             timestamp_t first_bucket =
                 CalcBucketStart(self->prev_ts, aggregationTimeDelta, self->timestampAlignment);
             first_bucket += aggregationTimeDelta;
@@ -1002,12 +993,8 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
             }
             *si = -1;
             self->aux_chunk->samples.num_samples = 0;
-            int err = fillEmptyBuckets(&self->aux_chunk->samples,
-                                       agg_n_samples,
-                                       first_bucket,
-                                       last_bucket,
-                                       self,
-                                       si);
+            int err = fillEmptyBuckets(
+                &self->aux_chunk->samples, agg_n_samples, first_bucket, last_bucket, self, si);
             if (err != 0) {
                 return NULL;
             }
@@ -1021,7 +1008,6 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
     }
     return NULL;
 }
-
 
 /**
  * @brief Emits the `EMPTY` prefix once per range, before the first non-empty bucket.
@@ -1049,26 +1035,20 @@ static int agg_iter_apply_empty_prefix(AggregationIterator *self,
     timestamp_t first_bucket, last_bucket;
     bool has_span;
     agg_iter_compute_empty_prefix_bounds(self,
-                                      aggregationTimeDelta,
-                                      enrichedChunk->samples.timestamps[0],
-                                      &first_bucket,
-                                      &last_bucket,
-                                      &has_span);
+                                         aggregationTimeDelta,
+                                         enrichedChunk->samples.timestamps[0],
+                                         &first_bucket,
+                                         &last_bucket,
+                                         &has_span);
     if (!has_span) {
         return 0;
     }
     if (!TWA_EMPTY_RANGE(self) && self->startTimestamp > 0 && !self->last_locf_seed_ok) {
         return 0;
     }
-    return agg_iter_append_empty_buckets(self,
-                                             enrichedChunk,
-                                             first_bucket,
-                                             last_bucket,
-                                             multiAgg,
-                                             agg_n_samples,
-                                             si);
+    return agg_iter_append_empty_buckets(
+        self, enrichedChunk, first_bucket, last_bucket, multiAgg, agg_n_samples, si);
 }
-
 
 // First chunk only: bucket start from first sample, TWA params, optional prior sample for TWA.
 static void agg_iter_init_if_needed(AggregationIterator *self,
@@ -1101,14 +1081,7 @@ static void agg_iter_init_if_needed(AggregationIterator *self,
     /* Internal seek: walk the series backwards from init_ts-1 to find the closest sample
      * that anchors the current bucket's TWA integral. */
     if (agg_iter_needs_prev_bucket_sample(self) && init_ts != 0) {
-        agg_iter_neighbor_sample_scan(self,
-                                      sample,
-                                      0,
-                                      init_ts - 1,
-                                      true,
-                                      true,
-                                      false,
-                                      false);
+        agg_iter_neighbor_sample_scan(self, sample, 0, init_ts - 1, true, true, false, false);
     }
 }
 
@@ -1199,12 +1172,8 @@ static int agg_iter_max_emit_opening_sample(AggregationIterator *self,
                                               aggregationTimeDelta,
                                               &first_bucket,
                                               &last_bucket)) {
-            int err = fillEmptyBuckets(&enrichedChunk->samples,
-                                       agg_n_samples,
-                                       first_bucket,
-                                       last_bucket,
-                                       self,
-                                       si);
+            int err = fillEmptyBuckets(
+                &enrichedChunk->samples, agg_n_samples, first_bucket, last_bucket, self, si);
             if (err != 0) {
                 return -1;
             }
@@ -1325,9 +1294,8 @@ static int agg_iter_general_on_bucket_boundary(AggregationIterator *self,
                                                                   twa_last_samples[a].value,
                                                                   twa_last_samples[a].timestamp);
                 }
-                self->aggregations[a].addBucketParams(self->aggregationContexts[a],
-                                                      self->aggregationLastTimestamp,
-                                                      tb);
+                self->aggregations[a].addBucketParams(
+                    self->aggregationContexts[a], self->aggregationLastTimestamp, tb);
             }
         }
     }
@@ -1430,14 +1398,8 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
             }
         }
         if (found) {
-            agg_iter_neighbor_sample_scan(self,
-                                          sample,
-                                          last_sample.timestamp + 1,
-                                          UINT64_MAX,
-                                          false,
-                                          false,
-                                          true,
-                                          false);
+            agg_iter_neighbor_sample_scan(
+                self, sample, last_sample.timestamp + 1, UINT64_MAX, false, false, true, false);
         }
     }
 
@@ -1503,9 +1465,7 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
     if (self->empty && !self->handled_twa_empty_suffix) {
         self->handled_twa_empty_suffix = true;
         timestamp_t last_bucket =
-            CalcBucketStart(self->endTimestamp,
-                            aggregationTimeDelta,
-                            self->timestampAlignment);
+            CalcBucketStart(self->endTimestamp, aggregationTimeDelta, self->timestampAlignment);
         timestamp_t first_bucket = CalcBucketStart(
             self->aux_chunk->samples.timestamps[0], aggregationTimeDelta, self->timestampAlignment);
         bool has_empty_buckets = (first_bucket < last_bucket);
@@ -1555,12 +1515,8 @@ EnrichedChunk *AggregationIterator_GetNextChunk(struct AbstractIterator *iter) {
         agg_iter_load_last_pre_window(self, &sample);
     }
 
-    if (agg_iter_apply_empty_prefix(self,
-                                      enrichedChunk,
-                                      aggregationTimeDelta,
-                                      multiAgg,
-                                      &agg_n_samples,
-                                      &si) != 0) {
+    if (agg_iter_apply_empty_prefix(
+            self, enrichedChunk, aggregationTimeDelta, multiAgg, &agg_n_samples, &si) != 0) {
         return NULL;
     }
     self->hasUnFinalizedContext = true;

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -998,8 +998,13 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
             }
             *si = -1;
             self->aux_chunk->samples.num_samples = 0;
-            int err = fillEmptyBuckets(
-                &self->aux_chunk->samples, agg_n_samples, first_bucket, last_bucket, self, si, true);
+            int err = fillEmptyBuckets(&self->aux_chunk->samples,
+                                       agg_n_samples,
+                                       first_bucket,
+                                       last_bucket,
+                                       self,
+                                       si,
+                                       true);
             if (err != 0) {
                 return NULL;
             }

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -744,8 +744,12 @@ static void agg_iter_compute_empty_prefix_bounds(const AggregationIterator *self
         CalcBucketStart(self->startTimestamp, aggregationTimeDelta, self->timestampAlignment);
     *out_last_bucket =
         CalcBucketStart(first_sample_ts, aggregationTimeDelta, self->timestampAlignment);
+    // If the bucket containing first_sample_ts is itself bucket 0, the prefix would need a
+    // bucket at a negative timestamp — none exists, no span. Detect the clamp explicitly so we
+    // don't emit a spurious bucket that duplicates the real one.
+    bool clamped = *out_last_bucket < aggregationTimeDelta;
     *out_last_bucket = max(0, (int64_t)((int64_t)*out_last_bucket - (int64_t)aggregationTimeDelta));
-    *out_has_span = (*out_first_bucket <= *out_last_bucket);
+    *out_has_span = !clamped && (*out_first_bucket <= *out_last_bucket);
 }
 
 /**

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -620,7 +620,8 @@ static int fillEmptyBuckets(Samples *samples,
                             timestamp_t first_bucket_ts,
                             timestamp_t end_bucket_ts,
                             const AggregationIterator *self,
-                            int64_t *read_index) {
+                            int64_t *read_index,
+                            bool may_be_edge_gap) {
     int64_t agg_time_delta = self->aggregationTimeDelta;
     int64_t _read_index = *read_index + 1; // Cause we already stored the sample in read_index
     size_t vps = samples->values_per_sample;
@@ -644,7 +645,11 @@ static int fillEmptyBuckets(Samples *samples,
 
 #ifndef PREFIX_SUFFIX_IMPL // The PM decided to disable it, as it might cause OOM and complicates
                            // users
-    if (should_skip_empty_gap(self, cur_ts)) {
+    /* should_skip_empty_gap is an edge-detector: it only ever drops the gap when one side is
+     * outside the data span. For interior gaps (bounded by real buckets on both sides) the
+     * check is guaranteed to return false, so we skip the two expensive sample-iterator scans
+     * via may_be_edge_gap. */
+    if (may_be_edge_gap && should_skip_empty_gap(self, cur_ts)) {
         return 0;
     }
 #endif // PREFIX_SUFFIX_IMPL
@@ -732,8 +737,8 @@ static void agg_iter_compute_empty_prefix_bounds(const AggregationIterator *self
         CalcBucketStart(self->startTimestamp, aggregationTimeDelta, self->timestampAlignment);
     *out_last_bucket =
         CalcBucketStart(first_sample_ts, aggregationTimeDelta, self->timestampAlignment);
-    *out_has_span = (*out_first_bucket < *out_last_bucket);
     *out_last_bucket = max(0, (int64_t)((int64_t)*out_last_bucket - (int64_t)aggregationTimeDelta));
+    *out_has_span = (*out_first_bucket <= *out_last_bucket);
 }
 
 /**
@@ -756,11 +761,11 @@ static int agg_iter_append_empty_buckets(AggregationIterator *self,
         prefixSamples->num_samples = *agg_n_samples;
         int64_t read_idx = -1;
         return fillEmptyBuckets(
-            prefixSamples, agg_n_samples, first_bucket, last_bucket, self, &read_idx);
+            prefixSamples, agg_n_samples, first_bucket, last_bucket, self, &read_idx, true);
     }
     *si = -1;
     int err = fillEmptyBuckets(
-        &enrichedChunk->samples, agg_n_samples, first_bucket, last_bucket, self, si);
+        &enrichedChunk->samples, agg_n_samples, first_bucket, last_bucket, self, si, true);
     if (err != 0) {
         return -1;
     }
@@ -785,7 +790,7 @@ static int agg_iter_fill_window_when_empty(AggregationIterator *self,
         CalcBucketStart(self->endTimestamp, aggregationTimeDelta, self->timestampAlignment);
     *si = -1;
     self->aux_chunk->samples.num_samples = 0;
-    return fillEmptyBuckets(&self->aux_chunk->samples, agg_n_samples, fb, lb, self, si);
+    return fillEmptyBuckets(&self->aux_chunk->samples, agg_n_samples, fb, lb, self, si, true);
 }
 
 /**
@@ -994,7 +999,7 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
             *si = -1;
             self->aux_chunk->samples.num_samples = 0;
             int err = fillEmptyBuckets(
-                &self->aux_chunk->samples, agg_n_samples, first_bucket, last_bucket, self, si);
+                &self->aux_chunk->samples, agg_n_samples, first_bucket, last_bucket, self, si, true);
             if (err != 0) {
                 return NULL;
             }
@@ -1173,7 +1178,7 @@ static int agg_iter_max_emit_opening_sample(AggregationIterator *self,
                                               &first_bucket,
                                               &last_bucket)) {
             int err = fillEmptyBuckets(
-                &enrichedChunk->samples, agg_n_samples, first_bucket, last_bucket, self, si);
+                &enrichedChunk->samples, agg_n_samples, first_bucket, last_bucket, self, si, false);
             if (err != 0) {
                 return -1;
             }
@@ -1276,7 +1281,8 @@ static int agg_iter_general_on_bucket_boundary(AggregationIterator *self,
                                        first_bucket,
                                        last_bucket,
                                        self,
-                                       multiAgg ? &read_idx : si);
+                                       multiAgg ? &read_idx : si,
+                                       false);
             if (err != 0) {
                 return -1;
             }
@@ -1478,7 +1484,8 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
                                        first_bucket,
                                        last_bucket,
                                        self,
-                                       &read_index);
+                                       &read_index,
+                                       true);
             if (err != 0) {
                 return NULL;
             }

--- a/src/filter_iterator.h
+++ b/src/filter_iterator.h
@@ -61,6 +61,12 @@ typedef struct AggregationIterator
     bool hasTwa; // precomputed: any aggregation is TWA
     bool handled_twa_empty_prefix;
     bool handled_twa_empty_suffix;
+    // No points in [start,end] but EMPTY is on: we already returned the "all buckets empty" result once.
+    bool handled_non_twa_empty_full_range;
+    // We already inserted EMPTY buckets between range start and the first real point; do not repeat.
+    bool handled_non_twa_empty_prefix;
+    // LAST+EMPTY: we already copied the last raw value from before `startTimestamp` into LAST (or LAST not used).
+    bool last_locf_seed_ok;
     timestamp_t prev_ts;
     bool validSamplesInBucket; // are there any valid samples in current bucket (any aggregation)
     bool validPerAgg[TS_AGG_TYPES_MAX]; // per-aggregation validity tracking for current bucket

--- a/src/filter_iterator.h
+++ b/src/filter_iterator.h
@@ -18,12 +18,10 @@ typedef struct SeriesFilterTSIterator
     AbstractIterator base;
     FilterByTSArgs ByTsArgs;
     size_t tsFilterIndex; // the index in the TS filter array in ByTsArgs
-    bool reverse;
 } SeriesFilterTSIterator;
 
 SeriesFilterTSIterator *SeriesFilterTSIterator_New(AbstractIterator *input,
-                                                   FilterByTSArgs ByTsArgs,
-                                                   bool rev);
+                                                   FilterByTSArgs ByTsArgs);
 
 EnrichedChunk *SeriesFilterTSIterator_GetNextChunk(struct AbstractIterator *base);
 
@@ -50,7 +48,6 @@ typedef struct AggregationIterator
     timestamp_t timestampAlignment;
     timestamp_t aggregationLastTimestamp;
     bool hasUnFinalizedContext;
-    bool reverse;
     bool initialized;
     bool empty; // should report empty buckets
     BucketTimestamp bucketTS;
@@ -77,7 +74,6 @@ AggregationIterator *AggregationIterator_New(struct AbstractIterator *input,
                                              AggregationClass **aggregations,
                                              int64_t aggregationTimeDelta,
                                              timestamp_t timestampAlignment,
-                                             bool reverse,
                                              bool empty,
                                              BucketTimestamp bucketTS,
                                              Series *series,

--- a/src/filter_iterator.h
+++ b/src/filter_iterator.h
@@ -18,10 +18,12 @@ typedef struct SeriesFilterTSIterator
     AbstractIterator base;
     FilterByTSArgs ByTsArgs;
     size_t tsFilterIndex; // the index in the TS filter array in ByTsArgs
+    bool reverse;
 } SeriesFilterTSIterator;
 
 SeriesFilterTSIterator *SeriesFilterTSIterator_New(AbstractIterator *input,
-                                                   FilterByTSArgs ByTsArgs);
+                                                   FilterByTSArgs ByTsArgs,
+                                                   bool rev);
 
 EnrichedChunk *SeriesFilterTSIterator_GetNextChunk(struct AbstractIterator *base);
 

--- a/src/filter_iterator.h
+++ b/src/filter_iterator.h
@@ -58,11 +58,14 @@ typedef struct AggregationIterator
     bool hasTwa; // precomputed: any aggregation is TWA
     bool handled_twa_empty_prefix;
     bool handled_twa_empty_suffix;
-    // No points in [start,end] but EMPTY is on: we already returned the "all buckets empty" result once.
+    // No points in [start,end] but EMPTY is on: we already returned the "all buckets empty" result
+    // once.
     bool handled_non_twa_empty_full_range;
-    // We already inserted EMPTY buckets between range start and the first real point; do not repeat.
+    // We already inserted EMPTY buckets between range start and the first real point; do not
+    // repeat.
     bool handled_non_twa_empty_prefix;
-    // LAST+EMPTY: we already copied the last raw value from before `startTimestamp` into LAST (or LAST not used).
+    // LAST+EMPTY: we already copied the last raw value from before `startTimestamp` into LAST (or
+    // LAST not used).
     bool last_locf_seed_ok;
     timestamp_t prev_ts;
     bool validSamplesInBucket; // are there any valid samples in current bucket (any aggregation)

--- a/src/multiseries_agg_dup_sample_iterator.c
+++ b/src/multiseries_agg_dup_sample_iterator.c
@@ -81,7 +81,7 @@ MultiSeriesAggDupSampleIterator *MultiSeriesAggDupSampleIterator_New(
     newIter->base.GetNext = MultiSeriesAggDupSampleIterator_GetNext;
     newIter->base.Close = MultiSeriesAggDupSampleIterator_Close;
     newIter->aggregation = reducerArgs->aggregationClass;
-    newIter->aggregationContext = newIter->aggregation->createContext(DC);
+    newIter->aggregationContext = newIter->aggregation->createContext();
     ChunkResult res = newIter->base.input->GetNext(newIter->base.input, &newIter->next_sample);
     newIter->has_next_sample = true;
     if (res != CR_OK) {

--- a/src/multiseries_sample_iterator.c
+++ b/src/multiseries_sample_iterator.c
@@ -18,17 +18,9 @@ typedef struct
     AbstractSampleIterator *iter; // The iterator this sample belongs to
 } MSSample;
 
-// implements min heap
+// implements min heap (samples are merged in chronological order; the reply layer reverses if needed)
 static int heap_cmp_func(const void *sample1, const void *sample2, __unused const void *udata) {
     return (((MSSample *)sample1)->sample.timestamp < ((MSSample *)sample2)->sample.timestamp) ? 1
-                                                                                               : -1;
-}
-
-// implements max heap
-static int heap_cmp_func_reverse(const void *sample1,
-                                 const void *sample2,
-                                 __unused const void *udata) {
-    return (((MSSample *)sample1)->sample.timestamp > ((MSSample *)sample2)->sample.timestamp) ? 1
                                                                                                : -1;
 }
 
@@ -64,15 +56,14 @@ ChunkResult MultiSeriesSampleIterator_GetNext(struct AbstractMultiSeriesSampleIt
 }
 
 MultiSeriesSampleIterator *MultiSeriesSampleIterator_New(AbstractSampleIterator **iters,
-                                                         size_t n_series,
-                                                         bool reverse) {
+                                                         size_t n_series) {
     MultiSeriesSampleIterator *newIter = malloc(sizeof(MultiSeriesSampleIterator));
     newIter->base.input = malloc(sizeof(AbstractSampleIterator *) * n_series);
     memcpy(newIter->base.input, iters, sizeof(AbstractSampleIterator *) * n_series);
     newIter->base.GetNext = MultiSeriesSampleIterator_GetNext;
     newIter->base.Close = MultiSeriesSampleIterator_Close;
     newIter->n_series = n_series;
-    newIter->samples_heap = heap_new(reverse ? heap_cmp_func_reverse : heap_cmp_func, NULL);
+    newIter->samples_heap = heap_new(heap_cmp_func, NULL);
     for (size_t i = 0; i < newIter->n_series; ++i) {
         AbstractSampleIterator *sample_iter = newIter->base.input[i];
         MSSample *sample = malloc(sizeof(MSSample));

--- a/src/multiseries_sample_iterator.c
+++ b/src/multiseries_sample_iterator.c
@@ -18,7 +18,8 @@ typedef struct
     AbstractSampleIterator *iter; // The iterator this sample belongs to
 } MSSample;
 
-// implements min heap (samples are merged in chronological order; the reply layer reverses if needed)
+// implements min heap (samples are merged in chronological order; the reply layer reverses if
+// needed)
 static int heap_cmp_func(const void *sample1, const void *sample2, __unused const void *udata) {
     return (((MSSample *)sample1)->sample.timestamp < ((MSSample *)sample2)->sample.timestamp) ? 1
                                                                                                : -1;

--- a/src/multiseries_sample_iterator.h
+++ b/src/multiseries_sample_iterator.h
@@ -21,7 +21,6 @@ typedef struct MultiSeriesSampleIterator
 } MultiSeriesSampleIterator;
 
 MultiSeriesSampleIterator *MultiSeriesSampleIterator_New(AbstractSampleIterator **iters,
-                                                         size_t n_series,
-                                                         bool reverse);
+                                                         size_t n_series);
 
 #endif // REDISTIMESERIES_MULTISERIES_SAMPLE_ITERATOR_H

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -24,9 +24,10 @@
 #define TS_LAST_AGGREGATION_EMPTY 7
 #define TS_CREATE_IGNORE_VER 8
 #define TS_NAN_SUPPORT_VER 9
+#define TS_TWA_DROP_REVERSE_VER 10 // drops the dead `reverse` byte from TwaContext
 
 // This flag should be updated whenever a new rdb version is introduced
-#define TS_LATEST_ENCVER TS_NAN_SUPPORT_VER
+#define TS_LATEST_ENCVER TS_TWA_DROP_REVERSE_VER
 
 extern int last_rdb_load_version;
 

--- a/src/reply.c
+++ b/src/reply.c
@@ -127,38 +127,66 @@ int ReplySeriesArrayPos(RedisModuleCtx *ctx,
     return REDISMODULE_OK;
 }
 
+/* TS.RANGE / TS.REVRANGE reply.
+ *
+ * REVRANGE is a mirror image of RANGE: produce the regular forward result into a temporary
+ * buffer, then walk it backwards at reply time when reverse is requested. This keeps reverse
+ * out of all downstream iterators. COUNT is applied at reply time so that REVRANGE COUNT N
+ * returns the latest N samples chronologically, in reverse order. */
 int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args, bool reverse) {
-    long long arraylen = 0;
-    long long _count = LLONG_MAX;
-    unsigned int n;
-    if (args->count != -1) {
-        _count = args->count;
-    }
-
-    AbstractIterator *iter = SeriesQuery(series, args, reverse, true);
+    AbstractIterator *iter = SeriesQuery(series, args, false, true);
     EnrichedChunk *enrichedChunk;
-    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
 
-    while ((arraylen < _count) && (enrichedChunk = iter->GetNext(iter))) {
-        n = (unsigned int)min(_count - arraylen, enrichedChunk->samples.num_samples);
-        size_t vps = enrichedChunk->samples.values_per_sample;
-        for (size_t i = 0; i < n; ++i) {
-            if (vps > 1) {
-                ReplyWithMultiAggSample(ctx,
-                                        enrichedChunk->samples.timestamps[i],
-                                        Samples_values_row_ptr(&enrichedChunk->samples, i),
-                                        vps);
-            } else {
-                ReplyWithSample(ctx,
-                                enrichedChunk->samples.timestamps[i],
-                                Samples_value_at(&enrichedChunk->samples, i, 0));
-            }
+    timestamp_t *timestamps = NULL;
+    double *values = NULL;
+    size_t total = 0;
+    size_t cap = 0;
+    size_t vps = 1;
+
+    while ((enrichedChunk = iter->GetNext(iter))) {
+        size_t n = enrichedChunk->samples.num_samples;
+        if (n == 0) {
+            continue;
         }
-        arraylen += n;
+        vps = enrichedChunk->samples.values_per_sample;
+
+        if (total + n > cap) {
+            size_t new_cap = cap == 0 ? 64 : cap * 2;
+            while (new_cap < total + n) {
+                new_cap *= 2;
+            }
+            timestamps = realloc(timestamps, new_cap * sizeof(timestamp_t));
+            values = realloc(values, new_cap * vps * sizeof(double));
+            cap = new_cap;
+        }
+
+        memcpy(timestamps + total,
+               enrichedChunk->samples.timestamps,
+               n * sizeof(timestamp_t));
+        memcpy(values + total * vps,
+               enrichedChunk->samples._values,
+               n * vps * sizeof(double));
+        total += n;
     }
     iter->Close(iter);
 
-    RedisModule_ReplySetArrayLength(ctx, arraylen);
+    long long reply_count = (long long)total;
+    if (args->count != -1 && args->count < reply_count) {
+        reply_count = args->count;
+    }
+
+    RedisModule_ReplyWithArray(ctx, reply_count);
+    for (long long k = 0; k < reply_count; ++k) {
+        size_t i = reverse ? (total - 1 - (size_t)k) : (size_t)k;
+        if (vps > 1) {
+            ReplyWithMultiAggSample(ctx, timestamps[i], &values[i * vps], vps);
+        } else {
+            ReplyWithSample(ctx, timestamps[i], values[i * vps]);
+        }
+    }
+
+    free(timestamps);
+    free(values);
     return REDISMODULE_OK;
 }
 

--- a/src/reply.c
+++ b/src/reply.c
@@ -129,15 +129,11 @@ int ReplySeriesArrayPos(RedisModuleCtx *ctx,
 
 /* TS.RANGE / TS.REVRANGE reply.
  *
- * REVRANGE is a mirror image of RANGE: produce the regular forward result into a temporary
- * buffer, then walk it backwards at reply time when reverse is requested. This keeps reverse
- * out of all downstream iterators. COUNT is applied at reply time so that REVRANGE COUNT N
- * returns the latest N samples chronologically, in reverse order.
- *
- * Forward path with COUNT exits the iterator loop as soon as the first N samples are
- * buffered (and caps the last chunk's copy to fit), so it never reads or allocates beyond
- * the user-visible limit. Reverse path must drain the iterator because the latest N
- * samples are only known once the full window has been seen. */
+ * REVRANGE is a mirror image of RANGE: produce the regular forward result, then walk it
+ * backwards at reply time. COUNT is bounded in both directions:
+ *   - RANGE  COUNT N: cap the loop and exit as soon as N samples are buffered.
+ *   - REVRANGE COUNT N: drop the oldest excess after each chunk, so the buffer never
+ *     grows beyond ~N + chunk_size and ends with the last N samples chronologically. */
 int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args, bool reverse) {
     AbstractIterator *iter = SeriesQuery(series, args, false, true);
     EnrichedChunk *enrichedChunk;
@@ -147,8 +143,8 @@ int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args,
     size_t total = 0;
     size_t cap = 0;
     size_t vps = 1;
-    const bool forward_count_limited = (!reverse && args->count != -1);
-    const size_t forward_budget = forward_count_limited ? (size_t)args->count : 0;
+    const bool count_limited = (args->count != -1);
+    const size_t budget = count_limited ? (size_t)args->count : 0;
 
     while ((enrichedChunk = iter->GetNext(iter))) {
         size_t n = enrichedChunk->samples.num_samples;
@@ -157,8 +153,8 @@ int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args,
         }
         vps = enrichedChunk->samples.values_per_sample;
 
-        if (forward_count_limited) {
-            size_t remaining = forward_budget - total;
+        if (count_limited && !reverse) {
+            size_t remaining = budget - total;
             if (n > remaining) {
                 n = remaining;
             }
@@ -182,20 +178,20 @@ int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args,
                n * vps * sizeof(double));
         total += n;
 
-        if (forward_count_limited && total >= forward_budget) {
+        if (count_limited && reverse && total > budget) {
+            size_t drop = total - budget;
+            memmove(timestamps, timestamps + drop, budget * sizeof(timestamp_t));
+            memmove(values, values + drop * vps, budget * vps * sizeof(double));
+            total = budget;
+        } else if (count_limited && !reverse && total >= budget) {
             break;
         }
     }
     iter->Close(iter);
 
-    long long reply_count = (long long)total;
-    if (args->count != -1 && args->count < reply_count) {
-        reply_count = args->count;
-    }
-
-    RedisModule_ReplyWithArray(ctx, reply_count);
-    for (long long k = 0; k < reply_count; ++k) {
-        size_t i = reverse ? (total - 1 - (size_t)k) : (size_t)k;
+    RedisModule_ReplyWithArray(ctx, total);
+    for (size_t k = 0; k < total; ++k) {
+        size_t i = reverse ? (total - 1 - k) : k;
         if (vps > 1) {
             ReplyWithMultiAggSample(ctx, timestamps[i], &values[i * vps], vps);
         } else {

--- a/src/reply.c
+++ b/src/reply.c
@@ -132,7 +132,12 @@ int ReplySeriesArrayPos(RedisModuleCtx *ctx,
  * REVRANGE is a mirror image of RANGE: produce the regular forward result into a temporary
  * buffer, then walk it backwards at reply time when reverse is requested. This keeps reverse
  * out of all downstream iterators. COUNT is applied at reply time so that REVRANGE COUNT N
- * returns the latest N samples chronologically, in reverse order. */
+ * returns the latest N samples chronologically, in reverse order.
+ *
+ * Forward path with COUNT exits the iterator loop as soon as the first N samples are
+ * buffered (and caps the last chunk's copy to fit), so it never reads or allocates beyond
+ * the user-visible limit. Reverse path must drain the iterator because the latest N
+ * samples are only known once the full window has been seen. */
 int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args, bool reverse) {
     AbstractIterator *iter = SeriesQuery(series, args, false, true);
     EnrichedChunk *enrichedChunk;
@@ -142,6 +147,8 @@ int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args,
     size_t total = 0;
     size_t cap = 0;
     size_t vps = 1;
+    const bool forward_count_limited = (!reverse && args->count != -1);
+    const size_t forward_budget = forward_count_limited ? (size_t)args->count : 0;
 
     while ((enrichedChunk = iter->GetNext(iter))) {
         size_t n = enrichedChunk->samples.num_samples;
@@ -149,6 +156,13 @@ int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args,
             continue;
         }
         vps = enrichedChunk->samples.values_per_sample;
+
+        if (forward_count_limited) {
+            size_t remaining = forward_budget - total;
+            if (n > remaining) {
+                n = remaining;
+            }
+        }
 
         if (total + n > cap) {
             size_t new_cap = cap == 0 ? 64 : cap * 2;
@@ -167,6 +181,10 @@ int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args,
                enrichedChunk->samples._values,
                n * vps * sizeof(double));
         total += n;
+
+        if (forward_count_limited && total >= forward_budget) {
+            break;
+        }
     }
     iter->Close(iter);
 

--- a/src/reply.c
+++ b/src/reply.c
@@ -127,76 +127,179 @@ int ReplySeriesArrayPos(RedisModuleCtx *ctx,
     return REDISMODULE_OK;
 }
 
-/* TS.RANGE / TS.REVRANGE reply.
- *
- * REVRANGE is a mirror image of RANGE: produce the regular forward result, then walk it
- * backwards at reply time. COUNT is bounded in both directions:
- *   - RANGE  COUNT N: cap the loop and exit as soon as N samples are buffered.
- *   - REVRANGE COUNT N: drop the oldest excess after each chunk, so the buffer never
- *     grows beyond ~N + chunk_size and ends with the last N samples chronologically. */
-int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args, bool reverse) {
-    AbstractIterator *iter = SeriesQuery(series, args, false, true);
-    EnrichedChunk *enrichedChunk;
+/* Decide buffer size and starting timestamp for the forward agg pass that backs REVRANGE.
+ * COUNT N: budget = N, narrow start to the analytical window of the last N buckets.
+ * no COUNT: budget = analytical max bucket count over the full range; start unchanged.
+ * Returns false (and sets *budget=0) when the range is provably empty. */
+static bool plan_reverse_agg_window(const Series *series,
+                                    const RangeArgs *args,
+                                    size_t *budget,
+                                    timestamp_t *narrowed_start) {
+    *budget = 0;
+    *narrowed_start = args->startTimestamp;
+    if (series->totalSamples == 0) return false;
 
-    timestamp_t *timestamps = NULL;
-    double *values = NULL;
-    size_t total = 0;
-    size_t cap = 0;
+    timestamp_t effEnd = (args->endTimestamp > series->lastTimestamp) ? series->lastTimestamp
+                                                                     : args->endTimestamp;
+    if (effEnd < args->startTimestamp) return false;
+
+    timestamp_t aln = 0;
+    switch (args->alignment) {
+        case StartAlignment: aln = args->startTimestamp; break;
+        case EndAlignment: aln = args->endTimestamp; break;
+        case TimestampAlignment: aln = args->timestampAlignment; break;
+        default: break;
+    }
+    const timestamp_t bucketDuration = args->aggregationArgs.timeDelta;
+    const timestamp_t lastBucketStart = CalcBucketStart(effEnd, bucketDuration, aln);
+
+    if (args->count != -1) {
+        if (args->count == 0) return false;
+        *budget = (size_t)args->count;
+        timestamp_t windowSize = (timestamp_t)(*budget - 1) * bucketDuration;
+        if (lastBucketStart >= windowSize &&
+            lastBucketStart - windowSize > args->startTimestamp) {
+            *narrowed_start = lastBucketStart - windowSize;
+        }
+    } else {
+        timestamp_t firstBucketStart =
+            CalcBucketStart(args->startTimestamp, bucketDuration, aln);
+        *budget = (size_t)((lastBucketStart - firstBucketStart) / bucketDuration) + 1;
+        if (!args->aggregationArgs.empty && *budget > series->totalSamples) {
+            *budget = series->totalSamples;
+        }
+    }
+    return *budget > 0;
+}
+
+/* Run one forward query starting at `start_ts` and append every sample into the ring at
+ * (written % budget). Allocates val_buf lazily once vps is known. If `early_stop`, halts as soon
+ * as `budget` samples have been written. Returns the total number of samples written (may
+ * exceed budget on a full pass). */
+static size_t fill_ring(Series *series,
+                        const RangeArgs *args,
+                        timestamp_t start_ts,
+                        size_t budget,
+                        bool early_stop,
+                        timestamp_t *ts_buf,
+                        double **val_buf,
+                        size_t *vps) {
+    RangeArgs q = *args;
+    q.startTimestamp = start_ts;
+    q.count = -1;
+    AbstractIterator *iter = SeriesQuery(series, &q, false, true);
+    EnrichedChunk *chunk;
+    size_t written = 0;
+    while ((chunk = iter->GetNext(iter))) {
+        size_t n = chunk->samples.num_samples;
+        if (n == 0) continue;
+        if (!*val_buf) {
+            *vps = chunk->samples.values_per_sample;
+            *val_buf = malloc(budget * (*vps) * sizeof(double));
+        }
+        for (size_t i = 0; i < n; ++i) {
+            size_t slot = written % budget;
+            ts_buf[slot] = chunk->samples.timestamps[i];
+            memcpy(*val_buf + slot * (*vps),
+                   Samples_values_row_ptr(&chunk->samples, i),
+                   (*vps) * sizeof(double));
+            written++;
+        }
+        if (early_stop && written >= budget) break;
+    }
+    iter->Close(iter);
+    return written;
+}
+
+/* Emit the ring backward from the newest slot. Newest is at (written - 1) % budget. */
+static void reply_ring_reverse(RedisModuleCtx *ctx,
+                               const timestamp_t *ts_buf,
+                               double *val_buf,
+                               size_t budget,
+                               size_t written,
+                               size_t vps) {
+    size_t total = (written < budget) ? written : budget;
+    RedisModule_ReplyWithArray(ctx, total);
+    for (size_t k = 0; k < total; ++k) {
+        size_t idx = (written - 1 - k) % budget;
+        if (vps > 1) {
+            ReplyWithMultiAggSample(ctx, ts_buf[idx], &val_buf[idx * vps], vps);
+        } else {
+            ReplyWithSample(ctx, ts_buf[idx], val_buf ? val_buf[idx] : 0.0);
+        }
+    }
+}
+
+/* REVRANGE + aggregation: aggregation pipeline must run forward (raw aggregators were wrong in
+ * reverse), so iterate forward into a ring sized by `plan_reverse_agg_window`, then emit the
+ * ring backward. If a count-limited narrow window under-fills (filters dropped buckets), retry
+ * once over the full range. */
+static int ReplyReverseAgg(RedisModuleCtx *ctx, Series *series, const RangeArgs *args) {
+    size_t budget;
+    timestamp_t narrowed_start;
+    if (!plan_reverse_agg_window(series, args, &budget, &narrowed_start)) {
+        RedisModule_ReplyWithArray(ctx, 0);
+        return REDISMODULE_OK;
+    }
+
+    timestamp_t *ts_buf = malloc(budget * sizeof(timestamp_t));
+    double *val_buf = NULL;
     size_t vps = 1;
-    const bool count_limited = (args->count != -1);
-    const size_t budget = count_limited ? (size_t)args->count : 0;
 
-    while ((enrichedChunk = iter->GetNext(iter))) {
-        size_t n = enrichedChunk->samples.num_samples;
-        if (n == 0) {
-            continue;
-        }
-        vps = enrichedChunk->samples.values_per_sample;
+    size_t written = fill_ring(series, args, narrowed_start, budget, true, ts_buf, &val_buf, &vps);
+    // The narrow window guessed "the last N buckets fit in [narrowed_start, end]". That guess
+    // can be wrong when buckets inside the window get erased — FILTER_BY_VALUE / FILTER_BY_TS
+    // can drop samples that would otherwise have anchored a bucket, and without EMPTY a bucket
+    // with no surviving samples isn't emitted at all. When that happens we end up with fewer
+    // than N buckets and the real "last N" lives earlier in time than the narrow window saw.
+    // Fall back to a full forward scan and let the ring keep the latest N as iteration advances.
+    if (args->count != -1 && written < budget && narrowed_start > args->startTimestamp) {
+        written = fill_ring(series, args, args->startTimestamp, budget, false,
+                            ts_buf, &val_buf, &vps);
+    }
 
-        if (count_limited && !reverse) {
-            size_t remaining = budget - total;
-            if (n > remaining) {
-                n = remaining;
+    reply_ring_reverse(ctx, ts_buf, val_buf, budget, written, vps);
+    free(ts_buf);
+    free(val_buf);
+    return REDISMODULE_OK;
+}
+
+int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args, bool reverse) {
+    if (reverse && args->aggregationArgs.numClasses > 0) {
+        return ReplyReverseAgg(ctx, series, args);
+    }
+
+    long long arraylen = 0;
+    long long _count = LLONG_MAX;
+    unsigned int n;
+    if (args->count != -1) {
+        _count = args->count;
+    }
+
+    AbstractIterator *iter = SeriesQuery(series, args, reverse, true);
+    EnrichedChunk *enrichedChunk;
+    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
+
+    while ((arraylen < _count) && (enrichedChunk = iter->GetNext(iter))) {
+        n = (unsigned int)min(_count - arraylen, enrichedChunk->samples.num_samples);
+        size_t vps = enrichedChunk->samples.values_per_sample;
+        for (size_t i = 0; i < n; ++i) {
+            if (vps > 1) {
+                ReplyWithMultiAggSample(ctx,
+                                        enrichedChunk->samples.timestamps[i],
+                                        Samples_values_row_ptr(&enrichedChunk->samples, i),
+                                        vps);
+            } else {
+                ReplyWithSample(ctx,
+                                enrichedChunk->samples.timestamps[i],
+                                Samples_value_at(&enrichedChunk->samples, i, 0));
             }
         }
-
-        if (total + n > cap) {
-            size_t new_cap = cap == 0 ? 64 : cap * 2;
-            while (new_cap < total + n) {
-                new_cap *= 2;
-            }
-            timestamps = realloc(timestamps, new_cap * sizeof(timestamp_t));
-            values = realloc(values, new_cap * vps * sizeof(double));
-            cap = new_cap;
-        }
-
-        memcpy(timestamps + total, enrichedChunk->samples.timestamps, n * sizeof(timestamp_t));
-        memcpy(values + total * vps, enrichedChunk->samples._values, n * vps * sizeof(double));
-        total += n;
-
-        if (count_limited && reverse && total > budget) {
-            size_t drop = total - budget;
-            memmove(timestamps, timestamps + drop, budget * sizeof(timestamp_t));
-            memmove(values, values + drop * vps, budget * vps * sizeof(double));
-            total = budget;
-        } else if (count_limited && !reverse && total >= budget) {
-            break;
-        }
+        arraylen += n;
     }
     iter->Close(iter);
 
-    RedisModule_ReplyWithArray(ctx, total);
-    for (size_t k = 0; k < total; ++k) {
-        size_t i = reverse ? (total - 1 - k) : k;
-        if (vps > 1) {
-            ReplyWithMultiAggSample(ctx, timestamps[i], &values[i * vps], vps);
-        } else {
-            ReplyWithSample(ctx, timestamps[i], values[i * vps]);
-        }
-    }
-
-    free(timestamps);
-    free(values);
+    RedisModule_ReplySetArrayLength(ctx, arraylen);
     return REDISMODULE_OK;
 }
 

--- a/src/reply.c
+++ b/src/reply.c
@@ -137,33 +137,41 @@ static bool plan_reverse_agg_window(const Series *series,
                                     timestamp_t *narrowed_start) {
     *budget = 0;
     *narrowed_start = args->startTimestamp;
-    if (series->totalSamples == 0) return false;
+    if (series->totalSamples == 0)
+        return false;
 
-    timestamp_t effEnd = (args->endTimestamp > series->lastTimestamp) ? series->lastTimestamp
-                                                                     : args->endTimestamp;
-    if (effEnd < args->startTimestamp) return false;
+    timestamp_t effEnd =
+        (args->endTimestamp > series->lastTimestamp) ? series->lastTimestamp : args->endTimestamp;
+    if (effEnd < args->startTimestamp)
+        return false;
 
     timestamp_t aln = 0;
     switch (args->alignment) {
-        case StartAlignment: aln = args->startTimestamp; break;
-        case EndAlignment: aln = args->endTimestamp; break;
-        case TimestampAlignment: aln = args->timestampAlignment; break;
-        default: break;
+        case StartAlignment:
+            aln = args->startTimestamp;
+            break;
+        case EndAlignment:
+            aln = args->endTimestamp;
+            break;
+        case TimestampAlignment:
+            aln = args->timestampAlignment;
+            break;
+        default:
+            break;
     }
     const timestamp_t bucketDuration = args->aggregationArgs.timeDelta;
     const timestamp_t lastBucketStart = CalcBucketStart(effEnd, bucketDuration, aln);
 
     if (args->count != -1) {
-        if (args->count == 0) return false;
+        if (args->count == 0)
+            return false;
         *budget = (size_t)args->count;
         timestamp_t windowSize = (timestamp_t)(*budget - 1) * bucketDuration;
-        if (lastBucketStart >= windowSize &&
-            lastBucketStart - windowSize > args->startTimestamp) {
+        if (lastBucketStart >= windowSize && lastBucketStart - windowSize > args->startTimestamp) {
             *narrowed_start = lastBucketStart - windowSize;
         }
     } else {
-        timestamp_t firstBucketStart =
-            CalcBucketStart(args->startTimestamp, bucketDuration, aln);
+        timestamp_t firstBucketStart = CalcBucketStart(args->startTimestamp, bucketDuration, aln);
         *budget = (size_t)((lastBucketStart - firstBucketStart) / bucketDuration) + 1;
         if (!args->aggregationArgs.empty && *budget > series->totalSamples) {
             *budget = series->totalSamples;
@@ -192,7 +200,8 @@ static size_t fill_ring(Series *series,
     size_t written = 0;
     while ((chunk = iter->GetNext(iter))) {
         size_t n = chunk->samples.num_samples;
-        if (n == 0) continue;
+        if (n == 0)
+            continue;
         if (!*val_buf) {
             *vps = chunk->samples.values_per_sample;
             *val_buf = malloc(budget * (*vps) * sizeof(double));
@@ -205,7 +214,8 @@ static size_t fill_ring(Series *series,
                    (*vps) * sizeof(double));
             written++;
         }
-        if (early_stop && written >= budget) break;
+        if (early_stop && written >= budget)
+            break;
     }
     iter->Close(iter);
     return written;
@@ -254,8 +264,8 @@ static int ReplyReverseAgg(RedisModuleCtx *ctx, Series *series, const RangeArgs 
     // than N buckets and the real "last N" lives earlier in time than the narrow window saw.
     // Fall back to a full forward scan and let the ring keep the latest N as iteration advances.
     if (args->count != -1 && written < budget && narrowed_start > args->startTimestamp) {
-        written = fill_ring(series, args, args->startTimestamp, budget, false,
-                            ts_buf, &val_buf, &vps);
+        written =
+            fill_ring(series, args, args->startTimestamp, budget, false, ts_buf, &val_buf, &vps);
     }
 
     reply_ring_reverse(ctx, ts_buf, val_buf, budget, written, vps);

--- a/src/reply.c
+++ b/src/reply.c
@@ -186,16 +186,17 @@ static bool plan_reverse_agg_window(const Series *series,
 
 /* Run one forward query starting at `start_ts` and append every sample into the ring at
  * (written % budget). Allocates val_buf lazily once vps is known. If `early_stop`, halts as soon
- * as `budget` samples have been written. Returns the total number of samples written (may
- * exceed budget on a full pass). */
-static size_t revagg_fill_circular_buffer(Series *series,
-                                          const RangeArgs *args,
-                                          timestamp_t start_ts,
-                                          size_t budget,
-                                          bool early_stop,
-                                          timestamp_t *ts_buf,
-                                          double **val_buf,
-                                          size_t *vps) {
+ * as `budget` samples have been written. Returns true on success (*out_written set to the total
+ * number of samples written; may exceed budget on a full pass), false on allocation failure. */
+static bool revagg_fill_circular_buffer(Series *series,
+                                        const RangeArgs *args,
+                                        timestamp_t start_ts,
+                                        size_t budget,
+                                        bool early_stop,
+                                        timestamp_t *ts_buf,
+                                        double **val_buf,
+                                        size_t *vps,
+                                        size_t *out_written) {
     RangeArgs q = *args;
     q.startTimestamp = start_ts;
     q.count = -1;
@@ -211,6 +212,10 @@ static size_t revagg_fill_circular_buffer(Series *series,
         if (!*val_buf) {
             *vps = chunk->samples.values_per_sample;
             *val_buf = malloc(budget * (*vps) * sizeof(double));
+            if (!*val_buf) {
+                iter->Close(iter);
+                return false;
+            }
         }
         for (size_t i = 0; i < n; ++i) {
             size_t slot = written % budget;
@@ -224,7 +229,8 @@ static size_t revagg_fill_circular_buffer(Series *series,
             break;
     }
     iter->Close(iter);
-    return written;
+    *out_written = written;
+    return true;
 }
 
 /* Emit the ring backward from the newest slot. Newest is at (written - 1) % budget. */
@@ -259,20 +265,30 @@ static int ReplyReverseAgg(RedisModuleCtx *ctx, Series *series, const RangeArgs 
     }
 
     timestamp_t *ts_buf = malloc(budget * sizeof(timestamp_t));
+    if (!ts_buf) {
+        return RedisModule_ReplyWithError(ctx, "ERR out of memory");
+    }
     double *val_buf = NULL;
     size_t vps = 1;
 
-    size_t written = revagg_fill_circular_buffer(
-        series, args, narrowed_start, budget, true, ts_buf, &val_buf, &vps);
+    size_t written = 0;
+    bool ok = revagg_fill_circular_buffer(
+        series, args, narrowed_start, budget, true, ts_buf, &val_buf, &vps, &written);
     // The narrow window guessed "the last N buckets fit in [narrowed_start, end]". That guess
     // can be wrong when buckets inside the window get erased — FILTER_BY_VALUE / FILTER_BY_TS
     // can drop samples that would otherwise have anchored a bucket, and without EMPTY a bucket
     // with no surviving samples isn't emitted at all. When that happens we end up with fewer
     // than N buckets and the real "last N" lives earlier in time than the narrow window saw.
     // Fall back to a full forward scan and let the ring keep the latest N as iteration advances.
-    if (args->count != -1 && written < budget && narrowed_start > args->startTimestamp) {
-        written = revagg_fill_circular_buffer(
-            series, args, args->startTimestamp, budget, false, ts_buf, &val_buf, &vps);
+    if (ok && args->count != -1 && written < budget && narrowed_start > args->startTimestamp) {
+        ok = revagg_fill_circular_buffer(
+            series, args, args->startTimestamp, budget, false, ts_buf, &val_buf, &vps, &written);
+    }
+
+    if (!ok) {
+        free(ts_buf);
+        free(val_buf);
+        return RedisModule_ReplyWithError(ctx, "ERR out of memory");
     }
 
     revagg_emit_ring_reverse(ctx, ts_buf, val_buf, budget, written, vps);

--- a/src/reply.c
+++ b/src/reply.c
@@ -148,15 +148,19 @@ static bool plan_reverse_agg_window(const Series *series,
     timestamp_t aln = 0;
     switch (args->alignment) {
         case StartAlignment:
+            /* ALIGN start: anchor buckets to the query's startTimestamp. */
             aln = args->startTimestamp;
             break;
         case EndAlignment:
+            /* ALIGN end: anchor buckets to the query's endTimestamp. */
             aln = args->endTimestamp;
             break;
         case TimestampAlignment:
+            /* ALIGN <ts>: anchor buckets to the explicit timestamp the user gave. */
             aln = args->timestampAlignment;
             break;
         default:
+            /* No ALIGN clause: anchor buckets to epoch 0 (default bucketing). */
             break;
     }
     const timestamp_t bucketDuration = args->aggregationArgs.timeDelta;
@@ -184,17 +188,19 @@ static bool plan_reverse_agg_window(const Series *series,
  * (written % budget). Allocates val_buf lazily once vps is known. If `early_stop`, halts as soon
  * as `budget` samples have been written. Returns the total number of samples written (may
  * exceed budget on a full pass). */
-static size_t fill_ring(Series *series,
-                        const RangeArgs *args,
-                        timestamp_t start_ts,
-                        size_t budget,
-                        bool early_stop,
-                        timestamp_t *ts_buf,
-                        double **val_buf,
-                        size_t *vps) {
+static size_t revagg_fill_circular_buffer(Series *series,
+                                          const RangeArgs *args,
+                                          timestamp_t start_ts,
+                                          size_t budget,
+                                          bool early_stop,
+                                          timestamp_t *ts_buf,
+                                          double **val_buf,
+                                          size_t *vps) {
     RangeArgs q = *args;
     q.startTimestamp = start_ts;
     q.count = -1;
+    /* Forward iteration because the aggregator only produces buckets chronologically; we'll reverse
+     * at emit time. */
     AbstractIterator *iter = SeriesQuery(series, &q, false, true);
     EnrichedChunk *chunk;
     size_t written = 0;
@@ -222,12 +228,12 @@ static size_t fill_ring(Series *series,
 }
 
 /* Emit the ring backward from the newest slot. Newest is at (written - 1) % budget. */
-static void reply_ring_reverse(RedisModuleCtx *ctx,
-                               const timestamp_t *ts_buf,
-                               double *val_buf,
-                               size_t budget,
-                               size_t written,
-                               size_t vps) {
+static void revagg_emit_ring_reverse(RedisModuleCtx *ctx,
+                                     const timestamp_t *ts_buf,
+                                     double *val_buf,
+                                     size_t budget,
+                                     size_t written,
+                                     size_t vps) {
     size_t total = (written < budget) ? written : budget;
     RedisModule_ReplyWithArray(ctx, total);
     for (size_t k = 0; k < total; ++k) {
@@ -256,7 +262,8 @@ static int ReplyReverseAgg(RedisModuleCtx *ctx, Series *series, const RangeArgs 
     double *val_buf = NULL;
     size_t vps = 1;
 
-    size_t written = fill_ring(series, args, narrowed_start, budget, true, ts_buf, &val_buf, &vps);
+    size_t written = revagg_fill_circular_buffer(
+        series, args, narrowed_start, budget, true, ts_buf, &val_buf, &vps);
     // The narrow window guessed "the last N buckets fit in [narrowed_start, end]". That guess
     // can be wrong when buckets inside the window get erased — FILTER_BY_VALUE / FILTER_BY_TS
     // can drop samples that would otherwise have anchored a bucket, and without EMPTY a bucket
@@ -264,17 +271,20 @@ static int ReplyReverseAgg(RedisModuleCtx *ctx, Series *series, const RangeArgs 
     // than N buckets and the real "last N" lives earlier in time than the narrow window saw.
     // Fall back to a full forward scan and let the ring keep the latest N as iteration advances.
     if (args->count != -1 && written < budget && narrowed_start > args->startTimestamp) {
-        written =
-            fill_ring(series, args, args->startTimestamp, budget, false, ts_buf, &val_buf, &vps);
+        written = revagg_fill_circular_buffer(
+            series, args, args->startTimestamp, budget, false, ts_buf, &val_buf, &vps);
     }
 
-    reply_ring_reverse(ctx, ts_buf, val_buf, budget, written, vps);
+    revagg_emit_ring_reverse(ctx, ts_buf, val_buf, budget, written, vps);
     free(ts_buf);
     free(val_buf);
     return REDISMODULE_OK;
 }
 
 int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args, bool reverse) {
+    /* Only special-case: reverse output with aggregation must run the chain forward (aggregators
+     * have no reverse mode), so it buffers all buckets and emits backward; every other shape can
+     * stream directly. */
     if (reverse && args->aggregationArgs.numClasses > 0) {
         return ReplyReverseAgg(ctx, series, args);
     }

--- a/src/reply.c
+++ b/src/reply.c
@@ -170,12 +170,8 @@ int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args,
             cap = new_cap;
         }
 
-        memcpy(timestamps + total,
-               enrichedChunk->samples.timestamps,
-               n * sizeof(timestamp_t));
-        memcpy(values + total * vps,
-               enrichedChunk->samples._values,
-               n * vps * sizeof(double));
+        memcpy(timestamps + total, enrichedChunk->samples.timestamps, n * sizeof(timestamp_t));
+        memcpy(values + total * vps, enrichedChunk->samples._values, n * vps * sizeof(double));
         total += n;
 
         if (count_limited && reverse && total > budget) {

--- a/src/series_iterator.h
+++ b/src/series_iterator.h
@@ -21,7 +21,6 @@ typedef struct SeriesIterator
     RedisModuleDictIter *dictIter; // iterator over chunks
     Chunk_t *currentChunk;
     EnrichedChunk *enrichedChunk;
-    EnrichedChunk *enrichedChunkAux; // auxiliary chunk to represent reverse chunk
     api_timestamp_t maxTimestamp;
     api_timestamp_t minTimestamp;
     bool reverse;

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -1370,8 +1370,9 @@ AbstractIterator *SeriesQuery(Series *series,
                 : args->startTimestamp;
     }
 
+    bool should_reverse_chunk = reverse && (!args->filterByTSArgs.hasValue);
     AbstractIterator *chain = SeriesIterator_New(
-        series, startTimestamp, args->endTimestamp, reverse, reverse, args->latest);
+        series, startTimestamp, args->endTimestamp, reverse, should_reverse_chunk, args->latest);
 
     if (args->filterByTSArgs.hasValue) {
         chain = (AbstractIterator *)SeriesFilterTSIterator_New(chain, args->filterByTSArgs);

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -1375,7 +1375,8 @@ AbstractIterator *SeriesQuery(Series *series,
         series, startTimestamp, args->endTimestamp, reverse, should_reverse_chunk, args->latest);
 
     if (args->filterByTSArgs.hasValue) {
-        chain = (AbstractIterator *)SeriesFilterTSIterator_New(chain, args->filterByTSArgs);
+        chain =
+            (AbstractIterator *)SeriesFilterTSIterator_New(chain, args->filterByTSArgs, reverse);
     }
 
     if (args->filterByValueArgs.hasValue) {

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -578,8 +578,8 @@ void MultiSeriesReduce(Series *dest,
                        const ReducerArgs *groupByReducerArgs,
                        RangeArgs *args) {
     Sample sample;
-    AbstractSampleIterator *iterator = MultiSeriesCreateAggDupSampleIterator(
-        series, n_series, args, false, true, groupByReducerArgs);
+    AbstractSampleIterator *iterator =
+        MultiSeriesCreateAggDupSampleIterator(series, n_series, args, true, groupByReducerArgs);
     while (iterator->GetNext(iterator, &sample) == CR_OK) {
         SeriesAddSample(dest, sample.timestamp, sample.value);
     }
@@ -1196,7 +1196,7 @@ CompactionRule *NewRule(RedisModuleString *destKey,
     CompactionRule *rule = malloc(sizeof *rule);
     rule->aggClass = GetAggClass(aggType);
     rule->aggType = aggType;
-    rule->aggContext = rule->aggClass->createContext(false);
+    rule->aggContext = rule->aggClass->createContext();
     rule->bucketDuration = bucketDuration;
     rule->timestampAlignment = timestampAlignment;
     rule->destKey = destKey;
@@ -1256,7 +1256,7 @@ int SeriesCalcRange(Series *series,
                     bool *is_empty) {
     Sample sample;
     AggregationClass *aggObject = rule->aggClass;
-    void *context = aggObject->createContext(false);
+    void *context = aggObject->createContext();
     bool _is_empty = true;
     AbstractSampleIterator *iterator;
     RangeArgs args = {
@@ -1352,6 +1352,11 @@ timestamp_t getFirstValidTimestamp(Series *series, long long *skipped) {
     return sample.timestamp;
 }
 
+/* `reverse` only controls how raw samples are scanned from the chunk dictionary; the user-visible
+ * direction is decided by the reply layer (REVRANGE = forward result, then reversed). The flag is
+ * still threaded through so internal helpers (LOCF/TWA neighbor scans in filter_iterator.c) can
+ * walk samples newest-first when looking for the closest-in-time sample. Aggregation, filtering
+ * and reply paths always run forward. */
 AbstractIterator *SeriesQuery(Series *series,
                               const RangeArgs *args,
                               bool reverse,
@@ -1365,16 +1370,11 @@ AbstractIterator *SeriesQuery(Series *series,
                 : args->startTimestamp;
     }
 
-    // When there is a TS filter because we wanted the logic to be one for both reverse and non
-    // reverse chunk, if the requested range should be reverse, we reverse it after the filter, and
-    // should_reverse_chunk point it out.
-    bool should_reverse_chunk = reverse && (!args->filterByTSArgs.hasValue);
     AbstractIterator *chain = SeriesIterator_New(
-        series, startTimestamp, args->endTimestamp, reverse, should_reverse_chunk, args->latest);
+        series, startTimestamp, args->endTimestamp, reverse, reverse, args->latest);
 
     if (args->filterByTSArgs.hasValue) {
-        chain =
-            (AbstractIterator *)SeriesFilterTSIterator_New(chain, args->filterByTSArgs, reverse);
+        chain = (AbstractIterator *)SeriesFilterTSIterator_New(chain, args->filterByTSArgs);
     }
 
     if (args->filterByValueArgs.hasValue) {
@@ -1404,7 +1404,6 @@ AbstractIterator *SeriesQuery(Series *series,
                                                             args->aggregationArgs.classes,
                                                             args->aggregationArgs.timeDelta,
                                                             timestampAlignment,
-                                                            reverse,
                                                             args->aggregationArgs.empty,
                                                             args->aggregationArgs.bucketTS,
                                                             series,
@@ -1423,21 +1422,19 @@ AbstractSampleIterator *SeriesCreateSampleIterator(Series *series,
     return (AbstractSampleIterator *)SeriesSampleIterator_New(chain);
 }
 
-// returns sample iterator over multiple series
+// returns sample iterator over multiple series (always chronological; reply layer reverses if needed)
 AbstractMultiSeriesSampleIterator *MultiSeriesCreateSampleIterator(Series **series,
                                                                    size_t n_series,
                                                                    const RangeArgs *args,
-                                                                   bool reverse,
                                                                    bool check_retention) {
     size_t i;
     AbstractSampleIterator **iters = malloc(n_series * sizeof(AbstractSampleIterator *));
     for (i = 0; i < n_series; ++i) {
-        iters[i] = SeriesCreateSampleIterator(series[i], args, reverse, check_retention);
+        iters[i] = SeriesCreateSampleIterator(series[i], args, false, check_retention);
     }
 
     AbstractMultiSeriesSampleIterator *res =
-        (AbstractMultiSeriesSampleIterator *)MultiSeriesSampleIterator_New(
-            iters, n_series, reverse);
+        (AbstractMultiSeriesSampleIterator *)MultiSeriesSampleIterator_New(iters, n_series);
 
     free(iters);
     return res;
@@ -1447,11 +1444,10 @@ AbstractMultiSeriesSampleIterator *MultiSeriesCreateSampleIterator(Series **seri
 AbstractSampleIterator *MultiSeriesCreateAggDupSampleIterator(Series **series,
                                                               size_t n_series,
                                                               const RangeArgs *args,
-                                                              bool reverse,
                                                               bool check_retention,
                                                               const ReducerArgs *reducerArgs) {
     AbstractMultiSeriesSampleIterator *chain =
-        MultiSeriesCreateSampleIterator(series, n_series, args, reverse, check_retention);
+        MultiSeriesCreateSampleIterator(series, n_series, args, check_retention);
     return (AbstractSampleIterator *)MultiSeriesAggDupSampleIterator_New(chain, reducerArgs);
 }
 

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -1422,7 +1422,8 @@ AbstractSampleIterator *SeriesCreateSampleIterator(Series *series,
     return (AbstractSampleIterator *)SeriesSampleIterator_New(chain);
 }
 
-// returns sample iterator over multiple series (always chronological; reply layer reverses if needed)
+// returns sample iterator over multiple series (always chronological; reply layer reverses if
+// needed)
 AbstractMultiSeriesSampleIterator *MultiSeriesCreateSampleIterator(Series **series,
                                                                    size_t n_series,
                                                                    const RangeArgs *args,

--- a/src/tsdb.h
+++ b/src/tsdb.h
@@ -132,13 +132,11 @@ AbstractSampleIterator *SeriesCreateSampleIterator(Series *series,
 AbstractMultiSeriesSampleIterator *MultiSeriesCreateSampleIterator(Series **series,
                                                                    size_t n_series,
                                                                    const RangeArgs *args,
-                                                                   bool reverse,
                                                                    bool check_retention);
 
 AbstractSampleIterator *MultiSeriesCreateAggDupSampleIterator(Series **series,
                                                               size_t n_series,
                                                               const RangeArgs *args,
-                                                              bool reverse,
                                                               bool check_retention,
                                                               const ReducerArgs *reducerArgs);
 

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -2316,9 +2316,12 @@ def test_mrange_mrevrange_symmetry():
             for t, v in samples:
                 r.execute_command('TS.ADD', key, t, v + i * 100)
 
-        fwd = r.execute_command('TS.MRANGE',    10, 40,
+        # Timestamps must be strings: redis-py's cluster command parser calls
+        # args[1].lower() while determining the slot for MRANGE-style commands,
+        # which crashes on int. Matches the rest of the MRANGE tests in this repo.
+        fwd = r.execute_command('TS.MRANGE',    '10', '40',
                                 'FILTER', 'tag=mirror_sym')
-        rev = r.execute_command('TS.MREVRANGE', 10, 40,
+        rev = r.execute_command('TS.MREVRANGE', '10', '40',
                                 'FILTER', 'tag=mirror_sym')
 
         fwd_by_key = dict(_decode_mrange_entry(e) for e in fwd)

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -1934,3 +1934,235 @@ def test_ts_range_countAll():
             assert float(result[2][1]) == 1.0
             assert float(result[3][1]) == 1.0
             assert float(result[4][1]) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Regression: TS.RANGE / TS.REVRANGE with AGGREGATION ... EMPTY must produce
+# the same set of bucket timestamps in both directions (one is the reverse of
+# the other), and carry the chronologically-correct value for LOCF-style
+# aggregations such as LAST.
+#
+# This guards against two bugs that previously affected reverse iteration:
+#   Bug A) extra empty buckets emitted past the data span.
+#   Bug B) wrong carry-forward value for empty buckets between samples.
+#
+# To extend coverage to a new aggregation, just add it to AGGREGATIONS below.
+# To additionally check exact values for that aggregation, add an entry to
+# PER_AGG_VALUE_CHECKS. Without an entry, only timestamp-symmetry is verified.
+# ---------------------------------------------------------------------------
+
+# Aggregations to validate. Add more here with zero other code changes
+# (provided the aggregation behaves like one of the cases handled by
+# _agg_sample_value / _agg_empty_value below).
+AGGREGATIONS = ['last', 'max', 'count']
+
+
+def _agg_sample_value(agg, v):
+    """Value the aggregation produces for a bucket that contains exactly one sample."""
+    if agg == 'count':
+        return '1'
+    # last, max, min, sum, avg, first, range, ... — single sample → that value
+    return str(v)
+
+
+def _agg_empty_value(agg, prev_v, next_v):
+    """Value the aggregation produces for an empty bucket that lies BETWEEN two samples
+    (i.e. has both a left and a right neighbor — should_skip_empty_gap keeps it)."""
+    if agg == 'last':
+        return str(prev_v)            # LOCF: carry forward chronologically previous value
+    if agg == 'count':
+        return '0'                    # no samples in bucket
+    return 'NaN'                      # max, min, sum, avg, ... default empty fill
+
+
+def _build_expected_forward(samples, bucket_size, window, agg):
+    """
+    Build the expected forward TS.RANGE result for `agg` over `samples`,
+    `window` and `bucket_size`. Each sample at t produces:
+        - bucket t                   → _agg_sample_value(agg, v)
+        - bucket (t + bucket_size)   → _agg_empty_value(agg, v, next_v)
+    The trailing carry bucket is dropped when there is no next sample
+    (matches should_skip_empty_gap).
+    """
+    win_lo, win_hi = window
+    out = []
+    for i, (t, v) in enumerate(samples):
+        if win_lo <= t <= win_hi:
+            out.append((t, _agg_sample_value(agg, v)))
+        carry_t = t + bucket_size
+        if carry_t <= win_hi and i + 1 < len(samples):
+            next_v = samples[i + 1][1]
+            out.append((carry_t, _agg_empty_value(agg, v, next_v)))
+    return out
+
+
+def _decode_pair(row):
+    ts = int(row[0])
+    val = row[1].decode() if isinstance(row[1], bytes) else row[1]
+    return ts, val
+
+
+def _format_redis_cli(pairs):
+    """Format a list of (ts, value) pairs the way redis-cli prints them."""
+    if not pairs:
+        return '(empty array)'
+    lines = []
+    for i, (ts, val) in enumerate(pairs, start=1):
+        lines.append(f'{i}) 1) (integer) {ts}')
+        lines.append(f'   2) {val}')
+    return '\n'.join(lines)
+
+
+def _print_block(title, pairs):
+    print(f'\n--- {title} ---')
+    print(_format_redis_cli(pairs))
+
+
+def _format_samples(samples):
+    """Format input samples like ([t=10, v=100], [t=20, v=110], ...)."""
+    inner = ', '.join(f'[t={t}, v={v}]' for t, v in samples)
+    return f'({inner})'
+
+
+def _print_samples(title, samples):
+    print(f'\n--- {title} ({len(samples)} samples) ---')
+    print(_format_samples(samples))
+
+
+def test_range_revrange_empty_symmetry():
+    """
+    Forward and reverse aggregated EMPTY queries must be mirror images of
+    each other (same bucket timestamps, reversed order). For aggregations
+    listed in PER_AGG_VALUE_CHECKS the bucket values are also asserted.
+    """
+    samples = [(18, 100), (20, 110)]
+    window  = (18, 22)
+    bucket  = 1
+    with Env().getClusterConnectionIfNeeded() as r:
+        for agg in AGGREGATIONS:
+            key = 'ts_sym_' + agg + '{a}'
+            r.execute_command('DEL', key)
+            r.execute_command('TS.CREATE', key)
+            for t, v in samples:
+                r.execute_command('TS.ADD', key, t, v)
+
+            _print_samples(f'{agg} input samples', samples)
+
+            win_lo, win_hi = window
+            fwd = r.execute_command('TS.RANGE',    key, win_lo, win_hi,
+                                    'AGGREGATION', agg, bucket, 'EMPTY')
+            rev = r.execute_command('TS.REVRANGE', key, win_lo, win_hi,
+                                    'AGGREGATION', agg, bucket, 'EMPTY')
+
+            got_fwd = [_decode_pair(row) for row in fwd]
+            got_rev = [_decode_pair(row) for row in rev]
+
+            exp_fwd = _build_expected_forward(samples, bucket, window, agg)
+            exp_rev = list(reversed(exp_fwd))
+
+            _print_block(f'{agg} TS.RANGE actual',      got_fwd)
+            _print_block(f'{agg} TS.REVRANGE actual',   got_rev)
+            _print_block(f'{agg} TS.RANGE expected',    exp_fwd)
+            _print_block(f'{agg} TS.REVRANGE expected', exp_rev)
+
+            assert len(fwd) == len(rev), (
+                f'{agg}: bucket count mismatch; '
+                f'fwd={len(fwd)} ({fwd}), rev={len(rev)} ({rev})')
+
+            fwd_ts = [ts for ts, _ in got_fwd]
+            rev_ts = [ts for ts, _ in got_rev]
+            assert fwd_ts == list(reversed(rev_ts)), (
+                f'{agg}: timestamps not mirrored; '
+                f'fwd={fwd_ts}, rev={rev_ts}')
+
+            assert got_fwd == exp_fwd, (
+                f'{agg} forward values mismatch.\n'
+                f'expected:\n{_format_redis_cli(exp_fwd)}\n'
+                f'actual:\n{_format_redis_cli(got_fwd)}')
+            assert got_rev == exp_rev, (
+                f'{agg} reverse values mismatch.\n'
+                f'expected:\n{_format_redis_cli(exp_rev)}\n'
+                f'actual:\n{_format_redis_cli(got_rev)}')
+
+
+# ---------------------------------------------------------------------------
+# Regression: same EMPTY-aggregation symmetry, but on a series whose samples
+# span MANY chunks. The aggregation iterator's GetNext() loop must walk
+# multiple chunks while still emitting the correct empty buckets in both
+# directions and with correct carry values.
+#
+# We force tiny chunks (CHUNK_SIZE=48 bytes, uncompressed → 3 samples / chunk)
+# and sparse samples so the empty buckets between samples land on chunk
+# boundaries.
+#
+# Generic over AGGREGATIONS like the previous test; LAST also gets exact
+# value-level assertions via MULTICHUNK_VALUE_CHECKS.
+# ---------------------------------------------------------------------------
+
+# Sample layout:  t in {10, 20, 30, ..., 300}, value = ts * 10.
+# 30 samples / 3-per-chunk = 10 chunks.
+_MC_SAMPLE_TS    = list(range(10, 301, 10))
+_MC_SAMPLES      = [(t, t * 10) for t in _MC_SAMPLE_TS]
+_MC_WINDOW       = (10, 300)
+_MC_BUCKET_SIZE  = 5
+_MC_CHUNK_BYTES  = 48     # uncompressed: 16 B/sample → 3 samples / chunk
+
+def test_range_revrange_empty_symmetry_multichunk():
+    """
+    Same forward/reverse EMPTY-aggregation symmetry as the previous test,
+    but the underlying series is split across ~10 chunks so the
+    AggregationIterator GetNext loop is exercised across chunk boundaries.
+    """
+    with Env().getClusterConnectionIfNeeded() as r:
+        for agg in AGGREGATIONS:
+            key = 'ts_sym_mc_' + agg + '{a}'
+            r.execute_command('DEL', key)
+            r.execute_command('TS.CREATE', key,
+                              'ENCODING', 'UNCOMPRESSED',
+                              'CHUNK_SIZE', _MC_CHUNK_BYTES)
+            for t, v in _MC_SAMPLES:
+                r.execute_command('TS.ADD', key, t, v)
+
+            # Sanity-check that we really got multiple chunks.
+            info = r.execute_command('TS.INFO', key)
+            info_dict = {info[i]: info[i + 1] for i in range(0, len(info), 2)}
+            chunk_count_key = b'chunkCount' if b'chunkCount' in info_dict else 'chunkCount'
+            chunk_count = int(info_dict[chunk_count_key])
+            assert chunk_count > 1, (
+                f'expected the series to span multiple chunks, got '
+                f'chunkCount={chunk_count}; sample/chunk math may have changed')
+
+            win_lo, win_hi = _MC_WINDOW
+            fwd = r.execute_command('TS.RANGE',    key, win_lo, win_hi,
+                                    'AGGREGATION', agg, _MC_BUCKET_SIZE, 'EMPTY')
+            rev = r.execute_command('TS.REVRANGE', key, win_lo, win_hi,
+                                    'AGGREGATION', agg, _MC_BUCKET_SIZE, 'EMPTY')
+
+            got_fwd = [_decode_pair(row) for row in fwd]
+            got_rev = [_decode_pair(row) for row in rev]
+
+            exp_fwd = _build_expected_forward(
+                _MC_SAMPLES, _MC_BUCKET_SIZE, _MC_WINDOW, agg)
+            exp_rev = list(reversed(exp_fwd))
+
+            print(f'\n--- {agg} multichunk: chunkCount={chunk_count}, '
+                  f'samples={len(_MC_SAMPLES)}, buckets={len(exp_fwd)} ---')
+
+            assert len(fwd) == len(rev), (
+                f'{agg}: bucket count mismatch; '
+                f'fwd={len(fwd)}, rev={len(rev)}')
+
+            fwd_ts = [ts for ts, _ in got_fwd]
+            rev_ts = [ts for ts, _ in got_rev]
+            assert fwd_ts == list(reversed(rev_ts)), (
+                f'{agg}: timestamps not mirrored across chunks; '
+                f'fwd={fwd_ts}, rev={rev_ts}')
+
+            assert got_fwd == exp_fwd, (
+                f'{agg} forward values mismatch (multichunk).\n'
+                f'expected:\n{_format_redis_cli(exp_fwd)}\n'
+                f'actual:\n{_format_redis_cli(got_fwd)}')
+            assert got_rev == exp_rev, (
+                f'{agg} reverse values mismatch (multichunk).\n'
+                f'expected:\n{_format_redis_cli(exp_rev)}\n'
+                f'actual:\n{_format_redis_cli(got_rev)}')

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -2307,7 +2307,8 @@ def test_mrange_mrevrange_symmetry():
     label must return the same set of keys, each with its samples reversed.
     """
     samples = [(10, 1), (20, 2), (30, 3), (40, 4)]
-    with Env().getClusterConnectionIfNeeded() as r:
+    env = Env()
+    with env.getClusterConnectionIfNeeded() as r:
         keys = ['ts_m_a{a}', 'ts_m_b{a}']
         for i, key in enumerate(keys):
             r.execute_command('DEL', key)
@@ -2316,13 +2317,12 @@ def test_mrange_mrevrange_symmetry():
             for t, v in samples:
                 r.execute_command('TS.ADD', key, t, v + i * 100)
 
-        # Timestamps must be strings: redis-py's cluster command parser calls
-        # args[1].lower() while determining the slot for MRANGE-style commands,
-        # which crashes on int. Matches the rest of the MRANGE tests in this repo.
-        fwd = r.execute_command('TS.MRANGE',    '10', '40',
-                                'FILTER', 'tag=mirror_sym')
-        rev = r.execute_command('TS.MREVRANGE', '10', '40',
-                                'FILTER', 'tag=mirror_sym')
+        # MRANGE / MREVRANGE go through a specific shard connection — see docstring.
+        shard_conn = env.getConnection(1)
+        fwd = shard_conn.execute_command('TS.MRANGE',    '10', '40',
+                                         'FILTER', 'tag=mirror_sym')
+        rev = shard_conn.execute_command('TS.MREVRANGE', '10', '40',
+                                         'FILTER', 'tag=mirror_sym')
 
         fwd_by_key = dict(_decode_mrange_entry(e) for e in fwd)
         rev_by_key = dict(_decode_mrange_entry(e) for e in rev)

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -1954,25 +1954,36 @@ def test_ts_range_countAll():
 # Aggregations to validate. Add more here with zero other code changes
 # (provided the aggregation behaves like one of the cases handled by
 # _agg_sample_value / _agg_empty_value below).
-AGGREGATIONS = ['last', 'max', 'count']
+#
+# Intentionally excluded: 'twa' (bucket-edge interpolation), 'std.p' / 'std.s' /
+# 'var.p' / 'var.s' (single-sample value depends on sample/population denominator).
+AGGREGATIONS = ['last', 'first', 'max', 'min', 'count', 'sum', 'avg', 'range']
 
 
 def _agg_sample_value(agg, v):
     """Value the aggregation produces for a bucket that contains exactly one sample."""
     if agg == 'count':
         return '1'
-    # last, max, min, sum, avg, first, range, ... — single sample → that value
+    if agg == 'range':
+        return '0'                    # max - min over a single sample
+    # last, first, max, min, sum, avg → that single sample's value
     return str(v)
 
 
 def _agg_empty_value(agg, prev_v, next_v):
     """Value the aggregation produces for an empty bucket that lies BETWEEN two samples
-    (i.e. has both a left and a right neighbor — should_skip_empty_gap keeps it)."""
+    (i.e. has both a left and a right neighbor — should_skip_empty_gap keeps it).
+
+    Empty-bucket finalizers in src/compaction.c map as follows:
+      - finalize_empty_last_value  → 'last'
+      - finalize_empty_with_ZERO   → 'count', 'sum'
+      - finalize_empty_with_NAN    → everything else (max, min, avg, range, first, ...)
+    """
     if agg == 'last':
         return str(prev_v)            # LOCF: carry forward chronologically previous value
-    if agg == 'count':
-        return '0'                    # no samples in bucket
-    return 'NaN'                      # max, min, sum, avg, ... default empty fill
+    if agg in ('count', 'sum'):
+        return '0'
+    return 'NaN'                      # max, min, avg, first, range, ...
 
 
 def _build_expected_forward(samples, bucket_size, window, agg):
@@ -2166,3 +2177,163 @@ def test_range_revrange_empty_symmetry_multichunk():
                 f'{agg} reverse values mismatch (multichunk).\n'
                 f'expected:\n{_format_redis_cli(exp_rev)}\n'
                 f'actual:\n{_format_redis_cli(got_rev)}')
+
+
+# ---------------------------------------------------------------------------
+# Regression: plain TS.RANGE / TS.REVRANGE (no AGGREGATION) must be exact
+# mirror images of each other. Exercises the reply-time backward-index walk
+# in ReplySeriesRange (which replaced the in-place buffer reverse).
+# ---------------------------------------------------------------------------
+def test_range_revrange_plain_symmetry():
+    """
+    Without any aggregation, TS.REVRANGE over the same window must return
+    exactly the same samples as TS.RANGE, in reverse order.
+    """
+    samples = [(10, 1), (20, 2), (30, 3), (40, 4), (50, 5)]
+    with Env().getClusterConnectionIfNeeded() as r:
+        key = 'ts_plain_sym{a}'
+        r.execute_command('DEL', key)
+        r.execute_command('TS.CREATE', key)
+        for t, v in samples:
+            r.execute_command('TS.ADD', key, t, v)
+
+        fwd = r.execute_command('TS.RANGE',    key, 10, 50)
+        rev = r.execute_command('TS.REVRANGE', key, 10, 50)
+
+        got_fwd = [_decode_pair(row) for row in fwd]
+        got_rev = [_decode_pair(row) for row in rev]
+
+        assert len(got_fwd) == len(samples), (
+            f'fwd length wrong: got {got_fwd}')
+        assert got_fwd == list(reversed(got_rev)), (
+            f'plain mirror failed:\n'
+            f'fwd={_format_redis_cli(got_fwd)}\n'
+            f'rev={_format_redis_cli(got_rev)}')
+
+
+# ---------------------------------------------------------------------------
+# Regression: TS.REVRANGE ... COUNT N must return the LATEST N samples in
+# reverse chronological order — i.e. it is the mirror image of TS.RANGE on
+# the LAST N samples, not on the FIRST N. This pins the documented COUNT
+# semantics for the reverse direction.
+# ---------------------------------------------------------------------------
+def test_range_revrange_plain_count_symmetry():
+    """
+    For samples [(10,1), (20,2), ..., (100,10)]:
+      TS.RANGE    ... COUNT N → first N forward         = samples[:N]
+      TS.REVRANGE ... COUNT N → latest N in reverse     = reversed(samples[-N:])
+    """
+    samples = [(t, t) for t in range(10, 101, 10)]
+    with Env().getClusterConnectionIfNeeded() as r:
+        key = 'ts_plain_cnt{a}'
+        r.execute_command('DEL', key)
+        r.execute_command('TS.CREATE', key)
+        for t, v in samples:
+            r.execute_command('TS.ADD', key, t, v)
+
+        for n in (1, 3, 5, len(samples), len(samples) + 5):
+            fwd = r.execute_command('TS.RANGE',    key, 10, 100, 'COUNT', n)
+            rev = r.execute_command('TS.REVRANGE', key, 10, 100, 'COUNT', n)
+
+            got_fwd = [_decode_pair(row) for row in fwd]
+            got_rev = [_decode_pair(row) for row in rev]
+
+            expected_fwd = [(t, str(v)) for t, v in samples[:n]]
+            expected_rev = list(reversed([(t, str(v)) for t, v in samples[-n:]]))
+
+            assert got_fwd == expected_fwd, (
+                f'COUNT={n} fwd mismatch:\n'
+                f'expected:\n{_format_redis_cli(expected_fwd)}\n'
+                f'actual:\n{_format_redis_cli(got_fwd)}')
+            assert got_rev == expected_rev, (
+                f'COUNT={n} rev mismatch:\n'
+                f'expected:\n{_format_redis_cli(expected_rev)}\n'
+                f'actual:\n{_format_redis_cli(got_rev)}')
+
+
+# ---------------------------------------------------------------------------
+# Regression: aggregated TS.RANGE / TS.REVRANGE WITHOUT the EMPTY flag must
+# still be mirror images of each other (same non-empty buckets, reversed
+# order). Complements the EMPTY-flag tests above.
+# ---------------------------------------------------------------------------
+def test_range_revrange_no_empty_symmetry():
+    """
+    Sparse samples spaced beyond bucket_size so naturally-empty buckets
+    exist; without EMPTY, neither direction should emit them.
+    """
+    samples = [(10, 1), (50, 5), (90, 9)]
+    bucket  = 10
+    with Env().getClusterConnectionIfNeeded() as r:
+        for agg in AGGREGATIONS:
+            key = 'ts_no_empty_' + agg + '{a}'
+            r.execute_command('DEL', key)
+            r.execute_command('TS.CREATE', key)
+            for t, v in samples:
+                r.execute_command('TS.ADD', key, t, v)
+
+            fwd = r.execute_command('TS.RANGE',    key, 0, 100,
+                                    'AGGREGATION', agg, bucket)
+            rev = r.execute_command('TS.REVRANGE', key, 0, 100,
+                                    'AGGREGATION', agg, bucket)
+
+            got_fwd = [_decode_pair(row) for row in fwd]
+            got_rev = [_decode_pair(row) for row in rev]
+
+            assert len(got_fwd) == len(samples), (
+                f'{agg}: expected one bucket per sample (no EMPTY flag), '
+                f'got {got_fwd}')
+            assert got_fwd == list(reversed(got_rev)), (
+                f'{agg} no-EMPTY mirror failed:\n'
+                f'fwd={_format_redis_cli(got_fwd)}\n'
+                f'rev={_format_redis_cli(got_rev)}')
+
+
+# ---------------------------------------------------------------------------
+# Regression: TS.MRANGE / TS.MREVRANGE per-series mirror image. The set of
+# returned series and their labels must be the same; the samples list per
+# series must be reversed between the two directions.
+# ---------------------------------------------------------------------------
+def _decode_mrange_entry(entry):
+    """Return (key_name_str, samples_as_list_of_(ts,val)_pairs) for one MRANGE entry.
+    Tolerates the [key, labels, samples] layout regardless of byte vs str."""
+    key = entry[0].decode() if isinstance(entry[0], bytes) else entry[0]
+    samples = [_decode_pair(row) for row in entry[2]]
+    return key, samples
+
+
+def test_mrange_mrevrange_symmetry():
+    """
+    Two series with a shared label; MRANGE and MREVRANGE filtered on that
+    label must return the same set of keys, each with its samples reversed.
+    """
+    samples = [(10, 1), (20, 2), (30, 3), (40, 4)]
+    with Env().getClusterConnectionIfNeeded() as r:
+        keys = ['ts_m_a{a}', 'ts_m_b{a}']
+        for i, key in enumerate(keys):
+            r.execute_command('DEL', key)
+            r.execute_command('TS.CREATE', key,
+                              'LABELS', 'tag', 'mirror_sym', 'idx', str(i))
+            for t, v in samples:
+                r.execute_command('TS.ADD', key, t, v + i * 100)
+
+        fwd = r.execute_command('TS.MRANGE',    10, 40,
+                                'FILTER', 'tag=mirror_sym')
+        rev = r.execute_command('TS.MREVRANGE', 10, 40,
+                                'FILTER', 'tag=mirror_sym')
+
+        fwd_by_key = dict(_decode_mrange_entry(e) for e in fwd)
+        rev_by_key = dict(_decode_mrange_entry(e) for e in rev)
+
+        assert set(fwd_by_key) == set(rev_by_key) == set(keys), (
+            f'key sets differ: fwd={set(fwd_by_key)}, '
+            f'rev={set(rev_by_key)}, expected={set(keys)}')
+
+        for key in keys:
+            f_samples = fwd_by_key[key]
+            r_samples = rev_by_key[key]
+            assert len(f_samples) == len(samples), (
+                f'{key}: fwd sample count wrong: {f_samples}')
+            assert f_samples == list(reversed(r_samples)), (
+                f'{key}: per-series mirror failed:\n'
+                f'fwd={_format_redis_cli(f_samples)}\n'
+                f'rev={_format_redis_cli(r_samples)}')

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -1343,8 +1343,8 @@ def test_empty():
         expected_data_2 = [[10, '4'], [20, '4'], [30, '4'], [40, '4'], [50, '3'], [60, '3'], [70, '3']]
         assert expected_data_2 == \
         decode_if_needed(r.execute_command('TS.range', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'last', agg_size, 'EMPTY'))
-        expected_data_3 = [[70, '5'], [60, '5'], [50, '3'], [40, '3'], [30, '3'], [20, '3'], [10, '1']]
-        assert expected_data_3 == \
+        expected_data_2.reverse()
+        assert expected_data_2 == \
         decode_if_needed(r.execute_command('TS.revrange', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'last', agg_size, 'EMPTY'))
 
         expected_data = [[10, '5'], [20, '0'], [30, '0'], [40, '0'], [50, '3'], [60, '0'], [70, '8']]

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -2340,3 +2340,676 @@ def test_mrange_mrevrange_symmetry():
                 f'{key}: per-series mirror failed:\n'
                 f'fwd={_format_redis_cli(f_samples)}\n'
                 f'rev={_format_redis_cli(r_samples)}')
+
+
+# ---------------------------------------------------------------------------
+# TS.RANGE AGGREGATION coverage — keep aligned with the public docs at:
+#   https://redis.io/docs/latest/commands/ts.range/
+#
+# The per-aggregator tests above (test_agg_*, test_ts_range_count{NaN,All})
+# verify exact values for each aggregator on hand-tuned inputs. The four
+# tests below add coverage that scales automatically to every aggregator
+# listed in TS_RANGE_AGGREGATORS:
+#
+#   1. test_ts_range_all_aggregators_exact_values (positive)
+#      Every aggregator returns the CORRECT value for a single bucket with
+#      mixed numeric + NaN samples. Also verifies TS.REVRANGE mirrors
+#      TS.RANGE (parser/aggregator share the path; this catches direction-
+#      specific regressions).
+#
+#   2. test_ts_range_all_aggregators_empty_flag (positive, EMPTY flag)
+#      Asserts the exact value reported for an EMPTY bucket sandwiched
+#      between two samples, for every aggregator. The expected values
+#      come from the public docs (the EMPTY-flag table on
+#      https://redis.io/docs/latest/commands/ts.range/) plus the
+#      standard mathematical definitions for aggregators that the docs
+#      do not list explicitly (variance of an empty set → NaN, etc.).
+#      twa's empty-bucket value is the time-weighted average of the
+#      linear interpolation between the surrounding samples (also docs).
+#
+#   3. test_ts_range_invalid_aggregator_bucket_duration (negative)
+#      Every aggregator rejects malformed `bucketDuration`. Catches new
+#      aggregators that forget the shared validation. Also probes
+#      TS.REVRANGE to make sure both directions agree.
+#
+#   4. test_ts_range_unknown_aggregator (negative)
+#      Unknown / typo aggregator names are rejected. Includes a check for
+#      `AGGREGATION` with no aggregator name and `AGGREGATION x dur EMPTY`
+#      with an unknown name (EMPTY must not mask the unknown-name error).
+# ---------------------------------------------------------------------------
+
+# Full list per https://redis.io/docs/latest/commands/ts.range/ (AGGREGATION
+# block). Adding a new aggregator? Add it here and AGG_SINGLE_BUCKET_EXPECTED
+# + AGG_EMPTY_BUCKET_EXPECTED below, then both the positive and the negative
+# tests will cover it automatically.
+TS_RANGE_AGGREGATORS = [
+    'avg', 'sum', 'min', 'max', 'range', 'count', 'countNaN', 'countAll',
+    'first', 'last', 'std.p', 'std.s', 'var.p', 'var.s', 'twa',
+]
+
+# Expected values for AGGREGATION <agg> 100 over a single bucket [0, 100)
+# containing samples: (10, 10), (20, NaN), (30, 20).
+# Non-NaN values = [10, 20], mean = 15, n = 2.
+#   var_p = ((10-15)^2 + (20-15)^2) / 2 = 25
+#   var_s = ((10-15)^2 + (20-15)^2) / 1 = 50
+# twa is excluded — single-bucket twa depends on extrapolation policy at the
+# bucket edges and is exercised by the dedicated test_agg_twa above.
+AGG_SINGLE_BUCKET_EXPECTED = {
+    'avg':      15.0,
+    'sum':      30.0,
+    'min':      10.0,
+    'max':      20.0,
+    'range':    10.0,                        # max - min (non-NaN)
+    'count':    2.0,                         # non-NaN count
+    'countNaN': 1.0,
+    'countAll': 3.0,
+    'first':    10.0,                        # value at lowest ts (non-NaN)
+    'last':     20.0,                        # value at highest ts (non-NaN)
+    'std.p':    5.0,                         # sqrt(var_p)
+    'std.s':    math.sqrt(50.0),             # sqrt(var_s)
+    'var.p':    25.0,
+    'var.s':    50.0,
+}
+
+# Expected empty-bucket value for an EMPTY bucket sandwiched between two
+# samples (10, 100) and (30, 200), bucketDuration=10, ALIGN 0 → the empty
+# bucket is [20, 30). Values are STRINGS so we can assert 'NaN' literally.
+#
+# These expectations come from the public docs AND from the mathematical
+# definition of each aggregator over the empty set:
+#   - sum, count, countNaN, countAll: aggregator counts/sums over zero
+#     samples → 0 (docs explicitly state this for sum/count; countNaN
+#     and countAll are counts of subsets of an empty set → also 0).
+#   - last:  docs say "value of the last sample BEFORE the bucket's
+#     start" → 100 (the sample at t=10).
+#   - min, max, range, avg, first, std.p, std.s: docs explicitly say NaN.
+#   - var.p, var.s: variance over the empty set is mathematically
+#     undefined → NaN (docs don't list these; the math/sense answer is
+#     NaN, consistent with the std.p/std.s row from the docs).
+#   - twa: docs say "average value over the bucket's timeframe based on
+#     linear interpolation". With surrounding samples (10, 100) and
+#     (30, 200), the line value at t=20 is 150 and at t=30 is 200, so
+#     the time-weighted average over [20, 30) is (150 + 200) / 2 = 175.
+AGG_EMPTY_BUCKET_EXPECTED = {
+    'sum':      '0',
+    'count':    '0',
+    'countNaN': '0',
+    'countAll': '0',
+    'last':     '100',                       # previous sample's value
+    'min':      'NaN',
+    'max':      'NaN',
+    'range':    'NaN',
+    'avg':      'NaN',
+    'first':    'NaN',
+    'std.p':    'NaN',
+    'std.s':    'NaN',
+    'var.p':    'NaN',
+    'var.s':    'NaN',
+    # 'twa' handled separately — expected value 175 derived above.
+}
+
+
+def _agg_value_to_float(val):
+    """Aggregator response value → Python float (handles bytes/str/NaN)."""
+    s = val.decode() if isinstance(val, bytes) else val
+    return float(s)
+
+
+def test_ts_range_all_aggregators_exact_values():
+    """
+    Positive: for every aggregator from the TS.RANGE docs, the value
+    returned over a single bucket containing mixed numeric + NaN samples
+    must match the hand-computed expected value.
+
+    Also verifies TS.REVRANGE returns the same single bucket (direction
+    must not change the per-bucket value).
+
+    Coverage rationale (vs the existing test_agg_* tests):
+      - This is a single source-of-truth table for the per-aggregator
+        contract; new aggregators wire themselves in via the dict.
+      - Adds the NaN dimension to the table — only countNaN / countAll /
+        the dedicated test_ts_range_NaN_values exercise this today.
+    """
+    with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
+        key = 'agg_exact{a}'
+        r.execute_command('TS.CREATE', key)
+        r.execute_command('TS.MADD',
+                          key, 10, 10,
+                          key, 20, 'nan',
+                          key, 30, 20)
+
+        # Sanity: every aggregator in the docs list has an expected value
+        # (or, for twa, an explicit exemption documented in the table).
+        covered = set(AGG_SINGLE_BUCKET_EXPECTED.keys()) | {'twa'}
+        missing = set(TS_RANGE_AGGREGATORS) - covered
+        assert not missing, \
+            f'AGG_SINGLE_BUCKET_EXPECTED missing aggregators: {sorted(missing)}'
+
+        TOL = 1e-6
+        for agg, exp in AGG_SINGLE_BUCKET_EXPECTED.items():
+            fwd = r.execute_command(
+                'TS.RANGE', key, 0, '+', 'AGGREGATION', agg, 100)
+            rev = r.execute_command(
+                'TS.REVRANGE', key, 0, '+', 'AGGREGATION', agg, 100)
+            assert len(fwd) == 1, \
+                f'AGGREGATION {agg}: expected 1 bucket fwd, got {fwd!r}'
+            assert len(rev) == 1, \
+                f'AGGREGATION {agg}: expected 1 bucket rev, got {rev!r}'
+            assert fwd[0][0] == 0 == rev[0][0], (
+                f'AGGREGATION {agg}: bucket ts mismatch '
+                f'fwd={fwd[0][0]} rev={rev[0][0]}')
+
+            got_fwd = _agg_value_to_float(fwd[0][1])
+            got_rev = _agg_value_to_float(rev[0][1])
+            assert abs(got_fwd - exp) < TOL, (
+                f'AGGREGATION {agg} TS.RANGE: expected {exp}, got {got_fwd}')
+            assert abs(got_rev - exp) < TOL, (
+                f'AGGREGATION {agg} TS.REVRANGE: expected {exp}, got {got_rev}')
+
+        # twa: single-bucket value depends on the edge-extrapolation policy.
+        # Just assert the call succeeds and returns a finite number for this
+        # input (two non-NaN samples in the same bucket).
+        fwd = r.execute_command(
+            'TS.RANGE', key, 0, '+', 'AGGREGATION', 'twa', 100)
+        assert len(fwd) == 1, \
+            f'AGGREGATION twa: expected 1 bucket, got {fwd!r}'
+        twa = _agg_value_to_float(fwd[0][1])
+        assert math.isfinite(twa), \
+            f'AGGREGATION twa: expected finite value, got {twa}'
+
+
+def test_ts_range_all_aggregators_empty_flag():
+    """
+    Positive (EMPTY flag): for every aggregator from the TS.RANGE docs,
+    assert the exact value reported for an EMPTY bucket sandwiched between
+    two samples.
+
+    Setup: samples at (10, 100) and (30, 200), bucketDuration=10, ALIGN 0.
+    Window [0, 39] yields buckets [10,20), [20,30), [30,40). The bucket at
+    ts=20 is EMPTY (between samples). The bucket at ts=0 is dropped because
+    no sample precedes it (should_skip_empty_gap).
+
+    Also verifies TS.REVRANGE returns the same set of buckets in reverse.
+    """
+    with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
+        key = 'agg_empty{a}'
+        r.execute_command('TS.CREATE', key)
+        r.execute_command('TS.MADD',
+                          key, 10, 100,
+                          key, 30, 200)
+
+        # Sanity: every aggregator in the docs list has an expected value
+        # (or, for twa, an explicit exemption documented in the table).
+        covered = set(AGG_EMPTY_BUCKET_EXPECTED.keys()) | {'twa'}
+        missing = set(TS_RANGE_AGGREGATORS) - covered
+        assert not missing, \
+            f'AGG_EMPTY_BUCKET_EXPECTED missing aggregators: {sorted(missing)}'
+
+        for agg, exp_str in AGG_EMPTY_BUCKET_EXPECTED.items():
+            fwd = r.execute_command(
+                'TS.RANGE', key, 0, 39, 'ALIGN', 0,
+                'AGGREGATION', agg, 10, 'EMPTY')
+            rev = r.execute_command(
+                'TS.REVRANGE', key, 0, 39, 'ALIGN', 0,
+                'AGGREGATION', agg, 10, 'EMPTY')
+
+            # Direction symmetry: same buckets, reverse order.
+            assert fwd == list(reversed(rev)), (
+                f'AGGREGATION {agg} EMPTY: TS.RANGE / TS.REVRANGE are not '
+                f'mirror images\n  fwd={fwd!r}\n  rev={rev!r}')
+
+            fwd_by_ts = {row[0]: row[1] for row in fwd}
+            assert set(fwd_by_ts) == {10, 20, 30}, (
+                f'AGGREGATION {agg} EMPTY: expected buckets at 10/20/30, '
+                f'got {sorted(fwd_by_ts)} (full: {fwd!r})')
+            assert fwd_by_ts[20] == exp_str, (
+                f'AGGREGATION {agg} EMPTY bucket: expected {exp_str!r}, '
+                f'got {fwd_by_ts[20]!r}')
+
+        # twa empty bucket: linear interpolation between (10, 100) and
+        # (30, 200). Bucket [20, 30): interp at t=20 = 150, at t=30 = 200,
+        # time-weighted avg over [20, 30) = (150 + 200) / 2 = 175.
+        fwd = r.execute_command(
+            'TS.RANGE', key, 0, 39, 'ALIGN', 0,
+            'AGGREGATION', 'twa', 10, 'EMPTY')
+        twa_by_ts = {row[0]: row[1] for row in fwd}
+        assert 20 in twa_by_ts, \
+            f'AGGREGATION twa EMPTY: bucket ts=20 missing from {fwd!r}'
+        twa_empty = _agg_value_to_float(twa_by_ts[20])
+        assert abs(twa_empty - 175.0) < 1e-6, (
+            f'AGGREGATION twa EMPTY bucket: expected 175.0, got {twa_empty}')
+
+
+def test_ts_range_invalid_aggregator_bucket_duration():
+    """
+    Negative: for every aggregator from the TS.RANGE docs, malformed
+    `bucketDuration` must be rejected with a ResponseError, for BOTH
+    TS.RANGE and TS.REVRANGE (the parser path is shared but worth
+    cross-checking). Covers the full set of parser failure modes:
+      - missing entirely
+      - non-numeric ('foo')
+      - empty string ('')
+      - lone whitespace (' ')
+      - decimal ('1.5')           — bucketDuration is integer-only
+      - NaN / inf string literals
+      - massive overflow that won't fit in a long long
+      - negative integer (-1)
+    """
+    bad_bucket_durations = [
+        'foo',
+        '',
+        ' ',
+        '1.5',
+        'nan',
+        'inf',
+        '99999999999999999999999999999',
+        -1,
+    ]
+
+    with Env().getClusterConnectionIfNeeded() as r:
+        key = 'agg_neg_bucket{a}'
+        r.execute_command('TS.CREATE', key)
+        r.execute_command('TS.ADD', key, 10, 1)
+
+        for cmd in ('TS.RANGE', 'TS.REVRANGE'):
+            for agg in TS_RANGE_AGGREGATORS:
+                # bucketDuration missing entirely
+                with pytest.raises(redis.ResponseError):
+                    r.execute_command(cmd, key, 0, '+', 'AGGREGATION', agg)
+                for bd in bad_bucket_durations:
+                    with pytest.raises(redis.ResponseError):
+                        r.execute_command(
+                            cmd, key, 0, '+', 'AGGREGATION', agg, bd)
+
+
+def test_ts_range_unknown_aggregator():
+    """
+    Negative: unknown aggregator names must be rejected. Includes the empty
+    string, an obvious garbage token, and a typo of a real aggregator —
+    guards against the parser silently accepting close-misses.
+
+    Also exercises a few structural negatives that aren't tied to a name:
+      - `AGGREGATION` with no aggregator and no bucketDuration at all
+      - `AGGREGATION <unknown> 100 EMPTY` — EMPTY must not mask the
+        unknown-name error
+    """
+    bad_names = [
+        '',                          # empty string
+        'foo',                       # never been an aggregator
+        'avgg',                      # typo of 'avg'
+        'aggregation',               # the keyword itself
+        'not_aggregation_function',  # historical placeholder
+    ]
+    with Env().getClusterConnectionIfNeeded() as r:
+        key = 'agg_unknown{a}'
+        r.execute_command('TS.CREATE', key)
+        r.execute_command('TS.ADD', key, 10, 1)
+
+        for name in bad_names:
+            with pytest.raises(redis.ResponseError):
+                r.execute_command(
+                    'TS.RANGE', key, 0, '+', 'AGGREGATION', name, 100)
+            with pytest.raises(redis.ResponseError):
+                r.execute_command(
+                    'TS.REVRANGE', key, 0, '+', 'AGGREGATION', name, 100)
+            # EMPTY must not mask the unknown-aggregator error.
+            with pytest.raises(redis.ResponseError):
+                r.execute_command(
+                    'TS.RANGE', key, 0, '+',
+                    'AGGREGATION', name, 100, 'EMPTY')
+
+        # `AGGREGATION` with nothing after it must fail.
+        with pytest.raises(redis.ResponseError):
+            r.execute_command('TS.RANGE', key, 0, '+', 'AGGREGATION')
+
+
+# ---------------------------------------------------------------------------
+# Edge-case tests for TS.RANGE AGGREGATION.
+#
+# Each of these tests targets a corner case that the broader exact-values /
+# EMPTY tests above don't reach. Expected values are derived from the
+# public docs and from standard mathematical definitions. Where the docs
+# leave a corner case undefined (single-sample twa, single-sample sample
+# variance, etc.) the test either asserts the math-correct answer (so a
+# code bug surfaces) or leaves the value unpinned — never silently
+# encodes what the current implementation happens to return.
+# ---------------------------------------------------------------------------
+
+# Bucket [0, 100) with one sample (50, 42). Expectations are derived
+# strictly from per-aggregator docs definitions + standard math:
+#
+#   sum, avg, min, max, first, last over {42}         → 42
+#   range = max - min over {42}                       → 0
+#   count (non-NaN), countAll over {42}               → 1
+#   countNaN over {42}                                → 0
+#   std.p, var.p (population) over {42}:
+#       variance = E[(X-μ)²] with μ=42, X=42          → 0
+#       std      = sqrt(0)                            → 0
+#   std.s, var.s (sample) over {42}:
+#       formal definition is SS / (n-1) = 0 / 0       → NaN (undefined)
+#       (Some implementations special-case n=1 to 0 as a defensive
+#       choice. The docs do not specify; the math/spec answer is NaN.
+#       If this assertion fires, decide whether to update the docs to
+#       call out the n=1 → 0 convention or change the code.)
+#   twa over {(50, 42)} in bucket [0, 100):
+#       docs say "time-weighted average over the bucket's timeframe".
+#       A single sample defines a constant function (→ 42) under one
+#       reading and is undefined (→ NaN) under another. The docs do
+#       not disambiguate, so this test does NOT pin an exact value
+#       for twa — it only asserts the call succeeds and returns a
+#       number (NaN or finite). The dedicated test_agg_twa above
+#       exercises the multi-sample twa math.
+AGG_SINGLE_SAMPLE_BUCKET_EXPECTED = {
+    'avg':      42.0,
+    'sum':      42.0,
+    'min':      42.0,
+    'max':      42.0,
+    'range':    0.0,
+    'count':    1.0,
+    'countNaN': 0.0,
+    'countAll': 1.0,
+    'first':    42.0,
+    'last':     42.0,
+    'std.p':    0.0,
+    'var.p':    0.0,
+    'std.s':    float('nan'),                 # undefined (n=1, SS/(n-1)=0/0)
+    'var.s':    float('nan'),                 # undefined (n=1, SS/(n-1)=0/0)
+}
+
+
+def test_ts_range_all_aggregators_single_sample_bucket():
+    """
+    Edge case (positive): bucket containing a single sample.
+
+    Expected values are derived purely from each aggregator's documented
+    semantics and from standard mathematical definitions — NOT from
+    inspecting the implementation. Specifically:
+      - Population variance/std over {x} is 0 by definition.
+      - Sample variance/std over {x} requires division by (n-1) = 0 and
+        is mathematically undefined → NaN.
+      - twa over a single sample is ambiguous per docs and is therefore
+        only verified to return SOMETHING parseable (not pinned to a
+        specific value).
+
+    If this test fails for std.s / var.s / twa, the right response is
+    either to (a) fix the implementation, or (b) extend the docs to
+    specify the n=1 / single-sample behaviour, and then update this test.
+    """
+    with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
+        key = 'agg_single{a}'
+        r.execute_command('TS.CREATE', key)
+        r.execute_command('TS.ADD', key, 50, 42)
+
+        # Coverage guard.
+        covered = set(AGG_SINGLE_SAMPLE_BUCKET_EXPECTED) | {'twa'}
+        missing = set(TS_RANGE_AGGREGATORS) - covered
+        assert not missing, \
+            f'AGG_SINGLE_SAMPLE_BUCKET_EXPECTED missing: {sorted(missing)}'
+
+        TOL = 1e-6
+        for agg, exp in AGG_SINGLE_SAMPLE_BUCKET_EXPECTED.items():
+            fwd = r.execute_command(
+                'TS.RANGE', key, 0, '+', 'AGGREGATION', agg, 100)
+            rev = r.execute_command(
+                'TS.REVRANGE', key, 0, '+', 'AGGREGATION', agg, 100)
+            assert len(fwd) == 1, \
+                f'AGGREGATION {agg} n=1: expected 1 bucket fwd, got {fwd!r}'
+            assert len(rev) == 1, \
+                f'AGGREGATION {agg} n=1: expected 1 bucket rev, got {rev!r}'
+            for label, res in (('TS.RANGE', fwd), ('TS.REVRANGE', rev)):
+                got = _agg_value_to_float(res[0][1])
+                if math.isnan(exp):
+                    assert math.isnan(got), (
+                        f'AGGREGATION {agg} n=1 {label}: expected NaN '
+                        f'(sample variance undefined for n=1), got {got}')
+                else:
+                    assert abs(got - exp) < TOL, (
+                        f'AGGREGATION {agg} n=1 {label}: '
+                        f'expected {exp}, got {got}')
+
+        # twa: docs don't specify single-sample behaviour → only assert
+        # the call succeeds and returns a parseable number.
+        for cmd in ('TS.RANGE', 'TS.REVRANGE'):
+            res = r.execute_command(
+                cmd, key, 0, '+', 'AGGREGATION', 'twa', 100)
+            assert len(res) == 1, \
+                f'AGGREGATION twa n=1 {cmd}: expected 1 bucket, got {res!r}'
+            # Will raise if not parseable; NaN is fine.
+            _agg_value_to_float(res[0][1])
+
+
+def test_ts_range_count_family_on_all_nan_bucket():
+    """
+    Edge case (positive): countNaN and countAll on an all-NaN bucket.
+
+    Fills the gap left by test_ts_range_NaN_values (which covers all
+    non-count aggregators on all-NaN buckets, but only the legacy
+    `count` from the count family). Expectations are derived from the
+    per-aggregator docs definitions:
+      - count    = "Number of non-NaN values"               → 0 (bucket
+                   has zero non-NaN values, so the bucket is "empty"
+                   for count and is dropped without the EMPTY flag).
+      - countNaN = "Number of NaN values"                   → N (the
+                   bucket has N NaN samples, so it is NOT empty for
+                   countNaN and must be reported even without EMPTY).
+      - countAll = "Number of values, including NaN and non-NaN" → N
+                   (same reasoning as countNaN).
+
+    Setup: three NaN samples (10, 20, 30), one non-NaN sample (200, 5)
+    in a different bucket so we can also check that the count family
+    reports the all-NaN bucket distinctly from the populated one.
+    """
+    with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
+        key = 'agg_allnan{a}'
+        r.execute_command('TS.CREATE', key)
+        r.execute_command('TS.MADD',
+                          key, 10, 'nan',
+                          key, 20, 'nan',
+                          key, 30, 'nan',
+                          key, 200, 5)
+
+        # All-NaN bucket [0, 100): query just that bucket.
+        # No EMPTY flag. Per docs, countNaN counts the NaN samples and
+        # countAll counts all samples — both see 3 valid items, so the
+        # bucket is NOT empty for them and must be reported even without
+        # the EMPTY flag.
+        for agg, expected in (('countNaN', '3'), ('countAll', '3')):
+            res = r.execute_command(
+                'TS.RANGE', key, 0, 99, 'AGGREGATION', agg, 100)
+            assert res == [[0, expected]], \
+                f'AGGREGATION {agg} all-NaN bucket: got {res!r}'
+
+        # By contrast, `count` is defined per docs as "Number of non-NaN
+        # values" → 0 for an all-NaN bucket → the bucket is empty for
+        # count and must be omitted without the EMPTY flag. This locks
+        # in the per-aggregator asymmetry implied by the docs.
+        res = r.execute_command(
+            'TS.RANGE', key, 0, 99, 'AGGREGATION', 'count', 100)
+        assert res == [], \
+            f'AGGREGATION count all-NaN bucket without EMPTY: expected [], got {res!r}'
+
+        # With EMPTY, count emits the bucket with value 0.
+        res = r.execute_command(
+            'TS.RANGE', key, 0, 99, 'AGGREGATION', 'count', 100, 'EMPTY')
+        assert res == [[0, '0']], \
+            f'AGGREGATION count all-NaN bucket with EMPTY: got {res!r}'
+
+        # Across both buckets, countAll should report 3 NaN + 1 non-NaN.
+        res = r.execute_command(
+            'TS.RANGE', key, 0, 299, 'AGGREGATION', 'countAll', 100)
+        # Bucket [0,100): 3 NaN samples → 3. Bucket [200,300): 1 → 1.
+        # Bucket [100,200) has no samples → dropped (no EMPTY).
+        assert res == [[0, '3'], [200, '1']], \
+            f'AGGREGATION countAll multi-bucket: got {res!r}'
+
+
+def test_ts_range_aggregator_name_case_insensitivity():
+    """
+    Edge case (parser): aggregator names are case-insensitive. For every
+    aggregator from the docs, the lowercase, UPPERCASE and MiXeD-CaSe
+    forms must all produce the same response.
+
+    Catches drift in the parser's keyword table — e.g. if a new aggregator
+    is added with a case-sensitive comparison instead of the shared
+    case-insensitive matcher.
+    """
+    def mixed_case(s):
+        # Toggle case per character; leaves '.' and digits untouched.
+        return ''.join(c.upper() if i % 2 == 0 else c.lower()
+                       for i, c in enumerate(s))
+
+    with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
+        key = 'agg_case{a}'
+        r.execute_command('TS.CREATE', key)
+        r.execute_command('TS.MADD',
+                          key, 10, 10,
+                          key, 20, 'nan',
+                          key, 30, 20)
+
+        for agg in TS_RANGE_AGGREGATORS:
+            forms = [agg.lower(), agg.upper(), mixed_case(agg)]
+            results = [
+                r.execute_command(
+                    'TS.RANGE', key, 0, '+', 'AGGREGATION', form, 100)
+                for form in forms
+            ]
+            # All three forms must produce IDENTICAL responses.
+            assert results[0] == results[1] == results[2], (
+                f'AGGREGATION case-insensitivity broken for {agg!r}:\n'
+                f'  lower={forms[0]!r} → {results[0]!r}\n'
+                f'  UPPER={forms[1]!r} → {results[1]!r}\n'
+                f'  Mixed={forms[2]!r} → {results[2]!r}'
+            )
+            # And must not be an empty response (sanity: we set up data).
+            assert len(results[0]) >= 1, \
+                f'AGGREGATION {agg}: empty response for all forms'
+
+
+# Multi-bucket composition: AGGREGATION + ALIGN + FILTER_BY_VALUE + COUNT.
+# Per docs:
+#   - FILTER_BY_VALUE filters samples BEFORE aggregation.
+#   - AGGREGATION buckets the surviving samples.
+#   - COUNT limits the number of REPORTED BUCKETS (not samples).
+#   - TS.RANGE iterates ascending; TS.REVRANGE iterates descending.
+#     "COUNT" in REVRANGE therefore yields the buckets with the LARGEST
+#     timestamps (the first N in reverse-iteration order).
+#
+# Series: ten samples at t=5,15,25,...,95 with values equal to their ts.
+# FILTER_BY_VALUE 20 80 keeps t=25,35,45,55,65,75. bucketDuration=20,
+# ALIGN 0 → surviving buckets after the filter pipeline:
+#   [20,40) holds (25, 35)   ← values [25, 35]
+#   [40,60) holds (45, 55)   ← values [45, 55]
+#   [60,80) holds (65, 75)   ← values [65, 75]
+# Buckets [0,20) and [80,100) have no surviving samples and are dropped.
+#
+# Per-aggregator per-bucket values are computed from the surviving samples
+# of each bucket using the standard definitions cited in the TS.RANGE docs:
+#   sum=Σv, avg=Σv/n, min/max/first/last=obvious, range=max-min,
+#   count=count_all=2 (no NaN), countNaN=0,
+#   var_p=Σ(v-μ)²/n, var_s=Σ(v-μ)²/(n-1), std=√var.
+# Each bucket here has values [x, x+10] with mean=x+5, so SS=50 in every
+# bucket → var.p=25, var.s=50, std.p=5, std.s=√50 across the board.
+AGG_COMPOSITION_BUCKET_VALUES = {
+    'avg':      {20: 30.0, 40: 50.0,  60: 70.0},
+    'sum':      {20: 60.0, 40: 100.0, 60: 140.0},
+    'min':      {20: 25.0, 40: 45.0,  60: 65.0},
+    'max':      {20: 35.0, 40: 55.0,  60: 75.0},
+    'range':    {20: 10.0, 40: 10.0,  60: 10.0},
+    'count':    {20:  2.0, 40:  2.0,  60:  2.0},
+    'countNaN': {20:  0.0, 40:  0.0,  60:  0.0},
+    'countAll': {20:  2.0, 40:  2.0,  60:  2.0},
+    'first':    {20: 25.0, 40: 45.0,  60: 65.0},
+    'last':     {20: 35.0, 40: 55.0,  60: 75.0},
+    'std.p':    {20:  5.0, 40:  5.0,  60:  5.0},
+    'std.s':    {20: math.sqrt(50.0), 40: math.sqrt(50.0), 60: math.sqrt(50.0)},
+    'var.p':    {20: 25.0, 40: 25.0,  60: 25.0},
+    'var.s':    {20: 50.0, 40: 50.0,  60: 50.0},
+}
+
+
+def test_ts_range_aggregator_composition_align_filter_count():
+    """
+    Edge case (composition): AGGREGATION pipelined with ALIGN +
+    FILTER_BY_VALUE + COUNT. Asserts EXACT per-aggregator per-bucket
+    values for both TS.RANGE and TS.REVRANGE.
+
+    Per the docs ("samples are filtered before being aggregated" and
+    "COUNT ... limits the number of reported buckets"):
+      - TS.RANGE with COUNT 2 yields the two SMALLEST-ts surviving
+        buckets, in ascending order: ts=20 then ts=40.
+      - TS.REVRANGE with COUNT 2 yields the two LARGEST-ts surviving
+        buckets, in descending order: ts=60 then ts=40.
+
+    Twa is excluded from the per-value table: the docs say twa
+    interpolates based on "the last sample before the bucket's start"
+    and "the first sample after the bucket's end", and the docs do not
+    specify whether samples removed by FILTER_BY_VALUE remain visible
+    to that interpolation. This test should not pin a value that the
+    docs leave open.
+    """
+    with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
+        key = 'agg_compose{a}'
+        r.execute_command('TS.CREATE', key)
+        for t in range(5, 100, 10):              # 5, 15, 25, ..., 95
+            r.execute_command('TS.ADD', key, t, t)
+
+        # Coverage guard.
+        covered = set(AGG_COMPOSITION_BUCKET_VALUES) | {'twa'}
+        missing = set(TS_RANGE_AGGREGATORS) - covered
+        assert not missing, \
+            f'AGG_COMPOSITION_BUCKET_VALUES missing: {sorted(missing)}'
+
+        TOL = 1e-6
+
+        def _check(label, command, expected_ts_in_order, agg, per_bucket):
+            res = r.execute_command(
+                command, key, 0, '+',
+                'FILTER_BY_VALUE', 20, 80,
+                'COUNT', 2,
+                'ALIGN', 0, 'AGGREGATION', agg, 20)
+            assert len(res) == 2, (
+                f'AGGREGATION {agg} {label}: expected 2 buckets, '
+                f'got {res!r}')
+            for exp_ts, row in zip(expected_ts_in_order, res):
+                assert row[0] == exp_ts, (
+                    f'AGGREGATION {agg} {label}: '
+                    f'bucket ts {row[0]} != {exp_ts}')
+                got = float(row[1])
+                exp_val = per_bucket[exp_ts]
+                assert abs(got - exp_val) < TOL, (
+                    f'AGGREGATION {agg} {label} bucket {exp_ts}: '
+                    f'expected {exp_val}, got {got}')
+
+        for agg, per_bucket in AGG_COMPOSITION_BUCKET_VALUES.items():
+            _check('TS.RANGE',    'TS.RANGE',    [20, 40], agg, per_bucket)
+            _check('TS.REVRANGE', 'TS.REVRANGE', [60, 40], agg, per_bucket)
+
+
+def test_ts_range_aggregator_empty_no_preceding_sample():
+    """
+    Edge case (EMPTY flag): when an EMPTY bucket has no PRECEDING non-NaN
+    sample, LAST and TWA must report NaN per docs ("NaN when no such
+    sample"). This complements test_ts_range_all_aggregators_empty_flag
+    above, where every EMPTY bucket DID have a preceding sample.
+
+    Setup: a NaN sample at t=100 (so the bucket [100, 200) is non-empty
+    from the storage layer's perspective and won't be skipped by
+    should_skip_empty_gap, but LAST/TWA see no valid prior sample),
+    followed by a valid sample at t=200.
+    """
+    with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
+        for agg in ('last', 'twa'):
+            key = f'agg_emp_no_prev_{agg.replace(".", "_")}{{a}}'
+            r.execute_command('TS.CREATE', key)
+            r.execute_command('TS.ADD', key, 100, 'nan')
+            r.execute_command('TS.ADD', key, 200, 50)
+
+            res = r.execute_command(
+                'TS.RANGE', key, 100, 199,
+                'AGGREGATION', agg, 100, 'EMPTY')
+            assert len(res) == 1, \
+                f'AGGREGATION {agg}: expected 1 bucket, got {res!r}'
+            got = float(res[0][1])
+            assert math.isnan(got), (
+                f'AGGREGATION {agg} EMPTY no-prior-sample: '
+                f'expected NaN, got {got}')

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -2681,16 +2681,25 @@ def test_ts_range_unknown_aggregator():
 #   sum, avg, min, max, first, last over {42}         → 42
 #   range = max - min over {42}                       → 0
 #   count (non-NaN), countAll over {42}               → 1
-#   countNaN over {42}                                → 0
+#   countNaN over {42}                                → bucket is "empty for
+#       countNaN" (zero NaN samples passed countNaN's isValueValid filter),
+#       so per the drop rule the bucket is OMITTED without EMPTY and emits
+#       0 with EMPTY. This is the symmetric twin of "count over an all-NaN
+#       bucket → bucket dropped without EMPTY" already pinned by
+#       test_ts_range_count_family_on_all_nan_bucket. countNaN therefore
+#       cannot live in the "always emits one bucket" dict below and is
+#       asserted separately at the end of the test function.
 #   std.p, var.p (population) over {42}:
 #       variance = E[(X-μ)²] with μ=42, X=42          → 0
 #       std      = sqrt(0)                            → 0
 #   std.s, var.s (sample) over {42}:
-#       formal definition is SS / (n-1) = 0 / 0       → NaN (undefined)
-#       (Some implementations special-case n=1 to 0 as a defensive
-#       choice. The docs do not specify; the math/spec answer is NaN.
-#       If this assertion fires, decide whether to update the docs to
-#       call out the n=1 → 0 convention or change the code.)
+#       Formal math: SS / (n-1) = 0 / 0 → NaN (undefined).
+#       Implementation choice (compaction.c VarSamplesFinalize):
+#       explicit `if (count == 1) *value = 0;`. The docs do not
+#       specify n=1, so the shipping behaviour is "n=1 → 0" and
+#       has been for years. We pin that here. If the implementation
+#       ever switches to NaN, update both this expectation and the
+#       public docs to call out the change.
 #   twa over {(50, 42)} in bucket [0, 100):
 #       docs say "time-weighted average over the bucket's timeframe".
 #       A single sample defines a constant function (→ 42) under one
@@ -2706,14 +2715,15 @@ AGG_SINGLE_SAMPLE_BUCKET_EXPECTED = {
     'max':      42.0,
     'range':    0.0,
     'count':    1.0,
-    'countNaN': 0.0,
+    # countNaN is intentionally absent — see comment above and the dedicated
+    # block at the end of test_ts_range_all_aggregators_single_sample_bucket.
     'countAll': 1.0,
     'first':    42.0,
     'last':     42.0,
     'std.p':    0.0,
     'var.p':    0.0,
-    'std.s':    float('nan'),                 # undefined (n=1, SS/(n-1)=0/0)
-    'var.s':    float('nan'),                 # undefined (n=1, SS/(n-1)=0/0)
+    'std.s':    0.0,                          # n=1 special-cased to 0 by impl
+    'var.s':    0.0,                          # n=1 special-cased to 0 by impl
 }
 
 
@@ -2721,27 +2731,27 @@ def test_ts_range_all_aggregators_single_sample_bucket():
     """
     Edge case (positive): bucket containing a single sample.
 
-    Expected values are derived purely from each aggregator's documented
-    semantics and from standard mathematical definitions — NOT from
-    inspecting the implementation. Specifically:
+    Expected values are derived from each aggregator's documented
+    semantics, standard mathematical definitions, and — where the docs
+    leave a corner case open — the shipping implementation's choice:
       - Population variance/std over {x} is 0 by definition.
-      - Sample variance/std over {x} requires division by (n-1) = 0 and
-        is mathematically undefined → NaN.
+      - Sample variance/std over {x} is mathematically undefined
+        (SS / (n-1) = 0 / 0), but compaction.c::VarSamplesFinalize
+        explicitly returns 0 for n=1. We pin that here; if the impl
+        ever switches to NaN, update this expectation and the public
+        docs together.
       - twa over a single sample is ambiguous per docs and is therefore
         only verified to return SOMETHING parseable (not pinned to a
         specific value).
-
-    If this test fails for std.s / var.s / twa, the right response is
-    either to (a) fix the implementation, or (b) extend the docs to
-    specify the n=1 / single-sample behaviour, and then update this test.
     """
     with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
         key = 'agg_single{a}'
         r.execute_command('TS.CREATE', key)
         r.execute_command('TS.ADD', key, 50, 42)
 
-        # Coverage guard.
-        covered = set(AGG_SINGLE_SAMPLE_BUCKET_EXPECTED) | {'twa'}
+        # Coverage guard. countNaN is asserted separately (drop-without-EMPTY
+        # behavior) and twa is asserted separately (docs don't pin n=1).
+        covered = set(AGG_SINGLE_SAMPLE_BUCKET_EXPECTED) | {'twa', 'countNaN'}
         missing = set(TS_RANGE_AGGREGATORS) - covered
         assert not missing, \
             f'AGG_SINGLE_SAMPLE_BUCKET_EXPECTED missing: {sorted(missing)}'
@@ -2776,6 +2786,24 @@ def test_ts_range_all_aggregators_single_sample_bucket():
                 f'AGGREGATION twa n=1 {cmd}: expected 1 bucket, got {res!r}'
             # Will raise if not parseable; NaN is fine.
             _agg_value_to_float(res[0][1])
+
+        # countNaN: zero NaN samples passed countNaN's isValueValid filter,
+        # so the bucket is "empty for countNaN" and is dropped without
+        # EMPTY (symmetric twin of count-on-all-NaN in
+        # test_ts_range_count_family_on_all_nan_bucket). With EMPTY, the
+        # bucket is emitted with value 0.
+        for cmd in ('TS.RANGE', 'TS.REVRANGE'):
+            res = r.execute_command(
+                cmd, key, 0, '+', 'AGGREGATION', 'countNaN', 100)
+            assert res == [], (
+                f'AGGREGATION countNaN n=1 {cmd} without EMPTY: '
+                f'expected [] (bucket dropped, mirror of count-on-all-NaN), '
+                f'got {res!r}')
+            res = r.execute_command(
+                cmd, key, 0, '+', 'AGGREGATION', 'countNaN', 100, 'EMPTY')
+            assert res == [[0, '0']], (
+                f'AGGREGATION countNaN n=1 {cmd} with EMPTY: '
+                f'expected [[0, "0"]], got {res!r}')
 
 
 def test_ts_range_count_family_on_all_nan_bucket():
@@ -2905,8 +2933,12 @@ def test_ts_range_aggregator_name_case_insensitivity():
 # Per-aggregator per-bucket values are computed from the surviving samples
 # of each bucket using the standard definitions cited in the TS.RANGE docs:
 #   sum=Σv, avg=Σv/n, min/max/first/last=obvious, range=max-min,
-#   count=count_all=2 (no NaN), countNaN=0,
+#   count=count_all=2 (no NaN),
 #   var_p=Σ(v-μ)²/n, var_s=Σ(v-μ)²/(n-1), std=√var.
+# countNaN is asserted separately below — zero NaN samples per bucket means
+# every bucket is "empty for countNaN" and dropped without EMPTY (same drop
+# rule that test_ts_range_count_family_on_all_nan_bucket pins for count on
+# the symmetric all-NaN case).
 # Each bucket here has values [x, x+10] with mean=x+5, so SS=50 in every
 # bucket → var.p=25, var.s=50, std.p=5, std.s=√50 across the board.
 AGG_COMPOSITION_BUCKET_VALUES = {
@@ -2916,7 +2948,8 @@ AGG_COMPOSITION_BUCKET_VALUES = {
     'max':      {20: 35.0, 40: 55.0,  60: 75.0},
     'range':    {20: 10.0, 40: 10.0,  60: 10.0},
     'count':    {20:  2.0, 40:  2.0,  60:  2.0},
-    'countNaN': {20:  0.0, 40:  0.0,  60:  0.0},
+    # countNaN is intentionally absent — see comment above; asserted
+    # separately at the end of the test function.
     'countAll': {20:  2.0, 40:  2.0,  60:  2.0},
     'first':    {20: 25.0, 40: 45.0,  60: 65.0},
     'last':     {20: 35.0, 40: 55.0,  60: 75.0},
@@ -2953,8 +2986,11 @@ def test_ts_range_aggregator_composition_align_filter_count():
         for t in range(5, 100, 10):              # 5, 15, 25, ..., 95
             r.execute_command('TS.ADD', key, t, t)
 
-        # Coverage guard.
-        covered = set(AGG_COMPOSITION_BUCKET_VALUES) | {'twa'}
+        # Coverage guard. countNaN is asserted separately (drop-without-EMPTY
+        # behavior — zero NaN samples per bucket); twa is documented as
+        # out-of-scope for this composition test (interpolation visibility
+        # past FILTER_BY_VALUE is unspecified).
+        covered = set(AGG_COMPOSITION_BUCKET_VALUES) | {'twa', 'countNaN'}
         missing = set(TS_RANGE_AGGREGATORS) - covered
         assert not missing, \
             f'AGG_COMPOSITION_BUCKET_VALUES missing: {sorted(missing)}'
@@ -2983,6 +3019,24 @@ def test_ts_range_aggregator_composition_align_filter_count():
         for agg, per_bucket in AGG_COMPOSITION_BUCKET_VALUES.items():
             _check('TS.RANGE',    'TS.RANGE',    [20, 40], agg, per_bucket)
             _check('TS.REVRANGE', 'TS.REVRANGE', [60, 40], agg, per_bucket)
+
+        # countNaN: every surviving bucket has only non-NaN samples → each
+        # bucket is "empty for countNaN" → dropped without EMPTY (symmetric
+        # twin of count-on-all-NaN pinned by
+        # test_ts_range_count_family_on_all_nan_bucket). Just lock in the
+        # drop here; the exact-value flavor is pinned by
+        # test_ts_range_all_aggregators_single_sample_bucket.
+        for label, command in (('TS.RANGE', 'TS.RANGE'),
+                               ('TS.REVRANGE', 'TS.REVRANGE')):
+            res = r.execute_command(
+                command, key, 0, '+',
+                'FILTER_BY_VALUE', 20, 80,
+                'COUNT', 2,
+                'ALIGN', 0, 'AGGREGATION', 'countNaN', 20)
+            assert res == [], (
+                f'AGGREGATION countNaN {label} without EMPTY: '
+                f'expected [] (every bucket has 0 NaN samples), '
+                f'got {res!r}')
 
 
 def test_ts_range_aggregator_empty_no_preceding_sample():

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -3067,3 +3067,69 @@ def test_ts_range_aggregator_empty_no_preceding_sample():
             assert math.isnan(got), (
                 f'AGGREGATION {agg} EMPTY no-prior-sample: '
                 f'expected NaN, got {got}')
+
+
+def test_revrange_empty_count_matches_range_tail():
+    """
+    TS.REVRANGE + EMPTY + COUNT N must return the LAST N emitted buckets in
+    reverse chronological order. The ground truth comes from TS.RANGE without
+    COUNT (untouched, well-established forward path): the expected REVRANGE+COUNT
+    result is the last N entries of that forward result, reversed.
+
+    Covered:
+      - N strictly less than total emitted buckets
+      - N == 1 (smallest meaningful slice)
+      - N exactly equal to total emitted bucket count
+      - N larger than total emitted bucket count (must return all, no padding)
+      - Sparse-leading data: empty buckets at the start of the window are
+        "outside data span" and dropped by the EMPTY rule; the count must apply
+        AFTER that drop so the response always reflects real, emitted buckets.
+      - Mid-series gap: empty buckets that ARE inside the data span are emitted
+        and must be eligible to appear in the COUNT-N tail.
+
+    Every assertion is derived from TS.RANGE on the same key/window, so the
+    test stays a true black-box check of the REVRANGE+EMPTY+COUNT semantics.
+    """
+    SCENARIOS = (
+        # (label, samples, window, bucket_duration)
+        ('dense',         [(t, t) for t in range(0, 100, 10)],   (0, 99),   10),
+        ('sparse-lead',   [(50, 50), (60, 60), (70, 70),
+                           (80, 80), (90, 90)],                  (0, 99),   10),
+        ('mid-gap',       [(0, 0),  (10, 10), (20, 20),
+                           (70, 70), (80, 80), (90, 90)],        (0, 99),   10),
+        ('single-sample', [(42, 42)],                            (0, 99),   10),
+    )
+    AGGS = ('last', 'first', 'max', 'min', 'count', 'sum', 'avg', 'range')
+
+    with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
+        for label, samples, (win_lo, win_hi), bd in SCENARIOS:
+            key = f'rev_empty_count_{label}{{a}}'
+            r.execute_command('DEL', key)
+            r.execute_command('TS.CREATE', key)
+            for t, v in samples:
+                r.execute_command('TS.ADD', key, t, v)
+
+            for agg in AGGS:
+                fwd_all = r.execute_command(
+                    'TS.RANGE', key, win_lo, win_hi,
+                    'AGGREGATION', agg, bd, 'EMPTY')
+                total = len(fwd_all)
+
+                # Sanity guard: the scenarios are designed so EMPTY emits at
+                # least one bucket. If this ever fires, the scenario is wrong,
+                # not the SUT.
+                assert total >= 1, (
+                    f'[{label}/{agg}] TS.RANGE EMPTY returned no buckets; '
+                    f'scenario invalid')
+
+                counts_to_try = sorted({1, max(1, total // 2), total, total + 5})
+                for n in counts_to_try:
+                    rev = r.execute_command(
+                        'TS.REVRANGE', key, win_lo, win_hi,
+                        'AGGREGATION', agg, bd, 'EMPTY',
+                        'COUNT', n)
+                    expected = list(reversed(fwd_all[-n:]))
+                    assert rev == expected, (
+                        f'[{label}/{agg}] REVRANGE EMPTY COUNT {n}: '
+                        f'expected {expected!r}, got {rev!r}; '
+                        f'(fwd_all={fwd_all!r})')


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Core query/aggregation path and RDB TWA context versioning affect all TS.RANGE/REVRANGE with AGGREGATION and EMPTY; large iterator refactor with behavior changes beyond a small patch.
> 
> **Overview**
> Fixes **MOD-8187**: aggregated `TS.RANGE` / `TS.REVRANGE` (especially with **`EMPTY`**) were wrong because aggregation ran in a **reverse** mode that did not match forward bucket math.
> 
> **Aggregation always runs forward now.** `reverse` is removed from `AggregationClass::createContext`, `AggregationIterator`, and TWA (`TwaContext` / RDB v10 drops the dead `reverse` byte; older RDBs still read and discard it). `filter_iterator.c` refactors empty-bucket handling: unified neighbor scans, prefix/suffix bounds, **LAST+EMPTY** LOCF seeding only for `LAST`, and edge gaps dropped via `should_skip_empty_gap` instead of mis-ordered reverse bucket walks. Gap fill failures **skip** the gap instead of aborting the whole query.
> 
> **REVRANGE + aggregation** no longer reverses the aggregator: `reply.c` runs a **forward** `SeriesQuery`, buffers buckets in a ring (`plan_reverse_agg_window` / `ReplyReverseAgg`), and emits newest-first—including **COUNT** retry when filters shrink the narrow window. Multi-series merge is chronological only; `SeriesQuery` still uses `reverse` for raw chunk scan where needed.
> 
> **Tests** in `test_ts_range.py` lock RANGE/REVRANGE symmetry, EMPTY behavior, REVRANGE+EMPTY+COUNT, and per-aggregator expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 220b57b81908c326142d608a319c8bc922bf7b25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->