### PR TITLE
Revert Docker and CI redis-ref from 8.8 back to unstable

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -67,7 +67,7 @@ runs:
       shell: bash
       id: set-redis-ref
       run: |
-        export REDIS_REF="${{ inputs.redis-ref || '8.8'}}"
+        export REDIS_REF="${{ inputs.redis-ref || 'unstable'}}"
         echo "REDIS_REF=${REDIS_REF}" >> $GITHUB_OUTPUT
 
         echo "REDIS_REF=${REDIS_REF}"

--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: set env
         id: set-env
         run: |
-          echo "redis-ref=8.8" >> $GITHUB_OUTPUT
+          echo "redis-ref=unstable" >> $GITHUB_OUTPUT  # todo change per version/tag
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -18,7 +18,7 @@ on:
       redis-ref:
         description: 'Redis ref to checkout'
         required: true
-        default: '8.8'
+        default: 'unstable'
       send-slack-message:
         description: 'Send Slack notification on completion'
         required: false
@@ -40,7 +40,7 @@ jobs:
       - name: set env
         id: set-env
         run: |
-          echo "redis-ref=${{ inputs.redis-ref || '8.8' }}" >> $GITHUB_OUTPUT
+          echo "redis-ref=${{ inputs.redis-ref || 'unstable' }}" >> $GITHUB_OUTPUT
           
           # Generate timestamp at workflow start for consistent beta versioning
           TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")

--- a/.github/workflows/event-tag.yml
+++ b/.github/workflows/event-tag.yml
@@ -13,7 +13,7 @@ on:
       redis-ref:
         description: 'Redis ref to checkout'
         required: true
-        default: '8.8'
+        default: 'unstable'
 
 jobs:
   prepare-values:
@@ -24,7 +24,7 @@ jobs:
       - name: set env
         id: set-env
         run: |
-          echo "redis-ref=${{ inputs.redis-ref || '8.8' }}" >> $GITHUB_OUTPUT
+          echo "redis-ref=${{ inputs.redis-ref || 'unstable' }}" >> $GITHUB_OUTPUT  # todo change per version/tag
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit

--- a/.github/workflows/flow-random-traffic.yml
+++ b/.github/workflows/flow-random-traffic.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       redis-ref:
         description: 'Redis ref to checkout'
-        default: '8.8'
+        default: 'unstable'
       os:
         description: 'OS to run on (leave empty for random)'
         default: ''
@@ -14,7 +14,7 @@ on:
       redis-ref:
         description: 'Redis ref to checkout'
         type: string
-        default: '8.8'
+        default: 'unstable'
       beta-version:
         description: 'Beta version for S3 uploads'
         type: string
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_IMAGE: redistimeseries-${{ needs.pick-os.outputs.os }}:latest
-      REDIS_REF: ${{ inputs.redis-ref || '8.8' }}
+      REDIS_REF: ${{ inputs.redis-ref || 'unstable' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Dockerfile.alma10
+++ b/Dockerfile.alma10
@@ -11,7 +11,7 @@ RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync u
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.alma8
+++ b/Dockerfile.alma8
@@ -19,7 +19,7 @@ ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.alma9
+++ b/Dockerfile.alma9
@@ -14,7 +14,7 @@ ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH}"
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -40,7 +40,7 @@ RUN apk add --no-cache \
 COPY .install /workspace/.install
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.amazonlinux2
+++ b/Dockerfile.amazonlinux2
@@ -16,7 +16,7 @@ ENV LD_LIBRARY_PATH="/opt/rh/devtoolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
 COPY .install /workspace/.install
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.amazonlinux2023
+++ b/Dockerfile.amazonlinux2023
@@ -29,7 +29,7 @@ RUN dnf -y update && dnf -y install --allowerasing \
 COPY .install /workspace/.install
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.azurelinux3
+++ b/Dockerfile.azurelinux3
@@ -27,7 +27,7 @@ RUN tdnf -y update && \
 COPY .install /workspace/.install
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -25,7 +25,7 @@ RUN wget https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz \
 COPY .install /workspace/.install
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -12,7 +12,7 @@ RUN apt update -qq \
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y build-essential \
 COPY .install /workspace/.install
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -12,7 +12,7 @@ RUN apt update -qq \
 COPY .install /workspace/.install
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.jammy
+++ b/Dockerfile.jammy
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
 COPY .install /workspace/.install
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.mariner2
+++ b/Dockerfile.mariner2
@@ -9,7 +9,7 @@ RUN tdnf install -y git ca-certificates build-essential wget tar openssl-devel c
 COPY .install /workspace/.install
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.noble
+++ b/Dockerfile.noble
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
     rsync \
     python3-dev
 
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh

--- a/Dockerfile.resolute
+++ b/Dockerfile.resolute
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
     rsync \
     python3-dev
 
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -11,7 +11,7 @@ RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync u
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -18,7 +18,7 @@ ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -25,7 +25,7 @@ RUN yum -y install --nobest --skip-broken gcc gcc-c++ \
 COPY .install /workspace/.install
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.trixie
+++ b/Dockerfile.trixie
@@ -12,7 +12,7 @@ RUN apt update -qq \
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 


### PR DESCRIPTION
Reverts the REDIS_REF default in all Dockerfiles and GitHub workflow/action files from 8.8 to unstable, introduced in d507a2684d.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default Redis checkout/build ref used across CI workflows and Docker images, which can alter build/test behavior and introduce instability from tracking `unstable`. Scope is limited to configuration defaults (no runtime/module code changes).
> 
> **Overview**
> Reverts the default Redis reference used by builds from `8.8` back to `unstable` across GitHub Actions workflows/composite action and all OS-specific Dockerfiles.
> 
> CI jobs that don’t explicitly pass `redis-ref` (PR CI, nightly, tag builds, and random-traffic) will now build/test against `unstable` by default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acb1a8c9d6b394f39e4cf7cbee665a29c5e1eaaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->