### PR TITLE
fix(pack): set min_redis_version back to 8.6

### DIFF
--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -6,8 +6,8 @@ description: A time series database for Redis
 homepage: https://oss.redis.com/redistimeseries/
 license: Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1) or the GNU Affero General Public License version 3 (AGPLv3)
 command_line_args: ""
-compatible_redis_version: "99.99"
-min_redis_version: "99.99"
+compatible_redis_version: "8.6"
+min_redis_version: "8.6"
 min_redis_pack_version: "7.2.0"
 capabilities:
     - types


### PR DESCRIPTION
## Summary

After \`v8.6.1\` shipped, [\`pack/ramp.yml\`](pack/ramp.yml) was bumped to \`compatible_redis_version: "99.99"\` / \`min_redis_version: "99.99"\` — the dev placeholder for the next development cycle. As a result any snapshot built from this branch declares itself incompatible with a released Redis Enterprise running Redis 8.6, and Enterprise rejects BDB creation with:

\`\`\`
HTTP 406
description: Unable to find module timeseries compatible with BDB redis version
\`\`\`

This was hit when trying to ship a Redis Enterprise build for Dan that includes the MOD-12919 cherry-pick (the cherry-pick branch inherited the same \`99.99\` from \`v8.6.2\`).

This PR sets both values back to \`"8.6"\` so 8.6-branch snapshots can be deployed on a Redis 8.6 Enterprise cluster.

## Test plan

- [ ] CI passes on this branch
- [ ] Confirm \`module.json\` inside the produced snapshot zip has \`"min_redis_version": "8.6"\` (\`unzip -p ... module.json | jq .min_redis_version\`)
- [ ] BDB creation succeeds on a Redis 8.6 Enterprise build that bundles the resulting snapshot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts pack metadata for `compatible_redis_version`/`min_redis_version`, with no code-path or runtime behavior changes beyond compatibility gating.
> 
> **Overview**
> Updates `pack/ramp.yml` to set `compatible_redis_version` and `min_redis_version` back to `"8.6"` (from the `"99.99"` dev placeholder), so snapshots built from this branch are accepted as compatible with Redis 8.6 Enterprise deployments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff0b5f6115f720bdb76a65b846591181c07cff94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->