### PR TITLE
MOD-15728 - Tal.ba/feat/blocking get

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -1233,6 +1233,30 @@
         "since": "1.0.0",
         "group": "timeseries"
     },
+    "TS.BGET": {
+        "summary": "Blocking GET: wait up to `timeout` milliseconds and retrieve up to `count` samples with timestamp >= `timestamp`. Returns the oldest qualifying samples in ascending timestamp order. When `timeout` is 0 the command does not block and returns whatever is available now (possibly empty or fewer than `count`).",
+        "complexity": "O(log(n)+k) where n is the number of samples in the series and k is the number of returned samples",
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key"
+            },
+            {
+                "name": "timestamp",
+                "type": "string"
+            },
+            {
+                "name": "count",
+                "type": "integer"
+            },
+            {
+                "name": "timeout",
+                "type": "integer"
+            }
+        ],
+        "since": "8.10.0",
+        "group": "timeseries"
+    },
     "TS.INFO": {
         "summary": "Returns information and statistics for a time series",
         "complexity": "O(1)",

--- a/commands.json
+++ b/commands.json
@@ -1159,6 +1159,37 @@
         "since": "1.0.0",
         "group": "timeseries"
     },
+    "TS.BGET": {
+        "summary": "Get up to count samples with timestamp greater than the cursor, optionally blocking until they arrive",
+        "complexity": "O(k) where k is the number of samples returned (up to count)",
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key"
+            },
+            {
+                "name": "timestamp",
+                "type": "string"
+            },
+            {
+                "name": "count",
+                "type": "integer"
+            },
+            {
+                "name": "timeout",
+                "type": "integer"
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "blocking"
+        ],
+        "acl_categories": [
+            "read"
+        ],
+        "since": "1.14.0",
+        "group": "timeseries"
+    },
     "TS.MGET": {
         "summary": "Get the sample with the highest timestamp from each time series matching a specific filter",
         "complexity": "O(n) where n is the number of time-series that match the filters",

--- a/commands.json
+++ b/commands.json
@@ -1187,7 +1187,7 @@
         "acl_categories": [
             "read"
         ],
-        "since": "1.14.0",
+        "since": "8.10.0",
         "group": "timeseries"
     },
     "TS.MGET": {

--- a/commands.json
+++ b/commands.json
@@ -1160,8 +1160,8 @@
         "group": "timeseries"
     },
     "TS.BGET": {
-        "summary": "Get up to count samples with timestamp greater than the cursor, optionally blocking until they arrive",
-        "complexity": "O(k) where k is the number of samples returned (up to count)",
+        "summary": "Blocking GET: wait up to `timeout` milliseconds and retrieve up to `count` samples with timestamp >= `timestamp`. Returns the oldest qualifying samples in ascending timestamp order. When `timeout` is 0 the command does not block and returns whatever is available now (possibly empty or fewer than `count`).",
+        "complexity": "O(log(n)+k) where n is the number of samples in the series and k is the number of returned samples",
         "arguments": [
             {
                 "name": "key",
@@ -1262,30 +1262,6 @@
             }
         ],
         "since": "1.0.0",
-        "group": "timeseries"
-    },
-    "TS.BGET": {
-        "summary": "Blocking GET: wait up to `timeout` milliseconds and retrieve up to `count` samples with timestamp >= `timestamp`. Returns the oldest qualifying samples in ascending timestamp order. When `timeout` is 0 the command does not block and returns whatever is available now (possibly empty or fewer than `count`).",
-        "complexity": "O(log(n)+k) where n is the number of samples in the series and k is the number of returned samples",
-        "arguments": [
-            {
-                "name": "key",
-                "type": "key"
-            },
-            {
-                "name": "timestamp",
-                "type": "string"
-            },
-            {
-                "name": "count",
-                "type": "integer"
-            },
-            {
-                "name": "timeout",
-                "type": "integer"
-            }
-        ],
-        "since": "8.10.0",
         "group": "timeseries"
     },
     "TS.INFO": {

--- a/src/module.c
+++ b/src/module.c
@@ -1422,10 +1422,11 @@ static size_t TSDB_count_samples_up_to(Series *series,
  * @brief Try to satisfy a TS.BGET request from current series state.
  *
  * Single source of truth for "what should we reply with right now?", shared
- * by the fast path, the wake-up callback, and the timeout callback. Never
- * starts writing samples until it knows they will all go out (the Module
- * API has no "abort reply"); the count pre-walk via
- * TSDB_count_samples_up_to() is what makes that safe.
+ * by the fast path, the wake-up callback, and the timeout callback. In
+ * strict mode we count qualifying samples first (TSDB_count_samples_up_to)
+ * and only start writing once we know the full batch is available — purely
+ * a performance optimization to avoid materializing a partial reply that
+ * the reply_cb would then discard by returning REDISMODULE_ERR.
  *
  * Modes:
  *   - strict (@p require_full_batch == true): only reply when @p args->count
@@ -1671,10 +1672,26 @@ int TSDB_bget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return REDISMODULE_OK;
     }
 
+    // Preemptive refusal in MULTI / EVAL / deny-blocking contexts, mirroring
+    // TSDB_mget. Only applies when the caller actually asked to block; a
+    // timeout_ms == 0 request already resolved synchronously above.
+    if (args.timeout_ms > 0) {
+        const int ctxFlags = RedisModule_GetContextFlags(ctx);
+        if (ctxFlags & (REDISMODULE_CTX_FLAGS_LUA | REDISMODULE_CTX_FLAGS_MULTI |
+                        REDISMODULE_CTX_FLAGS_DENY_BLOCKING)) {
+            RedisModule_ReplyWithError(
+                ctx,
+                "TSDB: blocking TS.BGET (timeout > 0) is not allowed "
+                "inside MULTI, EVAL, or a deny-blocking context");
+            return REDISMODULE_OK;
+        }
+    }
+
     if (!TSDB_bget_block(ctx, &args)) {
-        // BlockClientOnKeys refused to park us (MULTI / Lua / deny-blocking
-        // context). TSDB_bget_block already freed privdata; reply with an
-        // error so the client doesn't hang on an empty pipeline.
+        // Defensive fallback: BlockClientOnKeys refused to park us even
+        // though the preemptive context check passed (e.g. a Redis version
+        // surfacing a new deny-blocking flag). Reply with an error so the
+        // client doesn't hang on an empty pipeline.
         RedisModule_ReplyWithError(
             ctx,
             "TSDB: blocking TS.BGET (timeout > 0) is not allowed "

--- a/src/module.c
+++ b/src/module.c
@@ -727,6 +727,11 @@ static int internalAdd(RedisModuleCtx *ctx,
             handleCompaction(ctx, series, rule, timestamp, value);
         }
     }
+    // Wake any TS.BGET waiters parked on this key. Cheap no-op when no client
+    // is blocked; harmless extra try_reply when the upsert was an in-place
+    // update (the reply_cb will re-check and stay parked if nothing changed).
+    RedisModule_SignalKeyAsReady(ctx, series->keyName);
+
     if (should_reply) {
         RedisModule_ReplyWithLongLong(ctx, timestamp);
     }

--- a/src/module.c
+++ b/src/module.c
@@ -1512,6 +1512,25 @@ static bool TSDB_bget_try_reply(RedisModuleCtx *ctx,
 }
 
 /**
+ * @brief Close the blocked-time stopwatch opened by RTS_BlockClientOnKey.
+ *
+ * Must be called from a BlockClientOnKeys callback (reply / timeout) on the
+ * unblock path — i.e. right before returning REDISMODULE_OK. Accumulates the
+ * elapsed wait into bc->background_duration so slowlog / commandstats /
+ * latency-history account for blocked TS.BGET time instead of dropping it.
+ *
+ * Safe no-op when the Redis build doesn't expose the MeasureTime APIs.
+ *
+ * @param ctx Module context bound to the blocked client.
+ */
+static void TSDB_bget_account_blocked_time(RedisModuleCtx *ctx) {
+    if (CheckVersionForBlockedClientMeasureTime()) {
+        RedisModule_BlockedClientMeasureTimeEnd(
+            RedisModule_GetBlockedClientHandle(ctx));
+    }
+}
+
+/**
  * @brief BlockClientOnKeys reply callback: strict-mode wake-up handler.
  *
  * Re-invoked on every RedisModule_SignalKeyAsReady() on the watched key
@@ -1529,8 +1548,13 @@ static int TSDB_bget_reply_callback(RedisModuleCtx *ctx,
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
     const BGetCtx *priv = RedisModule_GetBlockedClientPrivateData(ctx);
-    return TSDB_bget_try_reply(ctx, priv, /*require_full_batch=*/true) ? REDISMODULE_OK
-                                                                  : REDISMODULE_ERR;
+    if (!TSDB_bget_try_reply(ctx, priv, /*require_full_batch=*/true)) {
+        // Stay parked: keep the background timer running so the eventual
+        // unblock (next signal or timeout) accounts for the full wait.
+        return REDISMODULE_ERR;
+    }
+    TSDB_bget_account_blocked_time(ctx);
+    return REDISMODULE_OK;
 }
 
 /**
@@ -1552,6 +1576,7 @@ static int TSDB_bget_timeout_callback(RedisModuleCtx *ctx,
     REDISMODULE_NOT_USED(argc);
     const BGetCtx *priv = RedisModule_GetBlockedClientPrivateData(ctx);
     (void)TSDB_bget_try_reply(ctx, priv, /*require_full_batch=*/false);
+    TSDB_bget_account_blocked_time(ctx);
     return REDISMODULE_OK;
 }
 
@@ -1616,7 +1641,9 @@ static RedisModuleBlockedClient *TSDB_bget_block(RedisModuleCtx *ctx, const BGet
  * (or the key is unusable / `timeout_ms == 0`), replies inline via
  * TSDB_bget_try_reply(); otherwise parks the client via TSDB_bget_block().
  *
- * @todo Refuse blocking in MULTI / Lua / replica contexts.
+ * Blocking refusal in MULTI / EVAL / deny-blocking contexts is handled
+ * reactively: BlockClientOnKeys returns NULL, TSDB_bget_block cleans up the
+ * privdata, and we deliver an explanatory error here.
  *
  * @param ctx   Module context.
  * @param argv  Command argument vector: `TS.BGET key timestamp count timeout`.
@@ -1650,8 +1677,8 @@ int TSDB_bget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         // error so the client doesn't hang on an empty pipeline.
         RedisModule_ReplyWithError(
             ctx,
-            "TSDB: blocking TS.BGET is not allowed  "
-            "or in a deny-blocking context");
+            "TSDB: blocking TS.BGET (timeout > 0) is not allowed "
+            "inside MULTI, EVAL, or a deny-blocking context");
     }
     return REDISMODULE_OK;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -1268,7 +1268,7 @@ int TSDB_get(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
  *
  *  Syntax:  TS.BGET key timestamp count timeout
  *
- *  Returns up to `count` samples with sample-ts strictly greater than the
+ *  Returns up to `count` samples with sample-ts greater than or equal to the
  *  resolved cursor, sorted ascending. Blocks up to `timeout` ms waiting for
  *  qualifying samples. `timestamp` may be a literal UNIX-ms value or one of
  *  the sentinels `-` (earliest) / `+` (latest at command-receive time; first
@@ -1278,8 +1278,10 @@ int TSDB_get(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
  *  chokepoint of the engine (covers TS.ADD / TS.MADD / TS.INCRBY / TS.DECRBY
  *  on append, plus compaction-rule writes to the destination key).
  *
- *  The functions below are scaffolding only — bodies are intentionally
- *  unimplemented (TODOs) and will be filled in iteratively.
+ *  Sentinel support (all resolved inside parse_bget_args):
+ *    `-` -> cursor=0 (no lower bound).
+ *    `+` -> cursor=series->lastTimestamp+1, snapshotted once at command
+ *           receipt; missing/empty -> 0; wrong-type key -> WRONGTYPE.
  * ============================================================================
  */
 
@@ -1292,22 +1294,32 @@ int TSDB_get(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
  */
 typedef struct BGetCtx {
     RedisModuleString *key; ///< series key to read from
-    api_timestamp_t cursor; ///< strict lower bound: only samples with ts > cursor qualify
+    api_timestamp_t cursor; ///< inclusive lower bound: only samples with ts >= cursor qualify
     size_t count;           ///< max samples to return in this batch
     long long timeout_ms;   ///< 0 = do not block; >0 = max time to wait
 } BGetCtx;
 
 /**
- * @brief Parse TS.BGET argv into @p out and validate it.
+ * @brief Parse TS.BGET argv into @p out, including sentinel resolution.
  *
  * On error, replies to the client with a descriptive error.
  * @p out->key is borrowed from @p argv (not retained).
  *
- * @param ctx   Redis module context (used to reply on error).
+ * Timestamp resolution rules (argv[2]):
+ *   - literal non-negative integer : @p out->cursor = the integer.
+ *   - '-'                          : @p out->cursor = 0 (no lower bound).
+ *   - '+'                          : open the series ONCE and snapshot
+ *                                    @p out->cursor = lastTimestamp + 1;
+ *                                    missing or empty series -> 0; wrong-type
+ *                                    key -> reply WRONGTYPE and return ERR.
+ *
+ * After OK, @p out->cursor is a plain literal for the rest of the lifecycle.
+ *
+ * @param ctx   Redis module context (used to reply on error / WRONGTYPE).
  * @param argv  Command argument vector.
  * @param argc  Number of arguments in @p argv (must be 5).
  * @param out   Output struct populated on success.
- * @return REDISMODULE_OK on success, REDISMODULE_ERR on parse/validation error.
+ * @return REDISMODULE_OK on success, REDISMODULE_ERR on any reply written.
  */
 static int parse_bget_args(RedisModuleCtx *ctx,
                            RedisModuleString **argv,
@@ -1332,24 +1344,46 @@ static int parse_bget_args(RedisModuleCtx *ctx,
         return REDISMODULE_ERR;
     }
 
-    // argv[2] — timestamp: literal non-negative integer. The '-' / '+' sentinels
-    // require resolution against the series' first/last sample timestamps and
-    // are intentionally not yet accepted here; they'll be wired up once we open
-    // the series in TSDB_bget.
+    // argv[2] — timestamp: literal non-negative integer, or a '-' / '+' sentinel.
+    // '-' is a static substitution: cursor=0 matches every sample under our
+    // inclusive ts >= cursor semantic.
+    // '+' must be resolved against the live series exactly once (here) so
+    // the cursor stays stable across wake-ups; if we re-resolved on every
+    // signal, lastTs would chase forward and we'd never reply.
     api_timestamp_t cursor = 0;
     size_t ts_len = 0;
     const char *ts_str = RedisModule_StringPtrLen(argv[2], &ts_len);
-    if (ts_len == 1 && (ts_str[0] == '-' || ts_str[0] == '+')) {
-        RedisModule_ReplyWithError(
-            ctx, "TSDB: '-' / '+' timestamp sentinels are not yet supported");
-        return REDISMODULE_ERR;
+    if (ts_len == 1 && ts_str[0] == '-') {
+        cursor = 0;
+    } else if (ts_len == 1 && ts_str[0] == '+') {
+        RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_READ);
+        const int kt = key ? RedisModule_KeyType(key) : REDISMODULE_KEYTYPE_EMPTY;
+
+        if (kt == REDISMODULE_KEYTYPE_EMPTY) {
+            // Missing key: spec says cursor = 0 when empty.
+            cursor = 0;
+        } else if (RedisModule_ModuleTypeGetType(key) != SeriesType) {
+            RedisModule_CloseKey(key);
+            RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+            return REDISMODULE_ERR;
+        } else {
+            Series *series = RedisModule_ModuleTypeGetValue(key);
+            cursor = (SeriesGetNumSamples(series) == 0)
+                         ? 0
+                         : (api_timestamp_t)(series->lastTimestamp + 1);
+        }
+        if (key) {
+            RedisModule_CloseKey(key);
+        }
+    } else {
+        long long ts_ll = 0;
+        if (RedisModule_StringToLongLong(argv[2], &ts_ll) != REDISMODULE_OK ||
+            ts_ll < 0) {
+            RedisModule_ReplyWithError(ctx, "TSDB: invalid timestamp");
+            return REDISMODULE_ERR;
+        }
+        cursor = (api_timestamp_t)ts_ll;
     }
-    long long ts_ll = 0;
-    if (RedisModule_StringToLongLong(argv[2], &ts_ll) != REDISMODULE_OK || ts_ll < 0) {
-        RedisModule_ReplyWithError(ctx, "TSDB: invalid timestamp");
-        return REDISMODULE_ERR;
-    }
-    cursor = (api_timestamp_t)ts_ll;
 
     out->key = argv[1];
     out->cursor = cursor;
@@ -1366,7 +1400,7 @@ static int parse_bget_args(RedisModuleCtx *ctx,
  * irreversible ReplyWith* call.
  *
  * @param series     Time series to scan.
- * @param range      Range query (typically `(cursor, +inf] LIMIT count`).
+ * @param range      Range query (typically `[cursor, +inf] LIMIT count`).
  * @param threshold  Early-exit threshold.
  * @return Number of qualifying samples, clamped to @p threshold.
  */
@@ -1404,7 +1438,7 @@ static size_t TSDB_count_samples_up_to(Series *series,
  * Case breakdown:
  *   1. Missing key      : strict -> false; flush -> empty array.
  *   2. Wrong-type key   : always WRONGTYPE error.
- *   3a. lastTs <= cursor: strict -> false; flush -> empty array.
+ *   3a. lastTs <  cursor: strict -> false; flush -> empty array.
  *   3b. Else            : strict -> false if qualifying < count, else reply;
  *                         flush  -> reply (1..count samples).
  *
@@ -1441,10 +1475,10 @@ static bool TSDB_bget_try_reply(RedisModuleCtx *ctx,
 
     Series *series = RedisModule_ModuleTypeGetValue(key);
 
-    // Case 3a: O(1) shortcut. If the latest sample isn't newer than the
-    // cursor, no qualifying sample can exist (and the cursor + 1 below is
-    // safe — overflow would require lastTimestamp > UINT64_MAX, unreachable).
-    if (series->lastTimestamp <= args->cursor) {
+    // Case 3a: O(1) shortcut. If the latest sample is older than the cursor,
+    // no qualifying sample can exist (ts >= cursor is impossible when
+    // lastTimestamp < cursor).
+    if (series->lastTimestamp < args->cursor) {
         RedisModule_CloseKey(key);
         if (require_full_batch) {
             return false;
@@ -1453,10 +1487,10 @@ static bool TSDB_bget_try_reply(RedisModuleCtx *ctx,
         return true;
     }
 
-    // Case 3b: at least one sample exists. Build the range query equivalent
-    // to TS.RANGE (cursor, +inf] LIMIT count.
+    // Case 3b: at least one sample may qualify. Build the range query
+    // equivalent to TS.RANGE [cursor, +inf] LIMIT count.
     const RangeArgs range = {
-        .startTimestamp = args->cursor + 1,
+        .startTimestamp = args->cursor,
         .endTimestamp = LLONG_MAX,
         .latest = false,
         .count = (long long)args->count,
@@ -1578,26 +1612,27 @@ static RedisModuleBlockedClient *TSDB_bget_block(RedisModuleCtx *ctx, const BGet
 /**
  * @brief TS.BGET command entry point.
  *
- * Parses argv into a BGetCtx. If samples newer than the cursor already exist
+ * Parses argv into a BGetCtx. If samples at-or-after the cursor already exist
  * (or the key is unusable / `timeout_ms == 0`), replies inline via
  * TSDB_bget_try_reply(); otherwise parks the client via TSDB_bget_block().
  *
- * @todo Sentinel resolution ('-' / '+').
  * @todo Refuse blocking in MULTI / Lua / replica contexts.
  *
  * @param ctx   Module context.
  * @param argv  Command argument vector: `TS.BGET key timestamp count timeout`.
  * @param argc  Argument count (expected 5).
- * @return Always REDISMODULE_OK on the public success contract (errors are
- *         delivered via RedisModule_ReplyWithError); REDISMODULE_ERR only on
- *         parse failure where no reply has been written.
+ * @return Always REDISMODULE_OK — errors (parse, WRONGTYPE, blocking refused)
+ *         are delivered through RedisModule_ReplyWithError so the client
+ *         always sees a terminal reply.
  */
 int TSDB_bget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_AutoMemory(ctx);
 
     BGetCtx args = { 0 };
     if (parse_bget_args(ctx, argv, argc, &args) != REDISMODULE_OK) {
-        return REDISMODULE_ERR;
+        // parse_bget_args already wrote a reply (validation error, WRONGTYPE
+        // during '+' resolution, etc.).
+        return REDISMODULE_OK;
     }
 
     // timeout_ms == 0 means "do not block" — flush whatever is available now

--- a/src/module.c
+++ b/src/module.c
@@ -1667,24 +1667,21 @@ int TSDB_bget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     // (possibly empty / partial). timeout_ms  > 0 uses strict mode; if we
     // don't have args.count yet, fall through and park the client until a
     // SignalKeyAsReady wakes us with enough data, or the timeout fires.
-    const bool require_full_batch = args.timeout_ms > 0;
-    if (TSDB_bget_try_reply(ctx, &args, require_full_batch)) {
+    if (TSDB_bget_try_reply(ctx, &args, args.timeout_ms > 0)) {
         return REDISMODULE_OK;
     }
 
     // Preemptive refusal in MULTI / EVAL / deny-blocking contexts, mirroring
-    // TSDB_mget. Only applies when the caller actually asked to block; a
-    // timeout_ms == 0 request already resolved synchronously above.
-    if (args.timeout_ms > 0) {
-        const int ctxFlags = RedisModule_GetContextFlags(ctx);
-        if (ctxFlags & (REDISMODULE_CTX_FLAGS_LUA | REDISMODULE_CTX_FLAGS_MULTI |
-                        REDISMODULE_CTX_FLAGS_DENY_BLOCKING)) {
-            RedisModule_ReplyWithError(
-                ctx,
-                "TSDB: blocking TS.BGET (timeout > 0) is not allowed "
-                "inside MULTI, EVAL, or a deny-blocking context");
-            return REDISMODULE_OK;
-        }
+    // TSDB_mget. A timeout_ms == 0 request already resolved synchronously
+    // above, so reaching here implies the caller asked to block.
+    if (RedisModule_GetContextFlags(ctx) &
+        (REDISMODULE_CTX_FLAGS_LUA | REDISMODULE_CTX_FLAGS_MULTI |
+         REDISMODULE_CTX_FLAGS_DENY_BLOCKING)) {
+        RedisModule_ReplyWithError(
+            ctx,
+            "TSDB: blocking TS.BGET (timeout > 0) is not allowed "
+            "inside MULTI, EVAL, or a deny-blocking context");
+        return REDISMODULE_OK;
     }
 
     if (!TSDB_bget_block(ctx, &args)) {

--- a/src/module.c
+++ b/src/module.c
@@ -1292,7 +1292,8 @@ int TSDB_get(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
  * `key` is borrowed at parse time; TSDB_bget_block() retains it and
  * TSDB_bget_free_privdata() releases it.
  */
-typedef struct BGetCtx {
+typedef struct BGetCtx
+{
     RedisModuleString *key; ///< series key to read from
     api_timestamp_t cursor; ///< inclusive lower bound: only samples with ts >= cursor qualify
     size_t count;           ///< max samples to return in this batch
@@ -1321,10 +1322,7 @@ typedef struct BGetCtx {
  * @param out   Output struct populated on success.
  * @return REDISMODULE_OK on success, REDISMODULE_ERR on any reply written.
  */
-static int parse_bget_args(RedisModuleCtx *ctx,
-                           RedisModuleString **argv,
-                           int argc,
-                           BGetCtx *out) {
+static int parse_bget_args(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, BGetCtx *out) {
     if (argc != 5) {
         RedisModule_WrongArity(ctx);
         return REDISMODULE_ERR;
@@ -1377,8 +1375,7 @@ static int parse_bget_args(RedisModuleCtx *ctx,
         }
     } else {
         long long ts_ll = 0;
-        if (RedisModule_StringToLongLong(argv[2], &ts_ll) != REDISMODULE_OK ||
-            ts_ll < 0) {
+        if (RedisModule_StringToLongLong(argv[2], &ts_ll) != REDISMODULE_OK || ts_ll < 0) {
             RedisModule_ReplyWithError(ctx, "TSDB: invalid timestamp");
             return REDISMODULE_ERR;
         }
@@ -1404,9 +1401,7 @@ static int parse_bget_args(RedisModuleCtx *ctx,
  * @param threshold  Early-exit threshold.
  * @return Number of qualifying samples, clamped to @p threshold.
  */
-static size_t TSDB_count_samples_up_to(Series *series,
-                                       const RangeArgs *range,
-                                       size_t threshold) {
+static size_t TSDB_count_samples_up_to(Series *series, const RangeArgs *range, size_t threshold) {
     AbstractIterator *iter =
         SeriesQuery(series, range, /*reverse=*/false, /*check_retention=*/true);
     EnrichedChunk *chunk;
@@ -1449,9 +1444,7 @@ static size_t TSDB_count_samples_up_to(Series *series,
  * @return true if a reply was written, false only in strict mode when caller
  *         should block / stay parked.
  */
-static bool TSDB_bget_try_reply(RedisModuleCtx *ctx,
-                                const BGetCtx *args,
-                                bool require_full_batch) {
+static bool TSDB_bget_try_reply(RedisModuleCtx *ctx, const BGetCtx *args, bool require_full_batch) {
     RedisModuleKey *key = RedisModule_OpenKey(ctx, args->key, REDISMODULE_READ);
     const int keyType = key ? RedisModule_KeyType(key) : REDISMODULE_KEYTYPE_EMPTY;
 
@@ -1499,8 +1492,7 @@ static bool TSDB_bget_try_reply(RedisModuleCtx *ctx,
 
     // Strict mode: refuse to commit a reply until we know it will be
     // complete. The pre-count walk reads only chunk metadata.
-    if (require_full_batch &&
-        TSDB_count_samples_up_to(series, &range, args->count) < args->count) {
+    if (require_full_batch && TSDB_count_samples_up_to(series, &range, args->count) < args->count) {
         RedisModule_CloseKey(key);
         return false;
     }
@@ -1526,8 +1518,7 @@ static bool TSDB_bget_try_reply(RedisModuleCtx *ctx,
  */
 static void TSDB_bget_account_blocked_time(RedisModuleCtx *ctx) {
     if (CheckVersionForBlockedClientMeasureTime()) {
-        RedisModule_BlockedClientMeasureTimeEnd(
-            RedisModule_GetBlockedClientHandle(ctx));
+        RedisModule_BlockedClientMeasureTimeEnd(RedisModule_GetBlockedClientHandle(ctx));
     }
 }
 
@@ -1543,9 +1534,7 @@ static void TSDB_bget_account_blocked_time(RedisModuleCtx *ctx) {
  * @return REDISMODULE_OK to unblock and commit the reply, REDISMODULE_ERR to
  *         stay parked until the next signal or the timeout.
  */
-static int TSDB_bget_reply_callback(RedisModuleCtx *ctx,
-                                    RedisModuleString **argv,
-                                    int argc) {
+static int TSDB_bget_reply_callback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
     const BGetCtx *priv = RedisModule_GetBlockedClientPrivateData(ctx);
@@ -1570,9 +1559,7 @@ static int TSDB_bget_reply_callback(RedisModuleCtx *ctx,
  * @param argc  Unused.
  * @return Always REDISMODULE_OK (the client is unblocked unconditionally).
  */
-static int TSDB_bget_timeout_callback(RedisModuleCtx *ctx,
-                                      RedisModuleString **argv,
-                                      int argc) {
+static int TSDB_bget_timeout_callback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
     const BGetCtx *priv = RedisModule_GetBlockedClientPrivateData(ctx);
@@ -1677,10 +1664,9 @@ int TSDB_bget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (RedisModule_GetContextFlags(ctx) &
         (REDISMODULE_CTX_FLAGS_LUA | REDISMODULE_CTX_FLAGS_MULTI |
          REDISMODULE_CTX_FLAGS_DENY_BLOCKING)) {
-        RedisModule_ReplyWithError(
-            ctx,
-            "TSDB: blocking TS.BGET (timeout > 0) is not allowed "
-            "inside MULTI, EVAL, or a deny-blocking context");
+        RedisModule_ReplyWithError(ctx,
+                                   "TSDB: blocking TS.BGET (timeout > 0) is not allowed "
+                                   "inside MULTI, EVAL, or a deny-blocking context");
         return REDISMODULE_OK;
     }
 
@@ -1689,10 +1675,9 @@ int TSDB_bget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         // though the preemptive context check passed (e.g. a Redis version
         // surfacing a new deny-blocking flag). Reply with an error so the
         // client doesn't hang on an empty pipeline.
-        RedisModule_ReplyWithError(
-            ctx,
-            "TSDB: blocking TS.BGET (timeout > 0) is not allowed "
-            "inside MULTI, EVAL, or a deny-blocking context");
+        RedisModule_ReplyWithError(ctx,
+                                   "TSDB: blocking TS.BGET (timeout > 0) is not allowed "
+                                   "inside MULTI, EVAL, or a deny-blocking context");
     }
     return REDISMODULE_OK;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -1372,9 +1372,10 @@ static int parse_bget_args(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
             // (which would silently flip the cursor's meaning from "future
             // only" to "every sample"). No timestamp can exceed UINT64_MAX,
             // so cursor=UINT64_MAX is the correct unreachable upper bound.
-            cursor = (SeriesGetNumSamples(series) == 0)        ? 0
-                     : (series->lastTimestamp == UINT64_MAX)   ? UINT64_MAX
-                                                               : (api_timestamp_t)(series->lastTimestamp + 1);
+            cursor = (SeriesGetNumSamples(series) == 0) ? 0
+                     : (series->lastTimestamp == UINT64_MAX)
+                         ? UINT64_MAX
+                         : (api_timestamp_t)(series->lastTimestamp + 1);
         }
         if (key) {
             RedisModule_CloseKey(key);

--- a/src/module.c
+++ b/src/module.c
@@ -1311,6 +1311,8 @@ typedef struct BGetCtx
  *   - '-'                          : @p out->cursor = 0 (no lower bound).
  *   - '+'                          : open the series ONCE and snapshot
  *                                    @p out->cursor = lastTimestamp + 1;
+ *                                    saturated (lastTimestamp == UINT64_MAX)
+ *                                    -> UINT64_MAX to avoid wrap-to-0;
  *                                    missing or empty series -> 0; wrong-type
  *                                    key -> reply WRONGTYPE and return ERR.
  *
@@ -1366,9 +1368,13 @@ static int parse_bget_args(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
             return REDISMODULE_ERR;
         } else {
             Series *series = RedisModule_ModuleTypeGetValue(key);
-            cursor = (SeriesGetNumSamples(series) == 0)
-                         ? 0
-                         : (api_timestamp_t)(series->lastTimestamp + 1);
+            // Saturate at UINT64_MAX so `lastTimestamp + 1` cannot wrap to 0
+            // (which would silently flip the cursor's meaning from "future
+            // only" to "every sample"). No timestamp can exceed UINT64_MAX,
+            // so cursor=UINT64_MAX is the correct unreachable upper bound.
+            cursor = (SeriesGetNumSamples(series) == 0)        ? 0
+                     : (series->lastTimestamp == UINT64_MAX)   ? UINT64_MAX
+                                                               : (api_timestamp_t)(series->lastTimestamp + 1);
         }
         if (key) {
             RedisModule_CloseKey(key);

--- a/src/module.c
+++ b/src/module.c
@@ -32,6 +32,7 @@
 #include "rmutil/strings.h"
 #include "rmutil/util.h"
 #include "cmd_info/command_info.h"
+#include "utils/blocked_client.h"
 
 #include <ctype.h>
 #include <inttypes.h>
@@ -1257,6 +1258,296 @@ int TSDB_get(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return REDISMODULE_OK;
 }
 
+/* ============================================================================
+ *  TS.BGET — Blocking GET (cursor-style tailing of a series)
+ *
+ *  Syntax:  TS.BGET key timestamp count timeout
+ *
+ *  Returns up to `count` samples with sample-ts strictly greater than the
+ *  resolved cursor, sorted ascending. Blocks up to `timeout` ms waiting for
+ *  qualifying samples. `timestamp` may be a literal UNIX-ms value or one of
+ *  the sentinels `-` (earliest) / `+` (latest at command-receive time; first
+ *  call only).
+ *
+ *  Wake-up is driven by RedisModule_SignalKeyAsReady() in the sample-append
+ *  chokepoint of the engine (covers TS.ADD / TS.MADD / TS.INCRBY / TS.DECRBY
+ *  on append, plus compaction-rule writes to the destination key).
+ *
+ *  The functions below are scaffolding only — bodies are intentionally
+ *  unimplemented (TODOs) and will be filled in iteratively.
+ * ============================================================================
+ */
+
+// Parsed TS.BGET arguments. Populated once in TSDB_bget by parse_bget_args()
+// and then carried as blocked-client privdata so the callbacks never re-parse
+// argv. `key` is a borrowed pointer at parse time; TSDB_bget_block() retains
+// it before handing the struct to Redis, and TSDB_bget_free_privdata releases
+// it once the client is unblocked. `timeout_ms` is only consumed during block
+// setup; storing it here keeps "everything parsed" in a single record.
+typedef struct BGetCtx {
+    RedisModuleString *key; // series key to read from
+    api_timestamp_t cursor; // strict lower bound: only samples with ts > cursor qualify
+    size_t count;           // max samples to return in this batch
+    long long timeout_ms;   // 0 = do not block; >0 = max time to wait
+} BGetCtx;
+
+// Parse TS.BGET argv into `out`. On error, replies to the client with a
+// descriptive error and returns REDISMODULE_ERR; on success returns
+// REDISMODULE_OK with all fields of `out` populated. `out->key` is borrowed
+// from argv (not retained) — the caller is responsible for retaining it if
+// the struct outlives the command call.
+static int parse_bget_args(RedisModuleCtx *ctx,
+                           RedisModuleString **argv,
+                           int argc,
+                           BGetCtx *out) {
+    if (argc != 5) {
+        RedisModule_WrongArity(ctx);
+        return REDISMODULE_ERR;
+    }
+
+    // argv[3] — count: positive integer.
+    long long count_ll = 0;
+    if (RedisModule_StringToLongLong(argv[3], &count_ll) != REDISMODULE_OK || count_ll <= 0) {
+        RedisModule_ReplyWithError(ctx, "TSDB: count must be a positive integer");
+        return REDISMODULE_ERR;
+    }
+
+    // argv[4] — timeout_ms: non-negative integer. 0 means "do not block".
+    long long timeout_ms = 0;
+    if (RedisModule_StringToLongLong(argv[4], &timeout_ms) != REDISMODULE_OK || timeout_ms < 0) {
+        RedisModule_ReplyWithError(ctx, "TSDB: timeout must be a non-negative integer");
+        return REDISMODULE_ERR;
+    }
+
+    // argv[2] — timestamp: literal non-negative integer. The '-' / '+' sentinels
+    // require resolution against the series' first/last sample timestamps and
+    // are intentionally not yet accepted here; they'll be wired up once we open
+    // the series in TSDB_bget.
+    api_timestamp_t cursor = 0;
+    size_t ts_len = 0;
+    const char *ts_str = RedisModule_StringPtrLen(argv[2], &ts_len);
+    if (ts_len == 1 && (ts_str[0] == '-' || ts_str[0] == '+')) {
+        RedisModule_ReplyWithError(
+            ctx, "TSDB: '-' / '+' timestamp sentinels are not yet supported");
+        return REDISMODULE_ERR;
+    }
+    long long ts_ll = 0;
+    if (RedisModule_StringToLongLong(argv[2], &ts_ll) != REDISMODULE_OK || ts_ll < 0) {
+        RedisModule_ReplyWithError(ctx, "TSDB: invalid timestamp");
+        return REDISMODULE_ERR;
+    }
+    cursor = (api_timestamp_t)ts_ll;
+
+    out->key = argv[1];
+    out->cursor = cursor;
+    out->count = (size_t)count_ll;
+    out->timeout_ms = timeout_ms;
+    return REDISMODULE_OK;
+}
+
+// Walk the (cursor, +inf] range and count qualifying samples, stopping the
+// moment `threshold` is reached. Cost is bounded by `threshold` chunks of
+// metadata reads (not by series size). No per-sample work and no reply
+// writes — used purely to gate the strict "do we have >= count?" check
+// before any RedisModule_ReplyWith* call (which can't be undone).
+static size_t TSDB_count_samples_up_to(Series *series,
+                                       const RangeArgs *range,
+                                       size_t threshold) {
+    AbstractIterator *iter =
+        SeriesQuery(series, range, /*reverse=*/false, /*check_retention=*/true);
+    EnrichedChunk *chunk;
+    size_t total = 0;
+    while (total < threshold && (chunk = iter->GetNext(iter))) {
+        total += chunk->samples.num_samples;
+    }
+    iter->Close(iter);
+    return total;
+}
+
+// Try to satisfy a TS.BGET request from the current state of `args->key`.
+// Shared by the fast path in TSDB_bget, the wake-up callback, AND the
+// timeout callback so the "what should we reply with right now?" decision
+// lives in exactly one place.
+//
+// `require_full_batch` toggles between two modes:
+//
+//   true  — strict mode (fast path + on-signal wake-up). We will only write
+//           a reply when `args->count` samples are already available; if
+//           fewer exist, return false so the caller can block / stay parked.
+//           This honors the spec rule "return only when timeout OR count is
+//           reached, whichever first" — strict mode never partially flushes.
+//
+//   false — flush mode (timeout deadline + no-block fast path with
+//           `timeout_ms == 0`). Always writes a terminal reply, possibly an
+//           empty array (no samples available), the WRONGTYPE error, or up
+//           to `args->count` samples. Never returns false in this mode.
+//
+// We never start writing samples until we know they'll all go out — the
+// Module API has no "abort reply" once `ReplyWith*` is called. The count
+// pre-walk is what makes that safe.
+//
+// Case breakdown:
+//   1. Key is missing (does not exist yet).
+//        strict:  return false (caller should block — producer may create it).
+//        flush:   reply with an empty array.
+//   2. Key exists but holds the wrong type (not a TimeSeries).
+//        always:  reply WRONGTYPE error (waiting can't fix this).
+//   3. Key is a healthy TimeSeries.
+//      3a. series->lastTimestamp <= cursor: no qualifying sample exists.
+//          strict:  return false.
+//          flush:   reply with an empty array.
+//      3b. Otherwise:
+//          strict:  count (cursor, +inf]; if < count, return false; else
+//                   reply via ReplySeriesRange.
+//          flush:   reply via ReplySeriesRange (1..count samples).
+static bool TSDB_bget_try_reply(RedisModuleCtx *ctx,
+                                const BGetCtx *args,
+                                bool require_full_batch) {
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, args->key, REDISMODULE_READ);
+    const int keyType = key ? RedisModule_KeyType(key) : REDISMODULE_KEYTYPE_EMPTY;
+
+    // Case 1: missing key.
+    if (keyType == REDISMODULE_KEYTYPE_EMPTY) {
+        if (key) {
+            RedisModule_CloseKey(key);
+        }
+        if (require_full_batch) {
+            return false;
+        }
+        RedisModule_ReplyWithArray(ctx, 0);
+        return true;
+    }
+
+    // Case 2: wrong type — always fail-fast.
+    if (RedisModule_ModuleTypeGetType(key) != SeriesType) {
+        RedisModule_CloseKey(key);
+        RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+        return true;
+    }
+
+    Series *series = RedisModule_ModuleTypeGetValue(key);
+
+    // Case 3a: O(1) shortcut. If the latest sample isn't newer than the
+    // cursor, no qualifying sample can exist (and the cursor + 1 below is
+    // safe — overflow would require lastTimestamp > UINT64_MAX, unreachable).
+    if (series->lastTimestamp <= args->cursor) {
+        RedisModule_CloseKey(key);
+        if (require_full_batch) {
+            return false;
+        }
+        RedisModule_ReplyWithArray(ctx, 0);
+        return true;
+    }
+
+    // Case 3b: at least one sample exists. Build the range query equivalent
+    // to TS.RANGE (cursor, +inf] LIMIT count.
+    const RangeArgs range = {
+        .startTimestamp = args->cursor + 1,
+        .endTimestamp = LLONG_MAX,
+        .latest = false,
+        .count = (long long)args->count,
+    };
+
+    // Strict mode: refuse to commit a reply until we know it will be
+    // complete. The pre-count walk reads only chunk metadata.
+    if (require_full_batch &&
+        TSDB_count_samples_up_to(series, &range, args->count) < args->count) {
+        RedisModule_CloseKey(key);
+        return false;
+    }
+
+    // Either we have >= count (strict) or partial flushing is allowed.
+    // Either way, deliver up to args->count samples in ascending order.
+    ReplySeriesRange(ctx, series, &range, /*reverse=*/false);
+    RedisModule_CloseKey(key);
+    return true;
+}
+
+// Re-invoked on every SignalKeyAsReady() on the watched key (and once at
+// block setup). Strict mode: only unblock when args->count samples are
+// available. Returns REDISMODULE_OK to unblock, REDISMODULE_ERR to stay
+// parked until the next signal or the timeout.
+static int TSDB_bget_reply_callback(RedisModuleCtx *ctx,
+                                    RedisModuleString **argv,
+                                    int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+    const BGetCtx *priv = RedisModule_GetBlockedClientPrivateData(ctx);
+    return TSDB_bget_try_reply(ctx, priv, /*require_full_batch=*/true) ? REDISMODULE_OK
+                                                                  : REDISMODULE_ERR;
+}
+
+// Invoked when `timeout_ms` elapses without the client being unblocked.
+// Flush mode: deadline reached, deliver whatever's available (possibly
+// empty or fewer than count, per the spec).
+static int TSDB_bget_timeout_callback(RedisModuleCtx *ctx,
+                                      RedisModuleString **argv,
+                                      int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+    const BGetCtx *priv = RedisModule_GetBlockedClientPrivateData(ctx);
+    (void)TSDB_bget_try_reply(ctx, priv, /*require_full_batch=*/false);
+    return REDISMODULE_OK;
+}
+
+// Frees the BGetCtx attached to the blocked client. Called by Redis after
+// the client is unblocked (whether via reply, timeout, disconnect, or abort).
+static void TSDB_bget_free_privdata(RedisModuleCtx *ctx, void *privdata) {
+    if (!privdata) {
+        return;
+    }
+    BGetCtx *priv = privdata;
+    if (priv->key) {
+        RedisModule_FreeString(ctx, priv->key);
+    }
+    free(priv);
+}
+
+// Allocate the privdata (heap copy of `args`) and park the client on its key.
+// Redis owns the blocked-client lifecycle through the registered callbacks;
+// the key is retained for the privdata's lifetime and released by
+// TSDB_bget_free_privdata.
+static RedisModuleBlockedClient *TSDB_bget_block(RedisModuleCtx *ctx, const BGetCtx *args) {
+    BGetCtx *priv = malloc(sizeof(*priv));
+    *priv = *args;
+    RedisModule_RetainString(ctx, priv->key);
+
+    return RTS_BlockClientOnKey(ctx,
+                                TSDB_bget_reply_callback,
+                                TSDB_bget_timeout_callback,
+                                TSDB_bget_free_privdata,
+                                priv->timeout_ms,
+                                priv->key,
+                                priv);
+}
+
+// Main command entry point. Parses argv into a BGetCtx; if samples newer
+// than the cursor already exist (or the key is unusable), replies inline via
+// the shared TSDB_bget_try_reply helper. Otherwise parks the client via
+// TSDB_bget_block (or replies empty when timeout_ms == 0).
+//
+// TODO: sentinel resolution ('-' / '+'), MULTI/Lua/replica refusal.
+int TSDB_bget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+
+    BGetCtx args = { 0 };
+    if (parse_bget_args(ctx, argv, argc, &args) != REDISMODULE_OK) {
+        return REDISMODULE_ERR;
+    }
+
+    // timeout_ms == 0 means "do not block" — flush whatever is available now
+    // (possibly empty / partial). timeout_ms  > 0 uses strict mode; if we
+    // don't have args.count yet, fall through and park the client until a
+    // SignalKeyAsReady wakes us with enough data, or the timeout fires.
+    const bool require_full_batch = args.timeout_ms > 0;
+    if (TSDB_bget_try_reply(ctx, &args, require_full_batch)) {
+        return REDISMODULE_OK;
+    }
+
+    TSDB_bget_block(ctx, &args);
+    return REDISMODULE_OK;
+}
+
 int TSDB_mget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_AutoMemory(ctx);
     if (IsMRCluster()) {
@@ -1884,6 +2175,8 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
     RegisterCommandWithModesAndAcls(ctx, "ts.info", TSDB_info, "readonly", "read fast");
     RegisterCommandWithModesAndAcls(ctx, "ts.get", TSDB_get, "readonly", "read fast");
+    // TS.BGET may block on the key; intentionally NOT flagged "fast".
+    RegisterCommandWithModesAndAcls(ctx, "ts.bget", TSDB_bget, "readonly", "read");
     RegisterCommandWithModesAndAcls(ctx, "ts.del", TSDB_delete, "write", "write");
 
     if (RedisModule_CreateCommand(ctx, "ts.madd", TSDB_madd, "write deny-oom", 1, -1, 3) ==

--- a/src/module.c
+++ b/src/module.c
@@ -1512,18 +1512,26 @@ static void TSDB_bget_free_privdata(RedisModuleCtx *ctx, void *privdata) {
 // Redis owns the blocked-client lifecycle through the registered callbacks;
 // the key is retained for the privdata's lifetime and released by
 // TSDB_bget_free_privdata.
+//
+// Returns NULL if Redis refuses to block (e.g. MULTI / Lua / deny-blocking
+// context). In that case the free callback is never installed, so we free
+// `priv` (and the retained `priv->key`) here — otherwise they would leak.
 static RedisModuleBlockedClient *TSDB_bget_block(RedisModuleCtx *ctx, const BGetCtx *args) {
     BGetCtx *priv = malloc(sizeof(*priv));
     *priv = *args;
     RedisModule_RetainString(ctx, priv->key);
 
-    return RTS_BlockClientOnKey(ctx,
-                                TSDB_bget_reply_callback,
-                                TSDB_bget_timeout_callback,
-                                TSDB_bget_free_privdata,
-                                priv->timeout_ms,
-                                priv->key,
-                                priv);
+    RedisModuleBlockedClient *bc = RTS_BlockClientOnKey(ctx,
+                                                        TSDB_bget_reply_callback,
+                                                        TSDB_bget_timeout_callback,
+                                                        TSDB_bget_free_privdata,
+                                                        priv->timeout_ms,
+                                                        priv->key,
+                                                        priv);
+    if (!bc) {
+        TSDB_bget_free_privdata(ctx, priv);
+    }
+    return bc;
 }
 
 // Main command entry point. Parses argv into a BGetCtx; if samples newer

--- a/src/module.c
+++ b/src/module.c
@@ -1283,24 +1283,32 @@ int TSDB_get(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
  * ============================================================================
  */
 
-// Parsed TS.BGET arguments. Populated once in TSDB_bget by parse_bget_args()
-// and then carried as blocked-client privdata so the callbacks never re-parse
-// argv. `key` is a borrowed pointer at parse time; TSDB_bget_block() retains
-// it before handing the struct to Redis, and TSDB_bget_free_privdata releases
-// it once the client is unblocked. `timeout_ms` is only consumed during block
-// setup; storing it here keeps "everything parsed" in a single record.
+/**
+ * @brief Parsed TS.BGET arguments, also used as blocked-client privdata.
+ *
+ * Populated once by parse_bget_args() so callbacks never re-parse argv.
+ * `key` is borrowed at parse time; TSDB_bget_block() retains it and
+ * TSDB_bget_free_privdata() releases it.
+ */
 typedef struct BGetCtx {
-    RedisModuleString *key; // series key to read from
-    api_timestamp_t cursor; // strict lower bound: only samples with ts > cursor qualify
-    size_t count;           // max samples to return in this batch
-    long long timeout_ms;   // 0 = do not block; >0 = max time to wait
+    RedisModuleString *key; ///< series key to read from
+    api_timestamp_t cursor; ///< strict lower bound: only samples with ts > cursor qualify
+    size_t count;           ///< max samples to return in this batch
+    long long timeout_ms;   ///< 0 = do not block; >0 = max time to wait
 } BGetCtx;
 
-// Parse TS.BGET argv into `out`. On error, replies to the client with a
-// descriptive error and returns REDISMODULE_ERR; on success returns
-// REDISMODULE_OK with all fields of `out` populated. `out->key` is borrowed
-// from argv (not retained) — the caller is responsible for retaining it if
-// the struct outlives the command call.
+/**
+ * @brief Parse TS.BGET argv into @p out and validate it.
+ *
+ * On error, replies to the client with a descriptive error.
+ * @p out->key is borrowed from @p argv (not retained).
+ *
+ * @param ctx   Redis module context (used to reply on error).
+ * @param argv  Command argument vector.
+ * @param argc  Number of arguments in @p argv (must be 5).
+ * @param out   Output struct populated on success.
+ * @return REDISMODULE_OK on success, REDISMODULE_ERR on parse/validation error.
+ */
 static int parse_bget_args(RedisModuleCtx *ctx,
                            RedisModuleString **argv,
                            int argc,
@@ -1350,11 +1358,18 @@ static int parse_bget_args(RedisModuleCtx *ctx,
     return REDISMODULE_OK;
 }
 
-// Walk the (cursor, +inf] range and count qualifying samples, stopping the
-// moment `threshold` is reached. Cost is bounded by `threshold` chunks of
-// metadata reads (not by series size). No per-sample work and no reply
-// writes — used purely to gate the strict "do we have >= count?" check
-// before any RedisModule_ReplyWith* call (which can't be undone).
+/**
+ * @brief Count samples matching @p range, stopping once @p threshold is hit.
+ *
+ * Cost is bounded by @p threshold (chunk-metadata reads only, no per-sample
+ * work). Used to gate strict-mode "do we have >= count?" before any
+ * irreversible ReplyWith* call.
+ *
+ * @param series     Time series to scan.
+ * @param range      Range query (typically `(cursor, +inf] LIMIT count`).
+ * @param threshold  Early-exit threshold.
+ * @return Number of qualifying samples, clamped to @p threshold.
+ */
 static size_t TSDB_count_samples_up_to(Series *series,
                                        const RangeArgs *range,
                                        size_t threshold) {
@@ -1369,42 +1384,36 @@ static size_t TSDB_count_samples_up_to(Series *series,
     return total;
 }
 
-// Try to satisfy a TS.BGET request from the current state of `args->key`.
-// Shared by the fast path in TSDB_bget, the wake-up callback, AND the
-// timeout callback so the "what should we reply with right now?" decision
-// lives in exactly one place.
-//
-// `require_full_batch` toggles between two modes:
-//
-//   true  — strict mode (fast path + on-signal wake-up). We will only write
-//           a reply when `args->count` samples are already available; if
-//           fewer exist, return false so the caller can block / stay parked.
-//           This honors the spec rule "return only when timeout OR count is
-//           reached, whichever first" — strict mode never partially flushes.
-//
-//   false — flush mode (timeout deadline + no-block fast path with
-//           `timeout_ms == 0`). Always writes a terminal reply, possibly an
-//           empty array (no samples available), the WRONGTYPE error, or up
-//           to `args->count` samples. Never returns false in this mode.
-//
-// We never start writing samples until we know they'll all go out — the
-// Module API has no "abort reply" once `ReplyWith*` is called. The count
-// pre-walk is what makes that safe.
-//
-// Case breakdown:
-//   1. Key is missing (does not exist yet).
-//        strict:  return false (caller should block — producer may create it).
-//        flush:   reply with an empty array.
-//   2. Key exists but holds the wrong type (not a TimeSeries).
-//        always:  reply WRONGTYPE error (waiting can't fix this).
-//   3. Key is a healthy TimeSeries.
-//      3a. series->lastTimestamp <= cursor: no qualifying sample exists.
-//          strict:  return false.
-//          flush:   reply with an empty array.
-//      3b. Otherwise:
-//          strict:  count (cursor, +inf]; if < count, return false; else
-//                   reply via ReplySeriesRange.
-//          flush:   reply via ReplySeriesRange (1..count samples).
+/**
+ * @brief Try to satisfy a TS.BGET request from current series state.
+ *
+ * Single source of truth for "what should we reply with right now?", shared
+ * by the fast path, the wake-up callback, and the timeout callback. Never
+ * starts writing samples until it knows they will all go out (the Module
+ * API has no "abort reply"); the count pre-walk via
+ * TSDB_count_samples_up_to() is what makes that safe.
+ *
+ * Modes:
+ *   - strict (@p require_full_batch == true): only reply when @p args->count
+ *     samples qualify; otherwise return false so the caller can block / stay
+ *     parked. Used on the fast path and on SignalKeyAsReady wake-ups.
+ *   - flush  (@p require_full_batch == false): always reply (possibly empty
+ *     or partial). Used by the timeout callback and by the no-block fast
+ *     path when `timeout_ms == 0`.
+ *
+ * Case breakdown:
+ *   1. Missing key      : strict -> false; flush -> empty array.
+ *   2. Wrong-type key   : always WRONGTYPE error.
+ *   3a. lastTs <= cursor: strict -> false; flush -> empty array.
+ *   3b. Else            : strict -> false if qualifying < count, else reply;
+ *                         flush  -> reply (1..count samples).
+ *
+ * @param ctx                Module context for OpenKey/Reply* calls.
+ * @param args               Parsed BGET arguments (key, cursor, count).
+ * @param require_full_batch Strict (true) vs flush (false) mode.
+ * @return true if a reply was written, false only in strict mode when caller
+ *         should block / stay parked.
+ */
 static bool TSDB_bget_try_reply(RedisModuleCtx *ctx,
                                 const BGetCtx *args,
                                 bool require_full_batch) {
@@ -1468,10 +1477,18 @@ static bool TSDB_bget_try_reply(RedisModuleCtx *ctx,
     return true;
 }
 
-// Re-invoked on every SignalKeyAsReady() on the watched key (and once at
-// block setup). Strict mode: only unblock when args->count samples are
-// available. Returns REDISMODULE_OK to unblock, REDISMODULE_ERR to stay
-// parked until the next signal or the timeout.
+/**
+ * @brief BlockClientOnKeys reply callback: strict-mode wake-up handler.
+ *
+ * Re-invoked on every RedisModule_SignalKeyAsReady() on the watched key
+ * (and once at block setup).
+ *
+ * @param ctx   Module context bound to the blocked client.
+ * @param argv  Unused (command argv is not forwarded to wake-up callbacks).
+ * @param argc  Unused.
+ * @return REDISMODULE_OK to unblock and commit the reply, REDISMODULE_ERR to
+ *         stay parked until the next signal or the timeout.
+ */
 static int TSDB_bget_reply_callback(RedisModuleCtx *ctx,
                                     RedisModuleString **argv,
                                     int argc) {
@@ -1482,9 +1499,18 @@ static int TSDB_bget_reply_callback(RedisModuleCtx *ctx,
                                                                   : REDISMODULE_ERR;
 }
 
-// Invoked when `timeout_ms` elapses without the client being unblocked.
-// Flush mode: deadline reached, deliver whatever's available (possibly
-// empty or fewer than count, per the spec).
+/**
+ * @brief BlockClientOnKeys timeout callback: flush-mode deadline handler.
+ *
+ * Invoked when `timeout_ms` elapses without the client being unblocked.
+ * Flushes whatever is available (possibly empty or fewer than count) per
+ * the TS.BGET spec.
+ *
+ * @param ctx   Module context bound to the blocked client.
+ * @param argv  Unused.
+ * @param argc  Unused.
+ * @return Always REDISMODULE_OK (the client is unblocked unconditionally).
+ */
 static int TSDB_bget_timeout_callback(RedisModuleCtx *ctx,
                                       RedisModuleString **argv,
                                       int argc) {
@@ -1495,8 +1521,15 @@ static int TSDB_bget_timeout_callback(RedisModuleCtx *ctx,
     return REDISMODULE_OK;
 }
 
-// Frees the BGetCtx attached to the blocked client. Called by Redis after
-// the client is unblocked (whether via reply, timeout, disconnect, or abort).
+/**
+ * @brief Release the BGetCtx attached to the blocked client.
+ *
+ * Called by Redis once the client is unblocked (via reply, timeout,
+ * disconnect, or abort). Frees the retained key and the heap struct.
+ *
+ * @param ctx       Module context (used for RedisModule_FreeString).
+ * @param privdata  BGetCtx* allocated by TSDB_bget_block(); NULL-safe.
+ */
 static void TSDB_bget_free_privdata(RedisModuleCtx *ctx, void *privdata) {
     if (!privdata) {
         return;
@@ -1508,14 +1541,22 @@ static void TSDB_bget_free_privdata(RedisModuleCtx *ctx, void *privdata) {
     free(priv);
 }
 
-// Allocate the privdata (heap copy of `args`) and park the client on its key.
-// Redis owns the blocked-client lifecycle through the registered callbacks;
-// the key is retained for the privdata's lifetime and released by
-// TSDB_bget_free_privdata.
-//
-// Returns NULL if Redis refuses to block (e.g. MULTI / Lua / deny-blocking
-// context). In that case the free callback is never installed, so we free
-// `priv` (and the retained `priv->key`) here — otherwise they would leak.
+/**
+ * @brief Allocate privdata and park the client on @p args->key.
+ *
+ * Heap-copies @p args, retains the key for the privdata's lifetime, and
+ * registers the BGET reply / timeout / free callbacks. Redis owns the
+ * blocked-client lifecycle thereafter.
+ *
+ * If Redis refuses to block (MULTI / Lua / deny-blocking context),
+ * BlockClientOnKeys returns NULL and the free callback is never installed —
+ * in that case we free `priv` (and the retained `priv->key`) here to avoid
+ * a leak.
+ *
+ * @param ctx   Module context bound to the calling client.
+ * @param args  Parsed BGET arguments to capture into privdata.
+ * @return Handle to the blocked client, or NULL if blocking was refused.
+ */
 static RedisModuleBlockedClient *TSDB_bget_block(RedisModuleCtx *ctx, const BGetCtx *args) {
     BGetCtx *priv = malloc(sizeof(*priv));
     *priv = *args;
@@ -1534,12 +1575,23 @@ static RedisModuleBlockedClient *TSDB_bget_block(RedisModuleCtx *ctx, const BGet
     return bc;
 }
 
-// Main command entry point. Parses argv into a BGetCtx; if samples newer
-// than the cursor already exist (or the key is unusable), replies inline via
-// the shared TSDB_bget_try_reply helper. Otherwise parks the client via
-// TSDB_bget_block (or replies empty when timeout_ms == 0).
-//
-// TODO: sentinel resolution ('-' / '+'), MULTI/Lua/replica refusal.
+/**
+ * @brief TS.BGET command entry point.
+ *
+ * Parses argv into a BGetCtx. If samples newer than the cursor already exist
+ * (or the key is unusable / `timeout_ms == 0`), replies inline via
+ * TSDB_bget_try_reply(); otherwise parks the client via TSDB_bget_block().
+ *
+ * @todo Sentinel resolution ('-' / '+').
+ * @todo Refuse blocking in MULTI / Lua / replica contexts.
+ *
+ * @param ctx   Module context.
+ * @param argv  Command argument vector: `TS.BGET key timestamp count timeout`.
+ * @param argc  Argument count (expected 5).
+ * @return Always REDISMODULE_OK on the public success contract (errors are
+ *         delivered via RedisModule_ReplyWithError); REDISMODULE_ERR only on
+ *         parse failure where no reply has been written.
+ */
 int TSDB_bget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_AutoMemory(ctx);
 
@@ -1557,7 +1609,15 @@ int TSDB_bget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return REDISMODULE_OK;
     }
 
-    TSDB_bget_block(ctx, &args);
+    if (!TSDB_bget_block(ctx, &args)) {
+        // BlockClientOnKeys refused to park us (MULTI / Lua / deny-blocking
+        // context). TSDB_bget_block already freed privdata; reply with an
+        // error so the client doesn't hang on an empty pipeline.
+        RedisModule_ReplyWithError(
+            ctx,
+            "TSDB: blocking TS.BGET is not allowed  "
+            "or in a deny-blocking context");
+    }
     return REDISMODULE_OK;
 }
 

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -608,6 +608,10 @@ static bool RuleSeriesUpsertSample(RedisModuleCtx *ctx,
     } else {
         SeriesUpsertSample(destSeries, start, val, DP_LAST);
     }
+    // Wake any TS.BGET waiters parked on the destination key, so a
+    // compaction-rule bucket landing here triggers them just like a direct
+    // write would.
+    RedisModule_SignalKeyAsReady(ctx, rule->destKey);
     RedisModule_CloseKey(key);
 
     return true;

--- a/src/utils/blocked_client.c
+++ b/src/utils/blocked_client.c
@@ -44,14 +44,8 @@ RedisModuleBlockedClient *RTS_BlockClientOnKey(RedisModuleCtx *ctx,
     assert(ctx != NULL);
     assert(key != NULL);
 
-    RedisModuleBlockedClient *bc = RedisModule_BlockClientOnKeys(ctx,
-                                                                 reply_callback,
-                                                                 timeout_callback,
-                                                                 free_privdata,
-                                                                 timeout_ms,
-                                                                 &key,
-                                                                 1,
-                                                                 privdata);
+    RedisModuleBlockedClient *bc = RedisModule_BlockClientOnKeys(
+        ctx, reply_callback, timeout_callback, free_privdata, timeout_ms, &key, 1, privdata);
     if (bc && CheckVersionForBlockedClientMeasureTime()) {
         RedisModule_BlockedClientMeasureTimeStart(bc);
     }

--- a/src/utils/blocked_client.c
+++ b/src/utils/blocked_client.c
@@ -33,3 +33,27 @@ void RTS_UnblockClient(RedisModuleBlockedClient *bc, void *privdata) {
     }
     RedisModule_UnblockClient(bc, privdata);
 }
+
+RedisModuleBlockedClient *RTS_BlockClientOnKey(RedisModuleCtx *ctx,
+                                               RedisModuleCmdFunc reply_callback,
+                                               RedisModuleCmdFunc timeout_callback,
+                                               void (*free_privdata)(RedisModuleCtx *, void *),
+                                               long long timeout_ms,
+                                               RedisModuleString *key,
+                                               void *privdata) {
+    assert(ctx != NULL);
+    assert(key != NULL);
+
+    RedisModuleBlockedClient *bc = RedisModule_BlockClientOnKeys(ctx,
+                                                                 reply_callback,
+                                                                 timeout_callback,
+                                                                 free_privdata,
+                                                                 timeout_ms,
+                                                                 &key,
+                                                                 1,
+                                                                 privdata);
+    if (bc && CheckVersionForBlockedClientMeasureTime()) {
+        RedisModule_BlockedClientMeasureTimeStart(bc);
+    }
+    return bc;
+}

--- a/src/utils/blocked_client.h
+++ b/src/utils/blocked_client.h
@@ -15,3 +15,15 @@ RedisModuleBlockedClient *RTS_BlockClient(RedisModuleCtx *ctx,
 
 // unblock blocked client and report end time
 void RTS_UnblockClient(RedisModuleBlockedClient *bc, void *privdata);
+
+// Block the client on a single key. The reply_cb is invoked on every
+// RedisModule_SignalKeyAsReady on `key` (and once at setup); the timeout_cb
+// fires after `timeout_ms`. `privdata` is owned by the blocked client and
+// freed via `free_privdata` once the client is unblocked.
+RedisModuleBlockedClient *RTS_BlockClientOnKey(RedisModuleCtx *ctx,
+                                               RedisModuleCmdFunc reply_callback,
+                                               RedisModuleCmdFunc timeout_callback,
+                                               void (*free_privdata)(RedisModuleCtx *, void *),
+                                               long long timeout_ms,
+                                               RedisModuleString *key,
+                                               void *privdata);

--- a/src/utils/blocked_client.h
+++ b/src/utils/blocked_client.h
@@ -16,10 +16,26 @@ RedisModuleBlockedClient *RTS_BlockClient(RedisModuleCtx *ctx,
 // unblock blocked client and report end time
 void RTS_UnblockClient(RedisModuleBlockedClient *bc, void *privdata);
 
-// Block the client on a single key. The reply_cb is invoked on every
-// RedisModule_SignalKeyAsReady on `key` (and once at setup); the timeout_cb
-// fires after `timeout_ms`. `privdata` is owned by the blocked client and
-// freed via `free_privdata` once the client is unblocked.
+/**
+ * @brief Block the calling client on a single key.
+ *
+ * Thin wrapper over RedisModule_BlockClientOnKeys() that always parks on
+ * exactly one key. @p reply_callback is invoked on every
+ * RedisModule_SignalKeyAsReady() on @p key (and once at setup);
+ * @p timeout_callback fires after @p timeout_ms. @p privdata is owned by
+ * the blocked client and freed via @p free_privdata once it unblocks.
+ *
+ * Also starts BlockedClientMeasureTime when the linked Redis supports it.
+ *
+ * @param ctx               Module context bound to the calling client.
+ * @param reply_callback    Wake-up handler (return OK to commit, ERR to stay).
+ * @param timeout_callback  Deadline handler.
+ * @param free_privdata     Releases @p privdata after unblock; NULL-safe.
+ * @param timeout_ms        Max wait in ms (0 = no timeout).
+ * @param key               Single key to block on.
+ * @param privdata          Caller-owned context handed to the callbacks.
+ * @return Handle to the blocked client, or NULL if Redis refused to block.
+ */
 RedisModuleBlockedClient *RTS_BlockClientOnKey(RedisModuleCtx *ctx,
                                                RedisModuleCmdFunc reply_callback,
                                                RedisModuleCmdFunc timeout_callback,

--- a/tests/flow/test_ts_bget.py
+++ b/tests/flow/test_ts_bget.py
@@ -78,7 +78,8 @@ def test_bget_blocks_then_unblocks_when_count_is_reached():
 
     # cursor=101 -> initial qualifying = {200, 300} = 2 < 5, so BGET blocks.
     # NOTE: to reach count=5 with cursor=101 we need THREE more samples,
-    # not two — the sample at ts=100 doesn't qualify (cursor is strict).
+    # not two — the sample at ts=100 doesn't qualify because 100 < 101
+    # (cursor is an inclusive lower bound: only ts >= cursor qualifies).
     # Each TS.ADD fires SignalKeyAsReady -> reply_cb runs; only the third
     # add commits because that's when qualifying becomes 5.
     t, slot = _start_bget(env, "ts", 101, 5, 10_000)
@@ -136,8 +137,10 @@ def test_bget_returns_oldest_count_when_more_qualify():
     res = r.execute_command("TS.BGET", "ts", 101, 2, 1000)
     env.assertEqual(res, [[200, b"2"], [300, b"3"]])
 
-    # The caller pages forward by setting cursor to the last returned ts.
-    res = r.execute_command("TS.BGET", "ts", 300, 2, 1000)
+    # The caller pages forward by setting cursor to last_returned_ts + 1
+    # (cursor is inclusive: ts >= cursor qualifies, so passing 300 would
+    # re-emit the sample we already saw).
+    res = r.execute_command("TS.BGET", "ts", 301, 2, 1000)
     env.assertEqual(res, [[400, b"4"], [500, b"5"]])
 
 
@@ -170,5 +173,126 @@ def test_bget_timeout_flushes_available_samples():
     # The whole timeout should have elapsed (we expected to be blocked).
     env.assertTrue(elapsed >= 0.9,
                    message="Expected to wait ~1s on timeout, only waited %.3fs" % elapsed)
+    env.assertTrue(elapsed < 5.0,
+                   message="Timeout overshoot too large: %.3fs" % elapsed)
+
+
+# ---------------------------------------------------------------------------
+# 5. '-' sentinel: cursor=0, matches every existing sample.
+# ---------------------------------------------------------------------------
+
+def test_bget_dash_returns_all_existing_samples():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
+
+    # '-' resolves statically to cursor=0; with ts >= 0 every sample qualifies,
+    # so count=3 is already met and BGET returns synchronously.
+    res = r.execute_command("TS.BGET", "ts", "-", 3, 5000)
+    env.assertEqual(res, [[100, b"1"], [200, b"2"], [300, b"3"]])
+
+
+# ---------------------------------------------------------------------------
+# 6. '-' on a missing key: cursor=0, blocks until the first qualifying ADD.
+# ---------------------------------------------------------------------------
+
+def test_bget_dash_on_empty_series_blocks_until_first_add():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    r.execute_command("FLUSHALL")  # key "ts" must not exist for this scenario.
+
+    t, slot = _start_bget(env, "ts", "-", 1, 10_000)
+    time.sleep(0.3)
+    env.assertTrue(t.is_alive(),
+                   message="BGET '-' on missing key should block until ADD")
+
+    assert r.execute_command("TS.ADD", "ts", 100, "1.0") == 100
+
+    t.join(timeout=2.0)
+    env.assertFalse(t.is_alive(),
+                    message="BGET should have replied once the first sample arrived")
+    env.assertEqual(slot["error"], None)
+    env.assertEqual(slot["result"], [[100, b"1"]])
+
+
+# ---------------------------------------------------------------------------
+# 7. '+' sentinel on an empty / missing key: cursor=0, behaves like '-'.
+# ---------------------------------------------------------------------------
+
+def test_bget_plus_on_empty_series_blocks_until_first_add():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    r.execute_command("FLUSHALL")
+
+    t, slot = _start_bget(env, "ts", "+", 1, 10_000)
+    time.sleep(0.3)
+    env.assertTrue(t.is_alive(),
+                   message="BGET '+' on missing key should block until ADD")
+
+    assert r.execute_command("TS.ADD", "ts", 100, "1.0") == 100
+
+    t.join(timeout=2.0)
+    env.assertFalse(t.is_alive())
+    env.assertEqual(slot["error"], None)
+    env.assertEqual(slot["result"], [[100, b"1"]])
+
+
+# ---------------------------------------------------------------------------
+# 8. '+' sentinel: snapshot lastTs at command time, only NEW samples qualify.
+# ---------------------------------------------------------------------------
+
+def test_bget_plus_only_returns_samples_added_after_command():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
+
+    # '+' resolves now to lastTs + 1 = 301. Existing 100/200/300 must NOT
+    # qualify; only a future ADD with ts >= 301 should wake us.
+    t, slot = _start_bget(env, "ts", "+", 1, 10_000)
+    time.sleep(0.3)
+    env.assertTrue(t.is_alive(),
+                   message="BGET '+' should ignore pre-existing samples")
+
+    # Producer adds a strictly newer sample -> wake-up.
+    assert r.execute_command("TS.ADD", "ts", 400, "4.0") == 400
+
+    t.join(timeout=2.0)
+    env.assertFalse(t.is_alive())
+    env.assertEqual(slot["error"], None)
+    env.assertEqual(slot["result"], [[400, b"4"]])
+
+
+# ---------------------------------------------------------------------------
+# 9. '+' sentinel without producer: existing samples must NEVER be returned;
+#    on timeout we flush an empty array.
+# ---------------------------------------------------------------------------
+
+def test_bget_plus_with_no_new_samples_times_out_empty():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
+
+    t0 = time.time()
+    res = r.execute_command("TS.BGET", "ts", "+", 1, 1000)
+    elapsed = time.time() - t0
+
+    env.assertEqual(res, [])
+    env.assertTrue(elapsed >= 0.9,
+                   message="Expected to wait the full timeout, only %.3fs" % elapsed)
     env.assertTrue(elapsed < 5.0,
                    message="Timeout overshoot too large: %.3fs" % elapsed)

--- a/tests/flow/test_ts_bget.py
+++ b/tests/flow/test_ts_bget.py
@@ -296,3 +296,178 @@ def test_bget_plus_with_no_new_samples_times_out_empty():
                    message="Expected to wait the full timeout, only %.3fs" % elapsed)
     env.assertTrue(elapsed < 5.0,
                    message="Timeout overshoot too large: %.3fs" % elapsed)
+
+
+# ---------------------------------------------------------------------------
+# 10. Multi-client broadcast: every parked client receives the new sample
+#     (TS.BGET semantics — not BLPOP-style first-waiter-wins dequeue).
+# ---------------------------------------------------------------------------
+
+def test_bget_broadcasts_to_all_blocked_clients():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    _seed(r, "ts", [(100, "1.0")])
+
+    workers = [_start_bget(env, "ts", "+", 1, 10_000) for _ in range(4)]
+    time.sleep(0.3)
+    for t, _ in workers:
+        env.assertTrue(t.is_alive(), message="all clients should be parked")
+
+    # One producer ADD must wake every parked client with the same sample.
+    assert r.execute_command("TS.ADD", "ts", 200, "2.0") == 200
+
+    for t, slot in workers:
+        t.join(timeout=2.0)
+        env.assertFalse(t.is_alive(),
+                        message="every parked client should have unblocked")
+        env.assertEqual(slot["error"], None)
+        env.assertEqual(slot["result"], [[200, b"2"]])
+
+
+# ---------------------------------------------------------------------------
+# 11. Compaction wake-up: BGET parked on a compaction destination unblocks
+#     when a bucket commits into it.
+# ---------------------------------------------------------------------------
+
+def test_bget_on_compaction_destination_wakes_on_bucket_commit():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    assert r.execute_command("TS.CREATE", "src")
+    assert r.execute_command("TS.CREATE", "dst")
+    assert r.execute_command(
+        "TS.CREATERULE", "src", "dst", "AGGREGATION", "avg", 10)
+
+    t, slot = _start_bget(env, "dst", "-", 1, 10_000)
+    time.sleep(0.3)
+    env.assertTrue(t.is_alive(),
+                   message="BGET on empty dst should be parked")
+
+    # Two samples in bucket [0,9], then a sample in [10,19] closes the first
+    # bucket and writes the aggregated point into dst -> SignalKeyAsReady.
+    assert r.execute_command("TS.ADD", "src", 1, "1.0") == 1
+    assert r.execute_command("TS.ADD", "src", 2, "2.0") == 2
+    assert r.execute_command("TS.ADD", "src", 15, "3.0") == 15
+
+    t.join(timeout=2.0)
+    env.assertFalse(t.is_alive(),
+                    message="BGET on dst should wake on bucket commit")
+    env.assertEqual(slot["error"], None)
+    env.assertTrue(len(slot["result"]) >= 1)
+
+
+# ---------------------------------------------------------------------------
+# 12. WRONGTYPE on the literal-cursor path.
+# ---------------------------------------------------------------------------
+
+def test_bget_wrongtype_literal_cursor():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    r.set("not_a_ts", "hello")
+    with pytest.raises(redis.ResponseError, match="WRONGTYPE"):
+        r.execute_command("TS.BGET", "not_a_ts", 0, 1, 0)
+
+
+# ---------------------------------------------------------------------------
+# 13. Refusal inside MULTI / EVAL when timeout > 0.
+# ---------------------------------------------------------------------------
+
+def _is_deny_blocking_error(err):
+    s = str(err)
+    return "deny" in s.lower() or "MULTI" in s or "EVAL" in s or "BGET" in s
+
+
+def test_bget_inside_multi_refuses_with_clear_error():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    r.execute_command("FLUSHALL")  # key must not exist so strict try_reply
+                                   # bails and we reach the deny-blocking
+                                   # branch instead of replying synchronously.
+
+    r.execute_command("MULTI")
+    r.execute_command("TS.BGET", "ts", 0, 1, 1000)
+    try:
+        res = r.execute_command("EXEC")
+        env.assertEqual(len(res), 1)
+        env.assertTrue(_is_deny_blocking_error(res[0]),
+                       message="unexpected EXEC reply: %r" % (res[0],))
+    except redis.ResponseError as e:
+        env.assertTrue(_is_deny_blocking_error(e),
+                       message="unexpected error: %r" % (e,))
+
+
+def test_bget_inside_eval_refuses_with_clear_error():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    r.execute_command("FLUSHALL")  # same reason as the MULTI test above.
+
+    with pytest.raises(redis.ResponseError) as excinfo:
+        r.execute_command(
+            "EVAL", "return redis.call('TS.BGET','ts',0,1,1000)", 1, "ts")
+    env.assertTrue(_is_deny_blocking_error(excinfo.value),
+                   message="unexpected error: %r" % (excinfo.value,))
+
+
+# ---------------------------------------------------------------------------
+# 14. Parse / arity validation — every malformed call must surface an error.
+# ---------------------------------------------------------------------------
+
+def test_bget_parse_errors():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    _seed(r, "ts", [(100, "1.0")])
+
+    bad_argv = [
+        ("ts",),                          # wrong arity (too few)
+        ("ts", 0, 1, 0, "extra"),         # wrong arity (too many)
+        ("ts", 0, 0, 1000),               # count == 0
+        ("ts", 0, -1, 1000),              # count < 0
+        ("ts", 0, 1, -1),                 # timeout < 0
+        ("ts", 0, "abc", 1000),           # non-integer count
+        ("ts", 0, "1.5", 1000),           # non-integer count
+        ("ts", 0, 1, "abc"),              # non-integer timeout
+        ("ts", "abc", 1, 1000),           # non-integer / non-sentinel timestamp
+        ("ts", -1, 1, 1000),              # negative literal timestamp
+    ]
+    for argv in bad_argv:
+        with pytest.raises(redis.ResponseError):
+            r.execute_command("TS.BGET", *argv)
+
+
+# ---------------------------------------------------------------------------
+# 15. timeout_ms == 0: return whatever is available immediately, never block.
+# ---------------------------------------------------------------------------
+
+def test_bget_timeout_zero_returns_partial_without_blocking():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    _seed(r, "ts", [(100, "1.0"), (200, "2.0")])
+
+    # count=10, only 2 qualifying samples; timeout=0 must flush immediately.
+    t0 = time.time()
+    res = r.execute_command("TS.BGET", "ts", 0, 10, 0)
+    elapsed = time.time() - t0
+
+    env.assertEqual(res, [[100, b"1"], [200, b"2"]])
+    env.assertTrue(elapsed < 0.3,
+                   message="timeout=0 must not block, took %.3fs" % elapsed)

--- a/tests/flow/test_ts_bget.py
+++ b/tests/flow/test_ts_bget.py
@@ -1,0 +1,174 @@
+import time
+from threading import Thread
+
+from includes import *
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _start_bget(env, key, cursor, count, timeout_ms):
+    """Spawn a worker thread that issues TS.BGET on its own connection.
+
+    Returns (thread, slot) where `slot` is mutated by the worker:
+        slot["result"]  -> reply payload (or None if it errored / hasn't returned)
+        slot["error"]   -> exception text (or None)
+        slot["elapsed"] -> wall-clock seconds the BGET call took
+    """
+    slot = {"result": None, "error": None, "elapsed": None}
+
+    def worker():
+        conn = env.getConnection()
+        t0 = time.time()
+        try:
+            slot["result"] = conn.execute_command(
+                "TS.BGET", key, cursor, count, timeout_ms
+            )
+        except Exception as e:
+            slot["error"] = str(e)
+        finally:
+            slot["elapsed"] = time.time() - t0
+
+    t = Thread(target=worker, daemon=True)
+    t.start()
+    return t, slot
+
+
+def _seed(r, key, samples):
+    assert r.execute_command("TS.CREATE", key)
+    for ts, val in samples:
+        assert r.execute_command("TS.ADD", key, ts, val) == ts
+
+
+# ---------------------------------------------------------------------------
+# 1. Immediate reply when enough qualifying samples already exist.
+# ---------------------------------------------------------------------------
+
+def test_bget_returns_immediately_when_count_already_satisfied():
+    env = Env()
+    if env.is_cluster():
+        env.skip()  # BGET is a single-key primitive; cluster routing is orthogonal.
+
+    r = env.getConnection()
+    _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
+
+    # cursor=101 -> qualifying = {200, 300}; count=2 is already met,
+    # so BGET should NOT block and return synchronously.
+    t0 = time.time()
+    res = r.execute_command("TS.BGET", "ts", 101, 2, 1000)
+    elapsed = time.time() - t0
+
+    env.assertEqual(res, [[200, b"2"], [300, b"3"]])
+    # Sanity: nothing close to the 1s timeout.
+    env.assertTrue(elapsed < 0.5, message="BGET should be ~instant, got %.3fs" % elapsed)
+
+
+# ---------------------------------------------------------------------------
+# 2. Blocks until SignalKeyAsReady has pushed qualifying-count to >= count.
+# ---------------------------------------------------------------------------
+
+def test_bget_blocks_then_unblocks_when_count_is_reached():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
+
+    # cursor=101 -> initial qualifying = {200, 300} = 2 < 5, so BGET blocks.
+    # NOTE: to reach count=5 with cursor=101 we need THREE more samples,
+    # not two — the sample at ts=100 doesn't qualify (cursor is strict).
+    # Each TS.ADD fires SignalKeyAsReady -> reply_cb runs; only the third
+    # add commits because that's when qualifying becomes 5.
+    t, slot = _start_bget(env, "ts", 101, 5, 10_000)
+
+    # Give the worker enough time to issue BlockClientOnKeys on the server.
+    time.sleep(0.3)
+    env.assertTrue(t.is_alive(), message="BGET should be blocked (2 < 5 qualifying)")
+
+    # Add #1: qualifying = {200, 300, 400} = 3 < 5 -> stay blocked.
+    assert r.execute_command("TS.ADD", "ts", 400, "4.0") == 400
+    time.sleep(0.2)
+    env.assertTrue(t.is_alive(),
+                   message="BGET should still be blocked after 1st add (3 < 5)")
+
+    # Add #2: qualifying = {200, 300, 400, 500} = 4 < 5 -> stay blocked.
+    assert r.execute_command("TS.ADD", "ts", 500, "5.0") == 500
+    time.sleep(0.2)
+    env.assertTrue(t.is_alive(),
+                   message="BGET should still be blocked after 2nd add (4 < 5)")
+
+    # Add #3: qualifying = {200, 300, 400, 500, 600} = 5 -> reply_cb commits.
+    assert r.execute_command("TS.ADD", "ts", 600, "6.0") == 600
+
+    t.join(timeout=2.0)
+    env.assertFalse(t.is_alive(),
+                    message="BGET should have replied once qualifying >= count")
+
+    env.assertEqual(slot["error"], None)
+    env.assertEqual(
+        slot["result"],
+        [[200, b"2"], [300, b"3"], [400, b"4"], [500, b"5"], [600, b"6"]],
+    )
+    # Sanity: well below the 10s timeout — we unblocked on the signal, not on timeout.
+    env.assertTrue(slot["elapsed"] < 5.0,
+                   message="BGET took %.2fs, should have unblocked promptly" % slot["elapsed"])
+
+
+# ---------------------------------------------------------------------------
+# 3. Oldest-first paging: when MORE than `count` samples qualify, return the
+#    oldest `count` (so callers can advance the cursor to the last returned ts).
+# ---------------------------------------------------------------------------
+
+def test_bget_returns_oldest_count_when_more_qualify():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    _seed(r, "ts", [
+        (100, "1.0"), (200, "2.0"), (300, "3.0"),
+        (400, "4.0"), (500, "5.0"),
+    ])
+
+    # cursor=101 -> 4 qualifying (200, 300, 400, 500); count=2 -> take the OLDEST 2.
+    res = r.execute_command("TS.BGET", "ts", 101, 2, 1000)
+    env.assertEqual(res, [[200, b"2"], [300, b"3"]])
+
+    # The caller pages forward by setting cursor to the last returned ts.
+    res = r.execute_command("TS.BGET", "ts", 300, 2, 1000)
+    env.assertEqual(res, [[400, b"4"], [500, b"5"]])
+
+
+# ---------------------------------------------------------------------------
+# 4. Timeout flush: client blocks, no producer feeds it, timeout fires and we
+#    flush whatever is available (which may be fewer than count).
+# ---------------------------------------------------------------------------
+
+def test_bget_timeout_flushes_available_samples():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    _seed(r, "ts", [
+        (100, "1.0"), (200, "2.0"), (300, "3.0"),
+        (400, "4.0"), (500, "5.0"),
+    ])
+
+    # cursor=101 -> 4 qualifying; count=10 cannot be reached. Nobody else adds.
+    # After timeout_ms expires the timeout_cb flushes the 4 available samples.
+    t0 = time.time()
+    res = r.execute_command("TS.BGET", "ts", 101, 10, 1000)
+    elapsed = time.time() - t0
+
+    env.assertEqual(
+        res,
+        [[200, b"2"], [300, b"3"], [400, b"4"], [500, b"5"]],
+    )
+    # The whole timeout should have elapsed (we expected to be blocked).
+    env.assertTrue(elapsed >= 0.9,
+                   message="Expected to wait ~1s on timeout, only waited %.3fs" % elapsed)
+    env.assertTrue(elapsed < 5.0,
+                   message="Timeout overshoot too large: %.3fs" % elapsed)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New blocking command path and `SignalKeyAsReady` on every append/compaction destination write add server-side client lifecycle surface area; behavior is well-tested but touches hot write paths.
> 
> **Overview**
> Adds **`TS.BGET`**, a blocking read for cursor-style tailing: up to `count` samples with `timestamp >= cursor`, oldest-first, optionally waiting up to `timeout` ms for a full batch.
> 
> **Behavior:** With `timeout > 0`, the client blocks on the key until enough qualifying samples exist or the deadline hits (then partial/empty flush). With `timeout == 0`, it never blocks. Cursor supports literals, `-` (from start), and `+` (snapshotted `lastTimestamp + 1` at command time). Replies mirror a limited ascending range read; strict mode pre-counts before replying.
> 
> **Infrastructure:** New `RTS_BlockClientOnKey` wraps `BlockClientOnKeys` and blocked-client timing. Waiters wake via `RedisModule_SignalKeyAsReady` after sample appends in `internalAdd` and after compaction writes to destination keys in `tsdb.c`. Command is registered readonly (not `fast`); documented in `commands.json` (8.10.0).
> 
> **Tests:** Broad flow coverage in `tests/flow/test_ts_bget.py` (immediate reply, blocking until count, paging, timeout, sentinels, multi-client broadcast, compaction destination, MULTI/EVAL refusal, validation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a3790b63a2c865a76bcdd29f491a2186a06db68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->