### PR TITLE
MOD-8187 -  fix the aggregation bugs (fix reverse iterator)

### DIFF
--- a/src/compaction.c
+++ b/src/compaction.c
@@ -122,10 +122,12 @@ void LastValueReset(void *contextPtr) {
 
 /* LOCF seed for reverse-mode empty-bucket emission: the empty gap inherits the value of the
  * older (chronologically previous) sample. In reverse iteration that sample hasn't been seen
- * yet by the aggregator, so we plant it directly. */
-void LastValueSeedLocf(void *contextPtr, double value) {
+ * yet by the aggregator, so we plant it directly. Sets both value and ts so the context stays
+ * internally consistent — otherwise the stale ts from a newer bucket would linger. */
+void LastValueSeedLocf(void *contextPtr, double value, timestamp_t ts) {
     SingleValueContext *context = (SingleValueContext *)contextPtr;
     context->value = value;
+    context->ts = ts;
 }
 
 int SingleValueFinalize(void *contextPtr, double *val) {

--- a/src/compaction.c
+++ b/src/compaction.c
@@ -31,11 +31,14 @@ typedef struct FirstValueContext
 {
     double value;
     char isResetted;
+    timestamp_t ts; /* in-memory only; tracks oldest sample seen */
 } FirstValueContext;
 
 typedef struct SingleValueContext
 {
     double value;
+    timestamp_t ts;    /* in-memory only; tracks newest sample seen */
+    bool fresh_bucket; /* in-memory only; lets reverse-mode reset across buckets without losing LOCF */
 } SingleValueContext;
 
 typedef struct AvgContext
@@ -82,6 +85,8 @@ void finalize_empty_last_value(void *contextPtr, double *value) {
 void *SingleValueCreateContext(__unused bool reverse) {
     SingleValueContext *context = (SingleValueContext *)malloc(sizeof(SingleValueContext));
     context->value = 0;
+    context->ts = 0;
+    context->fresh_bucket = true;
     return context;
 }
 
@@ -94,17 +99,32 @@ void *SingleValueCloneContext(void *contextPtr) {
 void SingleValueReset(void *contextPtr) {
     SingleValueContext *context = (SingleValueContext *)contextPtr;
     context->value = 0;
+    context->ts = 0;
+    context->fresh_bucket = true;
 }
 
 void *LastValueCreateContext(__unused bool reverse) {
     SingleValueContext *context = malloc(sizeof *context);
     context->value = NAN;
+    context->ts = 0;
+    context->fresh_bucket = true;
     return context;
 }
 
 void LastValueReset(void *contextPtr) {
-    // Don't do anything cause with EMPTY flag we would like to use the last value
-    return;
+    /* Don't touch value — EMPTY+LAST wants LOCF carry-over. Mark bucket boundary so the next
+     * appendValue accepts a fresh sample regardless of stored ts (which may linger from a newer
+     * bucket processed earlier when iterating in reverse). */
+    SingleValueContext *context = (SingleValueContext *)contextPtr;
+    context->fresh_bucket = true;
+}
+
+/* LOCF seed for reverse-mode empty-bucket emission: the empty gap inherits the value of the
+ * older (chronologically previous) sample. In reverse iteration that sample hasn't been seen
+ * yet by the aggregator, so we plant it directly. */
+void LastValueSeedLocf(void *contextPtr, double value) {
+    SingleValueContext *context = (SingleValueContext *)contextPtr;
+    context->value = value;
 }
 
 int SingleValueFinalize(void *contextPtr, double *val) {
@@ -133,6 +153,7 @@ void *FirstValueCreateContext(__unused bool reverse) {
     FirstValueContext *context = (FirstValueContext *)malloc(sizeof(FirstValueContext));
     context->value = 0;
     context->isResetted = true;
+    context->ts = 0;
     return context;
 }
 
@@ -146,6 +167,7 @@ void FirstValueReset(void *contextPtr) {
     FirstValueContext *context = (FirstValueContext *)contextPtr;
     context->value = 0;
     context->isResetted = true;
+    context->ts = 0;
 }
 
 int FirstValueFinalize(void *contextPtr, double *val) {
@@ -750,17 +772,26 @@ int CountFinalize(void *contextPtr, double *val) {
     return TSDB_OK;
 }
 
-void FirstAppendValue(void *contextPtr, double value, __attribute__((unused)) timestamp_t ts) {
+void FirstAppendValue(void *contextPtr, double value, timestamp_t ts) {
     FirstValueContext *context = (FirstValueContext *)contextPtr;
-    if (context->isResetted) {
+    /* Direction-independent: keep the OLDEST sample by timestamp. */
+    if (context->isResetted || ts < context->ts) {
         context->isResetted = false;
         context->value = value;
+        context->ts = ts;
     }
 }
 
-void LastAppendValue(void *contextPtr, double value, __attribute__((unused)) timestamp_t ts) {
+void LastAppendValue(void *contextPtr, double value, timestamp_t ts) {
     SingleValueContext *context = (SingleValueContext *)contextPtr;
-    context->value = value;
+    /* Direction-independent: keep the NEWEST sample by timestamp. `fresh_bucket` lets the first
+     * sample of a new bucket always land — important for reverse mode where a newer-bucket value
+     * still sits in `ts` from the previous iteration. */
+    if (context->fresh_bucket || ts >= context->ts) {
+        context->value = value;
+        context->ts = ts;
+        context->fresh_bucket = false;
+    }
 }
 
 static AggregationClass aggMax = {

--- a/src/compaction.c
+++ b/src/compaction.c
@@ -38,7 +38,8 @@ typedef struct SingleValueContext
 {
     double value;
     timestamp_t ts;    /* in-memory only; tracks newest sample seen */
-    bool fresh_bucket; /* in-memory only; lets reverse-mode reset across buckets without losing LOCF */
+    bool fresh_bucket; /* in-memory only; lets reverse-mode reset across buckets without losing LOCF
+                        */
 } SingleValueContext;
 
 typedef struct AvgContext

--- a/src/compaction.h
+++ b/src/compaction.h
@@ -55,4 +55,8 @@ const char *AggTypeEnumToString(TS_AGG_TYPES_T aggType);
 const char *AggTypeEnumToStringLowerCase(TS_AGG_TYPES_T aggType);
 void initGlobalCompactionFunctions();
 
+/* LOCF seed for reverse-mode empty-bucket emission of TS_AGG_LAST. The caller must verify the
+ * aggregation is TS_AGG_LAST before calling. */
+void LastValueSeedLocf(void *contextPtr, double value);
+
 #endif

--- a/src/compaction.h
+++ b/src/compaction.h
@@ -57,6 +57,6 @@ void initGlobalCompactionFunctions();
 
 /* LOCF seed for reverse-mode empty-bucket emission of TS_AGG_LAST. The caller must verify the
  * aggregation is TS_AGG_LAST before calling. */
-void LastValueSeedLocf(void *contextPtr, double value);
+void LastValueSeedLocf(void *contextPtr, double value, timestamp_t ts);
 
 #endif

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -477,8 +477,7 @@ static void seed_locf_for_reverse_empty_gap(const AggregationIterator *self,
             continue;
         }
         Sample older, older_older;
-        if (twa_get_samples_from_left(
-                lowest_empty_bucket_start, self, &older, &older_older) > 0) {
+        if (twa_get_samples_from_left(lowest_empty_bucket_start, self, &older, &older_older) > 0) {
             LastValueSeedLocf(self->aggregationContexts[a], older.value);
         } else {
             LastValueSeedLocf(self->aggregationContexts[a], NAN);

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -466,6 +466,26 @@ static int64_t findLastIndexbeforeTS(const EnrichedChunk *chunk,
     return l;
 }
 
+/* When iterating reverse, empty-bucket LOCF (TS_AGG_LAST + EMPTY) inherits from the older
+ * neighbor of the gap. The aggregator hasn't seen that sample yet (it lives in a bucket the
+ * iterator will visit next), so we look it up directly and plant it into the context. The next
+ * non-empty bucket's appendValue will overwrite it via the fresh_bucket path. */
+static void seed_locf_for_reverse_empty_gap(const AggregationIterator *self,
+                                            timestamp_t lowest_empty_bucket_start) {
+    for (size_t a = 0; a < self->numAggregations; a++) {
+        if (self->aggregations[a].type != TS_AGG_LAST) {
+            continue;
+        }
+        Sample older, older_older;
+        if (twa_get_samples_from_left(
+                lowest_empty_bucket_start, self, &older, &older_older) > 0) {
+            LastValueSeedLocf(self->aggregationContexts[a], older.value);
+        } else {
+            LastValueSeedLocf(self->aggregationContexts[a], NAN);
+        }
+    }
+}
+
 // Empty bucket with no samples from left or right at all.
 static void fillEmptyBucketsWithDefaultVals(size_t *write_index,
                                             timestamp_t cur_ts,
@@ -724,6 +744,11 @@ static int fillEmptyBuckets(Samples *samples,
     if (self->hasTwa) {
         twa_fillEmptyBuckets(write_index, cur_ts, samples, self, n_empty_buckets, reversed);
     } else {
+        /* Reverse iteration loses LOCF carry-over for TS_AGG_LAST: the context still holds the
+         * NEWER bucket's value. Seed from the older neighbor before the gap is emitted. */
+        if (reversed) {
+            seed_locf_for_reverse_empty_gap(self, first_bucket_ts);
+        }
         fillEmptyBucketsWithDefaultVals(
             write_index, cur_ts, samples, self, n_empty_buckets, reversed);
     }

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -478,9 +478,12 @@ static void seed_locf_for_reverse_empty_gap(const AggregationIterator *self,
         }
         Sample older, older_older;
         if (twa_get_samples_from_left(lowest_empty_bucket_start, self, &older, &older_older) > 0) {
-            LastValueSeedLocf(self->aggregationContexts[a], older.value);
+            LastValueSeedLocf(self->aggregationContexts[a], older.value, older.timestamp);
         } else {
-            LastValueSeedLocf(self->aggregationContexts[a], NAN);
+            /* No older sample exists. The next non-empty bucket's appendValue will go through the
+             * fresh_bucket path so the planted ts won't matter — pass 0 to keep the context
+             * internally consistent with the NaN value. */
+            LastValueSeedLocf(self->aggregationContexts[a], NAN, 0);
         }
     }
 }

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -1343,8 +1343,8 @@ def test_empty():
         expected_data_2 = [[10, '4'], [20, '4'], [30, '4'], [40, '4'], [50, '3'], [60, '3'], [70, '3']]
         assert expected_data_2 == \
         decode_if_needed(r.execute_command('TS.range', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'last', agg_size, 'EMPTY'))
-        expected_data_3 = [[70, '5'], [60, '5'], [50, '3'], [40, '3'], [30, '3'], [20, '3'], [10, '1']]
-        assert expected_data_3 == \
+        expected_data_2.reverse()
+        assert expected_data_2 == \
         decode_if_needed(r.execute_command('TS.revrange', 't1', '0', '100', 'ALIGN', '0', 'AGGREGATION', 'last', agg_size, 'EMPTY'))
 
         expected_data = [[10, '5'], [20, '0'], [30, '0'], [40, '0'], [50, '3'], [60, '0'], [70, '8']]
@@ -1934,3 +1934,1202 @@ def test_ts_range_countAll():
             assert float(result[2][1]) == 1.0
             assert float(result[3][1]) == 1.0
             assert float(result[4][1]) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Regression: TS.RANGE / TS.REVRANGE with AGGREGATION ... EMPTY must produce
+# the same set of bucket timestamps in both directions (one is the reverse of
+# the other), and carry the chronologically-correct value for LOCF-style
+# aggregations such as LAST.
+#
+# This guards against two bugs that previously affected reverse iteration:
+#   Bug A) extra empty buckets emitted past the data span.
+#   Bug B) wrong carry-forward value for empty buckets between samples.
+#
+# To extend coverage to a new aggregation, just add it to AGGREGATIONS below.
+# To additionally check exact values for that aggregation, add an entry to
+# PER_AGG_VALUE_CHECKS. Without an entry, only timestamp-symmetry is verified.
+# ---------------------------------------------------------------------------
+
+# Aggregations to validate. Add more here with zero other code changes
+# (provided the aggregation behaves like one of the cases handled by
+# _agg_sample_value / _agg_empty_value below).
+#
+# Intentionally excluded: 'twa' (bucket-edge interpolation), 'std.p' / 'std.s' /
+# 'var.p' / 'var.s' (single-sample value depends on sample/population denominator).
+AGGREGATIONS = ['last', 'first', 'max', 'min', 'count', 'sum', 'avg', 'range']
+
+
+def _agg_sample_value(agg, v):
+    """Value the aggregation produces for a bucket that contains exactly one sample."""
+    if agg == 'count':
+        return '1'
+    if agg == 'range':
+        return '0'                    # max - min over a single sample
+    # last, first, max, min, sum, avg → that single sample's value
+    return str(v)
+
+
+def _agg_empty_value(agg, prev_v, next_v):
+    """Value the aggregation produces for an empty bucket that lies BETWEEN two samples
+    (i.e. has both a left and a right neighbor — should_skip_empty_gap keeps it).
+
+    Empty-bucket finalizers in src/compaction.c map as follows:
+      - finalize_empty_last_value  → 'last'
+      - finalize_empty_with_ZERO   → 'count', 'sum'
+      - finalize_empty_with_NAN    → everything else (max, min, avg, range, first, ...)
+    """
+    if agg == 'last':
+        return str(prev_v)            # LOCF: carry forward chronologically previous value
+    if agg in ('count', 'sum'):
+        return '0'
+    return 'NaN'                      # max, min, avg, first, range, ...
+
+
+def _build_expected_forward(samples, bucket_size, window, agg):
+    """
+    Build the expected forward TS.RANGE result for `agg` over `samples`,
+    `window` and `bucket_size`. Each sample at t produces:
+        - bucket t                   → _agg_sample_value(agg, v)
+        - bucket (t + bucket_size)   → _agg_empty_value(agg, v, next_v)
+    The trailing carry bucket is dropped when there is no next sample
+    (matches should_skip_empty_gap).
+    """
+    win_lo, win_hi = window
+    out = []
+    for i, (t, v) in enumerate(samples):
+        if win_lo <= t <= win_hi:
+            out.append((t, _agg_sample_value(agg, v)))
+        carry_t = t + bucket_size
+        if carry_t <= win_hi and i + 1 < len(samples):
+            next_v = samples[i + 1][1]
+            out.append((carry_t, _agg_empty_value(agg, v, next_v)))
+    return out
+
+
+def _decode_pair(row):
+    ts = int(row[0])
+    val = row[1].decode() if isinstance(row[1], bytes) else row[1]
+    return ts, val
+
+
+def _format_redis_cli(pairs):
+    """Format a list of (ts, value) pairs the way redis-cli prints them."""
+    if not pairs:
+        return '(empty array)'
+    lines = []
+    for i, (ts, val) in enumerate(pairs, start=1):
+        lines.append(f'{i}) 1) (integer) {ts}')
+        lines.append(f'   2) {val}')
+    return '\n'.join(lines)
+
+
+def _print_block(title, pairs):
+    print(f'\n--- {title} ---')
+    print(_format_redis_cli(pairs))
+
+
+def _format_samples(samples):
+    """Format input samples like ([t=10, v=100], [t=20, v=110], ...)."""
+    inner = ', '.join(f'[t={t}, v={v}]' for t, v in samples)
+    return f'({inner})'
+
+
+def _print_samples(title, samples):
+    print(f'\n--- {title} ({len(samples)} samples) ---')
+    print(_format_samples(samples))
+
+
+def test_range_revrange_empty_symmetry():
+    """
+    Forward and reverse aggregated EMPTY queries must be mirror images of
+    each other (same bucket timestamps, reversed order). For aggregations
+    listed in PER_AGG_VALUE_CHECKS the bucket values are also asserted.
+    """
+    samples = [(18, 100), (20, 110)]
+    window  = (18, 22)
+    bucket  = 1
+    with Env().getClusterConnectionIfNeeded() as r:
+        for agg in AGGREGATIONS:
+            key = 'ts_sym_' + agg + '{a}'
+            r.execute_command('DEL', key)
+            r.execute_command('TS.CREATE', key)
+            for t, v in samples:
+                r.execute_command('TS.ADD', key, t, v)
+
+            _print_samples(f'{agg} input samples', samples)
+
+            win_lo, win_hi = window
+            fwd = r.execute_command('TS.RANGE',    key, win_lo, win_hi,
+                                    'AGGREGATION', agg, bucket, 'EMPTY')
+            rev = r.execute_command('TS.REVRANGE', key, win_lo, win_hi,
+                                    'AGGREGATION', agg, bucket, 'EMPTY')
+
+            got_fwd = [_decode_pair(row) for row in fwd]
+            got_rev = [_decode_pair(row) for row in rev]
+
+            exp_fwd = _build_expected_forward(samples, bucket, window, agg)
+            exp_rev = list(reversed(exp_fwd))
+
+            _print_block(f'{agg} TS.RANGE actual',      got_fwd)
+            _print_block(f'{agg} TS.REVRANGE actual',   got_rev)
+            _print_block(f'{agg} TS.RANGE expected',    exp_fwd)
+            _print_block(f'{agg} TS.REVRANGE expected', exp_rev)
+
+            assert len(fwd) == len(rev), (
+                f'{agg}: bucket count mismatch; '
+                f'fwd={len(fwd)} ({fwd}), rev={len(rev)} ({rev})')
+
+            fwd_ts = [ts for ts, _ in got_fwd]
+            rev_ts = [ts for ts, _ in got_rev]
+            assert fwd_ts == list(reversed(rev_ts)), (
+                f'{agg}: timestamps not mirrored; '
+                f'fwd={fwd_ts}, rev={rev_ts}')
+
+            assert got_fwd == exp_fwd, (
+                f'{agg} forward values mismatch.\n'
+                f'expected:\n{_format_redis_cli(exp_fwd)}\n'
+                f'actual:\n{_format_redis_cli(got_fwd)}')
+            assert got_rev == exp_rev, (
+                f'{agg} reverse values mismatch.\n'
+                f'expected:\n{_format_redis_cli(exp_rev)}\n'
+                f'actual:\n{_format_redis_cli(got_rev)}')
+
+
+# ---------------------------------------------------------------------------
+# Regression: same EMPTY-aggregation symmetry, but on a series whose samples
+# span MANY chunks. The aggregation iterator's GetNext() loop must walk
+# multiple chunks while still emitting the correct empty buckets in both
+# directions and with correct carry values.
+#
+# We force tiny chunks (CHUNK_SIZE=48 bytes, uncompressed → 3 samples / chunk)
+# and sparse samples so the empty buckets between samples land on chunk
+# boundaries.
+#
+# Generic over AGGREGATIONS like the previous test; LAST also gets exact
+# value-level assertions via MULTICHUNK_VALUE_CHECKS.
+# ---------------------------------------------------------------------------
+
+# Sample layout:  t in {10, 20, 30, ..., 300}, value = ts * 10.
+# 30 samples / 3-per-chunk = 10 chunks.
+_MC_SAMPLE_TS    = list(range(10, 301, 10))
+_MC_SAMPLES      = [(t, t * 10) for t in _MC_SAMPLE_TS]
+_MC_WINDOW       = (10, 300)
+_MC_BUCKET_SIZE  = 5
+_MC_CHUNK_BYTES  = 48     # uncompressed: 16 B/sample → 3 samples / chunk
+
+def test_range_revrange_empty_symmetry_multichunk():
+    """
+    Same forward/reverse EMPTY-aggregation symmetry as the previous test,
+    but the underlying series is split across ~10 chunks so the
+    AggregationIterator GetNext loop is exercised across chunk boundaries.
+    """
+    with Env().getClusterConnectionIfNeeded() as r:
+        for agg in AGGREGATIONS:
+            key = 'ts_sym_mc_' + agg + '{a}'
+            r.execute_command('DEL', key)
+            r.execute_command('TS.CREATE', key,
+                              'ENCODING', 'UNCOMPRESSED',
+                              'CHUNK_SIZE', _MC_CHUNK_BYTES)
+            for t, v in _MC_SAMPLES:
+                r.execute_command('TS.ADD', key, t, v)
+
+            # Sanity-check that we really got multiple chunks.
+            info = r.execute_command('TS.INFO', key)
+            info_dict = {info[i]: info[i + 1] for i in range(0, len(info), 2)}
+            chunk_count_key = b'chunkCount' if b'chunkCount' in info_dict else 'chunkCount'
+            chunk_count = int(info_dict[chunk_count_key])
+            assert chunk_count > 1, (
+                f'expected the series to span multiple chunks, got '
+                f'chunkCount={chunk_count}; sample/chunk math may have changed')
+
+            win_lo, win_hi = _MC_WINDOW
+            fwd = r.execute_command('TS.RANGE',    key, win_lo, win_hi,
+                                    'AGGREGATION', agg, _MC_BUCKET_SIZE, 'EMPTY')
+            rev = r.execute_command('TS.REVRANGE', key, win_lo, win_hi,
+                                    'AGGREGATION', agg, _MC_BUCKET_SIZE, 'EMPTY')
+
+            got_fwd = [_decode_pair(row) for row in fwd]
+            got_rev = [_decode_pair(row) for row in rev]
+
+            exp_fwd = _build_expected_forward(
+                _MC_SAMPLES, _MC_BUCKET_SIZE, _MC_WINDOW, agg)
+            exp_rev = list(reversed(exp_fwd))
+
+            print(f'\n--- {agg} multichunk: chunkCount={chunk_count}, '
+                  f'samples={len(_MC_SAMPLES)}, buckets={len(exp_fwd)} ---')
+
+            assert len(fwd) == len(rev), (
+                f'{agg}: bucket count mismatch; '
+                f'fwd={len(fwd)}, rev={len(rev)}')
+
+            fwd_ts = [ts for ts, _ in got_fwd]
+            rev_ts = [ts for ts, _ in got_rev]
+            assert fwd_ts == list(reversed(rev_ts)), (
+                f'{agg}: timestamps not mirrored across chunks; '
+                f'fwd={fwd_ts}, rev={rev_ts}')
+
+            assert got_fwd == exp_fwd, (
+                f'{agg} forward values mismatch (multichunk).\n'
+                f'expected:\n{_format_redis_cli(exp_fwd)}\n'
+                f'actual:\n{_format_redis_cli(got_fwd)}')
+            assert got_rev == exp_rev, (
+                f'{agg} reverse values mismatch (multichunk).\n'
+                f'expected:\n{_format_redis_cli(exp_rev)}\n'
+                f'actual:\n{_format_redis_cli(got_rev)}')
+
+
+# ---------------------------------------------------------------------------
+# Regression: plain TS.RANGE / TS.REVRANGE (no AGGREGATION) must be exact
+# mirror images of each other. Exercises the reply-time backward-index walk
+# in ReplySeriesRange (which replaced the in-place buffer reverse).
+# ---------------------------------------------------------------------------
+def test_range_revrange_plain_symmetry():
+    """
+    Without any aggregation, TS.REVRANGE over the same window must return
+    exactly the same samples as TS.RANGE, in reverse order.
+    """
+    samples = [(10, 1), (20, 2), (30, 3), (40, 4), (50, 5)]
+    with Env().getClusterConnectionIfNeeded() as r:
+        key = 'ts_plain_sym{a}'
+        r.execute_command('DEL', key)
+        r.execute_command('TS.CREATE', key)
+        for t, v in samples:
+            r.execute_command('TS.ADD', key, t, v)
+
+        fwd = r.execute_command('TS.RANGE',    key, 10, 50)
+        rev = r.execute_command('TS.REVRANGE', key, 10, 50)
+
+        got_fwd = [_decode_pair(row) for row in fwd]
+        got_rev = [_decode_pair(row) for row in rev]
+
+        assert len(got_fwd) == len(samples), (
+            f'fwd length wrong: got {got_fwd}')
+        assert got_fwd == list(reversed(got_rev)), (
+            f'plain mirror failed:\n'
+            f'fwd={_format_redis_cli(got_fwd)}\n'
+            f'rev={_format_redis_cli(got_rev)}')
+
+
+# ---------------------------------------------------------------------------
+# Regression: TS.REVRANGE ... COUNT N must return the LATEST N samples in
+# reverse chronological order — i.e. it is the mirror image of TS.RANGE on
+# the LAST N samples, not on the FIRST N. This pins the documented COUNT
+# semantics for the reverse direction.
+# ---------------------------------------------------------------------------
+def test_range_revrange_plain_count_symmetry():
+    """
+    For samples [(10,1), (20,2), ..., (100,10)]:
+      TS.RANGE    ... COUNT N → first N forward         = samples[:N]
+      TS.REVRANGE ... COUNT N → latest N in reverse     = reversed(samples[-N:])
+    """
+    samples = [(t, t) for t in range(10, 101, 10)]
+    with Env().getClusterConnectionIfNeeded() as r:
+        key = 'ts_plain_cnt{a}'
+        r.execute_command('DEL', key)
+        r.execute_command('TS.CREATE', key)
+        for t, v in samples:
+            r.execute_command('TS.ADD', key, t, v)
+
+        for n in (1, 3, 5, len(samples), len(samples) + 5):
+            fwd = r.execute_command('TS.RANGE',    key, 10, 100, 'COUNT', n)
+            rev = r.execute_command('TS.REVRANGE', key, 10, 100, 'COUNT', n)
+
+            got_fwd = [_decode_pair(row) for row in fwd]
+            got_rev = [_decode_pair(row) for row in rev]
+
+            expected_fwd = [(t, str(v)) for t, v in samples[:n]]
+            expected_rev = list(reversed([(t, str(v)) for t, v in samples[-n:]]))
+
+            assert got_fwd == expected_fwd, (
+                f'COUNT={n} fwd mismatch:\n'
+                f'expected:\n{_format_redis_cli(expected_fwd)}\n'
+                f'actual:\n{_format_redis_cli(got_fwd)}')
+            assert got_rev == expected_rev, (
+                f'COUNT={n} rev mismatch:\n'
+                f'expected:\n{_format_redis_cli(expected_rev)}\n'
+                f'actual:\n{_format_redis_cli(got_rev)}')
+
+
+# ---------------------------------------------------------------------------
+# Regression: aggregated TS.RANGE / TS.REVRANGE WITHOUT the EMPTY flag must
+# still be mirror images of each other (same non-empty buckets, reversed
+# order). Complements the EMPTY-flag tests above.
+# ---------------------------------------------------------------------------
+def test_range_revrange_no_empty_symmetry():
+    """
+    Sparse samples spaced beyond bucket_size so naturally-empty buckets
+    exist; without EMPTY, neither direction should emit them.
+    """
+    samples = [(10, 1), (50, 5), (90, 9)]
+    bucket  = 10
+    with Env().getClusterConnectionIfNeeded() as r:
+        for agg in AGGREGATIONS:
+            key = 'ts_no_empty_' + agg + '{a}'
+            r.execute_command('DEL', key)
+            r.execute_command('TS.CREATE', key)
+            for t, v in samples:
+                r.execute_command('TS.ADD', key, t, v)
+
+            fwd = r.execute_command('TS.RANGE',    key, 0, 100,
+                                    'AGGREGATION', agg, bucket)
+            rev = r.execute_command('TS.REVRANGE', key, 0, 100,
+                                    'AGGREGATION', agg, bucket)
+
+            got_fwd = [_decode_pair(row) for row in fwd]
+            got_rev = [_decode_pair(row) for row in rev]
+
+            assert len(got_fwd) == len(samples), (
+                f'{agg}: expected one bucket per sample (no EMPTY flag), '
+                f'got {got_fwd}')
+            assert got_fwd == list(reversed(got_rev)), (
+                f'{agg} no-EMPTY mirror failed:\n'
+                f'fwd={_format_redis_cli(got_fwd)}\n'
+                f'rev={_format_redis_cli(got_rev)}')
+
+
+# ---------------------------------------------------------------------------
+# Regression: TS.MRANGE / TS.MREVRANGE per-series mirror image. The set of
+# returned series and their labels must be the same; the samples list per
+# series must be reversed between the two directions.
+# ---------------------------------------------------------------------------
+def _decode_mrange_entry(entry):
+    """Return (key_name_str, samples_as_list_of_(ts,val)_pairs) for one MRANGE entry.
+    Tolerates the [key, labels, samples] layout regardless of byte vs str."""
+    key = entry[0].decode() if isinstance(entry[0], bytes) else entry[0]
+    samples = [_decode_pair(row) for row in entry[2]]
+    return key, samples
+
+
+def test_mrange_mrevrange_symmetry():
+    """
+    Two series with a shared label; MRANGE and MREVRANGE filtered on that
+    label must return the same set of keys, each with its samples reversed.
+    """
+    samples = [(10, 1), (20, 2), (30, 3), (40, 4)]
+    env = Env()
+    with env.getClusterConnectionIfNeeded() as r:
+        keys = ['ts_m_a{a}', 'ts_m_b{a}']
+        for i, key in enumerate(keys):
+            r.execute_command('DEL', key)
+            r.execute_command('TS.CREATE', key,
+                              'LABELS', 'tag', 'mirror_sym', 'idx', str(i))
+            for t, v in samples:
+                r.execute_command('TS.ADD', key, t, v + i * 100)
+
+        # MRANGE / MREVRANGE go through a specific shard connection — see docstring.
+        shard_conn = env.getConnection(1)
+        fwd = shard_conn.execute_command('TS.MRANGE',    '10', '40',
+                                         'FILTER', 'tag=mirror_sym')
+        rev = shard_conn.execute_command('TS.MREVRANGE', '10', '40',
+                                         'FILTER', 'tag=mirror_sym')
+
+        fwd_by_key = dict(_decode_mrange_entry(e) for e in fwd)
+        rev_by_key = dict(_decode_mrange_entry(e) for e in rev)
+
+        assert set(fwd_by_key) == set(rev_by_key) == set(keys), (
+            f'key sets differ: fwd={set(fwd_by_key)}, '
+            f'rev={set(rev_by_key)}, expected={set(keys)}')
+
+        for key in keys:
+            f_samples = fwd_by_key[key]
+            r_samples = rev_by_key[key]
+            assert len(f_samples) == len(samples), (
+                f'{key}: fwd sample count wrong: {f_samples}')
+            assert f_samples == list(reversed(r_samples)), (
+                f'{key}: per-series mirror failed:\n'
+                f'fwd={_format_redis_cli(f_samples)}\n'
+                f'rev={_format_redis_cli(r_samples)}')
+
+
+# ---------------------------------------------------------------------------
+# TS.RANGE AGGREGATION coverage — keep aligned with the public docs at:
+#   https://redis.io/docs/latest/commands/ts.range/
+#
+# The per-aggregator tests above (test_agg_*, test_ts_range_count{NaN,All})
+# verify exact values for each aggregator on hand-tuned inputs. The four
+# tests below add coverage that scales automatically to every aggregator
+# listed in TS_RANGE_AGGREGATORS:
+#
+#   1. test_ts_range_all_aggregators_exact_values (positive)
+#      Every aggregator returns the CORRECT value for a single bucket with
+#      mixed numeric + NaN samples. Also verifies TS.REVRANGE mirrors
+#      TS.RANGE (parser/aggregator share the path; this catches direction-
+#      specific regressions).
+#
+#   2. test_ts_range_all_aggregators_empty_flag (positive, EMPTY flag)
+#      Asserts the exact value reported for an EMPTY bucket sandwiched
+#      between two samples, for every aggregator. The expected values
+#      come from the public docs (the EMPTY-flag table on
+#      https://redis.io/docs/latest/commands/ts.range/) plus the
+#      standard mathematical definitions for aggregators that the docs
+#      do not list explicitly (variance of an empty set → NaN, etc.).
+#      twa's empty-bucket value is the time-weighted average of the
+#      linear interpolation between the surrounding samples (also docs).
+#
+#   3. test_ts_range_invalid_aggregator_bucket_duration (negative)
+#      Every aggregator rejects malformed `bucketDuration`. Catches new
+#      aggregators that forget the shared validation. Also probes
+#      TS.REVRANGE to make sure both directions agree.
+#
+#   4. test_ts_range_unknown_aggregator (negative)
+#      Unknown / typo aggregator names are rejected. Includes a check for
+#      `AGGREGATION` with no aggregator name and `AGGREGATION x dur EMPTY`
+#      with an unknown name (EMPTY must not mask the unknown-name error).
+# ---------------------------------------------------------------------------
+
+# Full list per https://redis.io/docs/latest/commands/ts.range/ (AGGREGATION
+# block). Adding a new aggregator? Add it here and AGG_SINGLE_BUCKET_EXPECTED
+# + AGG_EMPTY_BUCKET_EXPECTED below, then both the positive and the negative
+# tests will cover it automatically.
+TS_RANGE_AGGREGATORS = [
+    'avg', 'sum', 'min', 'max', 'range', 'count', 'countNaN', 'countAll',
+    'first', 'last', 'std.p', 'std.s', 'var.p', 'var.s', 'twa',
+]
+
+# Expected values for AGGREGATION <agg> 100 over a single bucket [0, 100)
+# containing samples: (10, 10), (20, NaN), (30, 20).
+# Non-NaN values = [10, 20], mean = 15, n = 2.
+#   var_p = ((10-15)^2 + (20-15)^2) / 2 = 25
+#   var_s = ((10-15)^2 + (20-15)^2) / 1 = 50
+# twa is excluded — single-bucket twa depends on extrapolation policy at the
+# bucket edges and is exercised by the dedicated test_agg_twa above.
+AGG_SINGLE_BUCKET_EXPECTED = {
+    'avg':      15.0,
+    'sum':      30.0,
+    'min':      10.0,
+    'max':      20.0,
+    'range':    10.0,                        # max - min (non-NaN)
+    'count':    2.0,                         # non-NaN count
+    'countNaN': 1.0,
+    'countAll': 3.0,
+    'first':    10.0,                        # value at lowest ts (non-NaN)
+    'last':     20.0,                        # value at highest ts (non-NaN)
+    'std.p':    5.0,                         # sqrt(var_p)
+    'std.s':    math.sqrt(50.0),             # sqrt(var_s)
+    'var.p':    25.0,
+    'var.s':    50.0,
+}
+
+# Expected empty-bucket value for an EMPTY bucket sandwiched between two
+# samples (10, 100) and (30, 200), bucketDuration=10, ALIGN 0 → the empty
+# bucket is [20, 30). Values are STRINGS so we can assert 'NaN' literally.
+#
+# These expectations come from the public docs AND from the mathematical
+# definition of each aggregator over the empty set:
+#   - sum, count, countNaN, countAll: aggregator counts/sums over zero
+#     samples → 0 (docs explicitly state this for sum/count; countNaN
+#     and countAll are counts of subsets of an empty set → also 0).
+#   - last:  docs say "value of the last sample BEFORE the bucket's
+#     start" → 100 (the sample at t=10).
+#   - min, max, range, avg, first, std.p, std.s: docs explicitly say NaN.
+#   - var.p, var.s: variance over the empty set is mathematically
+#     undefined → NaN (docs don't list these; the math/sense answer is
+#     NaN, consistent with the std.p/std.s row from the docs).
+#   - twa: docs say "average value over the bucket's timeframe based on
+#     linear interpolation". With surrounding samples (10, 100) and
+#     (30, 200), the line value at t=20 is 150 and at t=30 is 200, so
+#     the time-weighted average over [20, 30) is (150 + 200) / 2 = 175.
+AGG_EMPTY_BUCKET_EXPECTED = {
+    'sum':      '0',
+    'count':    '0',
+    'countNaN': '0',
+    'countAll': '0',
+    'last':     '100',                       # previous sample's value
+    'min':      'NaN',
+    'max':      'NaN',
+    'range':    'NaN',
+    'avg':      'NaN',
+    'first':    'NaN',
+    'std.p':    'NaN',
+    'std.s':    'NaN',
+    'var.p':    'NaN',
+    'var.s':    'NaN',
+    # 'twa' handled separately — expected value 175 derived above.
+}
+
+
+def _agg_value_to_float(val):
+    """Aggregator response value → Python float (handles bytes/str/NaN)."""
+    s = val.decode() if isinstance(val, bytes) else val
+    return float(s)
+
+
+def test_ts_range_all_aggregators_exact_values():
+    """
+    Positive: for every aggregator from the TS.RANGE docs, the value
+    returned over a single bucket containing mixed numeric + NaN samples
+    must match the hand-computed expected value.
+
+    Also verifies TS.REVRANGE returns the same single bucket (direction
+    must not change the per-bucket value).
+
+    Coverage rationale (vs the existing test_agg_* tests):
+      - This is a single source-of-truth table for the per-aggregator
+        contract; new aggregators wire themselves in via the dict.
+      - Adds the NaN dimension to the table — only countNaN / countAll /
+        the dedicated test_ts_range_NaN_values exercise this today.
+    """
+    with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
+        key = 'agg_exact{a}'
+        r.execute_command('TS.CREATE', key)
+        r.execute_command('TS.MADD',
+                          key, 10, 10,
+                          key, 20, 'nan',
+                          key, 30, 20)
+
+        # Sanity: every aggregator in the docs list has an expected value
+        # (or, for twa, an explicit exemption documented in the table).
+        covered = set(AGG_SINGLE_BUCKET_EXPECTED.keys()) | {'twa'}
+        missing = set(TS_RANGE_AGGREGATORS) - covered
+        assert not missing, \
+            f'AGG_SINGLE_BUCKET_EXPECTED missing aggregators: {sorted(missing)}'
+
+        TOL = 1e-6
+        for agg, exp in AGG_SINGLE_BUCKET_EXPECTED.items():
+            fwd = r.execute_command(
+                'TS.RANGE', key, 0, '+', 'AGGREGATION', agg, 100)
+            rev = r.execute_command(
+                'TS.REVRANGE', key, 0, '+', 'AGGREGATION', agg, 100)
+            assert len(fwd) == 1, \
+                f'AGGREGATION {agg}: expected 1 bucket fwd, got {fwd!r}'
+            assert len(rev) == 1, \
+                f'AGGREGATION {agg}: expected 1 bucket rev, got {rev!r}'
+            assert fwd[0][0] == 0 == rev[0][0], (
+                f'AGGREGATION {agg}: bucket ts mismatch '
+                f'fwd={fwd[0][0]} rev={rev[0][0]}')
+
+            got_fwd = _agg_value_to_float(fwd[0][1])
+            got_rev = _agg_value_to_float(rev[0][1])
+            assert abs(got_fwd - exp) < TOL, (
+                f'AGGREGATION {agg} TS.RANGE: expected {exp}, got {got_fwd}')
+            assert abs(got_rev - exp) < TOL, (
+                f'AGGREGATION {agg} TS.REVRANGE: expected {exp}, got {got_rev}')
+
+        # twa: single-bucket value depends on the edge-extrapolation policy.
+        # Just assert the call succeeds and returns a finite number for this
+        # input (two non-NaN samples in the same bucket).
+        fwd = r.execute_command(
+            'TS.RANGE', key, 0, '+', 'AGGREGATION', 'twa', 100)
+        assert len(fwd) == 1, \
+            f'AGGREGATION twa: expected 1 bucket, got {fwd!r}'
+        twa = _agg_value_to_float(fwd[0][1])
+        assert math.isfinite(twa), \
+            f'AGGREGATION twa: expected finite value, got {twa}'
+
+
+def test_ts_range_all_aggregators_empty_flag():
+    """
+    Positive (EMPTY flag): for every aggregator from the TS.RANGE docs,
+    assert the exact value reported for an EMPTY bucket sandwiched between
+    two samples.
+
+    Setup: samples at (10, 100) and (30, 200), bucketDuration=10, ALIGN 0.
+    Window [0, 39] yields buckets [10,20), [20,30), [30,40). The bucket at
+    ts=20 is EMPTY (between samples). The bucket at ts=0 is dropped because
+    no sample precedes it (should_skip_empty_gap).
+
+    Also verifies TS.REVRANGE returns the same set of buckets in reverse.
+    """
+    with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
+        key = 'agg_empty{a}'
+        r.execute_command('TS.CREATE', key)
+        r.execute_command('TS.MADD',
+                          key, 10, 100,
+                          key, 30, 200)
+
+        # Sanity: every aggregator in the docs list has an expected value
+        # (or, for twa, an explicit exemption documented in the table).
+        covered = set(AGG_EMPTY_BUCKET_EXPECTED.keys()) | {'twa'}
+        missing = set(TS_RANGE_AGGREGATORS) - covered
+        assert not missing, \
+            f'AGG_EMPTY_BUCKET_EXPECTED missing aggregators: {sorted(missing)}'
+
+        for agg, exp_str in AGG_EMPTY_BUCKET_EXPECTED.items():
+            fwd = r.execute_command(
+                'TS.RANGE', key, 0, 39, 'ALIGN', 0,
+                'AGGREGATION', agg, 10, 'EMPTY')
+            rev = r.execute_command(
+                'TS.REVRANGE', key, 0, 39, 'ALIGN', 0,
+                'AGGREGATION', agg, 10, 'EMPTY')
+
+            # Direction symmetry: same buckets, reverse order.
+            assert fwd == list(reversed(rev)), (
+                f'AGGREGATION {agg} EMPTY: TS.RANGE / TS.REVRANGE are not '
+                f'mirror images\n  fwd={fwd!r}\n  rev={rev!r}')
+
+            fwd_by_ts = {row[0]: row[1] for row in fwd}
+            assert set(fwd_by_ts) == {10, 20, 30}, (
+                f'AGGREGATION {agg} EMPTY: expected buckets at 10/20/30, '
+                f'got {sorted(fwd_by_ts)} (full: {fwd!r})')
+            assert fwd_by_ts[20] == exp_str, (
+                f'AGGREGATION {agg} EMPTY bucket: expected {exp_str!r}, '
+                f'got {fwd_by_ts[20]!r}')
+
+        # twa empty bucket: linear interpolation between (10, 100) and
+        # (30, 200). Bucket [20, 30): interp at t=20 = 150, at t=30 = 200,
+        # time-weighted avg over [20, 30) = (150 + 200) / 2 = 175.
+        fwd = r.execute_command(
+            'TS.RANGE', key, 0, 39, 'ALIGN', 0,
+            'AGGREGATION', 'twa', 10, 'EMPTY')
+        twa_by_ts = {row[0]: row[1] for row in fwd}
+        assert 20 in twa_by_ts, \
+            f'AGGREGATION twa EMPTY: bucket ts=20 missing from {fwd!r}'
+        twa_empty = _agg_value_to_float(twa_by_ts[20])
+        assert abs(twa_empty - 175.0) < 1e-6, (
+            f'AGGREGATION twa EMPTY bucket: expected 175.0, got {twa_empty}')
+
+
+def test_ts_range_invalid_aggregator_bucket_duration():
+    """
+    Negative: for every aggregator from the TS.RANGE docs, malformed
+    `bucketDuration` must be rejected with a ResponseError, for BOTH
+    TS.RANGE and TS.REVRANGE (the parser path is shared but worth
+    cross-checking). Covers the full set of parser failure modes:
+      - missing entirely
+      - non-numeric ('foo')
+      - empty string ('')
+      - lone whitespace (' ')
+      - decimal ('1.5')           — bucketDuration is integer-only
+      - NaN / inf string literals
+      - massive overflow that won't fit in a long long
+      - negative integer (-1)
+    """
+    bad_bucket_durations = [
+        'foo',
+        '',
+        ' ',
+        '1.5',
+        'nan',
+        'inf',
+        '99999999999999999999999999999',
+        -1,
+    ]
+
+    with Env().getClusterConnectionIfNeeded() as r:
+        key = 'agg_neg_bucket{a}'
+        r.execute_command('TS.CREATE', key)
+        r.execute_command('TS.ADD', key, 10, 1)
+
+        for cmd in ('TS.RANGE', 'TS.REVRANGE'):
+            for agg in TS_RANGE_AGGREGATORS:
+                # bucketDuration missing entirely
+                with pytest.raises(redis.ResponseError):
+                    r.execute_command(cmd, key, 0, '+', 'AGGREGATION', agg)
+                for bd in bad_bucket_durations:
+                    with pytest.raises(redis.ResponseError):
+                        r.execute_command(
+                            cmd, key, 0, '+', 'AGGREGATION', agg, bd)
+
+
+def test_ts_range_unknown_aggregator():
+    """
+    Negative: unknown aggregator names must be rejected. Includes the empty
+    string, an obvious garbage token, and a typo of a real aggregator —
+    guards against the parser silently accepting close-misses.
+
+    Also exercises a few structural negatives that aren't tied to a name:
+      - `AGGREGATION` with no aggregator and no bucketDuration at all
+      - `AGGREGATION <unknown> 100 EMPTY` — EMPTY must not mask the
+        unknown-name error
+    """
+    bad_names = [
+        '',                          # empty string
+        'foo',                       # never been an aggregator
+        'avgg',                      # typo of 'avg'
+        'aggregation',               # the keyword itself
+        'not_aggregation_function',  # historical placeholder
+    ]
+    with Env().getClusterConnectionIfNeeded() as r:
+        key = 'agg_unknown{a}'
+        r.execute_command('TS.CREATE', key)
+        r.execute_command('TS.ADD', key, 10, 1)
+
+        for name in bad_names:
+            with pytest.raises(redis.ResponseError):
+                r.execute_command(
+                    'TS.RANGE', key, 0, '+', 'AGGREGATION', name, 100)
+            with pytest.raises(redis.ResponseError):
+                r.execute_command(
+                    'TS.REVRANGE', key, 0, '+', 'AGGREGATION', name, 100)
+            # EMPTY must not mask the unknown-aggregator error.
+            with pytest.raises(redis.ResponseError):
+                r.execute_command(
+                    'TS.RANGE', key, 0, '+',
+                    'AGGREGATION', name, 100, 'EMPTY')
+
+        # `AGGREGATION` with nothing after it must fail.
+        with pytest.raises(redis.ResponseError):
+            r.execute_command('TS.RANGE', key, 0, '+', 'AGGREGATION')
+
+
+# ---------------------------------------------------------------------------
+# Edge-case tests for TS.RANGE AGGREGATION.
+#
+# Each of these tests targets a corner case that the broader exact-values /
+# EMPTY tests above don't reach. Expected values are derived from the
+# public docs and from standard mathematical definitions. Where the docs
+# leave a corner case undefined (single-sample twa, single-sample sample
+# variance, etc.) the test either asserts the math-correct answer (so a
+# code bug surfaces) or leaves the value unpinned — never silently
+# encodes what the current implementation happens to return.
+# ---------------------------------------------------------------------------
+
+# Bucket [0, 100) with one sample (50, 42). Expectations are derived
+# strictly from per-aggregator docs definitions + standard math:
+#
+#   sum, avg, min, max, first, last over {42}         → 42
+#   range = max - min over {42}                       → 0
+#   count (non-NaN), countAll over {42}               → 1
+#   countNaN over {42}                                → bucket is "empty for
+#       countNaN" (zero NaN samples passed countNaN's isValueValid filter),
+#       so per the drop rule the bucket is OMITTED without EMPTY and emits
+#       0 with EMPTY. This is the symmetric twin of "count over an all-NaN
+#       bucket → bucket dropped without EMPTY" already pinned by
+#       test_ts_range_count_family_on_all_nan_bucket. countNaN therefore
+#       cannot live in the "always emits one bucket" dict below and is
+#       asserted separately at the end of the test function.
+#   std.p, var.p (population) over {42}:
+#       variance = E[(X-μ)²] with μ=42, X=42          → 0
+#       std      = sqrt(0)                            → 0
+#   std.s, var.s (sample) over {42}:
+#       Formal math: SS / (n-1) = 0 / 0 → NaN (undefined).
+#       Implementation choice (compaction.c VarSamplesFinalize):
+#       explicit `if (count == 1) *value = 0;`. The docs do not
+#       specify n=1, so the shipping behaviour is "n=1 → 0" and
+#       has been for years. We pin that here. If the implementation
+#       ever switches to NaN, update both this expectation and the
+#       public docs to call out the change.
+#   twa over {(50, 42)} in bucket [0, 100):
+#       docs say "time-weighted average over the bucket's timeframe".
+#       A single sample defines a constant function (→ 42) under one
+#       reading and is undefined (→ NaN) under another. The docs do
+#       not disambiguate, so this test does NOT pin an exact value
+#       for twa — it only asserts the call succeeds and returns a
+#       number (NaN or finite). The dedicated test_agg_twa above
+#       exercises the multi-sample twa math.
+AGG_SINGLE_SAMPLE_BUCKET_EXPECTED = {
+    'avg':      42.0,
+    'sum':      42.0,
+    'min':      42.0,
+    'max':      42.0,
+    'range':    0.0,
+    'count':    1.0,
+    # countNaN is intentionally absent — see comment above and the dedicated
+    # block at the end of test_ts_range_all_aggregators_single_sample_bucket.
+    'countAll': 1.0,
+    'first':    42.0,
+    'last':     42.0,
+    'std.p':    0.0,
+    'var.p':    0.0,
+    'std.s':    0.0,                          # n=1 special-cased to 0 by impl
+    'var.s':    0.0,                          # n=1 special-cased to 0 by impl
+}
+
+
+def test_ts_range_all_aggregators_single_sample_bucket():
+    """
+    Edge case (positive): bucket containing a single sample.
+
+    Expected values are derived from each aggregator's documented
+    semantics, standard mathematical definitions, and — where the docs
+    leave a corner case open — the shipping implementation's choice:
+      - Population variance/std over {x} is 0 by definition.
+      - Sample variance/std over {x} is mathematically undefined
+        (SS / (n-1) = 0 / 0), but compaction.c::VarSamplesFinalize
+        explicitly returns 0 for n=1. We pin that here; if the impl
+        ever switches to NaN, update this expectation and the public
+        docs together.
+      - twa over a single sample is ambiguous per docs and is therefore
+        only verified to return SOMETHING parseable (not pinned to a
+        specific value).
+    """
+    with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
+        key = 'agg_single{a}'
+        r.execute_command('TS.CREATE', key)
+        r.execute_command('TS.ADD', key, 50, 42)
+
+        # Coverage guard. countNaN is asserted separately (drop-without-EMPTY
+        # behavior) and twa is asserted separately (docs don't pin n=1).
+        covered = set(AGG_SINGLE_SAMPLE_BUCKET_EXPECTED) | {'twa', 'countNaN'}
+        missing = set(TS_RANGE_AGGREGATORS) - covered
+        assert not missing, \
+            f'AGG_SINGLE_SAMPLE_BUCKET_EXPECTED missing: {sorted(missing)}'
+
+        TOL = 1e-6
+        for agg, exp in AGG_SINGLE_SAMPLE_BUCKET_EXPECTED.items():
+            fwd = r.execute_command(
+                'TS.RANGE', key, 0, '+', 'AGGREGATION', agg, 100)
+            rev = r.execute_command(
+                'TS.REVRANGE', key, 0, '+', 'AGGREGATION', agg, 100)
+            assert len(fwd) == 1, \
+                f'AGGREGATION {agg} n=1: expected 1 bucket fwd, got {fwd!r}'
+            assert len(rev) == 1, \
+                f'AGGREGATION {agg} n=1: expected 1 bucket rev, got {rev!r}'
+            for label, res in (('TS.RANGE', fwd), ('TS.REVRANGE', rev)):
+                got = _agg_value_to_float(res[0][1])
+                if math.isnan(exp):
+                    assert math.isnan(got), (
+                        f'AGGREGATION {agg} n=1 {label}: expected NaN '
+                        f'(sample variance undefined for n=1), got {got}')
+                else:
+                    assert abs(got - exp) < TOL, (
+                        f'AGGREGATION {agg} n=1 {label}: '
+                        f'expected {exp}, got {got}')
+
+        # twa: docs don't specify single-sample behaviour → only assert
+        # the call succeeds and returns a parseable number.
+        for cmd in ('TS.RANGE', 'TS.REVRANGE'):
+            res = r.execute_command(
+                cmd, key, 0, '+', 'AGGREGATION', 'twa', 100)
+            assert len(res) == 1, \
+                f'AGGREGATION twa n=1 {cmd}: expected 1 bucket, got {res!r}'
+            # Will raise if not parseable; NaN is fine.
+            _agg_value_to_float(res[0][1])
+
+        # countNaN: zero NaN samples passed countNaN's isValueValid filter,
+        # so the bucket is "empty for countNaN" and is dropped without
+        # EMPTY (symmetric twin of count-on-all-NaN in
+        # test_ts_range_count_family_on_all_nan_bucket). With EMPTY, the
+        # bucket is emitted with value 0.
+        for cmd in ('TS.RANGE', 'TS.REVRANGE'):
+            res = r.execute_command(
+                cmd, key, 0, '+', 'AGGREGATION', 'countNaN', 100)
+            assert res == [], (
+                f'AGGREGATION countNaN n=1 {cmd} without EMPTY: '
+                f'expected [] (bucket dropped, mirror of count-on-all-NaN), '
+                f'got {res!r}')
+            res = r.execute_command(
+                cmd, key, 0, '+', 'AGGREGATION', 'countNaN', 100, 'EMPTY')
+            assert res == [[0, '0']], (
+                f'AGGREGATION countNaN n=1 {cmd} with EMPTY: '
+                f'expected [[0, "0"]], got {res!r}')
+
+
+def test_ts_range_count_family_on_all_nan_bucket():
+    """
+    Edge case (positive): countNaN and countAll on an all-NaN bucket.
+
+    Fills the gap left by test_ts_range_NaN_values (which covers all
+    non-count aggregators on all-NaN buckets, but only the legacy
+    `count` from the count family). Expectations are derived from the
+    per-aggregator docs definitions:
+      - count    = "Number of non-NaN values"               → 0 (bucket
+                   has zero non-NaN values, so the bucket is "empty"
+                   for count and is dropped without the EMPTY flag).
+      - countNaN = "Number of NaN values"                   → N (the
+                   bucket has N NaN samples, so it is NOT empty for
+                   countNaN and must be reported even without EMPTY).
+      - countAll = "Number of values, including NaN and non-NaN" → N
+                   (same reasoning as countNaN).
+
+    Setup: three NaN samples (10, 20, 30), one non-NaN sample (200, 5)
+    in a different bucket so we can also check that the count family
+    reports the all-NaN bucket distinctly from the populated one.
+    """
+    with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
+        key = 'agg_allnan{a}'
+        r.execute_command('TS.CREATE', key)
+        r.execute_command('TS.MADD',
+                          key, 10, 'nan',
+                          key, 20, 'nan',
+                          key, 30, 'nan',
+                          key, 200, 5)
+
+        # All-NaN bucket [0, 100): query just that bucket.
+        # No EMPTY flag. Per docs, countNaN counts the NaN samples and
+        # countAll counts all samples — both see 3 valid items, so the
+        # bucket is NOT empty for them and must be reported even without
+        # the EMPTY flag.
+        for agg, expected in (('countNaN', '3'), ('countAll', '3')):
+            res = r.execute_command(
+                'TS.RANGE', key, 0, 99, 'AGGREGATION', agg, 100)
+            assert res == [[0, expected]], \
+                f'AGGREGATION {agg} all-NaN bucket: got {res!r}'
+
+        # By contrast, `count` is defined per docs as "Number of non-NaN
+        # values" → 0 for an all-NaN bucket → the bucket is empty for
+        # count and must be omitted without the EMPTY flag. This locks
+        # in the per-aggregator asymmetry implied by the docs.
+        res = r.execute_command(
+            'TS.RANGE', key, 0, 99, 'AGGREGATION', 'count', 100)
+        assert res == [], \
+            f'AGGREGATION count all-NaN bucket without EMPTY: expected [], got {res!r}'
+
+        # With EMPTY, count emits the bucket with value 0.
+        res = r.execute_command(
+            'TS.RANGE', key, 0, 99, 'AGGREGATION', 'count', 100, 'EMPTY')
+        assert res == [[0, '0']], \
+            f'AGGREGATION count all-NaN bucket with EMPTY: got {res!r}'
+
+        # Across both buckets, countAll should report 3 NaN + 1 non-NaN.
+        res = r.execute_command(
+            'TS.RANGE', key, 0, 299, 'AGGREGATION', 'countAll', 100)
+        # Bucket [0,100): 3 NaN samples → 3. Bucket [200,300): 1 → 1.
+        # Bucket [100,200) has no samples → dropped (no EMPTY).
+        assert res == [[0, '3'], [200, '1']], \
+            f'AGGREGATION countAll multi-bucket: got {res!r}'
+
+
+def test_ts_range_aggregator_name_case_insensitivity():
+    """
+    Edge case (parser): aggregator names are case-insensitive. For every
+    aggregator from the docs, the lowercase, UPPERCASE and MiXeD-CaSe
+    forms must all produce the same response.
+
+    Catches drift in the parser's keyword table — e.g. if a new aggregator
+    is added with a case-sensitive comparison instead of the shared
+    case-insensitive matcher.
+    """
+    def mixed_case(s):
+        # Toggle case per character; leaves '.' and digits untouched.
+        return ''.join(c.upper() if i % 2 == 0 else c.lower()
+                       for i, c in enumerate(s))
+
+    with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
+        key = 'agg_case{a}'
+        r.execute_command('TS.CREATE', key)
+        r.execute_command('TS.MADD',
+                          key, 10, 10,
+                          key, 20, 'nan',
+                          key, 30, 20)
+
+        for agg in TS_RANGE_AGGREGATORS:
+            forms = [agg.lower(), agg.upper(), mixed_case(agg)]
+            results = [
+                r.execute_command(
+                    'TS.RANGE', key, 0, '+', 'AGGREGATION', form, 100)
+                for form in forms
+            ]
+            # All three forms must produce IDENTICAL responses.
+            assert results[0] == results[1] == results[2], (
+                f'AGGREGATION case-insensitivity broken for {agg!r}:\n'
+                f'  lower={forms[0]!r} → {results[0]!r}\n'
+                f'  UPPER={forms[1]!r} → {results[1]!r}\n'
+                f'  Mixed={forms[2]!r} → {results[2]!r}'
+            )
+            # And must not be an empty response (sanity: we set up data).
+            assert len(results[0]) >= 1, \
+                f'AGGREGATION {agg}: empty response for all forms'
+
+
+# Multi-bucket composition: AGGREGATION + ALIGN + FILTER_BY_VALUE + COUNT.
+# Per docs:
+#   - FILTER_BY_VALUE filters samples BEFORE aggregation.
+#   - AGGREGATION buckets the surviving samples.
+#   - COUNT limits the number of REPORTED BUCKETS (not samples).
+#   - TS.RANGE iterates ascending; TS.REVRANGE iterates descending.
+#     "COUNT" in REVRANGE therefore yields the buckets with the LARGEST
+#     timestamps (the first N in reverse-iteration order).
+#
+# Series: ten samples at t=5,15,25,...,95 with values equal to their ts.
+# FILTER_BY_VALUE 20 80 keeps t=25,35,45,55,65,75. bucketDuration=20,
+# ALIGN 0 → surviving buckets after the filter pipeline:
+#   [20,40) holds (25, 35)   ← values [25, 35]
+#   [40,60) holds (45, 55)   ← values [45, 55]
+#   [60,80) holds (65, 75)   ← values [65, 75]
+# Buckets [0,20) and [80,100) have no surviving samples and are dropped.
+#
+# Per-aggregator per-bucket values are computed from the surviving samples
+# of each bucket using the standard definitions cited in the TS.RANGE docs:
+#   sum=Σv, avg=Σv/n, min/max/first/last=obvious, range=max-min,
+#   count=count_all=2 (no NaN),
+#   var_p=Σ(v-μ)²/n, var_s=Σ(v-μ)²/(n-1), std=√var.
+# countNaN is asserted separately below — zero NaN samples per bucket means
+# every bucket is "empty for countNaN" and dropped without EMPTY (same drop
+# rule that test_ts_range_count_family_on_all_nan_bucket pins for count on
+# the symmetric all-NaN case).
+# Each bucket here has values [x, x+10] with mean=x+5, so SS=50 in every
+# bucket → var.p=25, var.s=50, std.p=5, std.s=√50 across the board.
+AGG_COMPOSITION_BUCKET_VALUES = {
+    'avg':      {20: 30.0, 40: 50.0,  60: 70.0},
+    'sum':      {20: 60.0, 40: 100.0, 60: 140.0},
+    'min':      {20: 25.0, 40: 45.0,  60: 65.0},
+    'max':      {20: 35.0, 40: 55.0,  60: 75.0},
+    'range':    {20: 10.0, 40: 10.0,  60: 10.0},
+    'count':    {20:  2.0, 40:  2.0,  60:  2.0},
+    # countNaN is intentionally absent — see comment above; asserted
+    # separately at the end of the test function.
+    'countAll': {20:  2.0, 40:  2.0,  60:  2.0},
+    'first':    {20: 25.0, 40: 45.0,  60: 65.0},
+    'last':     {20: 35.0, 40: 55.0,  60: 75.0},
+    'std.p':    {20:  5.0, 40:  5.0,  60:  5.0},
+    'std.s':    {20: math.sqrt(50.0), 40: math.sqrt(50.0), 60: math.sqrt(50.0)},
+    'var.p':    {20: 25.0, 40: 25.0,  60: 25.0},
+    'var.s':    {20: 50.0, 40: 50.0,  60: 50.0},
+}
+
+
+def test_ts_range_aggregator_composition_align_filter_count():
+    """
+    Edge case (composition): AGGREGATION pipelined with ALIGN +
+    FILTER_BY_VALUE + COUNT. Asserts EXACT per-aggregator per-bucket
+    values for both TS.RANGE and TS.REVRANGE.
+
+    Per the docs ("samples are filtered before being aggregated" and
+    "COUNT ... limits the number of reported buckets"):
+      - TS.RANGE with COUNT 2 yields the two SMALLEST-ts surviving
+        buckets, in ascending order: ts=20 then ts=40.
+      - TS.REVRANGE with COUNT 2 yields the two LARGEST-ts surviving
+        buckets, in descending order: ts=60 then ts=40.
+
+    Twa is excluded from the per-value table: the docs say twa
+    interpolates based on "the last sample before the bucket's start"
+    and "the first sample after the bucket's end", and the docs do not
+    specify whether samples removed by FILTER_BY_VALUE remain visible
+    to that interpolation. This test should not pin a value that the
+    docs leave open.
+    """
+    with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
+        key = 'agg_compose{a}'
+        r.execute_command('TS.CREATE', key)
+        for t in range(5, 100, 10):              # 5, 15, 25, ..., 95
+            r.execute_command('TS.ADD', key, t, t)
+
+        # Coverage guard. countNaN is asserted separately (drop-without-EMPTY
+        # behavior — zero NaN samples per bucket); twa is documented as
+        # out-of-scope for this composition test (interpolation visibility
+        # past FILTER_BY_VALUE is unspecified).
+        covered = set(AGG_COMPOSITION_BUCKET_VALUES) | {'twa', 'countNaN'}
+        missing = set(TS_RANGE_AGGREGATORS) - covered
+        assert not missing, \
+            f'AGG_COMPOSITION_BUCKET_VALUES missing: {sorted(missing)}'
+
+        TOL = 1e-6
+
+        def _check(label, command, expected_ts_in_order, agg, per_bucket):
+            res = r.execute_command(
+                command, key, 0, '+',
+                'FILTER_BY_VALUE', 20, 80,
+                'COUNT', 2,
+                'ALIGN', 0, 'AGGREGATION', agg, 20)
+            assert len(res) == 2, (
+                f'AGGREGATION {agg} {label}: expected 2 buckets, '
+                f'got {res!r}')
+            for exp_ts, row in zip(expected_ts_in_order, res):
+                assert row[0] == exp_ts, (
+                    f'AGGREGATION {agg} {label}: '
+                    f'bucket ts {row[0]} != {exp_ts}')
+                got = float(row[1])
+                exp_val = per_bucket[exp_ts]
+                assert abs(got - exp_val) < TOL, (
+                    f'AGGREGATION {agg} {label} bucket {exp_ts}: '
+                    f'expected {exp_val}, got {got}')
+
+        for agg, per_bucket in AGG_COMPOSITION_BUCKET_VALUES.items():
+            _check('TS.RANGE',    'TS.RANGE',    [20, 40], agg, per_bucket)
+            _check('TS.REVRANGE', 'TS.REVRANGE', [60, 40], agg, per_bucket)
+
+        # countNaN: every surviving bucket has only non-NaN samples → each
+        # bucket is "empty for countNaN" → dropped without EMPTY (symmetric
+        # twin of count-on-all-NaN pinned by
+        # test_ts_range_count_family_on_all_nan_bucket). Just lock in the
+        # drop here; the exact-value flavor is pinned by
+        # test_ts_range_all_aggregators_single_sample_bucket.
+        for label, command in (('TS.RANGE', 'TS.RANGE'),
+                               ('TS.REVRANGE', 'TS.REVRANGE')):
+            res = r.execute_command(
+                command, key, 0, '+',
+                'FILTER_BY_VALUE', 20, 80,
+                'COUNT', 2,
+                'ALIGN', 0, 'AGGREGATION', 'countNaN', 20)
+            assert res == [], (
+                f'AGGREGATION countNaN {label} without EMPTY: '
+                f'expected [] (every bucket has 0 NaN samples), '
+                f'got {res!r}')
+
+
+def test_ts_range_aggregator_empty_no_preceding_sample():
+    """
+    Edge case (EMPTY flag): when an EMPTY bucket has no PRECEDING non-NaN
+    sample, LAST and TWA must report NaN per docs ("NaN when no such
+    sample"). This complements test_ts_range_all_aggregators_empty_flag
+    above, where every EMPTY bucket DID have a preceding sample.
+
+    Setup: a NaN sample at t=100 (so the bucket [100, 200) is non-empty
+    from the storage layer's perspective and won't be skipped by
+    should_skip_empty_gap, but LAST/TWA see no valid prior sample),
+    followed by a valid sample at t=200.
+    """
+    with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
+        for agg in ('last', 'twa'):
+            key = f'agg_emp_no_prev_{agg.replace(".", "_")}{{a}}'
+            r.execute_command('TS.CREATE', key)
+            r.execute_command('TS.ADD', key, 100, 'nan')
+            r.execute_command('TS.ADD', key, 200, 50)
+
+            res = r.execute_command(
+                'TS.RANGE', key, 100, 199,
+                'AGGREGATION', agg, 100, 'EMPTY')
+            assert len(res) == 1, \
+                f'AGGREGATION {agg}: expected 1 bucket, got {res!r}'
+            got = float(res[0][1])
+            assert math.isnan(got), (
+                f'AGGREGATION {agg} EMPTY no-prior-sample: '
+                f'expected NaN, got {got}')
+
+
+def test_revrange_empty_count_matches_range_tail():
+    """
+    TS.REVRANGE + EMPTY + COUNT N must return the LAST N emitted buckets in
+    reverse chronological order. The ground truth comes from TS.RANGE without
+    COUNT (untouched, well-established forward path): the expected REVRANGE+COUNT
+    result is the last N entries of that forward result, reversed.
+
+    Covered:
+      - N strictly less than total emitted buckets
+      - N == 1 (smallest meaningful slice)
+      - N exactly equal to total emitted bucket count
+      - N larger than total emitted bucket count (must return all, no padding)
+      - Sparse-leading data: empty buckets at the start of the window are
+        "outside data span" and dropped by the EMPTY rule; the count must apply
+        AFTER that drop so the response always reflects real, emitted buckets.
+      - Mid-series gap: empty buckets that ARE inside the data span are emitted
+        and must be eligible to appear in the COUNT-N tail.
+
+    Every assertion is derived from TS.RANGE on the same key/window, so the
+    test stays a true black-box check of the REVRANGE+EMPTY+COUNT semantics.
+    """
+    SCENARIOS = (
+        # (label, samples, window, bucket_duration)
+        ('dense',         [(t, t) for t in range(0, 100, 10)],   (0, 99),   10),
+        ('sparse-lead',   [(50, 50), (60, 60), (70, 70),
+                           (80, 80), (90, 90)],                  (0, 99),   10),
+        ('mid-gap',       [(0, 0),  (10, 10), (20, 20),
+                           (70, 70), (80, 80), (90, 90)],        (0, 99),   10),
+        ('single-sample', [(42, 42)],                            (0, 99),   10),
+    )
+    AGGS = ('last', 'first', 'max', 'min', 'count', 'sum', 'avg', 'range')
+
+    with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
+        for label, samples, (win_lo, win_hi), bd in SCENARIOS:
+            key = f'rev_empty_count_{label}{{a}}'
+            r.execute_command('DEL', key)
+            r.execute_command('TS.CREATE', key)
+            for t, v in samples:
+                r.execute_command('TS.ADD', key, t, v)
+
+            for agg in AGGS:
+                fwd_all = r.execute_command(
+                    'TS.RANGE', key, win_lo, win_hi,
+                    'AGGREGATION', agg, bd, 'EMPTY')
+                total = len(fwd_all)
+
+                # Sanity guard: the scenarios are designed so EMPTY emits at
+                # least one bucket. If this ever fires, the scenario is wrong,
+                # not the SUT.
+                assert total >= 1, (
+                    f'[{label}/{agg}] TS.RANGE EMPTY returned no buckets; '
+                    f'scenario invalid')
+
+                counts_to_try = sorted({1, max(1, total // 2), total, total + 5})
+                for n in counts_to_try:
+                    rev = r.execute_command(
+                        'TS.REVRANGE', key, win_lo, win_hi,
+                        'AGGREGATION', agg, bd, 'EMPTY',
+                        'COUNT', n)
+                    expected = list(reversed(fwd_all[-n:]))
+                    assert rev == expected, (
+                        f'[{label}/{agg}] REVRANGE EMPTY COUNT {n}: '
+                        f'expected {expected!r}, got {rev!r}; '
+                        f'(fwd_all={fwd_all!r})')


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core aggregation and empty-bucket emission on the reverse iterator path; behavior fixes are user-visible but scoped to compaction/iterator logic with heavy new test coverage.
> 
> **Overview**
> Fixes **reverse aggregation** so `TS.REVRANGE` with `AGGREGATION` (especially `last` and `EMPTY`) matches forward semantics: same bucket timestamps in reverse order and correct LOCF for gaps between samples.
> 
> **Compaction:** `first` / `last` aggregators now pick samples by **timestamp** (oldest vs newest), not iteration order. `last` adds in-memory `ts` and `fresh_bucket` so bucket resets in reverse do not block the first sample of a bucket or leave a stale newer timestamp. **`LastValueSeedLocf`** plants the chronologically prior value when reverse empty buckets are filled.
> 
> **Aggregation iterator:** Before emitting empty buckets on reverse (non-TWA path), **`seed_locf_for_reverse_empty_gap`** looks up the older neighbor and seeds `TS_AGG_LAST` contexts so EMPTY gaps carry the correct prior value instead of a value from a bucket already processed in reverse.
> 
> **Tests:** Updates an existing `last` + `EMPTY` revrange expectation and adds broad regression coverage (forward/reverse symmetry with and without `EMPTY`, multichunk series, plain range, `COUNT`, `MRANGE`, per-aggregator values, parser negatives, and edge cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46bc8989dca01527bcde703a9a4e8162448b1189. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->