### PR TITLE
Tal.ba/cp/redis ref opt to 8.8

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -19,10 +19,12 @@ jobs:
     outputs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: set env
         id: set-env
         run: |
-          echo "redis-ref=unstable" >> $GITHUB_OUTPUT  # todo change per version/tag
+          echo "redis-ref=$(sbin/get-redis-ref.sh)" >> $GITHUB_OUTPUT
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -16,9 +16,9 @@ on:
   workflow_dispatch:
     inputs:
       redis-ref:
-        description: 'Redis ref to checkout'
-        required: true
-        default: 'unstable'
+        description: 'Redis ref to checkout (leave empty to use .install/redis_ref.txt)'
+        required: false
+        default: ''
       send-slack-message:
         description: 'Send Slack notification on completion'
         required: false
@@ -40,8 +40,13 @@ jobs:
       - name: set env
         id: set-env
         run: |
-          echo "redis-ref=${{ inputs.redis-ref || 'unstable' }}" >> $GITHUB_OUTPUT
-          
+          REDIS_REF="${{ inputs.redis-ref }}"
+          if [ -z "$REDIS_REF" ]; then
+            REDIS_REF="$(sbin/get-redis-ref.sh)"
+          fi
+          echo "redis-ref=${REDIS_REF}" >> $GITHUB_OUTPUT
+
+
           # Generate timestamp at workflow start for consistent beta versioning
           TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")
           WORKFLOW_NUM=${{ github.run_number }}

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -46,7 +46,6 @@ jobs:
           fi
           echo "redis-ref=${REDIS_REF}" >> $GITHUB_OUTPUT
 
-
           # Generate timestamp at workflow start for consistent beta versioning
           TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")
           WORKFLOW_NUM=${{ github.run_number }}

--- a/.github/workflows/event-tag.yml
+++ b/.github/workflows/event-tag.yml
@@ -11,9 +11,9 @@ on:
   workflow_dispatch:
     inputs:
       redis-ref:
-        description: 'Redis ref to checkout'
-        required: true
-        default: 'unstable'
+        description: 'Redis ref to checkout (leave empty to use .install/redis_ref.txt)'
+        required: false
+        default: ''
 
 jobs:
   prepare-values:
@@ -21,10 +21,16 @@ jobs:
     outputs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: set env
         id: set-env
         run: |
-          echo "redis-ref=${{ inputs.redis-ref || 'unstable' }}" >> $GITHUB_OUTPUT  # todo change per version/tag
+          REDIS_REF="${{ inputs.redis-ref }}"
+          if [ -z "$REDIS_REF" ]; then
+            REDIS_REF="$(sbin/get-redis-ref.sh)"
+          fi
+          echo "redis-ref=${REDIS_REF}" >> $GITHUB_OUTPUT
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit

--- a/.install/install_redis.sh
+++ b/.install/install_redis.sh
@@ -1,8 +1,20 @@
 #!/usr/bin/env bash
 set -e
 
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+# If REDIS_REF was not provided explicitly, fall back to the single
+# source-of-truth file shipped alongside this script (.install/redis_ref.txt).
+# Comment ('#') and blank lines are ignored; the first remaining line is used.
 if [ -z "${REDIS_REF}" ]; then
-    echo "Error: REDIS_REF environment variable is required"
+    REF_FILE="$HERE/redis_ref.txt"
+    if [ -f "$REF_FILE" ]; then
+        REDIS_REF="$(sed -e 's/#.*//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' "$REF_FILE" | grep -m1 -v '^$' || true)"
+    fi
+fi
+
+if [ -z "${REDIS_REF}" ]; then
+    echo "Error: REDIS_REF is not set and no ref found in $HERE/redis_ref.txt"
     exit 1
 fi
 

--- a/.install/redis_ref.txt
+++ b/.install/redis_ref.txt
@@ -1,0 +1,8 @@
+# Single source of truth for the Redis git ref (branch/tag/commit) that
+# redistimeseries is built and tested against in CI and Docker images.
+#
+# Update the value below to change the Redis version everywhere at once.
+# Lines starting with '#' and blank lines are ignored; the first remaining
+# line is used as the ref. Read it via sbin/get-redis-ref.sh (CI) or it is
+# consumed directly by .install/install_redis.sh when building Docker images.
+unstable

--- a/.install/redis_ref.txt
+++ b/.install/redis_ref.txt
@@ -5,4 +5,4 @@
 # Lines starting with '#' and blank lines are ignored; the first remaining
 # line is used as the ref. Read it via sbin/get-redis-ref.sh (CI) or it is
 # consumed directly by .install/install_redis.sh when building Docker images.
-unstable
+8.8

--- a/Dockerfile.alma10
+++ b/Dockerfile.alma10
@@ -11,7 +11,8 @@ RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync u
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.alma8
+++ b/Dockerfile.alma8
@@ -16,10 +16,8 @@ RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
 ENV PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
 
-COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
-
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.alma8
+++ b/Dockerfile.alma8
@@ -16,6 +16,9 @@ RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
 ENV PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
 
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+
 # Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
 ARG REDIS_REF=
 ARG SANITIZER=

--- a/Dockerfile.alma9
+++ b/Dockerfile.alma9
@@ -11,6 +11,9 @@ RUN cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh
 ENV PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH}"
 
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+
 # Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
 ARG REDIS_REF=
 ARG SANITIZER=

--- a/Dockerfile.alma9
+++ b/Dockerfile.alma9
@@ -11,10 +11,8 @@ RUN cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh
 ENV PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH}"
 
-COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
-
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -40,7 +40,8 @@ RUN apk add --no-cache \
 COPY .install /workspace/.install
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.amazonlinux2
+++ b/Dockerfile.amazonlinux2
@@ -13,6 +13,9 @@ RUN ln -s `which cmake3` /usr/bin/cmake
 ENV PATH="/opt/rh/devtoolset-11/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/devtoolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
 
+COPY .install /workspace/.install
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
 # Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
 ARG REDIS_REF=
 ARG SANITIZER=

--- a/Dockerfile.amazonlinux2
+++ b/Dockerfile.amazonlinux2
@@ -13,10 +13,8 @@ RUN ln -s `which cmake3` /usr/bin/cmake
 ENV PATH="/opt/rh/devtoolset-11/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/devtoolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
 
-COPY .install /workspace/.install
-
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.amazonlinux2023
+++ b/Dockerfile.amazonlinux2023
@@ -29,7 +29,8 @@ RUN dnf -y update && dnf -y install --allowerasing \
 COPY .install /workspace/.install
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.azurelinux3
+++ b/Dockerfile.azurelinux3
@@ -24,10 +24,8 @@ RUN tdnf -y update && \
     ca-certificates \
     tar
 
-COPY .install /workspace/.install
-
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.azurelinux3
+++ b/Dockerfile.azurelinux3
@@ -24,6 +24,9 @@ RUN tdnf -y update && \
     ca-certificates \
     tar
 
+COPY .install /workspace/.install
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
 # Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
 ARG REDIS_REF=
 ARG SANITIZER=

--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -24,6 +24,7 @@ RUN wget https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz \
     && ln -sf /usr/local/bin/cmake /usr/bin/cmake
 COPY .install /workspace/.install
 
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
 # Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
 ARG REDIS_REF=
 ARG SANITIZER=

--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -24,8 +24,8 @@ RUN wget https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz \
     && ln -sf /usr/local/bin/cmake /usr/bin/cmake
 COPY .install /workspace/.install
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -12,7 +12,8 @@ RUN apt update -qq \
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -27,8 +27,8 @@ RUN apt-get update && apt-get install -y build-essential \
 
 COPY .install /workspace/.install
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y build-essential \
 
 COPY .install /workspace/.install
 
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
 # Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
 ARG REDIS_REF=
 ARG SANITIZER=

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -11,6 +11,7 @@ RUN apt update -qq \
 
 COPY .install /workspace/.install
 
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
 # Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
 ARG REDIS_REF=
 ARG SANITIZER=

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -11,8 +11,8 @@ RUN apt update -qq \
 
 COPY .install /workspace/.install
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.jammy
+++ b/Dockerfile.jammy
@@ -24,7 +24,8 @@ RUN apt-get update && apt-get install -y \
 COPY .install /workspace/.install
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.mariner2
+++ b/Dockerfile.mariner2
@@ -6,10 +6,8 @@ RUN tdnf makecache
 RUN tdnf install -y git ca-certificates build-essential wget tar openssl-devel cmake which unzip jq \
     gcc g++ curl libffi-devel zlib-devel bzip2-devel
 
-COPY .install /workspace/.install
-
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.mariner2
+++ b/Dockerfile.mariner2
@@ -6,6 +6,9 @@ RUN tdnf makecache
 RUN tdnf install -y git ca-certificates build-essential wget tar openssl-devel cmake which unzip jq \
     gcc g++ curl libffi-devel zlib-devel bzip2-devel
 
+COPY .install /workspace/.install
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
 # Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
 ARG REDIS_REF=
 ARG SANITIZER=

--- a/Dockerfile.noble
+++ b/Dockerfile.noble
@@ -26,7 +26,8 @@ RUN apt-get update && apt-get install -y \
     rsync \
     python3-dev
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh

--- a/Dockerfile.resolute
+++ b/Dockerfile.resolute
@@ -26,7 +26,8 @@ RUN apt-get update && apt-get install -y \
     rsync \
     python3-dev
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -11,7 +11,8 @@ RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync u
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -15,10 +15,8 @@ RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
 ENV PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
 
-COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
-
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -15,6 +15,9 @@ RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
 ENV PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
 
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+
 # Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
 ARG REDIS_REF=
 ARG SANITIZER=

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -24,6 +24,7 @@ RUN yum -y install --nobest --skip-broken gcc gcc-c++ \
 
 COPY .install /workspace/.install
 
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
 # Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
 ARG REDIS_REF=
 ARG SANITIZER=

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -24,8 +24,8 @@ RUN yum -y install --nobest --skip-broken gcc gcc-c++ \
 
 COPY .install /workspace/.install
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh

--- a/Dockerfile.trixie
+++ b/Dockerfile.trixie
@@ -12,7 +12,8 @@ RUN apt update -qq \
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to .install/redis_ref.txt (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/sbin/get-redis-ref.sh
+++ b/sbin/get-redis-ref.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Print the Redis git ref that redistimeseries is built/tested against.
+#
+# The value lives in a single source-of-truth file (.install/redis_ref.txt) so it
+# does not have to be duplicated across Dockerfiles and CI workflows. Comment
+# lines (starting with '#') and blank lines in that file are ignored; the first
+# remaining line is treated as the ref.
+#
+# Usage:
+#   sbin/get-redis-ref.sh            # prints the ref, e.g. "unstable"
+#
+# In a GitHub Actions step:
+#   echo "redis-ref=$(sbin/get-redis-ref.sh)" >> "$GITHUB_OUTPUT"
+
+set -euo pipefail
+
+PROGNAME="${BASH_SOURCE[0]}"
+HERE="$(cd "$(dirname "$PROGNAME")" &>/dev/null && pwd)"
+ROOT="$(cd "$HERE/.." &>/dev/null && pwd)"
+REF_FILE="$ROOT/.install/redis_ref.txt"
+
+if [[ ! -f "$REF_FILE" ]]; then
+	echo "Error: redis ref file not found at $REF_FILE" >&2
+	exit 1
+fi
+
+# First non-comment, non-blank line, trimmed of surrounding whitespace.
+REDIS_REF="$(sed -e 's/#.*//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' "$REF_FILE" | grep -m1 -v '^$' || true)"
+
+if [[ -z "$REDIS_REF" ]]; then
+	echo "Error: no redis ref defined in $REF_FILE" >&2
+	exit 1
+fi
+
+echo "$REDIS_REF"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI/Docker and install-script wiring only; no module runtime logic, though pinning Redis 8.8 changes what all pipelines compile and test against.
> 
> **Overview**
> Introduces **`.install/redis_ref.txt`** as the single place to pin the Redis git ref used for builds and tests (currently **`8.8`**, replacing scattered **`unstable`** defaults).
> 
> **`sbin/get-redis-ref.sh`** reads that file for GitHub Actions; **`event-ci`**, **`event-nightly`**, and **`event-tag`** now set `redis-ref` from the script (with checkout where needed). Nightly/tag **`workflow_dispatch`** `redis-ref` is optional—empty input uses the file.
> 
> **`.install/install_redis.sh`** falls back to the same file when `REDIS_REF` is unset. All platform **Dockerfiles** use empty **`ARG REDIS_REF=`** so image builds follow the file unless overridden at build time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 435d4cc75b01e694d9735a0607078dc5ec5b6236. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->