### PR TITLE
MOD-8187 - fix non twa aggregation

### DIFF
--- a/src/compaction.c
+++ b/src/compaction.c
@@ -130,6 +130,13 @@ void LastValueSeedLocf(void *contextPtr, double value, timestamp_t ts) {
     context->ts = ts;
 }
 
+/* True when a TS_AGG_LAST context holds no carry-over value yet (created but no sample appended).
+ * Used to decide whether a forward empty gap needs LOCF seeding from the older neighbor. */
+bool LastValueIsUnseeded(void *contextPtr) {
+    SingleValueContext *context = (SingleValueContext *)contextPtr;
+    return isnan(context->value);
+}
+
 int SingleValueFinalize(void *contextPtr, double *val) {
     SingleValueContext *context = (SingleValueContext *)contextPtr;
     *val = context->value;

--- a/src/compaction.c
+++ b/src/compaction.c
@@ -131,7 +131,9 @@ void LastValueSeedLocf(void *contextPtr, double value, timestamp_t ts) {
 }
 
 /* True when a TS_AGG_LAST context holds no carry-over value yet (created but no sample appended).
- * Used to decide whether a forward empty gap needs LOCF seeding from the older neighbor. */
+ * Used to decide whether a forward empty gap needs LOCF seeding from the older neighbor.
+ * NaN is a reliable "unseeded" sentinel here: aggLast.isValueValid == nonNaNValueValid, so a NaN
+ * sample is never appended, hence context->value is NaN iff no sample has ever been observed. */
 bool LastValueIsUnseeded(void *contextPtr) {
     SingleValueContext *context = (SingleValueContext *)contextPtr;
     return isnan(context->value);

--- a/src/compaction.h
+++ b/src/compaction.h
@@ -55,8 +55,12 @@ const char *AggTypeEnumToString(TS_AGG_TYPES_T aggType);
 const char *AggTypeEnumToStringLowerCase(TS_AGG_TYPES_T aggType);
 void initGlobalCompactionFunctions();
 
-/* LOCF seed for reverse-mode empty-bucket emission of TS_AGG_LAST. The caller must verify the
+/* LOCF seed for empty-bucket emission of TS_AGG_LAST. The caller must verify the
  * aggregation is TS_AGG_LAST before calling. */
 void LastValueSeedLocf(void *contextPtr, double value, timestamp_t ts);
+
+/* True when a TS_AGG_LAST context has not yet observed a sample. The caller must verify the
+ * aggregation is TS_AGG_LAST before calling. */
+bool LastValueIsUnseeded(void *contextPtr);
 
 #endif

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -1442,8 +1442,7 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
             if (first_bucket <= last_bucket) {
                 has_empty_buckets = false;
             }
-            first_bucket =
-                max(0, (int64_t)((int64_t)first_bucket - (int64_t)aggregationTimeDelta));
+            first_bucket = max(0, (int64_t)((int64_t)first_bucket - (int64_t)aggregationTimeDelta));
         } else {
             if (first_bucket >= last_bucket) {
                 has_empty_buckets = false;

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -832,7 +832,7 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
                                        last_bucket,
                                        self,
                                        is_reversed,
-                                       true, // edge gap (whole-range / suffix)
+                                       true, // edge gap (whole-range / prefix)
                                        si);
             if (err != 0) {
                 return NULL;
@@ -1442,7 +1442,8 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
             if (first_bucket <= last_bucket) {
                 has_empty_buckets = false;
             }
-            first_bucket = (int64_t)((int64_t)first_bucket - (int64_t)aggregationTimeDelta);
+            first_bucket =
+                max(0, (int64_t)((int64_t)first_bucket - (int64_t)aggregationTimeDelta));
         } else {
             if (first_bucket >= last_bucket) {
                 has_empty_buckets = false;

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -886,12 +886,12 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
 // EMPTY range: fill empty buckets from query start to the first raw sample. Returns 0 or -1 on
 // error. Edge gaps with no older neighbor are dropped inside fillEmptyBuckets.
 static int agg_iter_apply_empty_prefix(AggregationIterator *self,
-                                           EnrichedChunk *enrichedChunk,
-                                           uint64_t aggregationTimeDelta,
-                                           bool is_reversed,
-                                           bool multiAgg,
-                                           size_t *agg_n_samples,
-                                           int64_t *si) {
+                                       EnrichedChunk *enrichedChunk,
+                                       uint64_t aggregationTimeDelta,
+                                       bool is_reversed,
+                                       bool multiAgg,
+                                       size_t *agg_n_samples,
+                                       int64_t *si) {
     if (!self->empty || self->handled_empty_prefix) {
         return 0;
     }
@@ -1494,12 +1494,12 @@ EnrichedChunk *AggregationIterator_GetNextChunk(struct AbstractIterator *iter) {
     }
 
     if (agg_iter_apply_empty_prefix(self,
-                                        enrichedChunk,
-                                        aggregationTimeDelta,
-                                        is_reversed,
-                                        multiAgg,
-                                        &agg_n_samples,
-                                        &si) != 0) {
+                                    enrichedChunk,
+                                    aggregationTimeDelta,
+                                    is_reversed,
+                                    multiAgg,
+                                    &agg_n_samples,
+                                    &si) != 0) {
         return NULL;
     }
     self->hasUnFinalizedContext = true;

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -466,14 +466,23 @@ static int64_t findLastIndexbeforeTS(const EnrichedChunk *chunk,
     return l;
 }
 
-/* When iterating reverse, empty-bucket LOCF (TS_AGG_LAST + EMPTY) inherits from the older
- * neighbor of the gap. The aggregator hasn't seen that sample yet (it lives in a bucket the
- * iterator will visit next), so we look it up directly and plant it into the context. The next
- * non-empty bucket's appendValue will overwrite it via the fresh_bucket path. */
-static void seed_locf_for_reverse_empty_gap(const AggregationIterator *self,
-                                            timestamp_t lowest_empty_bucket_start) {
+/* Empty-bucket LOCF (TS_AGG_LAST + EMPTY) inherits from the older (chronologically previous)
+ * neighbor of the gap. We look that sample up directly and plant it into the context; the next
+ * non-empty bucket's appendValue overwrites it via the fresh_bucket path.
+ *
+ * Reverse iteration: the aggregator holds the NEWER neighbor's value (the gap's older neighbor
+ * lives in a bucket the iterator visits next), so we must always overwrite it.
+ * Forward iteration: an interior gap already carries the correct LOCF value from the preceding
+ * in-range sample, so we only seed prefix / whole-range gaps where the context is still unseeded
+ * (no in-range sample observed yet) — this also avoids an extra series scan on the common path. */
+static void seed_locf_for_empty_gap(const AggregationIterator *self,
+                                    timestamp_t lowest_empty_bucket_start,
+                                    bool reversed) {
     for (size_t a = 0; a < self->numAggregations; a++) {
         if (self->aggregations[a].type != TS_AGG_LAST) {
+            continue;
+        }
+        if (!reversed && !LastValueIsUnseeded(self->aggregationContexts[a])) {
             continue;
         }
         Sample older, older_older;
@@ -691,7 +700,10 @@ static int fillEmptyBuckets(Samples *samples,
 
 #ifndef PREFIX_SUFFIX_IMPL // The PM decided to disable it, as it might cause OOM and complicates
                            // users
-    if (self->hasTwa) {
+    // Edge gaps (no sample on one side) are dropped for every aggregator, not just TWA: empty
+    // buckets before the first-ever sample or after the last-ever sample are not emitted (the PM
+    // canceled cases 6 and 7). Reached only when self->empty, so this applies whenever we fill.
+    {
         Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
         timestamp_t ta;
         int64_t agg_time_delta = self->aggregationTimeDelta;
@@ -701,7 +713,7 @@ static int fillEmptyBuckets(Samples *samples,
             twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore);
         size_t n_samples_after =
             twa_get_samples_from_right(ta, self, &sample_after, &sample_afAfter);
-        if (n_samples_before == 0 || n_samples_after == 0) { // the PM canceled cases 6 and 7
+        if (n_samples_before == 0 || n_samples_after == 0) {
             return 0;
         }
     }
@@ -746,19 +758,16 @@ static int fillEmptyBuckets(Samples *samples,
     if (self->hasTwa) {
         twa_fillEmptyBuckets(write_index, cur_ts, samples, self, n_empty_buckets, reversed);
     } else {
-        /* Reverse iteration loses LOCF carry-over for TS_AGG_LAST: the context still holds the
-         * NEWER bucket's value. Seed from the older neighbor before the gap is emitted. */
-        if (reversed) {
-            seed_locf_for_reverse_empty_gap(self, first_bucket_ts);
-        }
+        /* TS_AGG_LAST + EMPTY repeats the last value (LOCF). Seed the context from the older
+         * neighbor before the gap is emitted (always in reverse, where the context holds the
+         * newer neighbor; only for unseeded prefix/whole-range gaps in forward). */
+        seed_locf_for_empty_gap(self, first_bucket_ts, reversed);
         fillEmptyBucketsWithDefaultVals(
             write_index, cur_ts, samples, self, n_empty_buckets, reversed);
     }
 
     return 0;
 }
-
-#define TWA_EMPTY_RANGE(iter) (((iter)->empty) && ((iter)->hasTwa))
 
 static inline Samples *ensureOutputSamples(AggregationIterator *self,
                                            EnrichedChunk *enrichedChunk,
@@ -772,7 +781,7 @@ static inline Samples *ensureOutputSamples(AggregationIterator *self,
     return &enrichedChunk->samples;
 }
 
-// No samples from upstream: finalize, TWA-only empty range, or end stream.
+// No samples from upstream: finalize, EMPTY-range gap fill, or end stream.
 // Sets *enter_finalize when caller must run agg_iter_finalize().
 static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
                                               uint64_t aggregationTimeDelta,
@@ -785,7 +794,7 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
         *enter_finalize = true;
         return NULL;
     }
-    if (TWA_EMPTY_RANGE(self)) {
+    if (self->empty) {
         if (!self->handled_twa_empty_prefix) {
             self->handled_twa_empty_prefix = true;
             self->handled_twa_empty_suffix = true; // The prefix in this case is also the suffix
@@ -853,7 +862,8 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
     return NULL;
 }
 
-// TWA empty range: fill buckets from query start to first raw sample. Returns 0 or -1 on error.
+// EMPTY range: fill empty buckets from query start to the first raw sample. Returns 0 or -1 on
+// error. Edge gaps with no older neighbor are dropped inside fillEmptyBuckets.
 static int agg_iter_apply_twa_empty_prefix(AggregationIterator *self,
                                            EnrichedChunk *enrichedChunk,
                                            uint64_t aggregationTimeDelta,
@@ -861,7 +871,7 @@ static int agg_iter_apply_twa_empty_prefix(AggregationIterator *self,
                                            bool multiAgg,
                                            size_t *agg_n_samples,
                                            int64_t *si) {
-    if (!TWA_EMPTY_RANGE(self) || self->handled_twa_empty_prefix) {
+    if (!self->empty || self->handled_twa_empty_prefix) {
         return 0;
     }
     self->handled_twa_empty_prefix = true;
@@ -1389,7 +1399,7 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
     self->aux_chunk->samples.timestamps[0] =
         calc_bucket_ts(self->bucketTS, self->aggregationLastTimestamp, self->aggregationTimeDelta);
     size_t n_samples = 1;
-    if (TWA_EMPTY_RANGE(self) && !self->handled_twa_empty_suffix) {
+    if (self->empty && !self->handled_twa_empty_suffix) {
         self->handled_twa_empty_suffix = true;
         timestamp_t last_bucket =
             CalcBucketStart(is_reversed ? self->startTimestamp : self->endTimestamp,

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -755,13 +755,14 @@ static int fillEmptyBuckets(Samples *samples,
         samples->num_samples = _read_index + n_read_samples_left;
     }
 
+    /* Seed TS_AGG_LAST contexts from older neighbor for LOCF semantics (applies to all paths).
+     * In TWA+LAST multi-agg, twa_fillEmptyBuckets() calls finalizeEmpty() for non-TWA aggs
+     * without seeding, so we must seed here first. */
+    seed_locf_for_empty_gap(self, first_bucket_ts, reversed);
+
     if (self->hasTwa) {
         twa_fillEmptyBuckets(write_index, cur_ts, samples, self, n_empty_buckets, reversed);
     } else {
-        /* TS_AGG_LAST + EMPTY repeats the last value (LOCF). Seed the context from the older
-         * neighbor before the gap is emitted (always in reverse, where the context holds the
-         * newer neighbor; only for unseeded prefix/whole-range gaps in forward). */
-        seed_locf_for_empty_gap(self, first_bucket_ts, reversed);
         fillEmptyBucketsWithDefaultVals(
             write_index, cur_ts, samples, self, n_empty_buckets, reversed);
     }

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -271,8 +271,8 @@ AggregationIterator *AggregationIterator_New(struct AbstractIterator *input,
             break;
         }
     }
-    iter->handled_twa_empty_prefix = false;
-    iter->handled_twa_empty_suffix = false;
+    iter->handled_empty_prefix = false;
+    iter->handled_empty_suffix = false;
     iter->prev_ts = DC;
     iter->validSamplesInBucket = false;
     memset(iter->validPerAgg, 0, sizeof(iter->validPerAgg));
@@ -474,7 +474,8 @@ static int64_t findLastIndexbeforeTS(const EnrichedChunk *chunk,
  * lives in a bucket the iterator visits next), so we must always overwrite it.
  * Forward iteration: an interior gap already carries the correct LOCF value from the preceding
  * in-range sample, so we only seed prefix / whole-range gaps where the context is still unseeded
- * (no in-range sample observed yet) — this also avoids an extra series scan on the common path. */
+ * (no in-range sample observed yet). Skipping redundant seeding calls avoids duplicate neighbor
+ * lookups for already-seeded contexts, though edge-detection still scans neighbors separately. */
 static void seed_locf_for_empty_gap(const AggregationIterator *self,
                                     timestamp_t lowest_empty_bucket_start,
                                     bool reversed) {
@@ -667,13 +668,23 @@ static void twa_fillEmptyBuckets(size_t *write_index,
     }
 }
 
+// check_edge_gaps: when true, drop the run if it has no sample on one side (prefix/suffix/whole-
+// range gap). Interior callers — between a finalized real bucket and the next in-range sample —
+// pass false: both neighbors provably exist, so the edge check would always pass and the two
+// series scans it costs would be pure overhead.
 static int fillEmptyBuckets(Samples *samples,
                             size_t *write_index,
                             timestamp_t first_bucket_ts,
                             timestamp_t end_bucket_ts,
                             const AggregationIterator *self,
                             bool reversed,
+                            bool check_edge_gaps,
                             int64_t *read_index) {
+    /* Enforce load-bearing invariant: this function must only be called when self->empty is true.
+     * All callers must gate on this condition. Without this assertion, a future caller that
+     * violates this precondition would silently produce wrong results (dropped edge buckets)
+     * rather than failing loudly. The assertion catches such bugs immediately. */
+    assert(self->empty);
     int64_t agg_time_delta = self->aggregationTimeDelta;
     int64_t _read_index = *read_index + 1; // Cause we already stored the sample in read_index
     size_t vps = samples->values_per_sample;
@@ -702,12 +713,13 @@ static int fillEmptyBuckets(Samples *samples,
                            // users
     // Edge gaps (no sample on one side) are dropped for every aggregator, not just TWA: empty
     // buckets before the first-ever sample or after the last-ever sample are not emitted (the PM
-    // canceled cases 6 and 7). Reached only when self->empty, so this applies whenever we fill.
-    {
+    // canceled cases 6 and 7). Only the prefix/suffix/whole-range callers (check_edge_gaps) can
+    // produce such a run; interior callers always have a sample on both sides, so we skip the two
+    // series scans there. Reached only when self->empty (asserted at function entry), so this
+    // applies whenever we fill.
+    if (check_edge_gaps) {
         Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
-        timestamp_t ta;
-        int64_t agg_time_delta = self->aggregationTimeDelta;
-        ta = twa_calc_ta(
+        timestamp_t ta = twa_calc_ta(
             false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
         size_t n_samples_before =
             twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore);
@@ -758,6 +770,8 @@ static int fillEmptyBuckets(Samples *samples,
     /* Seed TS_AGG_LAST contexts from older neighbor for LOCF semantics (applies to all paths).
      * In TWA+LAST multi-agg, twa_fillEmptyBuckets() calls finalizeEmpty() for non-TWA aggs
      * without seeding, so we must seed here first. */
+    // NOTE: seed AFTER the in-place realloc/memmove above. That block moves samples buffers but
+    // not the aggregation contexts; keep seeding here so it stays decoupled from the compaction.
     seed_locf_for_empty_gap(self, first_bucket_ts, reversed);
 
     if (self->hasTwa) {
@@ -795,10 +809,12 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
         *enter_finalize = true;
         return NULL;
     }
+    // Empty-range gap fill drives ALL aggregators (not just TWA): the previous TWA_EMPTY_RANGE
+    // gate has been replaced by a plain self->empty check throughout.
     if (self->empty) {
-        if (!self->handled_twa_empty_prefix) {
-            self->handled_twa_empty_prefix = true;
-            self->handled_twa_empty_suffix = true; // The prefix in this case is also the suffix
+        if (!self->handled_empty_prefix) {
+            self->handled_empty_prefix = true;
+            self->handled_empty_suffix = true; // The prefix in this case is also the suffix
             timestamp_t first_bucket = CalcBucketStart(
                 self->startTimestamp, aggregationTimeDelta, self->timestampAlignment);
             timestamp_t last_bucket =
@@ -806,6 +822,8 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
             if (is_reversed) {
                 __SWAP(first_bucket, last_bucket);
             }
+            // Whole-range empty result is emitted via aux_chunk for every aggregator (verified by
+            // the EMPTY single-agg flow tests); the normal sample path still uses enrichedChunk.
             *si = -1;
             self->aux_chunk->samples.num_samples = 0;
             int err = fillEmptyBuckets(&self->aux_chunk->samples,
@@ -814,6 +832,7 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
                                        last_bucket,
                                        self,
                                        is_reversed,
+                                       true, // edge gap (whole-range / suffix)
                                        si);
             if (err != 0) {
                 return NULL;
@@ -822,8 +841,8 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
             self->aux_chunk->samples.num_samples = *agg_n_samples;
             return self->aux_chunk;
         }
-        if (!self->handled_twa_empty_suffix) {
-            self->handled_twa_empty_suffix = true;
+        if (!self->handled_empty_suffix) {
+            self->handled_empty_suffix = true;
             timestamp_t last_bucket =
                 CalcBucketStart(is_reversed ? self->startTimestamp : self->endTimestamp,
                                 aggregationTimeDelta,
@@ -850,6 +869,7 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
                                        last_bucket,
                                        self,
                                        is_reversed,
+                                       true, // edge gap (whole-range / suffix)
                                        si);
             if (err != 0) {
                 return NULL;
@@ -865,17 +885,17 @@ static EnrichedChunk *agg_iter_on_empty_chunk(AggregationIterator *self,
 
 // EMPTY range: fill empty buckets from query start to the first raw sample. Returns 0 or -1 on
 // error. Edge gaps with no older neighbor are dropped inside fillEmptyBuckets.
-static int agg_iter_apply_twa_empty_prefix(AggregationIterator *self,
+static int agg_iter_apply_empty_prefix(AggregationIterator *self,
                                            EnrichedChunk *enrichedChunk,
                                            uint64_t aggregationTimeDelta,
                                            bool is_reversed,
                                            bool multiAgg,
                                            size_t *agg_n_samples,
                                            int64_t *si) {
-    if (!self->empty || self->handled_twa_empty_prefix) {
+    if (!self->empty || self->handled_empty_prefix) {
         return 0;
     }
-    self->handled_twa_empty_prefix = true;
+    self->handled_empty_prefix = true;
     timestamp_t first_bucket =
         CalcBucketStart(is_reversed ? self->endTimestamp : self->startTimestamp,
                         aggregationTimeDelta,
@@ -902,8 +922,14 @@ static int agg_iter_apply_twa_empty_prefix(AggregationIterator *self,
         Samples *prefixSamples = ensureOutputSamples(self, enrichedChunk, *agg_n_samples + 256);
         prefixSamples->num_samples = *agg_n_samples;
         int64_t read_idx = -1;
-        int err = fillEmptyBuckets(
-            prefixSamples, agg_n_samples, first_bucket, last_bucket, self, is_reversed, &read_idx);
+        int err = fillEmptyBuckets(prefixSamples,
+                                   agg_n_samples,
+                                   first_bucket,
+                                   last_bucket,
+                                   self,
+                                   is_reversed,
+                                   true, // edge gap (prefix)
+                                   &read_idx);
         if (err != 0) {
             return -1;
         }
@@ -915,6 +941,7 @@ static int agg_iter_apply_twa_empty_prefix(AggregationIterator *self,
                                    last_bucket,
                                    self,
                                    is_reversed,
+                                   true, // edge gap (prefix)
                                    si);
         if (err != 0) {
             return -1;
@@ -1087,6 +1114,7 @@ static int agg_iter_max_emit_opening_sample(AggregationIterator *self,
                                        last_bucket,
                                        self,
                                        is_reversed,
+                                       false, // interior gap: neighbors exist on both sides
                                        si);
             if (err != 0) {
                 return -1;
@@ -1196,6 +1224,7 @@ static int agg_iter_general_on_bucket_boundary(AggregationIterator *self,
                                        last_bucket,
                                        self,
                                        is_reversed,
+                                       false, // interior gap: neighbors exist on both sides
                                        multiAgg ? &read_idx : si);
             if (err != 0) {
                 return -1;
@@ -1400,8 +1429,8 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
     self->aux_chunk->samples.timestamps[0] =
         calc_bucket_ts(self->bucketTS, self->aggregationLastTimestamp, self->aggregationTimeDelta);
     size_t n_samples = 1;
-    if (self->empty && !self->handled_twa_empty_suffix) {
-        self->handled_twa_empty_suffix = true;
+    if (self->empty && !self->handled_empty_suffix) {
+        self->handled_empty_suffix = true;
         timestamp_t last_bucket =
             CalcBucketStart(is_reversed ? self->startTimestamp : self->endTimestamp,
                             aggregationTimeDelta,
@@ -1429,6 +1458,7 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
                                        last_bucket,
                                        self,
                                        is_reversed,
+                                       true, // edge gap (suffix)
                                        &read_index);
             if (err != 0) {
                 return NULL;
@@ -1463,7 +1493,7 @@ EnrichedChunk *AggregationIterator_GetNextChunk(struct AbstractIterator *iter) {
         return r;
     }
 
-    if (agg_iter_apply_twa_empty_prefix(self,
+    if (agg_iter_apply_empty_prefix(self,
                                         enrichedChunk,
                                         aggregationTimeDelta,
                                         is_reversed,

--- a/src/filter_iterator.h
+++ b/src/filter_iterator.h
@@ -59,8 +59,8 @@ typedef struct AggregationIterator
     api_timestamp_t startTimestamp;
     api_timestamp_t endTimestamp;
     bool hasTwa; // precomputed: any aggregation is TWA
-    bool handled_twa_empty_prefix;
-    bool handled_twa_empty_suffix;
+    bool handled_empty_prefix;
+    bool handled_empty_suffix;
     timestamp_t prev_ts;
     bool validSamplesInBucket; // are there any valid samples in current bucket (any aggregation)
     bool validPerAgg[TS_AGG_TYPES_MAX]; // per-aggregation validity tracking for current bucket

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -1420,6 +1420,37 @@ def test_empty_gap_fill_prefix_suffix_whole_range():
         assert rng(11, 16, 'twa') == twa3
         assert revrng(11, 16, 'twa') == list(reversed(twa3))
 
+        # --- bucket size > 1 and non-zero ALIGN: exercises the CalcBucketStart / +-delta edge math
+        # in the prefix & suffix helpers (the bucket-1/ALIGN-0 cases above keep every ts in its own
+        # bucket and never hit it). Samples 12 (=100) and 42 (=200); bucket size 5, ALIGN 2 -> bucket
+        # starts at 2,7,12,...  [12,17) and [42,47) are real; [17..42) is an interior gap; buckets
+        # before 12 and after 47 are edge gaps and must be dropped. ---
+        assert r.execute_command('TS.CREATE', 'b')
+        assert r.execute_command('TS.MADD', 'b', 12, 100, 'b', 42, 200) == [12, 42]
+
+        def brng(start, end, agg):
+            return decode_if_needed(
+                r.execute_command('TS.range', 'b', start, end, 'ALIGN', '2', 'AGGREGATION', agg, 5, 'EMPTY'))
+
+        def brevrng(start, end, agg):
+            return decode_if_needed(
+                r.execute_command('TS.revrange', 'b', start, end, 'ALIGN', '2', 'AGGREGATION', agg, 5, 'EMPTY'))
+
+        last_aligned = [[12, '100'], [17, '100'], [22, '100'], [27, '100'], [32, '100'], [37, '100'], [42, '200']]
+        assert brng(0, 60, 'last') == last_aligned
+        assert brevrng(0, 60, 'last') == list(reversed(last_aligned))
+
+        sum_aligned = [[12, '100'], [17, '0'], [22, '0'], [27, '0'], [32, '0'], [37, '0'], [42, '200']]
+        assert brng(0, 60, 'sum') == sum_aligned
+
+        max_aligned = [[12, '100'], [17, 'NaN'], [22, 'NaN'], [27, 'NaN'], [32, 'NaN'], [37, 'NaN'], [42, '200']]
+        assert brng(0, 60, 'max') == max_aligned
+
+        # Edge-only ranges (before first / after last real bucket) stay empty under alignment too.
+        for agg in ('last', 'twa', 'sum', 'max'):
+            assert brng(0, 11, agg) == []
+            assert brng(47, 60, agg) == []
+
 
 def test_bucket_timestamp():
     agg_size = 10
@@ -3196,66 +3227,130 @@ def test_revrange_empty_count_matches_range_tail():
 
 def test_empty_gap_fill_twa_last_multi_agg():
     """
-    Test TWA+LAST multi-agg gap-filling: critical edge case fixed.
+    TWA+LAST multi-agg gap-filling.
 
-    The bug: When TWA and LAST aggregators were both in a query, LAST contexts
-    didn't get seeded for gap-filled buckets in fillEmptyBuckets(), so LAST
-    aggregators would output wrong values for empty buckets.
-
-    The fix: Always seed LAST contexts before filling (moved seed_locf_for_empty_gap
+    Bug: with TWA and LAST in the same query, LAST contexts were not seeded for
+    gap-filled buckets in fillEmptyBuckets(), so LAST produced wrong values for
+    empty buckets.
+    Fix: always seed LAST contexts before filling (seed_locf_for_empty_gap moved
     outside the if/else in fillEmptyBuckets).
 
-    This test verifies:
-    - Interior gaps with LAST+TWA work correctly
-    - LAST uses LOCF for gap buckets
-    - Multiple LAST aggregators all get seeded
+    Verifies an interior gap with TWA+LAST: LAST carries LOCF while TWA
+    interpolates, asserting exact deterministic values in both directions
+    (reverse exercises the always-overwrite seeding branch).
     """
     with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
-        # Test: Interior gap with TWA+LAST multi-agg (correct syntax: twa,last)
         r.execute_command('DEL', 'gap_twa_last_test')
         assert r.execute_command('TS.CREATE', 'gap_twa_last_test')
 
-        # Samples: t=5 (value=100), t=45 (value=300)
-        # Interior gap in buckets [10,20), [20,30), [30,40)
+        # Samples t=5 (=100), t=45 (=300); bucket size 10 over [0,50].
+        # [0,10) and [40,50) hold real samples; [10,20) [20,30) [30,40) are an interior gap.
         r.execute_command('TS.ADD', 'gap_twa_last_test', 5, 100)
         r.execute_command('TS.ADD', 'gap_twa_last_test', 45, 300)
 
-        # Query with TWA+LAST multi-agg (correct syntax: twa,last)
-        result = r.execute_command('TS.RANGE', 'gap_twa_last_test', 0, 50,
-                                   'AGGREGATION', 'twa,last', 10, 'EMPTY')
+        # Per bucket: [ts, twa, last]. LAST is LOCF (100 until the t=45 bucket); TWA interpolates.
+        expected = [
+            [0,  '112.5', '100'],
+            [10, '150',   '100'],
+            [20, '200',   '100'],
+            [30, '250',   '100'],
+            [40, '287.5', '300'],
+        ]
+        fwd = decode_if_needed(r.execute_command(
+            'TS.RANGE', 'gap_twa_last_test', 0, 50, 'AGGREGATION', 'twa,last', 10, 'EMPTY'))
+        assert fwd == expected, f'fwd: {fwd!r} != {expected!r}'
 
-        # Result format: [[ts, twa_val, last_val], [ts, twa_val, last_val], ...]
-        assert len(result) == 5, f"Expected 5 buckets, got {len(result)}"
+        rev = decode_if_needed(r.execute_command(
+            'TS.REVRANGE', 'gap_twa_last_test', 0, 50, 'AGGREGATION', 'twa,last', 10, 'EMPTY'))
+        assert rev == list(reversed(expected)), f'rev: {rev!r} != {list(reversed(expected))!r}'
 
-        # Bucket [0,10): contains sample at t=5 (value=100)
-        assert result[0][0] == 0
-        assert float(result[0][2]) == 100.0, \
-            f"Bucket [0,10): expected LAST=100, got {result[0][2]}"
 
-        # Bucket [10,20): interior gap
-        # LAST should be LOCF from t=5 sample (100)
-        # TWA should interpolate between 100 and 300
-        assert result[1][0] == 10
-        assert 100 <= float(result[1][1]) <= 300, \
-            f"Bucket [10,20): TWA should be 100-300, got {result[1][1]}"
-        assert float(result[1][2]) == 100.0, \
-            f"Bucket [10,20): expected LAST=100 (LOCF), got {result[1][2]}"
+def test_empty_gap_fill_interior_no_edge_scan():
+    """
+    Guards the check_edge_gaps optimization in fillEmptyBuckets().
 
-        # Bucket [20,30): interior gap
-        assert result[2][0] == 20
-        assert 100 <= float(result[2][1]) <= 300, \
-            f"Bucket [20,30): TWA should be 100-300, got {result[2][1]}"
-        assert float(result[2][2]) == 100.0, \
-            f"Bucket [20,30): expected LAST=100 (LOCF), got {result[2][2]}"
+    Interior gap fills (the main aggregation loop and the single-agg MAX forward
+    fast path) now pass check_edge_gaps=False and skip the two edge-detection
+    series scans, because a sample provably exists on both sides. The
+    prefix/suffix/whole-range callers still pass True and must still DROP edge
+    gaps.
 
-        # Bucket [30,40): interior gap
-        assert result[3][0] == 30
-        assert 100 <= float(result[3][1]) <= 300, \
-            f"Bucket [30,40): TWA should be 100-300, got {result[3][1]}"
-        assert float(result[3][2]) == 100.0, \
-            f"Bucket [30,40): expected LAST=100 (LOCF), got {result[3][2]}"
+    This test packs several interior gaps AND real edge gaps into one EMPTY query
+    so both behaviors run together, for every aggregator and in both directions.
+    If the optimization ever wrongly skipped or mis-classified a gap, the emitted
+    bucket set or values would change here.
 
-        # Bucket [40,50): contains sample at t=45 (value=300)
-        assert result[4][0] == 40
-        assert float(result[4][2]) == 300.0, \
-            f"Bucket [40,50): expected LAST=300, got {result[4][2]}"
+    Layout (bucket size 10, ALIGN 0), samples at t=25, 55, 85:
+        [0,10) [10,20)     -> before first sample  -> dropped (prefix edge)
+        [20,30)            -> sample 25 (=100)
+        [30,40) [40,50)    -> interior gap         -> filled (check_edge_gaps=False)
+        [50,60)            -> sample 55 (=200)
+        [60,70) [70,80)    -> interior gap         -> filled (check_edge_gaps=False)
+        [80,90)            -> sample 85 (=300)
+        [90,100) [100,110) -> after last sample    -> dropped (suffix edge)
+    => exactly 7 emitted buckets: ts 20, 30, 40, 50, 60, 70, 80
+    """
+    with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
+        assert r.execute_command('TS.CREATE', 'g')
+        assert r.execute_command('TS.MADD', 'g', 25, 100, 'g', 55, 200, 'g', 85, 300) == [25, 55, 85]
+
+        def rng(agg, start=0, end=109):
+            return decode_if_needed(r.execute_command(
+                'TS.range', 'g', start, end, 'ALIGN', '0', 'AGGREGATION', agg, 10, 'EMPTY'))
+
+        def revrng(agg, start=0, end=109):
+            return decode_if_needed(r.execute_command(
+                'TS.revrange', 'g', start, end, 'ALIGN', '0', 'AGGREGATION', agg, 10, 'EMPTY'))
+
+        ts = [20, 30, 40, 50, 60, 70, 80]
+
+        def expected(by_ts):
+            return [[t, by_ts[t]] for t in ts]
+
+        # LAST: LOCF carried across every interior gap (the seeded path).
+        last_vals = {20: '100', 30: '100', 40: '100', 50: '200', 60: '200', 70: '200', 80: '300'}
+        # SUM / COUNT: documented empty-bucket value 0 in gaps.
+        sum_vals = {20: '100', 30: '0', 40: '0', 50: '200', 60: '0', 70: '0', 80: '300'}
+        count_vals = {20: '1', 30: '0', 40: '0', 50: '1', 60: '0', 70: '0', 80: '1'}
+        # MAX/MIN/FIRST/AVG: NaN in gaps, sample value in real buckets.
+        nan_vals = {20: '100', 30: 'NaN', 40: 'NaN', 50: '200', 60: 'NaN', 70: 'NaN', 80: '300'}
+
+        # 'max' specifically exercises the single-agg forward FAST PATH (the second
+        # interior caller that now skips the edge scan).
+        cases = (
+            ('last', last_vals),
+            ('sum', sum_vals),
+            ('count', count_vals),
+            ('max', nan_vals),
+            ('min', nan_vals),
+            ('first', nan_vals),
+            ('avg', nan_vals),
+        )
+        for agg, vals in cases:
+            exp = expected(vals)
+            assert rng(agg) == exp, f'{agg} fwd: {rng(agg)!r} != {exp!r}'
+            assert revrng(agg) == list(reversed(exp)), \
+                f'{agg} rev: {revrng(agg)!r} != {list(reversed(exp))!r}'
+
+        # Ranges entirely before the first / after the last sample have no neighbor on one
+        # side and must stay empty for every aggregator. This is the edge path that still
+        # scans & drops - proving the optimization didn't disable edge handling.
+        for agg in ('last', 'sum', 'count', 'max', 'min', 'first', 'avg', 'twa'):
+            assert rng(agg, 0, 19) == [], f'{agg}: prefix-only range should be empty'
+            assert rng(agg, 90, 109) == [], f'{agg}: suffix-only range should be empty'
+            assert revrng(agg, 0, 19) == [], f'{agg}: prefix-only revrange should be empty'
+            assert revrng(agg, 90, 109) == [], f'{agg}: suffix-only revrange should be empty'
+
+        # TWA interior multi-gap fill also goes through the check_edge_gaps=False after-finalize
+        # path. Use a constant value so the interpolated gap buckets are exactly 100 (deterministic,
+        # no float fragility): samples 5,35,65 (=100) over [0,69], bucket 10 -> 7 buckets all 100,
+        # interior gaps filled (not dropped) in both directions.
+        assert r.execute_command('TS.CREATE', 'c')
+        assert r.execute_command('TS.MADD', 'c', 5, 100, 'c', 35, 100, 'c', 65, 100) == [5, 35, 65]
+        twa_const = [[t, '100'] for t in (0, 10, 20, 30, 40, 50, 60)]
+        twa_fwd = decode_if_needed(r.execute_command(
+            'TS.range', 'c', 0, 69, 'ALIGN', '0', 'AGGREGATION', 'twa', 10, 'EMPTY'))
+        twa_rev = decode_if_needed(r.execute_command(
+            'TS.revrange', 'c', 0, 69, 'ALIGN', '0', 'AGGREGATION', 'twa', 10, 'EMPTY'))
+        assert twa_fwd == twa_const, f'twa interior fwd: {twa_fwd!r} != {twa_const!r}'
+        assert twa_rev == list(reversed(twa_const)), f'twa interior rev: {twa_rev!r}'

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -3192,3 +3192,70 @@ def test_revrange_empty_count_matches_range_tail():
                         f'[{label}/{agg}] REVRANGE EMPTY COUNT {n}: '
                         f'expected {expected!r}, got {rev!r}; '
                         f'(fwd_all={fwd_all!r})')
+
+
+def test_empty_gap_fill_twa_last_multi_agg():
+    """
+    Test TWA+LAST multi-agg gap-filling: critical edge case fixed.
+
+    The bug: When TWA and LAST aggregators were both in a query, LAST contexts
+    didn't get seeded for gap-filled buckets in fillEmptyBuckets(), so LAST
+    aggregators would output wrong values for empty buckets.
+
+    The fix: Always seed LAST contexts before filling (moved seed_locf_for_empty_gap
+    outside the if/else in fillEmptyBuckets).
+
+    This test verifies:
+    - Interior gaps with LAST+TWA work correctly
+    - LAST uses LOCF for gap buckets
+    - Multiple LAST aggregators all get seeded
+    """
+    with Env(decodeResponses=True).getClusterConnectionIfNeeded() as r:
+        # Test: Interior gap with TWA+LAST multi-agg (correct syntax: twa,last)
+        r.execute_command('DEL', 'gap_twa_last_test')
+        assert r.execute_command('TS.CREATE', 'gap_twa_last_test')
+
+        # Samples: t=5 (value=100), t=45 (value=300)
+        # Interior gap in buckets [10,20), [20,30), [30,40)
+        r.execute_command('TS.ADD', 'gap_twa_last_test', 5, 100)
+        r.execute_command('TS.ADD', 'gap_twa_last_test', 45, 300)
+
+        # Query with TWA+LAST multi-agg (correct syntax: twa,last)
+        result = r.execute_command('TS.RANGE', 'gap_twa_last_test', 0, 50,
+                                   'AGGREGATION', 'twa,last', 10, 'EMPTY')
+
+        # Result format: [[ts, twa_val, last_val], [ts, twa_val, last_val], ...]
+        assert len(result) == 5, f"Expected 5 buckets, got {len(result)}"
+
+        # Bucket [0,10): contains sample at t=5 (value=100)
+        assert result[0][0] == 0
+        assert float(result[0][2]) == 100.0, \
+            f"Bucket [0,10): expected LAST=100, got {result[0][2]}"
+
+        # Bucket [10,20): interior gap
+        # LAST should be LOCF from t=5 sample (100)
+        # TWA should interpolate between 100 and 300
+        assert result[1][0] == 10
+        assert 100 <= float(result[1][1]) <= 300, \
+            f"Bucket [10,20): TWA should be 100-300, got {result[1][1]}"
+        assert float(result[1][2]) == 100.0, \
+            f"Bucket [10,20): expected LAST=100 (LOCF), got {result[1][2]}"
+
+        # Bucket [20,30): interior gap
+        assert result[2][0] == 20
+        assert 100 <= float(result[2][1]) <= 300, \
+            f"Bucket [20,30): TWA should be 100-300, got {result[2][1]}"
+        assert float(result[2][2]) == 100.0, \
+            f"Bucket [20,30): expected LAST=100 (LOCF), got {result[2][2]}"
+
+        # Bucket [30,40): interior gap
+        assert result[3][0] == 30
+        assert 100 <= float(result[3][1]) <= 300, \
+            f"Bucket [30,40): TWA should be 100-300, got {result[3][1]}"
+        assert float(result[3][2]) == 100.0, \
+            f"Bucket [30,40): expected LAST=100 (LOCF), got {result[3][2]}"
+
+        # Bucket [40,50): contains sample at t=45 (value=300)
+        assert result[4][0] == 40
+        assert float(result[4][2]) == 300.0, \
+            f"Bucket [40,50): expected LAST=300, got {result[4][2]}"

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -1362,6 +1362,65 @@ def test_empty():
         decode_if_needed(r.execute_command('TS.revrange', 't2', '0', '30', 'ALIGN', '0', 'AGGREGATION', 'max', agg_size, 'EMPTY'))
 
 
+# MOD-8187: EMPTY gap filling must work for every aggregator, not only TWA, when the empty buckets
+# are a prefix, a suffix, or the whole queried range (cases 3, 4 and 5 of PM-1229). Before the fix
+# only TWA emitted those buckets, so LAST (and the rest) returned a truncated / empty result.
+# The existing test_empty only exercised *interior* gaps (first/last bucket hold real samples),
+# which is why these cases were never caught.
+def test_empty_gap_fill_prefix_suffix_whole_range():
+    env = Env(decodeResponses=True)
+    with env.getClusterConnectionIfNeeded() as r:
+        assert r.execute_command('TS.CREATE', 'a')
+        assert r.execute_command('TS.MADD', 'a', 10, 100, 'a', 20, 110) == [10, 20]
+
+        def rng(start, end, agg):
+            return decode_if_needed(
+                r.execute_command('TS.range', 'a', start, end, 'ALIGN', '0', 'AGGREGATION', agg, 1, 'EMPTY'))
+
+        def revrng(start, end, agg):
+            return decode_if_needed(
+                r.execute_command('TS.revrange', 'a', start, end, 'ALIGN', '0', 'AGGREGATION', agg, 1, 'EMPTY'))
+
+        # --- LAST: repeats the previous value (LOCF) for the gap-filled buckets ---
+        # Case 3: whole range is a gap between sample 10 and sample 20 -> all carry 100.
+        case3 = [[ts, '100'] for ts in range(11, 17)]
+        assert rng(11, 16, 'last') == case3
+        assert revrng(11, 16, 'last') == list(reversed(case3))
+
+        # Case 4: sample 10 is in range; trailing buckets 11,12 are an interior gap (sample 20
+        # follows) -> LOCF 100. Buckets 8,9 (before the first-ever sample) are dropped.
+        case4 = [[10, '100'], [11, '100'], [12, '100']]
+        assert rng(8, 12, 'last') == case4
+        assert revrng(8, 12, 'last') == list(reversed(case4))
+
+        # Case 5: leading buckets 18,19 are an interior gap -> LOCF 100; bucket 20 holds 110.
+        # Buckets 21,22 (after the last-ever sample) are dropped.
+        case5 = [[18, '100'], [19, '100'], [20, '110']]
+        assert rng(18, 22, 'last') == case5
+        assert revrng(18, 22, 'last') == list(reversed(case5))
+
+        # Edge gaps with no neighbor on one side are dropped for every aggregator (PM canceled
+        # cases 6 and 7): a range entirely before the first / after the last sample is empty.
+        for agg in ('last', 'twa', 'avg', 'max', 'min', 'sum', 'first', 'count'):
+            assert rng(2, 5, agg) == []
+            assert rng(25, 30, agg) == []
+            assert revrng(2, 5, agg) == []
+            assert revrng(25, 30, agg) == []
+
+        # Non-LOCF aggregators report the documented empty-bucket value in interior gaps.
+        nan6 = [[ts, 'NaN'] for ts in range(11, 17)]
+        for agg in ('avg', 'max', 'min', 'first', 'range', 'std.p', 'var.p'):
+            assert rng(11, 16, agg) == nan6
+        zero6 = [[ts, '0'] for ts in range(11, 17)]
+        for agg in ('sum', 'count'):
+            assert rng(11, 16, agg) == zero6
+
+        # TWA was already correct - guard against regressions in the shared code path.
+        twa3 = [[11, '101.5'], [12, '102.5'], [13, '103.5'], [14, '104.5'], [15, '105.5'], [16, '106']]
+        assert rng(11, 16, 'twa') == twa3
+        assert revrng(11, 16, 'twa') == list(reversed(twa3))
+
+
 def test_bucket_timestamp():
     agg_size = 10
     env = Env(decodeResponses=True)

--- a/tests/flow/test_ts_range.py
+++ b/tests/flow/test_ts_range.py
@@ -1399,6 +1399,15 @@ def test_empty_gap_fill_prefix_suffix_whole_range():
         assert rng(18, 22, 'last') == case5
         assert revrng(18, 22, 'last') == list(reversed(case5))
 
+        # Case prefix-emit: a leading gap whose older neighbor is OUT of range. Sample 10 (=100)
+        # is before the query, sample 20 (=110) is the first in-range sample. Buckets 13..19 form
+        # a prefix gap that must be EMITTED via LOCF from the out-of-range sample 10, then 20 holds
+        # 110. Unlike case 3 (whole-range, entered via agg_iter_on_empty_chunk), this drives the
+        # forward agg_iter_apply_empty_prefix emit path directly.
+        case_prefix = [[ts, '100'] for ts in range(13, 20)] + [[20, '110']]
+        assert rng(13, 20, 'last') == case_prefix
+        assert revrng(13, 20, 'last') == list(reversed(case_prefix))
+
         # Edge gaps with no neighbor on one side are dropped for every aggregator (PM canceled
         # cases 6 and 7): a range entirely before the first / after the last sample is empty.
         for agg in ('last', 'twa', 'avg', 'max', 'min', 'sum', 'first', 'count'):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core aggregation iterator empty-bucket logic used by TS.RANGE/REVRANGE; behavior changes for non-TWA EMPTY queries but is heavily covered by new flow tests.
> 
> **Overview**
> Fixes **MOD-8187**: with `EMPTY`, prefix/suffix/whole-range gap filling now runs for **every** aggregator, not only TWA. The old `TWA_EMPTY_RANGE` gate is replaced by `self->empty` everywhere; iterator flags are renamed to `handled_empty_prefix` / `handled_empty_suffix`.
> 
> **LAST (LOCF)** empty gaps use shared `seed_locf_for_empty_gap()` (forward + reverse): reverse always seeds from the older neighbor; forward seeds only when `LastValueIsUnseeded()` (new helper). Seeding runs once in `fillEmptyBuckets()` before TWA vs default fill so **TWA+LAST** multi-agg gets correct LAST values.
> 
> `fillEmptyBuckets()` gains **`check_edge_gaps`**: prefix/suffix/whole-range callers still drop buckets with no neighbor on one side (all aggs); interior gap callers skip the two series scans. Adds `assert(self->empty)` on entry.
> 
> Flow tests cover prefix/suffix/whole-range, aligned buckets, TWA+LAST multi-agg, and interior vs edge gap behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47ce097565da0baf3890af8e6c14f63b422a626c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->