### PR TITLE
MOD-14615 Make LibMR multi-shard max-idle configurable (fix valgrind nightly)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -48,6 +48,7 @@ void InitConfig(void) {
     TSGlobalConfig.options = SERIES_OPT_DEFAULT_COMPRESSION;
     TSGlobalConfig.libmrProtocol = LIBMR_PROTOCOL_DEFAULT;
     TSGlobalConfig.password = NULL;
+    TSGlobalConfig.libmrMaxIdleMS = DEFAULT_LIBMR_MAX_IDLE_MS;
 
     if (getConfigStringCache) {
         RedisModule_FreeString(rts_staticCtx, getConfigStringCache);
@@ -365,6 +366,8 @@ static long long getModernIntegerConfigValue(const char *name, void *privdata) {
         return TSGlobalConfig.chunkSizeBytes;
     } else if (!strcasecmp("ts-ignore-max-time-diff", name)) {
         return TSGlobalConfig.ignoreMaxTimeDiff;
+    } else if (!strcasecmp("ts-libmr-max-idle-ms", name)) {
+        return TSGlobalConfig.libmrMaxIdleMS;
     }
 
     return 0;
@@ -406,6 +409,18 @@ static int setModernIntegerConfigValue(const char *name,
         }
 
         TSGlobalConfig.ignoreMaxTimeDiff = value;
+
+        return REDISMODULE_OK;
+    } else if (!strcasecmp("ts-libmr-max-idle-ms", name)) {
+        if (value < LIBMR_MAX_IDLE_MS_MIN) {
+            *err = RedisModule_CreateStringPrintf(
+                NULL,
+                "Invalid value for `ts-libmr-max-idle-ms`. Value must be >= %d",
+                LIBMR_MAX_IDLE_MS_MIN);
+            return REDISMODULE_ERR;
+        }
+
+        TSGlobalConfig.libmrMaxIdleMS = value;
 
         return REDISMODULE_OK;
     }
@@ -455,6 +470,27 @@ bool RegisterModernConfigurationOptions(RedisModuleCtx *ctx) {
 
     RedisModule_Log(
         ctx, "notice", "\t{ %-*s: %*lld }", 23, "ts-num-threads", 12, TSGlobalConfig.numThreads);
+
+    if (RedisModule_RegisterNumericConfig(ctx,
+                                          "ts-libmr-max-idle-ms",
+                                          TSGlobalConfig.libmrMaxIdleMS,
+                                          REDISMODULE_CONFIG_UNPREFIXED,
+                                          LIBMR_MAX_IDLE_MS_MIN,
+                                          LIBMR_MAX_IDLE_MS_MAX,
+                                          getModernIntegerConfigValue,
+                                          setModernIntegerConfigValue,
+                                          NULL,
+                                          NULL)) {
+        return false;
+    }
+
+    RedisModule_Log(ctx,
+                    "notice",
+                    "\t{ %-*s: %*lld }",
+                    23,
+                    "ts-libmr-max-idle-ms",
+                    12,
+                    TSGlobalConfig.libmrMaxIdleMS);
 
     if (RedisModule_RegisterStringConfig(ctx,
                                          "ts-libmr-protocol",
@@ -900,6 +936,25 @@ int ReadDeprecatedLoadTimeConfig(RedisModuleCtx *ctx,
         TSGlobalConfig.ignoreMaxTimeDiff = ignoreMaxTimeDiff;
         LOG_DEPRECATED_OPTION(
             "IGNORE_MAX_TIME_DIFF", "ts-ignore-max-time-diff", showDeprecationWarning);
+        isDeprecated = true;
+    }
+
+    TSGlobalConfig.libmrMaxIdleMS = DEFAULT_LIBMR_MAX_IDLE_MS;
+    if (argc > 1 && RMUtil_ArgIndex("LIBMR_MAX_IDLE_MS", argv, argc) >= 0) {
+        long long libmrMaxIdleMS = 0;
+        if (RMUtil_ParseArgsAfter("LIBMR_MAX_IDLE_MS", argv, argc, "l", &libmrMaxIdleMS) !=
+            REDISMODULE_OK) {
+            RedisModule_Log(ctx, "warning", "Unable to parse argument after LIBMR_MAX_IDLE_MS");
+            return TSDB_ERROR;
+        }
+        if (libmrMaxIdleMS < LIBMR_MAX_IDLE_MS_MIN) {
+            RedisModule_Log(
+                ctx, "warning", "LIBMR_MAX_IDLE_MS must be >= %d", LIBMR_MAX_IDLE_MS_MIN);
+            return TSDB_ERROR;
+        }
+        TSGlobalConfig.libmrMaxIdleMS = libmrMaxIdleMS;
+        LOG_DEPRECATED_OPTION(
+            "LIBMR_MAX_IDLE_MS", "ts-libmr-max-idle-ms", showDeprecationWarning);
         isDeprecated = true;
     }
 

--- a/src/config.h
+++ b/src/config.h
@@ -26,6 +26,9 @@
 #define IGNORE_MAX_TIME_DIFF_MAX LLONG_MAX
 #define IGNORE_MAX_VAL_DIFF_MIN 0.0
 #define IGNORE_MAX_VAL_DIFF_MAX DBL_MAX
+#define LIBMR_MAX_IDLE_MS_MIN 1
+#define LIBMR_MAX_IDLE_MS_MAX LLONG_MAX
+#define DEFAULT_LIBMR_MAX_IDLE_MS 5000
 
 typedef struct
 {
@@ -42,6 +45,7 @@ typedef struct
     bool dontAssertOnFailure;    // Internal debug configuration param
     long long ignoreMaxTimeDiff; // Insert filter max time diff with the last sample
     double ignoreMaxValDiff;     // Insert filter max value diff with the last sample
+    long long libmrMaxIdleMS;    // LibMR multi-shard execution max-idle timeout (milliseconds)
 } TSConfig;
 
 extern TSConfig TSGlobalConfig;

--- a/src/libmr_commands.c
+++ b/src/libmr_commands.c
@@ -570,6 +570,8 @@ int TSDB_mget_MR(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModuleBlockedClient *bc = RTS_BlockClient(ctx, rts_free_rctx);
     MR_ExecutionSetOnDoneHandler(exec, mget_done, bc);
 
+    MR_ExecutionSetMaxIdle(exec, (size_t)TSGlobalConfig.libmrMaxIdleMS);
+
     MR_Run(exec);
     MR_FreeExecution(exec);
     MR_FreeExecutionBuilder(builder);
@@ -637,6 +639,8 @@ int TSDB_mrange_MR(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool
     data->args = args;
     MR_ExecutionSetOnDoneHandler(exec, mrange_done, data);
 
+    MR_ExecutionSetMaxIdle(exec, (size_t)TSGlobalConfig.libmrMaxIdleMS);
+
     MR_Run(exec);
     MR_FreeExecution(exec);
     MR_FreeExecutionBuilder(builder);
@@ -688,6 +692,8 @@ int TSDB_queryindex_MR(RedisModuleCtx *ctx, QueryPredicateList *queries) {
 
     RedisModuleBlockedClient *bc = RTS_BlockClient(ctx, rts_free_rctx);
     MR_ExecutionSetOnDoneHandler(exec, queryindex_done, bc);
+
+    MR_ExecutionSetMaxIdle(exec, (size_t)TSGlobalConfig.libmrMaxIdleMS);
 
     MR_Run(exec);
     MR_FreeExecution(exec);

--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -91,6 +91,15 @@ def Env(*args, **kwargs):
         kwargs['redisConfigFile'] = create_config_file(kwargs['redisConfigFileContent'])
         del kwargs['redisConfigFileContent']
 
+    # Under Valgrind/Sanitizer, LibMR's default 5s multi-shard max-idle is too tight: a single
+    # shard can pause >5s producing output and the execution gets killed with
+    # "multi-shard command failed because at least one shard did not reply within the given
+    # timeframe." Bump the timeout here so all tests inherit it. Tests can still override.
+    if VALGRIND or SANITIZER:
+        existing = kwargs.get('moduleArgs', '') or ''
+        if 'LIBMR_MAX_IDLE_MS' not in existing and 'ts-libmr-max-idle-ms' not in existing:
+            kwargs['moduleArgs'] = ('LIBMR_MAX_IDLE_MS 60000; ' + existing).rstrip('; ').strip()
+
     temp_no_log = Defaults.no_log
     no_capture_output = Defaults.no_capture_output
 


### PR DESCRIPTION
## Summary

Fixes MOD-14615 (and the related MOD-14289). Both nightlies fail with the same Redis-replied error:

> `A multi-shard command failed because at least one shard did not reply within the given timeframe.`

## Root cause

LibMR's per-execution **max-idle** default is 5s ([deps/LibMR/src/mr.c#L27](../deps/LibMR/src/mr.c#L27)). RedisTimeSeries never overrides it, so every `TS.MRANGE` / `TS.MGET` / `TS.QUERYINDEX` inherits that ceiling. Under valgrind a single shard can pause >5s producing or forwarding records → LibMR fires `"execution max idle reached"` → the module surfaces the user-visible error above (src/libmr_commands.c:108-111).

This explains both Jira tickets:
- **MOD-14615** — `test_asm:test_asm_with_data_and_queries_during_migrations` (migration + concurrent multi-shard query)
- **MOD-14289** — `test_ts_mrange_groupby:test_filterby` (no migrations, just a slow multi-shard query under valgrind)

Previously merged mitigations (smaller keys, longer migration wait) only eased load; they never touched the per-execution wall.

## Change

- `src/config.{h,c}` — add `libmrMaxIdleMS` to `TSConfig` (default `5000`, matching LibMR). Register modern config `ts-libmr-max-idle-ms` and add the deprecated `LIBMR_MAX_IDLE_MS` load-time form (same shape as `IGNORE_MAX_TIME_DIFF` etc.).
- `src/libmr_commands.c` — call `MR_ExecutionSetMaxIdle(exec, TSGlobalConfig.libmrMaxIdleMS)` before each `MR_Run` in `TSDB_mget_MR` / `TSDB_mrange_MR` / `TSDB_queryindex_MR`.
- `tests/flow/includes.py` — in the `Env()` wrapper, prepend `LIBMR_MAX_IDLE_MS 60000` to `moduleArgs` when `VALGRIND` or `SANITIZER` is set, **only if** the test hasn't already set its own value. Production default stays at 5s.

## Test plan

- [x] `make build` succeeds locally (macOS clang) — `redistimeseries.so` linked, no new warnings.
- [ ] CI: full flow suite on x64-jammy.
- [ ] CI: linux-valgrind / x64-jammy nightly — confirm `test_asm_with_data_and_queries_during_migrations` and `test_filterby` pass across multiple iterations.
- [ ] CI: linux-sanitizer / x64-jammy — same.

## Notes

- Production default unchanged (5s).
- The new config is reachable via:
  - `CONFIG SET ts-libmr-max-idle-ms <ms>`
  - load-time `--loadmodule ... LIBMR_MAX_IDLE_MS <ms>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Production default stays 5s; changes are config plumbing plus three pre-Run timeout calls and test-only module args under instrumentation.
> 
> **Overview**
> Adds a configurable **LibMR multi-shard max-idle** timeout so RedisTimeSeries can override LibMR’s fixed 5s default before each multi-shard run.
> 
> **Config:** `TSConfig` gains `libmrMaxIdleMS` (default **5000** ms). It is exposed as `ts-libmr-max-idle-ms` (`CONFIG SET` / numeric registration with min ≥ 1) and as deprecated load-time **`LIBMR_MAX_IDLE_MS`**, wired through `InitConfig`, getters/setters, and `ReadDeprecatedLoadTimeConfig`.
> 
> **Runtime:** `TSDB_mget_MR`, `TSDB_mrange_MR`, and `TSDB_queryindex_MR` call `MR_ExecutionSetMaxIdle(exec, TSGlobalConfig.libmrMaxIdleMS)` immediately before `MR_Run`, so `TS.MGET` / `TS.MRANGE` / `TS.QUERYINDEX` use the configured ceiling instead of only LibMR’s built-in default.
> 
> **Tests:** The shared `Env()` helper prepends `LIBMR_MAX_IDLE_MS 60000` to `moduleArgs` when Valgrind or sanitizer is enabled, unless the test already sets that option—reducing flaky “shard did not reply within the given timeframe” failures under slow instrumentation while leaving production at 5s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb8bd6876a40ef2e086cfc8659587118f2f5fa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->