### PR TITLE
MOD-15899 - oom try calloc

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -334,7 +334,12 @@ int Uncompressed_LoadFromRDB(Chunk_t **chunk, struct RedisModuleIO *io) {
     bool err = false;
     errdefer(err, *chunk = NULL);
 
-    Chunk *uncompchunk = (Chunk *)calloc(1, sizeof(*uncompchunk));
+    Chunk *uncompchunk = (Chunk *)rts_try_calloc(1, sizeof(*uncompchunk));
+    if (uncompchunk == NULL) {
+        RedisModule_LogIOError(io, "error", "Failed to allocate chunk while loading from RDB");
+        err = true;
+        return TSDB_ERROR;
+    }
     errdefer(err, Uncompressed_FreeChunk(uncompchunk));
 
     uncompchunk->base_timestamp = LoadUnsigned_IOError(io, err, TSDB_ERROR);

--- a/src/common.h
+++ b/src/common.h
@@ -4,6 +4,14 @@
 #include <string.h>
 #include "RedisModulesSDK/redismodule.h"
 
+// Non-aborting allocation: RedisModule_Calloc aborts the process on OOM (VDP-4658),
+// so prefer RedisModule_Try* (returns NULL). Falls back to the default allocator
+// when Try* isn't bound (libc in unit builds; the aborting RedisModule_Calloc/Alloc
+// in the module build, where Try* is always bound on Redis >= 7.0).
+#define rts_try_calloc(count, size)                                                                \
+    (RedisModule_TryCalloc ? RedisModule_TryCalloc((count), (size)) : calloc((count), (size)))
+#define rts_try_alloc(size) (RedisModule_TryAlloc ? RedisModule_TryAlloc((size)) : malloc((size)))
+
 #define RTS_ERR "ERR"
 #define RTS_NOPERM "NOPERM"
 #define RTS_ReplyError(ctx, err_type, msg) RedisModule_ReplyWithError(ctx, err_type " " msg)

--- a/src/compressed_chunk.c
+++ b/src/compressed_chunk.c
@@ -515,7 +515,12 @@ int Compressed_LoadFromRDB(Chunk_t **chunk, struct RedisModuleIO *io) {
     bool err = false;
     errdefer(err, *chunk = NULL);
 
-    CompressedChunk *compchunk = (CompressedChunk *)malloc(sizeof(*compchunk));
+    CompressedChunk *compchunk = (CompressedChunk *)rts_try_alloc(sizeof(*compchunk));
+    if (compchunk == NULL) {
+        RedisModule_LogIOError(io, "error", "Failed to allocate chunk while loading from RDB");
+        err = true;
+        return TSDB_ERROR;
+    }
     errdefer(err, Compressed_FreeChunk(compchunk));
 
     compchunk->data = NULL;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -8,6 +8,7 @@
  */
 #include "rdb.h"
 
+#include "common.h"
 #include "consts.h"
 #include "endianconv.h"
 #include "load_io_error_macros.h"
@@ -60,8 +61,13 @@ void *series_rdb_load(RedisModuleIO *io, int encver) {
         Load_IOError_OrDefault(io, err, NULL, encver >= TS_CREATE_IGNORE_VER, 0.0);
 
     cCtx.labelsCount = LoadUnsigned_IOError(io, err, NULL);
-    cCtx.labels = calloc(cCtx.labelsCount, sizeof *cCtx.labels);
-    errdefer(err, if (!series) FreeLabels(cCtx.labels, cCtx.labelsCount));
+    cCtx.labels = rts_try_calloc(cCtx.labelsCount, sizeof *cCtx.labels);
+    errdefer(err, if (!series && cCtx.labels) FreeLabels(cCtx.labels, cCtx.labelsCount));
+    if (unlikely(cCtx.labelsCount > 0 && cCtx.labels == NULL)) {
+        RedisModule_LogIOError(io, "error", "OOM allocating labels");
+        err = true;
+        return NULL;
+    }
     for (int i = 0; i < cCtx.labelsCount; i++) {
         cCtx.labels[i].key = LoadString_IOError(io, err, NULL);
         cCtx.labels[i].value = LoadString_IOError(io, err, NULL);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -85,6 +85,11 @@ void *series_rdb_load(RedisModuleIO *io, int encver) {
         const timestamp_t startCurrentTimeBucket = LoadUnsigned_IOError(io, err, NULL);
 
         CompactionRule *rule = NewRule(destKey, aggType, bucketDuration, timestampAlignment);
+        if (rule == NULL) {
+            RedisModule_LogIOError(io, "error", "Failed to create rule while loading from RDB");
+            err = true;
+            return NULL;
+        }
         destKey = NULL;
 
         rule->startCurrentTimeBucket = startCurrentTimeBucket;

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -1197,7 +1197,10 @@ CompactionRule *NewRule(RedisModuleString *destKey,
         return NULL;
     }
 
-    CompactionRule *rule = malloc(sizeof *rule);
+    CompactionRule *rule = rts_try_alloc(sizeof *rule);
+    if (rule == NULL) {
+        return NULL;
+    }
     rule->aggClass = GetAggClass(aggType);
     rule->aggType = aggType;
     rule->aggContext = rule->aggClass->createContext(false);

--- a/tests/unit/unittests.c
+++ b/tests/unit/unittests.c
@@ -17,6 +17,7 @@
 #include "unittests_parse_policies.c"
 #include "unittests_uncompressed_chunk.c"
 #include "unittests_cmd_info.c"
+#include "unittests_rdb_load_oom.c"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -30,6 +31,7 @@ int main(int argc, char *argv[]) {
     MU_RUN_SUITE(compressed_chunk_test_suite);
     MU_RUN_SUITE(parse_duplicate_policy_test_suite);
     MU_RUN_SUITE(command_info_test_suite);
+    MU_RUN_SUITE(rdb_load_oom_test_suite);
     MU_REPORT();
     return minunit_fail;
 }

--- a/tests/unit/unittests_rdb_load_oom.c
+++ b/tests/unit/unittests_rdb_load_oom.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of (a) the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+/*
+ * These tests exercise the RDB chunk-load functions' allocation-failure path.
+ *
+ * The loaders live in chunk.c / compressed_chunk.c and allocate via the
+ * rts_try_calloc / rts_try_alloc macros (RedisModule_Try* with a fallback).
+ * To force that allocation to fail deterministically we compile the loaders
+ * straight into this translation unit so their allocations resolve to *this*
+ * binary's RedisModule_Try* pointers, which we override below. (Overriding the
+ * pre-built module .so's allocator from the test binary is not possible.)
+ *
+ * The allocation is the first thing each loader does, before reading the RDB
+ * stream, so the RedisModuleIO argument is never dereferenced and can be NULL.
+ *
+ * NOTE: the test binary also links redistimeseries.so, which defines these same
+ * loaders (compiled WITH REDIS_MODULE_TARGET). We rely on symbol interposition:
+ * the executable's in-TU copies (libc allocators) win, including for the other
+ * chunk suites. If a linker/visibility change ever breaks that, an allocator
+ * crossing would surface here under ASan (run by the sanitizer unit job).
+ */
+
+#include "minunit.h"
+
+#include "chunk.c"
+#include "compressed_chunk.c"
+
+static void *rdb_oom_calloc(size_t nmemb, size_t size) {
+    (void)nmemb;
+    (void)size;
+    return NULL; // simulate an exhausted allocator
+}
+
+static void *rdb_oom_alloc(size_t size) {
+    (void)size;
+    return NULL; // simulate an exhausted allocator
+}
+
+static void rdb_oom_noop_log(RedisModuleIO *io, const char *levelstr, const char *fmt, ...) {
+    (void)io;
+    (void)levelstr;
+    (void)fmt; // no-op; RedisModule_LogIOError is unset in unit builds
+}
+
+MU_TEST(test_Uncompressed_LoadFromRDB_oom_returns_error) {
+    void *(*saved_try_calloc)(size_t, size_t) = RedisModule_TryCalloc;
+    void (*saved_log)(RedisModuleIO *, const char *, const char *, ...) = RedisModule_LogIOError;
+    RedisModule_TryCalloc = rdb_oom_calloc;
+    RedisModule_LogIOError = rdb_oom_noop_log;
+
+    Chunk_t *chunk = (Chunk_t *)0xDEAD; // sentinel; must be cleared to NULL on error
+    int rc = Uncompressed_LoadFromRDB(&chunk, NULL);
+
+    RedisModule_TryCalloc = saved_try_calloc;
+    RedisModule_LogIOError = saved_log;
+
+    mu_assert_int_eq(TSDB_ERROR, rc);
+    mu_assert(chunk == NULL, "chunk must be cleared to NULL when allocation fails");
+}
+
+MU_TEST(test_Compressed_LoadFromRDB_oom_returns_error) {
+    void *(*saved_try_alloc)(size_t) = RedisModule_TryAlloc;
+    void (*saved_log)(RedisModuleIO *, const char *, const char *, ...) = RedisModule_LogIOError;
+    RedisModule_TryAlloc = rdb_oom_alloc;
+    RedisModule_LogIOError = rdb_oom_noop_log;
+
+    Chunk_t *chunk = (Chunk_t *)0xDEAD; // sentinel; must be cleared to NULL on error
+    int rc = Compressed_LoadFromRDB(&chunk, NULL);
+
+    RedisModule_TryAlloc = saved_try_alloc;
+    RedisModule_LogIOError = saved_log;
+
+    mu_assert_int_eq(TSDB_ERROR, rc);
+    mu_assert(chunk == NULL, "chunk must be cleared to NULL when allocation fails");
+}
+
+MU_TEST_SUITE(rdb_load_oom_test_suite) {
+    MU_RUN_TEST(test_Uncompressed_LoadFromRDB_oom_returns_error);
+    MU_RUN_TEST(test_Compressed_LoadFromRDB_oom_returns_error);
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches persistence/RDB load and compaction rule creation on memory pressure; failures should fail load safely rather than crash, but behavior under OOM during restore changes.
> 
> **Overview**
> Introduces **`rts_try_calloc`** / **`rts_try_alloc`** in `common.h` so RDB and related paths use **`RedisModule_Try*`** (NULL on OOM) instead of allocators that can **abort Redis** on failure (VDP-4658).
> 
> **RDB load** now handles OOM explicitly: chunk loaders (`Uncompressed_LoadFromRDB`, `Compressed_LoadFromRDB`) return **`TSDB_ERROR`**, log via **`RedisModule_LogIOError`**, and clear the output chunk pointer; **`series_rdb_load`** uses try-calloc for labels and bails on **`NewRule`** failure; **`NewRule`** allocates with **`rts_try_alloc`**.
> 
> Adds unit tests that stub failing **`TryCalloc`/`TryAlloc`** and assert error return and **`chunk == NULL`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8adcb759834a41c445898a9c950da7fcb9bee08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->