### PR TITLE
test(asm): tolerate LibMR shard-idle timeout under valgrind/sanitizer

### DIFF
--- a/tests/flow/test_asm.py
+++ b/tests/flow/test_asm.py
@@ -61,13 +61,23 @@ def test_asm_with_data_and_queries_during_migrations():
     def validate_command_in_a_loop():
         # Note: should be the same as in libmr_commands.c
         SLOT_RANGES_ERROR = "Query requires unavailable slots"
+        # Under valgrind/sanitizer the LibMR per-execution idle timeout (5s, see
+        # EXECUTION_DEFAULT_MAX_IDLE_MS in deps/LibMR/src/mr.c) can be exceeded
+        # while slot migration is in flight, surfacing as the shard-timeout error.
+        SHARD_TIMEOUT_ERROR = (
+            "A multi-keys command failed because at least one shard "
+            "did not reply within the given timeframe."
+        )
+        tolerated_errors = {SLOT_RANGES_ERROR}
+        if VALGRIND or SANITIZER:
+            tolerated_errors.add(SHARD_TIMEOUT_ERROR)
         while not done.is_set():
             try:
                 result = conn.execute_command(command)
             except redis.exceptions.ResponseError as x:
                 error_message = str(x)
-                # An occasional SLOT_RANGES_ERROR is expected
-                assert error_message == SLOT_RANGES_ERROR, error_message
+                # An occasional transient error is expected during migrations
+                assert error_message in tolerated_errors, error_message
                 continue
             validate_result(result)
 


### PR DESCRIPTION
The validator loop in test_asm_with_data_and_queries_during_migrations only accepted the application-layer "Query requires unavailable slots" transient error. Under valgrind the shards run ~30x slower, so a TS.MRANGE issued while a slot migration is in flight can easily exceed the LibMR per-execution idle timeout
(EXECUTION_DEFAULT_MAX_IDLE_MS = 5000 ms, deps/LibMR/src/mr.c) and surface as "A multi-keys command failed because at least one shard did not reply within the given timeframe." (libmr_commands.c). That's a transient transport-layer error during migration, same flavor as the unavailable-slots one we already tolerate, but the test would assert on it and fail every valgrind nightly.

Confirmed pattern over 5 consecutive nightlies (run IDs 25972287570, 25940406860, 25825900255, 25696749349, 25611188764) — same test, same exception, only the linux-valgrind/x64-jammy job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that broadens tolerated transient errors during slot migrations, potentially masking unexpected failures only in valgrind/sanitizer runs.
> 
> **Overview**
> Updates `test_asm_with_data_and_queries_during_migrations` to treat LibMR shard idle timeouts as an expected transient failure during slot migrations under *valgrind/sanitizer*.
> 
> The validator loop now accepts either `"Query requires unavailable slots"` or (only under `VALGRIND`/`SANITIZER`) the shard timeout error, instead of asserting solely on the unavailable-slots message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d23ed90fbfb31d6c3a53725b912b5cb349c81d49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->