### PR TITLE
ci: bump GitHub Actions to Node24-compatible versions

### DIFF
--- a/.github/actions/capture-test-results/action.yml
+++ b/.github/actions/capture-test-results/action.yml
@@ -94,7 +94,7 @@ runs:
     - name: Upload test results artifact
       continue-on-error: true
       if: always() && steps.parse.outputs.results-file != '' && steps.parse.outputs.results-file != 'null'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ steps.parse.outputs.artifact-name }}
         path: ${{ steps.parse.outputs.results-file }}

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -17,7 +17,7 @@ runs:
         echo ::endgroup::
     - name: Setup Python for testing
       if: contains(fromJSON('["ubuntu:jammy"]'), inputs.image)
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.9'
         architecture: 'x64'

--- a/.github/actions/pack-module-and-upload-artifacts-to-s3/action.yml
+++ b/.github/actions/pack-module-and-upload-artifacts-to-s3/action.yml
@@ -19,7 +19,7 @@ runs:
         source .venv/bin/activate
         gmake pack BRANCH=${{inputs.tag_or_branch}} SHOW=1
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-access-key-id: ${{ inputs.aws_access_key_id }}
         aws-secret-access-key: ${{ inputs.aws_secret_access_key }}

--- a/.github/actions/test-summary/action.yml
+++ b/.github/actions/test-summary/action.yml
@@ -60,12 +60,12 @@ runs:
   using: composite
   steps:
     - name: Checkout for commit info
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 1
 
     - name: Download all test result artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       continue-on-error: true
       with:
         pattern: test-results-*

--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -19,7 +19,7 @@ runs:
           sed -e 's/[":\/\\<>\|*?]/_/g' -e 's/__*/_/g' -e 's/^_//' -e 's/_$//')" >> $GITHUB_OUTPUT
     - name: Upload test artifacts
       if: inputs.image != 'amazonlinux:2'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Test logs ${{ steps.artifact-names.outputs.name }}
         path: |

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Empty ref => default checkout (the ref that triggered the workflow).
           ref: ${{ inputs.module_ref }}
@@ -69,7 +69,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.PERFORMANCE_EC2_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.PERFORMANCE_EC2_SECRET_KEY }}

--- a/.github/workflows/benchmark-trigger.yml
+++ b/.github/workflows/benchmark-trigger.yml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       benchmark: ${{ steps.haslabel.outputs.labeled-run-benchmark }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check if labeled with run-benchmark
         id: haslabel
         uses: DanielTamkin/HasLabel@v1.0.4

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -57,7 +57,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.validate-and-check.outputs.release_branch }}
           path: release-branch

--- a/.github/workflows/event-backport_pr.yml
+++ b/.github/workflows/event-backport_pr.yml
@@ -30,18 +30,18 @@ jobs:
     steps:
       - name: 🔑 Generate GitHub App Token
         id: generate-app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
           owner: RediTimeSeries
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ steps.generate-app-token.outputs.token }}
       - name: Create backport pull requests
         id: backport
-        uses: korthout/backport-action@v3
+        uses: korthout/backport-action@v4
         with:
           github_token: ${{ steps.generate-app-token.outputs.token }}
           pull_title: '[${target_branch}] ${pull_title}'

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -35,7 +35,7 @@ jobs:
       snapshot-template: ${{ steps.set-env.outputs.snapshot-template }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: set env
         id: set-env
@@ -92,7 +92,7 @@ jobs:
           MODULE_VERSION: ${{ steps.get-version.outputs.module-version }}
   
       - name: Upload build metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-metadata
           path: build-metadata.json
@@ -165,7 +165,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build job results JSON
         id: build-results

--- a/.github/workflows/flow-linter.yml
+++ b/.github/workflows/flow-linter.yml
@@ -6,7 +6,7 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
       - name: Install build dependencies

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -84,7 +84,7 @@ jobs:
       TAG_OR_BRANCH: ${{ steps.set-env.outputs.TAG }}${{ steps.set-env.outputs.BRANCH }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: set env
         id: set-env
         uses: ./.github/actions/setup-env
@@ -136,7 +136,7 @@ jobs:
       DOCKER_IMAGE: redistimeseries-${{ matrix.platform.os }}:latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -190,7 +190,7 @@ jobs:
 
       - name: Upload test artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-artifacts-${{ inputs.arch }}-${{ matrix.platform.os }}${{ inputs.run_valgrind && '-valgrind' || '' }}${{ inputs.run_sanitizer && '-sanitizer' || '' }}
           path: |

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -89,7 +89,7 @@ jobs:
       os: ${{ steps.set-matrix.outputs.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: set env
         id: set-env
         uses: ./.github/actions/setup-env
@@ -129,11 +129,11 @@ jobs:
         run: |
           brew install make coreutils autoconf automake pyenv-virtualenv libtool
       - name: Full checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Checkout Redis
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: 'redis/redis'
           ref: ${{ needs.setup-environment.outputs.redis-ref }}

--- a/.github/workflows/flow-random-traffic.yml
+++ b/.github/workflows/flow-random-traffic.yml
@@ -59,7 +59,7 @@ jobs:
       REDIS_REF: ${{ inputs.redis-ref || 'unstable' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload random traffic
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: random-traffic-${{ needs.pick-os.outputs.os }}-log
           path: random_traffic.txt

--- a/.github/workflows/flow-spellcheck.yml
+++ b/.github/workflows/flow-spellcheck.yml
@@ -6,7 +6,7 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Spellcheck
         uses: rojopolis/spellcheck-github-actions@0.45.0
         with:

--- a/.github/workflows/mariner2.yml
+++ b/.github/workflows/mariner2.yml
@@ -27,7 +27,7 @@ jobs:
       TAG_OR_BRANCH: ${{ steps.set-env.outputs.TAG }}${{ steps.set-env.outputs.BRANCH }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: set env
         id: set-env
         uses: ./.github/actions/setup-env
@@ -52,14 +52,14 @@ jobs:
       - name: Install pre-checkout dependencies
         run: tdnf install --noplugins --skipsignature -y ca-certificates git
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
       - name: Install dependencies
         run: |
           bash .install/mariner2.sh
       - name: Get Redis
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: redis/redis
           ref: ${{inputs.redis-ref}}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter-config.yml

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: release-drafter/release-drafter@v7
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-           config-name: release-drafter-config.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          config-name: release-drafter-config.yml
+          token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

GitHub is removing Node20 from Actions runners on **2026-06-16** (default switch to Node24), with full removal in fall 2026.
See the [deprecation announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

Bumps each action to the lowest Node24-compatible major:

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v5 |
| `actions/upload-artifact` | v4 | v6 (v5 is still node20) |
| `actions/download-artifact` | v4 | v7 (v5/v6 are still node20) |
| `actions/setup-python` | v5 | v6 |
| `aws-actions/configure-aws-credentials` | v4 | v6 (v5 is still node20) |
| `release-drafter/release-drafter` | v5 | v7 (v6 is still node20) |
| `korthout/backport-action` | v3 | v4 |
| `actions/create-github-app-token` | v1 | v3 |

Verified via `action.yml` of each chosen ref:
```
actions/checkout@v5:                          using: node24
actions/upload-artifact@v6:                   using: node24
actions/download-artifact@v7:                 using: node24
actions/setup-python@v6:                      using: node24
aws-actions/configure-aws-credentials@v6:     using: node24
release-drafter/release-drafter@v7:           using: node24
korthout/backport-action@v4:                  using: node24
actions/create-github-app-token@v3:           using: node24
```

### Not changed
- `DanielTamkin/HasLabel@v1.0.4` — only ships node12; no Node24 release available. Action is small enough to inline if it becomes a problem.
- `rojopolis/spellcheck-github-actions@0.45.0` — docker action, runtime is unaffected.

## Test plan
- [ ] CI passes on this branch (covers checkout, setup-python, upload/download-artifact, aws-credentials in benchmark/flow-linux/flow-macos/flow-random-traffic/event-nightly/mariner2)
- [ ] Visual spot-check that release-drafter, backport, and create-github-app-token workflows are unchanged in syntax — they fire on events not exercised by PR CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-pin-only CI changes with no application code; main residual risk is upstream action breaking changes on event-driven workflows not fully exercised in PR CI.
> 
> **Overview**
> Prepares CI for GitHub’s Node20 deprecation by upgrading action pins everywhere this PR touches—composite actions and reusable workflows for Linux/macOS/nightly/benchmark/backport/release flows.
> 
> **`actions/checkout`** v4→v5, **`upload-artifact`** v4→v6, **`download-artifact`** v4→v7 (test-summary), **`setup-python`** v5→v6, **`aws-actions/configure-aws-credentials`** v4→v6, **`release-drafter`** v5→v7, **`korthout/backport-action`** v3→v4, and **`actions/create-github-app-token`** v1→v3. Step inputs and workflow logic are otherwise unchanged.
> 
> **`release-drafter/release-drafter@v7`** now passes **`token`** as an input instead of **`GITHUB_TOKEN`** via **`env`**, matching the newer action API.
> 
> Third-party actions left on older runtimes (e.g. **`HasLabel`**, docker-based spellcheck) are out of scope for this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c34534c4e093d439e236206fdb0ba8314b4f6b62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->