### PR TITLE
CI: switch flow-linux arm64 runner to standard ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -95,7 +95,7 @@ jobs:
         id: set-runner
         run: |
           if [ "${{ inputs.arch }}" == "arm64" ]; then
-            echo "runner=ubuntu24-arm64-4-16" >> $GITHUB_OUTPUT
+            echo "runner=org-level-ubuntu24-arm64-2-8" >> $GITHUB_OUTPUT
           else
             echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -95,7 +95,7 @@ jobs:
         id: set-runner
         run: |
           if [ "${{ inputs.arch }}" == "arm64" ]; then
-            echo "runner=org-level-ubuntu24-arm64-2-8" >> $GITHUB_OUTPUT
+            echo "runner=ubuntu-24.04-arm" >> $GITHUB_OUTPUT
           else
             echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Summary
Changes the arm64 runner used by the `flow-linux` workflow from `ubuntu24-arm64-4-16` to GitHub's standard public-repo arm64 runner `ubuntu-24.04-arm`.

## Details
The runner is selected in the `Set runner` step of `.github/workflows/flow-linux.yml` based on `inputs.arch`. Only the `arm64` branch is changed; the `x64` path (`ubuntu-latest`) is untouched.

The previously-tried org-level pool (`org-level-ubuntu24-arm64-2-8`) still queued jobs without picking them up. `ubuntu-24.04-arm` is a [standard GitHub-hosted runner](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories) available free for public repos, with the same CPU/memory specs as `ubuntu-latest` used on the x64 path — so it should match capacity and avoid the enterprise-pool starvation we were seeing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)