### PR TITLE
CI: trigger OSS cluster (multi-shard) benchmarks on demand

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -9,6 +9,12 @@ on:
       module_path:
         type: string
         default: bin/linux-x64-release/redistimeseries.so
+      module_ref:
+        # Git ref (branch, tag or commit SHA) of RedisTimeSeries to check out and
+        # benchmark. Empty keeps the default checkout (the ref that triggered the
+        # workflow), so existing callers are unaffected.
+        type: string
+        default: ""
       profile_env:
         type: number # for default of 0
       cluster_env:
@@ -40,10 +46,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Empty ref => default checkout (the ref that triggered the workflow).
+          ref: ${{ inputs.module_ref }}
       - run: |
           git init
           git config --global --add safe.directory '*'
           git submodule update --init --recursive
+
+      - name: Resolve benchmarked ref
+        id: bench_ref
+        env:
+          MODULE_REF: ${{ inputs.module_ref }}
+          DEFAULT_BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: |
+          # Tag results with the ref actually benchmarked, not the workflow ref.
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          if [ -n "$MODULE_REF" ]; then
+            echo "branch=$MODULE_REF" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch=$DEFAULT_BRANCH" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -103,8 +126,8 @@ jobs:
               --github_repo ${{ github.event.repository.name }}
               --github_org ${{ github.repository_owner }}
               --required-module ${{ inputs.required_module }}
-              --github_sha ${{ github.sha }}
-              --github_branch ${{ github.head_ref || github.ref_name }}
+              --github_sha ${{ steps.bench_ref.outputs.sha }}
+              --github_branch ${{ steps.bench_ref.outputs.branch }}
               --upload_results_s3
               --triggering_env ${{ inputs.triggering_env }}
               --allowed-envs ${{ inputs.allowed_envs }}

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -7,6 +7,10 @@ on:
         type: boolean
         description: 'Run profiler benchmarks'
         default: false
+      module_ref:
+        type: string
+        description: 'Git ref (branch, tag or commit SHA) of RedisTimeSeries to benchmark. Empty uses the branch selected for this run (e.g. set "8.6" then "8.8" to compare versions).'
+        default: ""
       run_cluster:
         type: boolean
         description: 'Run OSS cluster (multi-shard) benchmarks. Off by default to avoid recurrent cost; enable on demand (e.g. to measure TS.MRANGE multi-shard speedups).'
@@ -24,6 +28,9 @@ on:
       run_profiler:
         type: boolean
         default: false
+      module_ref:
+        type: string
+        default: ""
       run_cluster:
         type: boolean
         default: false
@@ -42,6 +49,7 @@ jobs:
     uses: ./.github/workflows/benchmark-flow.yml
     secrets: inherit
     with:
+      module_ref: ${{ inputs.module_ref }}
       benchmark_glob: ${{ inputs.benchmark_glob }}
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
@@ -57,6 +65,7 @@ jobs:
       profile_env: 1
       # TODO: change to "github-actions.profilers" when ready on grafana
       triggering_env: "circleci.profilers" # results generated with profilers attached are not mixed with the ones without it
+      module_ref: ${{ inputs.module_ref }}
       benchmark_glob: ${{ inputs.benchmark_glob }}
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
@@ -75,6 +84,7 @@ jobs:
     with:
       allowed_envs: "oss-cluster"
       allowed_setups: ${{ inputs.cluster_allowed_setups }}
+      module_ref: ${{ inputs.module_ref }}
       benchmark_glob: ${{ inputs.benchmark_glob }}
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -7,11 +7,32 @@ on:
         type: boolean
         description: 'Run profiler benchmarks'
         default: false
+      run_cluster:
+        type: boolean
+        description: 'Run OSS cluster (multi-shard) benchmarks. Off by default to avoid recurrent cost; enable on demand (e.g. to measure TS.MRANGE multi-shard speedups).'
+        default: false
+      benchmark_glob:
+        type: string
+        description: 'Glob of benchmark definitions to run (e.g. "*mrange*.yml" to focus the multi-shard comparison).'
+        default: "*.yml"
+      cluster_allowed_setups:
+        type: string
+        description: 'Optional comma-separated cluster setups to limit cost (e.g. "oss-cluster-03-primaries"). Empty runs every cluster topology, including the 15/30-primary ones, which is expensive.'
+        default: ""
   workflow_call:
     inputs:
       run_profiler:
         type: boolean
         default: false
+      run_cluster:
+        type: boolean
+        default: false
+      benchmark_glob:
+        type: string
+        default: "*.yml"
+      cluster_allowed_setups:
+        type: string
+        default: ""
 
 jobs:
   benchmark-timeseries-oss-standalone:
@@ -21,6 +42,7 @@ jobs:
     uses: ./.github/workflows/benchmark-flow.yml
     secrets: inherit
     with:
+      benchmark_glob: ${{ inputs.benchmark_glob }}
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
 
@@ -35,6 +57,24 @@ jobs:
       profile_env: 1
       # TODO: change to "github-actions.profilers" when ready on grafana
       triggering_env: "circleci.profilers" # results generated with profilers attached are not mixed with the ones without it
+      benchmark_glob: ${{ inputs.benchmark_glob }}
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
 
+  # Multi-shard OSS cluster benchmarks. Disabled on the recurrent push trigger
+  # (run_cluster defaults to false) so there is no recurring cost; trigger it
+  # on demand from the Actions tab to capture cluster results, e.g. to show the
+  # TS.MRANGE multi-shard performance boost across versions.
+  benchmark-timeseries-oss-cluster:
+    if: ${{ inputs.run_cluster }}
+    strategy:
+      matrix:
+        member_id: [1, 2, 3]
+    uses: ./.github/workflows/benchmark-flow.yml
+    secrets: inherit
+    with:
+      allowed_envs: "oss-cluster"
+      allowed_setups: ${{ inputs.cluster_allowed_setups }}
+      benchmark_glob: ${{ inputs.benchmark_glob }}
+      benchmark_runner_group_member_id: ${{ matrix.member_id }}
+      benchmark_runner_group_total: ${{ strategy.job-total }}


### PR DESCRIPTION
## Why

In 8.8 we shipped a TS.MRANGE performance boost on multi-shard clusters (OSS cluster and Enterprise cluster). However, our recurrent benchmark CI only exercises **oss-standalone** setups, so that multi-shard speedup (e.g. ~4x on 8.6 → 8.8) was never being measured.

The benchmark definitions under `tests/benchmarks/` already declare the `oss-cluster-*` topologies (`scaling-ts_mrange_*`, `scaling-ts_mget_*`, …); we just never had a runner job that targets them — nor a way to benchmark an arbitrary version ref.

## What

**1. On-demand OSS cluster job.** Adds `benchmark-timeseries-oss-cluster` to `benchmark-runner.yml`, gated behind a new `run_cluster` input that **defaults to `false`**:

- The push (`event-push-to-integ.yml`) and PR-label (`benchmark-trigger.yml`) callers invoke the runner with defaults → `run_cluster` stays off → **no recurring cluster cost**.
- A maintainer triggers cluster runs **on demand** from the Actions tab → *Run RedisTimeSeries Benchmarks* → *Run workflow*, ticking **Run OSS cluster (multi-shard) benchmarks**.

**2. Benchmark an arbitrary ref.** Adds a `module_ref` input (branch, tag or commit SHA), threaded from `benchmark-runner.yml` through `benchmark-flow.yml` into the checkout step. When empty it falls back to the normal checkout, so existing callers are unaffected. Results are tagged with the ref actually checked out (`git rev-parse HEAD`) rather than the workflow ref, so cross-version comparison data is labeled correctly. This means you can compare `8.6` vs `8.8` without switching branches — just dispatch twice with different `module_ref`.

Helper inputs to keep on-demand runs cheap and focused:

| Input | Purpose |
|-------|---------|
| `module_ref` | Branch/tag/SHA of RedisTimeSeries to benchmark. Empty = the selected branch. |
| `benchmark_glob` | Limit which benchmark definitions run. Pin a **single** file for a clean comparison, e.g. `scaling-ts_mrange_1K-series-tsbs-devops.yml`. |
| `cluster_allowed_setups` | Comma-separated cluster setups, e.g. `oss-cluster-03-primaries`, to avoid the expensive 15/30-primary topologies. |

The cluster job passes `allowed_envs: "oss-cluster"` to `benchmark-flow.yml`; cluster init is already handled by the `clusterconfig.init_commands` (`timeseries.REFRESHCLUSTER`) in `tests/benchmarks/defaults.yml`.

## How to demonstrate the 8.6 → 8.8 boost

Dispatch *Run RedisTimeSeries Benchmarks* twice (once per version):

- `run_cluster: true`
- `module_ref: 8.6` then `module_ref: 8.8`
- `cluster_allowed_setups: oss-cluster-03-primaries`
- `benchmark_glob: scaling-ts_mrange_1K-series-tsbs-devops.yml` — pin a **single** config (see notes on why).

Results land in the perf RedisTimeSeries / Grafana exporter under `…/oss-cluster/oss-cluster-03-primaries/ts_mrange_1K-series-tsbs-devops/Ops/sec`, tagged by branch (`8.6`/`8.8`) and hash, plus the JSON in S3.

### Validated result

Ran end-to-end through this workflow on `oss-cluster-03-primaries`, plain read-only `TS.MRANGE` (`scaling-ts_mrange_1K-series-tsbs-devops.yml`):

| Metric | 8.6 (`2aa3f53`) | 8.8 (`90289f8`) | 8.8 vs 8.6 |
|---|--:|--:|:--:|
| Ops/sec | 5.87 | 19.12 | **3.26× faster** |
| Avg latency | 15,734 ms | 5,076 ms | 3.10× lower |
| p50 | 15,860 ms | 5,046 ms | 3.14× lower |
| p99 | 16,646 ms | 6,816 ms | 2.44× lower |

(Runs [8.6](https://github.com/RedisTimeSeries/RedisTimeSeries/actions/runs/26823175860) · [8.8](https://github.com/RedisTimeSeries/RedisTimeSeries/actions/runs/26823179087); 8.8 reproduced to <0.2% across two runs.)

## Notes / current behavior

- **A cluster dispatch also runs the standalone baseline.** `benchmark-timeseries-oss-standalone` is not gated by `run_cluster`, so when you enable the cluster job you also get an `oss-standalone` run of the same glob — handy as a baseline, but worth knowing for cost.
- **Pin a single benchmark file.** With the 3-member runner group, a multi-file glob (e.g. `*mrange*.yml`) is split across matrix members, so the results scatter across jobs and per-job logs for non-last members can be awkward to retrieve. Pinning one file keeps the run on a single, readable member.
- **Pick a light config.** Heavy configs (e.g. `ts_mrange_10K`, which returns ~1/10 of the dataset per query → 30–150 s latencies) can overwhelm the benchmark client; the `1K` config is a reliable choice for the multi-shard comparison.
- **`continue-on-error` masks failures.** The benchmark step is `continue-on-error: true`, so a failed/empty run still shows a green job. A follow-up to fail/annotate when `Total benchmarks executed: 0` would make problems (e.g. a full results DB) visible.

## Risk

Standalone/recurrent behavior is unchanged — existing jobs keep their previous defaults (`module_ref` and `benchmark_glob` default to the prior behavior). The new cluster job is skipped unless explicitly requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)