### PR TITLE
MOD-12919: cherry-pick minimize ksn to 8.6

### DIFF
--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -6,8 +6,8 @@ description: A time series database for Redis
 homepage: https://oss.redis.com/redistimeseries/
 license: Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1) or the GNU Affero General Public License version 3 (AGPLv3)
 command_line_args: ""
-compatible_redis_version: "99.99"
-min_redis_version: "99.99"
+compatible_redis_version: "8.6"
+min_redis_version: "8.6"
 min_redis_pack_version: "7.2.0"
 capabilities:
     - types

--- a/src/common.c
+++ b/src/common.c
@@ -5,7 +5,7 @@
 int NotifyCallback(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) {
     if (strcasecmp(event, "del") ==
             0 || // unlink also notifies with del with freeseries called before
-        strcasecmp(event, "set") == 0 ||
+        strcasecmp(event, "type_changed") == 0 ||
         strcasecmp(event, "expired") == 0 || strcasecmp(event, "evict") == 0 ||
         strcasecmp(event, "evicted") == 0 || strcasecmp(event, "key_trimmed") == 0 ||
         strcasecmp(event, "trimmed") == 0 // only on enterprise

--- a/src/common.h
+++ b/src/common.h
@@ -79,7 +79,7 @@ static inline void lazyModuleInitialize(RedisModuleCtx *ctx) {
     if (!lazy_initialized) {
         RedisModule_SubscribeToKeyspaceEvents(
             ctx,
-            REDISMODULE_NOTIFY_GENERIC | REDISMODULE_NOTIFY_SET | REDISMODULE_NOTIFY_STRING |
+            REDISMODULE_NOTIFY_GENERIC | REDISMODULE_NOTIFY_TYPE_CHANGED |
                 REDISMODULE_NOTIFY_EVICTED | REDISMODULE_NOTIFY_EXPIRED |
                 REDISMODULE_NOTIFY_LOADED | REDISMODULE_NOTIFY_KEY_TRIMMED |
                 REDISMODULE_NOTIFY_TRIMMED, // Only during redis enterprise sharding

--- a/src/module.c
+++ b/src/module.c
@@ -1735,6 +1735,12 @@ __attribute__((weak)) int (*RedisModule_SetDataTypeExtensions)(
     RedisModuleType *mt,
     RedisModuleTypeExtMethods *typemethods) REDISMODULE_ATTR = NULL;
 
+__attribute__((weak)) int (*RedisModule_ClusterDisableTrim)(RedisModuleCtx *ctx)
+    REDISMODULE_ATTR = NULL;
+
+__attribute__((weak)) int (*RedisModule_ClusterEnableTrim)(RedisModuleCtx *ctx)
+    REDISMODULE_ATTR = NULL;
+
 int RedisModule_OnUnload(RedisModuleCtx *ctx) {
     if (rts_staticCtx) {
         FreeConfigAndStaticCtx();

--- a/src/module.c
+++ b/src/module.c
@@ -1735,12 +1735,6 @@ __attribute__((weak)) int (*RedisModule_SetDataTypeExtensions)(
     RedisModuleType *mt,
     RedisModuleTypeExtMethods *typemethods) REDISMODULE_ATTR = NULL;
 
-__attribute__((weak)) int (*RedisModule_ClusterDisableTrim)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR = NULL;
-
-__attribute__((weak)) int (*RedisModule_ClusterEnableTrim)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR = NULL;
-
 int RedisModule_OnUnload(RedisModuleCtx *ctx) {
     if (rts_staticCtx) {
         FreeConfigAndStaticCtx();


### PR DESCRIPTION
## Summary
- Cherry-picks PR #1865 (`MOD-12919 minimize ksn`) onto `8.6`.
- Switches keyspace notification handling from `set` to `type_changed` for indexed metric cleanup.
- Includes the same follow-up cleanup commit (`remove unneeded`) so the backport matches the merged fix.

## Test plan
- [ ] Build RedisTimeSeries on `8.6` branch.
- [ ] Run relevant keyspace notification tests (including delete/type change flows).
- [ ] Verify no regressions in indexing behavior for metric keys.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk backport that only adjusts keyspace notification subscription/events and the declared compatible Redis version; behavior changes are limited to when indexed-metric cleanup triggers on key updates/type changes.
> 
> **Overview**
> Declares RedisTimeSeries compatibility/minimum Redis version as `8.6` in `pack/ramp.yml` (replacing placeholder `99.99`).
> 
> Adjusts keyspace notification handling so indexed-metric cleanup (`RemoveIndexedMetric`) is triggered on `type_changed` events, and updates the subscription mask accordingly (removing `SET` notifications).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 983c99488b718c39cc3ad7f91c738d39c5d3434a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->