### PR TITLE
MOD-16160 -update blocking get syntax

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -1388,7 +1388,7 @@
         "group": "timeseries"
     },
     "TS.BGET": {
-        "summary": "Blocking GET: wait up to `timeout` milliseconds and retrieve up to `count` samples with timestamp >= `timestamp`. Returns the oldest qualifying samples in ascending timestamp order. When `timeout` is 0 the command does not block and returns whatever is available now (possibly empty or fewer than `count`).",
+        "summary": "Blocking GET: wait up to `timeout` milliseconds or until at least `min_count` samples with timestamp >= `timestamp` are available (whichever occurs first), then retrieve up to `max_count` of the oldest qualifying samples in ascending timestamp order. When `timeout` is 0 the command does not block and returns whatever is available now (possibly empty or fewer than `min_count`). Defaults: `min_count` 1, `max_count` unlimited.",
         "complexity": "O(log(n)+k) where n is the number of samples in the series and k is the number of returned samples",
         "arguments": [
             {
@@ -1400,12 +1400,20 @@
                 "type": "string"
             },
             {
-                "name": "count",
+                "name": "timeout",
                 "type": "integer"
             },
             {
-                "name": "timeout",
-                "type": "integer"
+                "name": "min_count",
+                "token": "MIN_COUNT",
+                "type": "integer",
+                "optional": true
+            },
+            {
+                "name": "max_count",
+                "token": "MAX_COUNT",
+                "type": "integer",
+                "optional": true
             }
         ],
         "command_flags": [

--- a/src/cmd_info/ts_info.c
+++ b/src/cmd_info/ts_info.c
@@ -723,6 +723,51 @@ static const RedisModuleCommandInfo TS_GET_INFO = {
 };
 
 // ===============================
+// TS.BGET key timestamp timeout [MIN_COUNT min_count] [MAX_COUNT max_count]
+// ===============================
+static const RedisModuleCommandKeySpec TS_BGET_KEYSPECS[] = {
+    { .flags = REDISMODULE_CMD_KEY_RO,
+      .begin_search_type = REDISMODULE_KSPEC_BS_INDEX,
+      .bs.index = { .pos = 1 },
+      .find_keys_type = REDISMODULE_KSPEC_FK_RANGE,
+      .fk.range = { .lastkey = 0, .keystep = 1, .limit = 0 } },
+    { 0 }
+};
+
+static const RedisModuleCommandArg TS_BGET_ARGS[] = {
+    { .name = "key", .type = REDISMODULE_ARG_TYPE_KEY, .key_spec_index = 0 },
+    { .name = "timestamp", .type = REDISMODULE_ARG_TYPE_STRING },
+    { .name = "timeout", .type = REDISMODULE_ARG_TYPE_INTEGER },
+    { .name = "MIN_COUNT",
+      .type = REDISMODULE_ARG_TYPE_BLOCK,
+      .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+      .subargs =
+          (RedisModuleCommandArg[]){
+              { .name = "min_count", .type = REDISMODULE_ARG_TYPE_INTEGER, .token = "MIN_COUNT" },
+              { 0 } } },
+    { .name = "MAX_COUNT",
+      .type = REDISMODULE_ARG_TYPE_BLOCK,
+      .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+      .subargs =
+          (RedisModuleCommandArg[]){
+              { .name = "max_count", .type = REDISMODULE_ARG_TYPE_INTEGER, .token = "MAX_COUNT" },
+              { 0 } } },
+    { 0 }
+};
+
+static const RedisModuleCommandInfo TS_BGET_INFO = {
+    .version = REDISMODULE_COMMAND_INFO_VERSION,
+    .summary = "Blocking GET: wait up to timeout ms or until min_count samples with timestamp >= "
+               "timestamp are available, then return up to max_count of the oldest such samples",
+    .complexity = "O(log(n)+k) where n is the number of samples in the series and k is the number "
+                  "of returned samples",
+    .since = "8.10.0",
+    .arity = -4,
+    .key_specs = (RedisModuleCommandKeySpec *)TS_BGET_KEYSPECS,
+    .args = (RedisModuleCommandArg *)TS_BGET_ARGS,
+};
+
+// ===============================
 // TS.REVRANGE key fromTimestamp toTimestamp
 //  [LATEST]
 //  [FILTER_BY_TS ts...]
@@ -1629,6 +1674,11 @@ int RegisterTSCommandInfos(RedisModuleCtx *ctx) {
     // Register TS.GET command info
     RedisModuleCommand *cmd_get = RedisModule_GetCommand(ctx, "TS.GET");
     if (!cmd_get || RedisModule_SetCommandInfo(cmd_get, &TS_GET_INFO) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    // Register TS.BGET command info
+    RedisModuleCommand *cmd_bget = RedisModule_GetCommand(ctx, "TS.BGET");
+    if (!cmd_bget || RedisModule_SetCommandInfo(cmd_bget, &TS_BGET_INFO) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     // Register TS.RANGE command info

--- a/src/module.c
+++ b/src/module.c
@@ -1586,9 +1586,10 @@ static int parse_bget_args(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     // timestamp: literal non-negative integer, or a '-' / '+' sentinel.
     // '-' is a static substitution: cursor=0 matches every sample under our
     // inclusive ts >= cursor semantic.
-    // '+' must be resolved against the live series exactly once (here) so
-    // the cursor stays stable across wake-ups; if we re-resolved on every
-    // signal, lastTs would chase forward and we'd never reply.
+    // '+' denotes the latest sample's timestamp (0 when the series is empty),
+    // aligned with TS.RANGE. It must be resolved against the live series exactly
+    // once (here) so the cursor stays stable across wake-ups; if we re-resolved
+    // on every signal, lastTs would chase forward and we'd never reply.
     api_timestamp_t cursor = 0;
     size_t ts_len = 0;
     const char *ts_str = RedisModule_StringPtrLen(argv[BGET_ARGV_TIMESTAMP], &ts_len);
@@ -1607,14 +1608,7 @@ static int parse_bget_args(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
             return REDISMODULE_ERR;
         } else {
             Series *series = RedisModule_ModuleTypeGetValue(key);
-            // Saturate at UINT64_MAX so `lastTimestamp + 1` cannot wrap to 0
-            // (which would silently flip the cursor's meaning from "future
-            // only" to "every sample"). No timestamp can exceed UINT64_MAX,
-            // so cursor=UINT64_MAX is the correct unreachable upper bound.
-            cursor = (SeriesGetNumSamples(series) == 0) ? 0
-                     : (series->lastTimestamp == UINT64_MAX)
-                         ? UINT64_MAX
-                         : (api_timestamp_t)(series->lastTimestamp + 1);
+            cursor = (SeriesGetNumSamples(series) == 0) ? 0 : (api_timestamp_t)series->lastTimestamp;
         }
         if (key) {
             RedisModule_CloseKey(key);

--- a/src/module.c
+++ b/src/module.c
@@ -1453,22 +1453,25 @@ int TSDB_get(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 /* ============================================================================
  *  TS.BGET — Blocking GET (cursor-style tailing of a series)
  *
- *  Syntax:  TS.BGET key timestamp count timeout
+ *  Syntax:  TS.BGET key timestamp timeout [MIN_COUNT min_count] [MAX_COUNT max_count]
  *
- *  Returns up to `count` samples with sample-ts greater than or equal to the
- *  resolved cursor, sorted ascending. Blocks up to `timeout` ms waiting for
- *  qualifying samples. `timestamp` may be a literal UNIX-ms value or one of
- *  the sentinels `-` (earliest) / `+` (latest at command-receive time; first
- *  call only).
+ *  Returns up to `max_count` samples (default unlimited) with sample-ts greater
+ *  than or equal to the resolved cursor, sorted ascending. Blocks up to
+ *  `timeout` ms waiting until at least `min_count` qualifying samples exist
+ *  (default 1). `timestamp` may be a literal UNIX-ms value or one of the
+ *  sentinels `-` (earliest) / `+` (latest existing sample, inclusive) /
+ *  `$` (latest sample's ts + 1, i.e. only post-command samples qualify).
  *
  *  Wake-up is driven by RedisModule_SignalKeyAsReady() in the sample-append
  *  chokepoint of the engine (covers TS.ADD / TS.MADD / TS.INCRBY / TS.DECRBY
  *  on append, plus compaction-rule writes to the destination key).
  *
- *  Sentinel support (all resolved inside parse_bget_args):
+ *  Sentinel support (all resolved once inside parse_bget_args):
  *    `-` -> cursor=0 (no lower bound).
- *    `+` -> cursor=series->lastTimestamp+1, snapshotted once at command
- *           receipt; missing/empty -> 0; wrong-type key -> WRONGTYPE.
+ *    `+` -> cursor=series->lastTimestamp (latest existing sample qualifies,
+ *           aligned with TS.RANGE); missing/empty -> 0; wrong-type -> WRONGTYPE.
+ *    `$` -> cursor=series->lastTimestamp+1 (only post-command samples qualify);
+ *           missing/empty -> 0; wrong-type -> WRONGTYPE.
  * ============================================================================
  */
 
@@ -1482,7 +1485,7 @@ typedef enum BGetArgv
 {
     BGET_ARGV_COMMAND = 0,     ///< the command name itself
     BGET_ARGV_KEY = 1,         ///< series key
-    BGET_ARGV_TIMESTAMP = 2,   ///< cursor / '-' / '+'
+    BGET_ARGV_TIMESTAMP = 2,   ///< cursor / '-' / '+' / '$'
     BGET_ARGV_TIMEOUT = 3,     ///< timeout in ms
     BGET_ARGV_FIRST_OPTION = 4 ///< first MIN_COUNT/MAX_COUNT keyword (options follow in pairs)
 } BGetArgv;
@@ -1542,7 +1545,12 @@ typedef struct BGetCtx
  * @return REDISMODULE_OK on success, REDISMODULE_ERR on any reply written.
  */
 static int parse_bget_args(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, BGetCtx *out) {
-    if (argc < BGET_MIN_ARGC || argc > BGET_MAX_ARGC) {
+    // Optional args come only as MIN_COUNT/MAX_COUNT keyword+value pairs, so
+    // anything past the fixed args must be a whole number of BGET_OPTION_STRIDE
+    // tokens. This rejects a stray trailing token or a lone keyword (e.g. an
+    // odd argc of 5 or 7) instead of silently ignoring it.
+    if (argc < BGET_MIN_ARGC || argc > BGET_MAX_ARGC ||
+        (argc - BGET_MIN_ARGC) % BGET_OPTION_STRIDE != 0) {
         RedisModule_WrongArity(ctx);
         return REDISMODULE_ERR;
     }

--- a/src/module.c
+++ b/src/module.c
@@ -1472,6 +1472,29 @@ int TSDB_get(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
  * ============================================================================
  */
 
+/// TS.BGET MIN_COUNT default: unblock as soon as one sample qualifies.
+#define BGET_DEFAULT_MIN_COUNT 1
+/// TS.BGET MAX_COUNT default: unlimited (maps to RangeArgs.count == -1).
+#define BGET_DEFAULT_MAX_COUNT (-1)
+
+/// TS.BGET fixed argv layout: TS.BGET key timestamp timeout [MIN_COUNT n] [MAX_COUNT n]
+typedef enum BGetArgv
+{
+    BGET_ARGV_COMMAND = 0,    ///< the command name itself
+    BGET_ARGV_KEY = 1,        ///< series key
+    BGET_ARGV_TIMESTAMP = 2,  ///< cursor / '-' / '+'
+    BGET_ARGV_TIMEOUT = 3,    ///< timeout in ms
+    BGET_ARGV_FIRST_OPTION = 4 ///< first MIN_COUNT/MAX_COUNT keyword (options follow in pairs)
+} BGetArgv;
+
+#define BGET_OPTION_STRIDE 2 ///< each option is a keyword + value pair
+/// timeout_ms value meaning "do not block": reply with whatever is available now.
+#define BGET_NO_BLOCK_TIMEOUT 0
+/// Min argc: just the fixed args (command key timestamp timeout), no options.
+#define BGET_MIN_ARGC BGET_ARGV_FIRST_OPTION
+/// Max argc: the fixed args plus both MIN_COUNT and MAX_COUNT pairs.
+#define BGET_MAX_ARGC (BGET_ARGV_FIRST_OPTION + 2 * BGET_OPTION_STRIDE)
+
 /**
  * @brief Parsed TS.BGET arguments, also used as blocked-client privdata.
  *
@@ -1483,7 +1506,8 @@ typedef struct BGetCtx
 {
     RedisModuleString *key; ///< series key to read from
     api_timestamp_t cursor; ///< inclusive lower bound: only samples with ts >= cursor qualify
-    size_t count;           ///< max samples to return in this batch
+    size_t min_count;       ///< unblock threshold: wait until this many samples qualify (default 1)
+    long long max_count;    ///< reply cap: max samples to return; -1 = unlimited (default)
     long long timeout_ms;   ///< 0 = do not block; >0 = max time to wait
 } BGetCtx;
 
@@ -1505,33 +1529,61 @@ typedef struct BGetCtx
  *
  * After OK, @p out->cursor is a plain literal for the rest of the lifecycle.
  *
+ * Syntax: TS.BGET key timestamp timeout [MIN_COUNT min_count] [MAX_COUNT max_count]
+ *   - argv[3] (timeout): non-negative integer milliseconds; 0 means "do not block".
+ *   - MIN_COUNT (optional): unblock threshold, positive integer. Default 1.
+ *   - MAX_COUNT (optional): reply cap, positive integer. Default unlimited (-1).
+ *   - Requires min_count <= max_count.
+ *
  * @param ctx   Redis module context (used to reply on error / WRONGTYPE).
  * @param argv  Command argument vector.
- * @param argc  Number of arguments in @p argv (must be 5).
+ * @param argc  Number of arguments in @p argv (4 to 8).
  * @param out   Output struct populated on success.
  * @return REDISMODULE_OK on success, REDISMODULE_ERR on any reply written.
  */
 static int parse_bget_args(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, BGetCtx *out) {
-    if (argc != 5) {
+    if (argc < BGET_MIN_ARGC || argc > BGET_MAX_ARGC) {
         RedisModule_WrongArity(ctx);
         return REDISMODULE_ERR;
     }
 
-    // argv[3] — count: positive integer.
-    long long count_ll = 0;
-    if (RedisModule_StringToLongLong(argv[3], &count_ll) != REDISMODULE_OK || count_ll <= 0) {
-        RedisModule_ReplyWithError(ctx, "TSDB: count must be a positive integer");
-        return REDISMODULE_ERR;
-    }
-
-    // argv[4] — timeout_ms: non-negative integer. 0 means "do not block".
-    long long timeout_ms = 0;
-    if (RedisModule_StringToLongLong(argv[4], &timeout_ms) != REDISMODULE_OK || timeout_ms < 0) {
+    // timeout_ms: non-negative integer. BGET_NO_BLOCK_TIMEOUT means "do not block".
+    long long timeout_ms = BGET_NO_BLOCK_TIMEOUT;
+    if (RedisModule_StringToLongLong(argv[BGET_ARGV_TIMEOUT], &timeout_ms) != REDISMODULE_OK ||
+        timeout_ms < 0) {
         RedisModule_ReplyWithError(ctx, "TSDB: timeout must be a non-negative integer");
         return REDISMODULE_ERR;
     }
 
-    // argv[2] — timestamp: literal non-negative integer, or a '-' / '+' sentinel.
+    // Optional MIN_COUNT / MAX_COUNT, parsed like every other TS optional
+    // keyword argument: locate the token with RMUtil_ArgIndex and read its
+    // value with RMUtil_ParseArgsAfter.
+    long long min_count = BGET_DEFAULT_MIN_COUNT;
+    long long max_count = BGET_DEFAULT_MAX_COUNT;
+
+    if (RMUtil_ArgIndex("MIN_COUNT", argv, argc) > 0) {
+        if (RMUtil_ParseArgsAfter("MIN_COUNT", argv, argc, "l", &min_count) != REDISMODULE_OK ||
+            min_count <= 0) {
+            RedisModule_ReplyWithError(ctx, "TSDB: MIN_COUNT must be a positive integer");
+            return REDISMODULE_ERR;
+        }
+    }
+
+    if (RMUtil_ArgIndex("MAX_COUNT", argv, argc) > 0) {
+        if (RMUtil_ParseArgsAfter("MAX_COUNT", argv, argc, "l", &max_count) != REDISMODULE_OK ||
+            max_count <= 0) {
+            RedisModule_ReplyWithError(ctx, "TSDB: MAX_COUNT must be a positive integer");
+            return REDISMODULE_ERR;
+        }
+    }
+
+    // Unlimited max_count is >= any min_count, so only validate when capped.
+    if (max_count != BGET_DEFAULT_MAX_COUNT && min_count > max_count) {
+        RedisModule_ReplyWithError(ctx, "TSDB: MIN_COUNT must be <= MAX_COUNT");
+        return REDISMODULE_ERR;
+    }
+
+    // timestamp: literal non-negative integer, or a '-' / '+' sentinel.
     // '-' is a static substitution: cursor=0 matches every sample under our
     // inclusive ts >= cursor semantic.
     // '+' must be resolved against the live series exactly once (here) so
@@ -1539,11 +1591,11 @@ static int parse_bget_args(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     // signal, lastTs would chase forward and we'd never reply.
     api_timestamp_t cursor = 0;
     size_t ts_len = 0;
-    const char *ts_str = RedisModule_StringPtrLen(argv[2], &ts_len);
+    const char *ts_str = RedisModule_StringPtrLen(argv[BGET_ARGV_TIMESTAMP], &ts_len);
     if (ts_len == 1 && ts_str[0] == '-') {
         cursor = 0;
     } else if (ts_len == 1 && ts_str[0] == '+') {
-        RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_READ);
+        RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[BGET_ARGV_KEY], REDISMODULE_READ);
         const int kt = key ? RedisModule_KeyType(key) : REDISMODULE_KEYTYPE_EMPTY;
 
         if (kt == REDISMODULE_KEYTYPE_EMPTY) {
@@ -1569,16 +1621,18 @@ static int parse_bget_args(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
         }
     } else {
         long long ts_ll = 0;
-        if (RedisModule_StringToLongLong(argv[2], &ts_ll) != REDISMODULE_OK || ts_ll < 0) {
+        if (RedisModule_StringToLongLong(argv[BGET_ARGV_TIMESTAMP], &ts_ll) != REDISMODULE_OK ||
+            ts_ll < 0) {
             RedisModule_ReplyWithError(ctx, "TSDB: invalid timestamp");
             return REDISMODULE_ERR;
         }
         cursor = (api_timestamp_t)ts_ll;
     }
 
-    out->key = argv[1];
+    out->key = argv[BGET_ARGV_KEY];
     out->cursor = cursor;
-    out->count = (size_t)count_ll;
+    out->min_count = (size_t)min_count;
+    out->max_count = max_count;
     out->timeout_ms = timeout_ms;
     return REDISMODULE_OK;
 }
@@ -1618,22 +1672,25 @@ static size_t TSDB_count_samples_up_to(Series *series, const RangeArgs *range, s
  * the reply_cb would then discard by returning REDISMODULE_ERR.
  *
  * Modes:
- *   - strict (@p require_full_batch == true): only reply when @p args->count
- *     samples qualify; otherwise return false so the caller can block / stay
- *     parked. Used on the fast path and on SignalKeyAsReady wake-ups.
+ *   - strict (@p require_full_batch == true): only reply when at least
+ *     @p args->min_count samples qualify; otherwise return false so the caller
+ *     can block / stay parked. Used on the fast path and on SignalKeyAsReady
+ *     wake-ups.
  *   - flush  (@p require_full_batch == false): always reply (possibly empty
  *     or partial). Used by the timeout callback and by the no-block fast
  *     path when `timeout_ms == 0`.
+ *
+ * In all reply cases at most @p args->max_count samples are returned.
  *
  * Case breakdown:
  *   1. Missing key      : strict -> false; flush -> empty array.
  *   2. Wrong-type key   : always WRONGTYPE error.
  *   3a. lastTs <  cursor: strict -> false; flush -> empty array.
- *   3b. Else            : strict -> false if qualifying < count, else reply;
- *                         flush  -> reply (1..count samples).
+ *   3b. Else            : strict -> false if qualifying < min_count, else reply;
+ *                         flush  -> reply (0..max_count samples).
  *
  * @param ctx                Module context for OpenKey/Reply* calls.
- * @param args               Parsed BGET arguments (key, cursor, count).
+ * @param args               Parsed BGET arguments (key, cursor, min/max count).
  * @param require_full_batch Strict (true) vs flush (false) mode.
  * @return true if a reply was written, false only in strict mode when caller
  *         should block / stay parked.
@@ -1676,23 +1733,24 @@ static bool TSDB_bget_try_reply(RedisModuleCtx *ctx, const BGetCtx *args, bool r
     }
 
     // Case 3b: at least one sample may qualify. Build the range query
-    // equivalent to TS.RANGE [cursor, +inf] LIMIT count.
+    // equivalent to TS.RANGE [cursor, +inf] LIMIT max_count (-1 = unlimited).
     const RangeArgs range = {
         .startTimestamp = args->cursor,
         .endTimestamp = LLONG_MAX,
         .latest = false,
-        .count = (long long)args->count,
+        .count = args->max_count,
     };
 
-    // Strict mode: refuse to commit a reply until we know it will be
-    // complete. The pre-count walk reads only chunk metadata.
-    if (require_full_batch && TSDB_count_samples_up_to(series, &range, args->count) < args->count) {
+    // Strict mode: refuse to commit a reply until at least min_count samples
+    // qualify. The pre-count walk reads only chunk metadata.
+    if (require_full_batch &&
+        TSDB_count_samples_up_to(series, &range, args->min_count) < args->min_count) {
         RedisModule_CloseKey(key);
         return false;
     }
 
-    // Either we have >= count (strict) or partial flushing is allowed.
-    // Either way, deliver up to args->count samples in ascending order.
+    // Either we have >= min_count (strict) or partial flushing is allowed.
+    // Either way, deliver up to max_count samples in ascending order.
     ReplySeriesRange(ctx, series, &range, /*reverse=*/false);
     RedisModule_CloseKey(key);
     return true;
@@ -1828,8 +1886,9 @@ static RedisModuleBlockedClient *TSDB_bget_block(RedisModuleCtx *ctx, const BGet
  * privdata, and we deliver an explanatory error here.
  *
  * @param ctx   Module context.
- * @param argv  Command argument vector: `TS.BGET key timestamp count timeout`.
- * @param argc  Argument count (expected 5).
+ * @param argv  Command argument vector:
+ *              `TS.BGET key timestamp timeout [MIN_COUNT min_count] [MAX_COUNT max_count]`.
+ * @param argc  Argument count (4 to 8).
  * @return Always REDISMODULE_OK — errors (parse, WRONGTYPE, blocking refused)
  *         are delivered through RedisModule_ReplyWithError so the client
  *         always sees a terminal reply.
@@ -1844,11 +1903,11 @@ int TSDB_bget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return REDISMODULE_OK;
     }
 
-    // timeout_ms == 0 means "do not block" — flush whatever is available now
-    // (possibly empty / partial). timeout_ms  > 0 uses strict mode; if we
-    // don't have args.count yet, fall through and park the client until a
+    // BGET_NO_BLOCK_TIMEOUT means "do not block" — flush whatever is available
+    // now (possibly empty / partial). A positive timeout uses strict mode; if
+    // we don't have min_count yet, fall through and park the client until a
     // SignalKeyAsReady wakes us with enough data, or the timeout fires.
-    if (TSDB_bget_try_reply(ctx, &args, args.timeout_ms > 0)) {
+    if (TSDB_bget_try_reply(ctx, &args, args.timeout_ms > BGET_NO_BLOCK_TIMEOUT)) {
         return REDISMODULE_OK;
     }
 

--- a/src/module.c
+++ b/src/module.c
@@ -1480,10 +1480,10 @@ int TSDB_get(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 /// TS.BGET fixed argv layout: TS.BGET key timestamp timeout [MIN_COUNT n] [MAX_COUNT n]
 typedef enum BGetArgv
 {
-    BGET_ARGV_COMMAND = 0,    ///< the command name itself
-    BGET_ARGV_KEY = 1,        ///< series key
-    BGET_ARGV_TIMESTAMP = 2,  ///< cursor / '-' / '+'
-    BGET_ARGV_TIMEOUT = 3,    ///< timeout in ms
+    BGET_ARGV_COMMAND = 0,     ///< the command name itself
+    BGET_ARGV_KEY = 1,         ///< series key
+    BGET_ARGV_TIMESTAMP = 2,   ///< cursor / '-' / '+'
+    BGET_ARGV_TIMEOUT = 3,     ///< timeout in ms
     BGET_ARGV_FIRST_OPTION = 4 ///< first MIN_COUNT/MAX_COUNT keyword (options follow in pairs)
 } BGetArgv;
 

--- a/src/module.c
+++ b/src/module.c
@@ -1583,19 +1583,24 @@ static int parse_bget_args(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
         return REDISMODULE_ERR;
     }
 
-    // timestamp: literal non-negative integer, or a '-' / '+' sentinel.
+    // timestamp: literal non-negative integer, or a '-' / '+' / '$' sentinel.
     // '-' is a static substitution: cursor=0 matches every sample under our
     // inclusive ts >= cursor semantic.
     // '+' denotes the latest sample's timestamp (0 when the series is empty),
-    // aligned with TS.RANGE. It must be resolved against the live series exactly
-    // once (here) so the cursor stays stable across wake-ups; if we re-resolved
-    // on every signal, lastTs would chase forward and we'd never reply.
+    // aligned with TS.RANGE; the latest existing sample qualifies.
+    // '$' denotes the latest sample's timestamp + 1 (0 when the series is empty):
+    // only samples reported after this command qualify (the latest existing
+    // sample is excluded).
+    // '+' / '$' must be resolved against the live series exactly once (here) so
+    // the cursor stays stable across wake-ups; if we re-resolved on every signal,
+    // lastTs would chase forward and we'd never reply.
     api_timestamp_t cursor = 0;
     size_t ts_len = 0;
     const char *ts_str = RedisModule_StringPtrLen(argv[BGET_ARGV_TIMESTAMP], &ts_len);
     if (ts_len == 1 && ts_str[0] == '-') {
         cursor = 0;
-    } else if (ts_len == 1 && ts_str[0] == '+') {
+    } else if (ts_len == 1 && (ts_str[0] == '+' || ts_str[0] == '$')) {
+        const bool future_only = (ts_str[0] == '$');
         RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[BGET_ARGV_KEY], REDISMODULE_READ);
         const int kt = key ? RedisModule_KeyType(key) : REDISMODULE_KEYTYPE_EMPTY;
 
@@ -1608,7 +1613,19 @@ static int parse_bget_args(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
             return REDISMODULE_ERR;
         } else {
             Series *series = RedisModule_ModuleTypeGetValue(key);
-            cursor = (SeriesGetNumSamples(series) == 0) ? 0 : (api_timestamp_t)series->lastTimestamp;
+            if (SeriesGetNumSamples(series) == 0) {
+                cursor = 0;
+            } else if (!future_only) {
+                cursor = (api_timestamp_t)series->lastTimestamp;
+            } else {
+                // '$': saturate at UINT64_MAX so `lastTimestamp + 1` cannot wrap to
+                // 0 (which would silently flip the cursor's meaning from "future
+                // only" to "every sample"). No timestamp can exceed UINT64_MAX, so
+                // cursor=UINT64_MAX is the correct unreachable lower bound.
+                cursor = (series->lastTimestamp == UINT64_MAX)
+                             ? UINT64_MAX
+                             : (api_timestamp_t)(series->lastTimestamp + 1);
+            }
         }
         if (key) {
             RedisModule_CloseKey(key);

--- a/tests/flow/test_ts_bget.py
+++ b/tests/flow/test_ts_bget.py
@@ -284,32 +284,6 @@ def test_bget_timeout_flushes_available_samples():
                    message="Timeout overshoot too large: %.3fs" % elapsed)
 
 
-def test_bget_timeout_flush_respects_max_count():
-    env = Env()
-    if env.is_cluster():
-        env.skip()
-
-    r = env.getConnection()
-    _seed(r, "ts", [
-        (100, "1.0"), (200, "2.0"), (300, "3.0"),
-        (400, "4.0"), (500, "5.0"),
-    ])
-
-    # cursor=101 -> 4 qualifying samples; MIN_COUNT 10 can never be reached and
-    # nobody adds, so the timeout_cb flushes. Even on the flush path the reply
-    # must honor MAX_COUNT and return only the oldest 2 (not all 4 available).
-    t0 = time.time()
-    res = r.execute_command("TS.BGET", "ts", 101, 1000,
-                            "MIN_COUNT", 10, "MAX_COUNT", 2)
-    elapsed = time.time() - t0
-
-    env.assertEqual(res, [[200, b"2"], [300, b"3"]])
-    env.assertTrue(elapsed >= 0.9,
-                   message="Expected to wait ~1s on timeout, only waited %.3fs" % elapsed)
-    env.assertTrue(elapsed < 5.0,
-                   message="Timeout overshoot too large: %.3fs" % elapsed)
-
-
 # ---------------------------------------------------------------------------
 # 5. '-' sentinel: cursor=0, matches every existing sample.
 # ---------------------------------------------------------------------------

--- a/tests/flow/test_ts_bget.py
+++ b/tests/flow/test_ts_bget.py
@@ -8,7 +8,18 @@ from includes import *
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _start_bget(env, key, cursor, count, timeout_ms):
+def _bget_argv(key, cursor, timeout_ms, min_count=None, max_count=None):
+    """Build a TS.BGET argument list for the
+    `key timestamp timeout [MIN_COUNT n] [MAX_COUNT n]` syntax."""
+    argv = [key, cursor, timeout_ms]
+    if min_count is not None:
+        argv += ["MIN_COUNT", min_count]
+    if max_count is not None:
+        argv += ["MAX_COUNT", max_count]
+    return argv
+
+
+def _start_bget(env, key, cursor, timeout_ms, min_count=None, max_count=None):
     """Spawn a worker thread that issues TS.BGET on its own connection.
 
     Returns (thread, slot) where `slot` is mutated by the worker:
@@ -17,14 +28,13 @@ def _start_bget(env, key, cursor, count, timeout_ms):
         slot["elapsed"] -> wall-clock seconds the BGET call took
     """
     slot = {"result": None, "error": None, "elapsed": None}
+    argv = _bget_argv(key, cursor, timeout_ms, min_count, max_count)
 
     def worker():
         conn = env.getConnection()
         t0 = time.time()
         try:
-            slot["result"] = conn.execute_command(
-                "TS.BGET", key, cursor, count, timeout_ms
-            )
+            slot["result"] = conn.execute_command("TS.BGET", *argv)
         except Exception as e:
             slot["error"] = str(e)
         finally:
@@ -45,7 +55,7 @@ def _seed(r, key, samples):
 # 1. Immediate reply when enough qualifying samples already exist.
 # ---------------------------------------------------------------------------
 
-def test_bget_returns_immediately_when_count_already_satisfied():
+def test_bget_returns_immediately_when_min_count_already_satisfied():
     env = Env()
     if env.is_cluster():
         env.skip()  # BGET is a single-key primitive; cluster routing is orthogonal.
@@ -53,10 +63,10 @@ def test_bget_returns_immediately_when_count_already_satisfied():
     r = env.getConnection()
     _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
 
-    # cursor=101 -> qualifying = {200, 300}; count=2 is already met,
-    # so BGET should NOT block and return synchronously.
+    # cursor=101 -> qualifying = {200, 300}; MIN_COUNT 2 is already met, so BGET
+    # should NOT block and return synchronously (MAX_COUNT 2 caps the reply).
     t0 = time.time()
-    res = r.execute_command("TS.BGET", "ts", 101, 2, 1000)
+    res = r.execute_command("TS.BGET", "ts", 101, 1000, "MIN_COUNT", 2, "MAX_COUNT", 2)
     elapsed = time.time() - t0
 
     env.assertEqual(res, [[200, b"2"], [300, b"3"]])
@@ -65,10 +75,10 @@ def test_bget_returns_immediately_when_count_already_satisfied():
 
 
 # ---------------------------------------------------------------------------
-# 2. Blocks until SignalKeyAsReady has pushed qualifying-count to >= count.
+# 2. Blocks until SignalKeyAsReady has pushed qualifying-count to >= min_count.
 # ---------------------------------------------------------------------------
 
-def test_bget_blocks_then_unblocks_when_count_is_reached():
+def test_bget_blocks_then_unblocks_when_min_count_is_reached():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -77,12 +87,12 @@ def test_bget_blocks_then_unblocks_when_count_is_reached():
     _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
 
     # cursor=101 -> initial qualifying = {200, 300} = 2 < 5, so BGET blocks.
-    # NOTE: to reach count=5 with cursor=101 we need THREE more samples,
+    # NOTE: to reach min_count=5 with cursor=101 we need THREE more samples,
     # not two — the sample at ts=100 doesn't qualify because 100 < 101
     # (cursor is an inclusive lower bound: only ts >= cursor qualifies).
     # Each TS.ADD fires SignalKeyAsReady -> reply_cb runs; only the third
     # add commits because that's when qualifying becomes 5.
-    t, slot = _start_bget(env, "ts", 101, 5, 10_000)
+    t, slot = _start_bget(env, "ts", 101, 10_000, min_count=5, max_count=5)
 
     # Give the worker enough time to issue BlockClientOnKeys on the server.
     time.sleep(0.3)
@@ -105,7 +115,7 @@ def test_bget_blocks_then_unblocks_when_count_is_reached():
 
     t.join(timeout=2.0)
     env.assertFalse(t.is_alive(),
-                    message="BGET should have replied once qualifying >= count")
+                    message="BGET should have replied once qualifying >= min_count")
 
     env.assertEqual(slot["error"], None)
     env.assertEqual(
@@ -118,11 +128,11 @@ def test_bget_blocks_then_unblocks_when_count_is_reached():
 
 
 # ---------------------------------------------------------------------------
-# 3. Oldest-first paging: when MORE than `count` samples qualify, return the
-#    oldest `count` (so callers can advance the cursor to the last returned ts).
+# 3. Oldest-first paging: when MORE than `max_count` samples qualify, return the
+#    oldest `max_count` (so callers can advance the cursor to the last returned ts).
 # ---------------------------------------------------------------------------
 
-def test_bget_returns_oldest_count_when_more_qualify():
+def test_bget_returns_oldest_max_count_when_more_qualify():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -133,20 +143,59 @@ def test_bget_returns_oldest_count_when_more_qualify():
         (400, "4.0"), (500, "5.0"),
     ])
 
-    # cursor=101 -> 4 qualifying (200, 300, 400, 500); count=2 -> take the OLDEST 2.
-    res = r.execute_command("TS.BGET", "ts", 101, 2, 1000)
+    # cursor=101 -> 4 qualifying (200, 300, 400, 500); MAX_COUNT 2 -> take the OLDEST 2.
+    res = r.execute_command("TS.BGET", "ts", 101, 1000, "MAX_COUNT", 2)
     env.assertEqual(res, [[200, b"2"], [300, b"3"]])
 
     # The caller pages forward by setting cursor to last_returned_ts + 1
     # (cursor is inclusive: ts >= cursor qualifies, so passing 300 would
     # re-emit the sample we already saw).
-    res = r.execute_command("TS.BGET", "ts", 301, 2, 1000)
+    res = r.execute_command("TS.BGET", "ts", 301, 1000, "MAX_COUNT", 2)
     env.assertEqual(res, [[400, b"4"], [500, b"5"]])
 
 
 # ---------------------------------------------------------------------------
+# 3b. MIN_COUNT vs MAX_COUNT divergence: wait for min_count, then return the
+#     oldest max_count (which may be fewer than what qualifies).
+# ---------------------------------------------------------------------------
+
+def test_bget_min_below_max_returns_oldest_max_count():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    _seed(r, "ts", [
+        (100, "1.0"), (200, "2.0"), (300, "3.0"),
+        (400, "4.0"), (500, "5.0"), (600, "6.0"),
+    ])
+
+    # cursor=0 -> 6 qualify; MIN_COUNT 2 already met, MAX_COUNT 4 caps to oldest 4.
+    res = r.execute_command("TS.BGET", "ts", 0, 1000, "MIN_COUNT", 2, "MAX_COUNT", 4)
+    env.assertEqual(res, [[100, b"1"], [200, b"2"], [300, b"3"], [400, b"4"]])
+
+
+# ---------------------------------------------------------------------------
+# 3c. Defaults: no MIN_COUNT/MAX_COUNT -> min_count=1, max_count=unlimited.
+# ---------------------------------------------------------------------------
+
+def test_bget_defaults_min_one_max_unlimited():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
+
+    # min_count defaults to 1 (already met), max_count defaults to unlimited
+    # so every qualifying sample is returned.
+    res = r.execute_command("TS.BGET", "ts", 0, 1000)
+    env.assertEqual(res, [[100, b"1"], [200, b"2"], [300, b"3"]])
+
+
+# ---------------------------------------------------------------------------
 # 4. Timeout flush: client blocks, no producer feeds it, timeout fires and we
-#    flush whatever is available (which may be fewer than count).
+#    flush whatever is available (which may be fewer than min_count).
 # ---------------------------------------------------------------------------
 
 def test_bget_timeout_flushes_available_samples():
@@ -160,10 +209,10 @@ def test_bget_timeout_flushes_available_samples():
         (400, "4.0"), (500, "5.0"),
     ])
 
-    # cursor=101 -> 4 qualifying; count=10 cannot be reached. Nobody else adds.
+    # cursor=101 -> 4 qualifying; MIN_COUNT 10 cannot be reached. Nobody else adds.
     # After timeout_ms expires the timeout_cb flushes the 4 available samples.
     t0 = time.time()
-    res = r.execute_command("TS.BGET", "ts", 101, 10, 1000)
+    res = r.execute_command("TS.BGET", "ts", 101, 1000, "MIN_COUNT", 10)
     elapsed = time.time() - t0
 
     env.assertEqual(
@@ -190,8 +239,8 @@ def test_bget_dash_returns_all_existing_samples():
     _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
 
     # '-' resolves statically to cursor=0; with ts >= 0 every sample qualifies,
-    # so count=3 is already met and BGET returns synchronously.
-    res = r.execute_command("TS.BGET", "ts", "-", 3, 5000)
+    # so MIN_COUNT 3 is already met and BGET returns synchronously.
+    res = r.execute_command("TS.BGET", "ts", "-", 5000, "MIN_COUNT", 3, "MAX_COUNT", 3)
     env.assertEqual(res, [[100, b"1"], [200, b"2"], [300, b"3"]])
 
 
@@ -207,7 +256,7 @@ def test_bget_dash_on_empty_series_blocks_until_first_add():
     r = env.getConnection()
     r.execute_command("FLUSHALL")  # key "ts" must not exist for this scenario.
 
-    t, slot = _start_bget(env, "ts", "-", 1, 10_000)
+    t, slot = _start_bget(env, "ts", "-", 10_000)
     time.sleep(0.3)
     env.assertTrue(t.is_alive(),
                    message="BGET '-' on missing key should block until ADD")
@@ -233,7 +282,7 @@ def test_bget_plus_on_empty_series_blocks_until_first_add():
     r = env.getConnection()
     r.execute_command("FLUSHALL")
 
-    t, slot = _start_bget(env, "ts", "+", 1, 10_000)
+    t, slot = _start_bget(env, "ts", "+", 10_000)
     time.sleep(0.3)
     env.assertTrue(t.is_alive(),
                    message="BGET '+' on missing key should block until ADD")
@@ -260,7 +309,7 @@ def test_bget_plus_only_returns_samples_added_after_command():
 
     # '+' resolves now to lastTs + 1 = 301. Existing 100/200/300 must NOT
     # qualify; only a future ADD with ts >= 301 should wake us.
-    t, slot = _start_bget(env, "ts", "+", 1, 10_000)
+    t, slot = _start_bget(env, "ts", "+", 10_000)
     time.sleep(0.3)
     env.assertTrue(t.is_alive(),
                    message="BGET '+' should ignore pre-existing samples")
@@ -288,7 +337,7 @@ def test_bget_plus_with_no_new_samples_times_out_empty():
     _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
 
     t0 = time.time()
-    res = r.execute_command("TS.BGET", "ts", "+", 1, 1000)
+    res = r.execute_command("TS.BGET", "ts", "+", 1000)
     elapsed = time.time() - t0
 
     env.assertEqual(res, [])
@@ -311,7 +360,7 @@ def test_bget_broadcasts_to_all_blocked_clients():
     r = env.getConnection()
     _seed(r, "ts", [(100, "1.0")])
 
-    workers = [_start_bget(env, "ts", "+", 1, 10_000) for _ in range(4)]
+    workers = [_start_bget(env, "ts", "+", 10_000) for _ in range(4)]
     time.sleep(0.3)
     for t, _ in workers:
         env.assertTrue(t.is_alive(), message="all clients should be parked")
@@ -343,7 +392,7 @@ def test_bget_on_compaction_destination_wakes_on_bucket_commit():
     assert r.execute_command(
         "TS.CREATERULE", "src", "dst", "AGGREGATION", "avg", 10)
 
-    t, slot = _start_bget(env, "dst", "-", 1, 10_000)
+    t, slot = _start_bget(env, "dst", "-", 10_000)
     time.sleep(0.3)
     env.assertTrue(t.is_alive(),
                    message="BGET on empty dst should be parked")
@@ -373,7 +422,7 @@ def test_bget_wrongtype_literal_cursor():
     r = env.getConnection()
     r.set("not_a_ts", "hello")
     with pytest.raises(redis.ResponseError, match="WRONGTYPE"):
-        r.execute_command("TS.BGET", "not_a_ts", 0, 1, 0)
+        r.execute_command("TS.BGET", "not_a_ts", 0, 0)
 
 
 # ---------------------------------------------------------------------------
@@ -396,7 +445,7 @@ def test_bget_inside_multi_refuses_with_clear_error():
                                    # branch instead of replying synchronously.
 
     r.execute_command("MULTI")
-    r.execute_command("TS.BGET", "ts", 0, 1, 1000)
+    r.execute_command("TS.BGET", "ts", 0, 1000)
     try:
         res = r.execute_command("EXEC")
         env.assertEqual(len(res), 1)
@@ -417,7 +466,7 @@ def test_bget_inside_eval_refuses_with_clear_error():
 
     with pytest.raises(redis.ResponseError) as excinfo:
         r.execute_command(
-            "EVAL", "return redis.call('TS.BGET','ts',0,1,1000)", 1, "ts")
+            "EVAL", "return redis.call('TS.BGET','ts',0,1000)", 1, "ts")
     env.assertTrue(_is_deny_blocking_error(excinfo.value),
                    message="unexpected error: %r" % (excinfo.value,))
 
@@ -435,16 +484,20 @@ def test_bget_parse_errors():
     _seed(r, "ts", [(100, "1.0")])
 
     bad_argv = [
-        ("ts",),                          # wrong arity (too few)
-        ("ts", 0, 1, 0, "extra"),         # wrong arity (too many)
-        ("ts", 0, 0, 1000),               # count == 0
-        ("ts", 0, -1, 1000),              # count < 0
-        ("ts", 0, 1, -1),                 # timeout < 0
-        ("ts", 0, "abc", 1000),           # non-integer count
-        ("ts", 0, "1.5", 1000),           # non-integer count
-        ("ts", 0, 1, "abc"),              # non-integer timeout
-        ("ts", "abc", 1, 1000),           # non-integer / non-sentinel timestamp
-        ("ts", -1, 1, 1000),              # negative literal timestamp
+        ("ts",),                                       # wrong arity (too few)
+        ("ts", 0),                                     # wrong arity (too few)
+        ("ts", 0, 0, "MIN_COUNT", 1, "MAX_COUNT", 1, "x"),  # arity (too many)
+        ("ts", 0, 1000, "MIN_COUNT", 0),               # min_count == 0
+        ("ts", 0, 1000, "MIN_COUNT", -1),              # min_count < 0
+        ("ts", 0, 1000, "MAX_COUNT", 0),               # max_count == 0
+        ("ts", 0, -1),                                 # timeout < 0
+        ("ts", 0, 1000, "MIN_COUNT", "abc"),           # non-integer min_count
+        ("ts", 0, 1000, "MIN_COUNT", "1.5"),           # non-integer min_count
+        ("ts", 0, "abc"),                              # non-integer timeout
+        ("ts", "abc", 1000),                           # non-integer / non-sentinel ts
+        ("ts", -1, 1000),                              # negative literal timestamp
+        ("ts", 0, 1000, "MIN_COUNT", 5, "MAX_COUNT", 2),   # min_count > max_count
+        ("ts", 0, 1000, "MIN_COUNT"),                  # dangling keyword (no value)
     ]
     for argv in bad_argv:
         with pytest.raises(redis.ResponseError):
@@ -463,9 +516,9 @@ def test_bget_timeout_zero_returns_partial_without_blocking():
     r = env.getConnection()
     _seed(r, "ts", [(100, "1.0"), (200, "2.0")])
 
-    # count=10, only 2 qualifying samples; timeout=0 must flush immediately.
+    # MIN_COUNT 10, only 2 qualifying samples; timeout=0 must flush immediately.
     t0 = time.time()
-    res = r.execute_command("TS.BGET", "ts", 0, 10, 0)
+    res = r.execute_command("TS.BGET", "ts", 0, 0, "MIN_COUNT", 10)
     elapsed = time.time() - t0
 
     env.assertEqual(res, [[100, b"1"], [200, b"2"]])

--- a/tests/flow/test_ts_bget.py
+++ b/tests/flow/test_ts_bget.py
@@ -404,6 +404,62 @@ def test_bget_paging_past_latest_times_out_empty():
 
 
 # ---------------------------------------------------------------------------
+# 9b. '$' sentinel: resolves to lastTs + 1, so the latest EXISTING sample is
+#     excluded and only samples reported after the command qualify. The first
+#     call blocks until a strictly-newer sample arrives.
+# ---------------------------------------------------------------------------
+
+def test_bget_dollar_only_returns_samples_added_after_command():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
+
+    # '$' resolves to lastTs + 1 = 301. Existing 100/200/300 must NOT qualify;
+    # only a future ADD with ts >= 301 should wake us.
+    t, slot = _start_bget(env, "ts", "$", 10_000)
+    time.sleep(0.3)
+    env.assertTrue(t.is_alive(),
+                   message="BGET '$' should ignore pre-existing samples and block")
+
+    # Producer adds a strictly newer sample -> wake-up.
+    assert r.execute_command("TS.ADD", "ts", 400, "4.0") == 400
+
+    t.join(timeout=2.0)
+    env.assertFalse(t.is_alive())
+    env.assertEqual(slot["error"], None)
+    env.assertEqual(slot["result"], [[400, b"4"]])
+
+
+# ---------------------------------------------------------------------------
+# 9c. '$' on an empty / missing series: resolves to cursor=0 (like '-'/'+'),
+#     so it blocks until the first sample is added.
+# ---------------------------------------------------------------------------
+
+def test_bget_dollar_on_empty_series_blocks_until_first_add():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    r.execute_command("FLUSHALL")
+
+    t, slot = _start_bget(env, "ts", "$", 10_000)
+    time.sleep(0.3)
+    env.assertTrue(t.is_alive(),
+                   message="BGET '$' on missing key should block until ADD")
+
+    assert r.execute_command("TS.ADD", "ts", 100, "1.0") == 100
+
+    t.join(timeout=2.0)
+    env.assertFalse(t.is_alive())
+    env.assertEqual(slot["error"], None)
+    env.assertEqual(slot["result"], [[100, b"1"]])
+
+
+# ---------------------------------------------------------------------------
 # 10. Multi-client broadcast: every parked client receives the new sample
 #     (TS.BGET semantics — not BLPOP-style first-waiter-wins dequeue).
 # ---------------------------------------------------------------------------

--- a/tests/flow/test_ts_bget.py
+++ b/tests/flow/test_ts_bget.py
@@ -176,6 +176,64 @@ def test_bget_min_below_max_returns_oldest_max_count():
 
 
 # ---------------------------------------------------------------------------
+# 3d. Blocking path with MIN_COUNT < MAX_COUNT: the wake-up gate uses min_count,
+#     but the committed reply is still capped to the oldest max_count. A single
+#     TS.MADD lands all samples before the wake-up callback runs, so qualifying
+#     jumps past max_count in one shot — exercising gate vs cap in the async
+#     (reply-callback) path, not just the synchronous fast path (test 3b).
+# ---------------------------------------------------------------------------
+
+def test_bget_blocking_min_gate_max_cap():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    _seed(r, "ts", [(100, "1.0")])
+
+    # cursor = 101 (literal), so the existing sample at 100 doesn't qualify and
+    # BGET blocks (0 < MIN_COUNT 2). MAX_COUNT 3 caps whatever we eventually return.
+    t, slot = _start_bget(env, "ts", 101, 10_000, min_count=2, max_count=3)
+    time.sleep(0.3)
+    env.assertTrue(t.is_alive(), message="BGET should block until min_count qualifies")
+
+    # One MADD adds 5 new qualifying samples atomically; the wake-up sees 5 >= 2
+    # (gate satisfied) and must return the OLDEST 3 (cap), not all 5.
+    assert r.execute_command(
+        "TS.MADD",
+        "ts", 200, "2.0",
+        "ts", 300, "3.0",
+        "ts", 400, "4.0",
+        "ts", 500, "5.0",
+        "ts", 600, "6.0",
+    ) == [200, 300, 400, 500, 600]
+
+    t.join(timeout=2.0)
+    env.assertFalse(t.is_alive(), message="BGET should have unblocked once min_count qualified")
+    env.assertEqual(slot["error"], None)
+    env.assertEqual(slot["result"], [[200, b"2"], [300, b"3"], [400, b"4"]])
+
+
+# ---------------------------------------------------------------------------
+# 3e. Keyword matching is case-insensitive (house-style RMUtil_ArgIndex).
+# ---------------------------------------------------------------------------
+
+def test_bget_count_keywords_are_case_insensitive():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    _seed(r, "ts", [
+        (100, "1.0"), (200, "2.0"), (300, "3.0"), (400, "4.0"),
+    ])
+
+    # cursor=0 -> 4 qualify; lower/mixed-case keywords must behave like uppercase.
+    res = r.execute_command("TS.BGET", "ts", 0, 1000, "min_count", 1, "Max_Count", 2)
+    env.assertEqual(res, [[100, b"1"], [200, b"2"]])
+
+
+# ---------------------------------------------------------------------------
 # 3c. Defaults: no MIN_COUNT/MAX_COUNT -> min_count=1, max_count=unlimited.
 # ---------------------------------------------------------------------------
 
@@ -296,10 +354,12 @@ def test_bget_plus_on_empty_series_blocks_until_first_add():
 
 
 # ---------------------------------------------------------------------------
-# 8. '+' sentinel: snapshot lastTs at command time, only NEW samples qualify.
+# 8. '+' sentinel: resolves to the latest sample's timestamp (aligned with
+#    TS.RANGE). Because the cursor is inclusive, the latest EXISTING sample
+#    qualifies, so the first call returns it immediately without blocking.
 # ---------------------------------------------------------------------------
 
-def test_bget_plus_only_returns_samples_added_after_command():
+def test_bget_plus_returns_latest_existing_sample():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -307,37 +367,33 @@ def test_bget_plus_only_returns_samples_added_after_command():
     r = env.getConnection()
     _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
 
-    # '+' resolves now to lastTs + 1 = 301. Existing 100/200/300 must NOT
-    # qualify; only a future ADD with ts >= 301 should wake us.
-    t, slot = _start_bget(env, "ts", "+", 10_000)
-    time.sleep(0.3)
-    env.assertTrue(t.is_alive(),
-                   message="BGET '+' should ignore pre-existing samples")
-
-    # Producer adds a strictly newer sample -> wake-up.
-    assert r.execute_command("TS.ADD", "ts", 400, "4.0") == 400
-
-    t.join(timeout=2.0)
-    env.assertFalse(t.is_alive())
-    env.assertEqual(slot["error"], None)
-    env.assertEqual(slot["result"], [[400, b"4"]])
-
-
-# ---------------------------------------------------------------------------
-# 9. '+' sentinel without producer: existing samples must NEVER be returned;
-#    on timeout we flush an empty array.
-# ---------------------------------------------------------------------------
-
-def test_bget_plus_with_no_new_samples_times_out_empty():
-    env = Env()
-    if env.is_cluster():
-        env.skip()
-
-    r = env.getConnection()
-    _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
-
+    # '+' resolves to lastTs = 300. With inclusive ts >= 300, only the latest
+    # sample qualifies; min_count defaults to 1 so it returns synchronously.
     t0 = time.time()
     res = r.execute_command("TS.BGET", "ts", "+", 1000)
+    elapsed = time.time() - t0
+
+    env.assertEqual(res, [[300, b"3"]])
+    env.assertTrue(elapsed < 0.5, message="BGET '+' should be ~instant, got %.3fs" % elapsed)
+
+
+# ---------------------------------------------------------------------------
+# 9. Paging continuation: after consuming via '+', a follow-up call from
+#    (last retrieved ts + 1) has nothing newer and times out with an empty reply.
+# ---------------------------------------------------------------------------
+
+def test_bget_paging_past_latest_times_out_empty():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
+
+    # Caller already consumed up to ts=300 and pages forward to 301; no sample
+    # has ts >= 301, so the call blocks and flushes empty on timeout.
+    t0 = time.time()
+    res = r.execute_command("TS.BGET", "ts", 301, 1000)
     elapsed = time.time() - t0
 
     env.assertEqual(res, [])
@@ -360,7 +416,9 @@ def test_bget_broadcasts_to_all_blocked_clients():
     r = env.getConnection()
     _seed(r, "ts", [(100, "1.0")])
 
-    workers = [_start_bget(env, "ts", "+", 10_000) for _ in range(4)]
+    # cursor = 101 (literal): the existing sample at 100 doesn't qualify, so all
+    # clients block until a newer sample arrives.
+    workers = [_start_bget(env, "ts", 101, 10_000) for _ in range(4)]
     time.sleep(0.3)
     for t, _ in workers:
         env.assertTrue(t.is_alive(), message="all clients should be parked")

--- a/tests/flow/test_ts_bget.py
+++ b/tests/flow/test_ts_bget.py
@@ -284,6 +284,32 @@ def test_bget_timeout_flushes_available_samples():
                    message="Timeout overshoot too large: %.3fs" % elapsed)
 
 
+def test_bget_timeout_flush_respects_max_count():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    _seed(r, "ts", [
+        (100, "1.0"), (200, "2.0"), (300, "3.0"),
+        (400, "4.0"), (500, "5.0"),
+    ])
+
+    # cursor=101 -> 4 qualifying samples; MIN_COUNT 10 can never be reached and
+    # nobody adds, so the timeout_cb flushes. Even on the flush path the reply
+    # must honor MAX_COUNT and return only the oldest 2 (not all 4 available).
+    t0 = time.time()
+    res = r.execute_command("TS.BGET", "ts", 101, 1000,
+                            "MIN_COUNT", 10, "MAX_COUNT", 2)
+    elapsed = time.time() - t0
+
+    env.assertEqual(res, [[200, b"2"], [300, b"3"]])
+    env.assertTrue(elapsed >= 0.9,
+                   message="Expected to wait ~1s on timeout, only waited %.3fs" % elapsed)
+    env.assertTrue(elapsed < 5.0,
+                   message="Timeout overshoot too large: %.3fs" % elapsed)
+
+
 # ---------------------------------------------------------------------------
 # 5. '-' sentinel: cursor=0, matches every existing sample.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Breaking change to TS.BGET argument order and + sentinel semantics for a blocking read API; clients and scripts using the old five-argument form or + for future-only tailing must migrate.
> 
> **Overview**
> **`TS.BGET`** is reshaped from `key timestamp count timeout` to **`key timestamp timeout [MIN_COUNT n] [MAX_COUNT n]`**, splitting the old single **`count`** into a **blocking threshold** (`MIN_COUNT`, default **1**) and a **reply cap** (`MAX_COUNT`, default **unlimited**). Blocking still waits until enough qualifying samples exist (or timeout); replies return the **oldest** qualifying samples up to **`max_count`**.
> 
> **Cursor sentinels change:** **`+`** now resolves to the **latest existing sample’s timestamp** (inclusive, aligned with **`TS.RANGE`**), so the tail sample can return immediately. **`$`** is new and uses **`lastTimestamp + 1`**, preserving the prior “only samples after the command” tailing behavior. **`commands.json`**, **`TS_BGET_INFO`** registration in **`ts_info.c`**, and **`test_ts_bget.py`** are updated for the new arity, validation (`min_count <= max_count`, dangling keywords), defaults, and blocking paths where **`MIN_COUNT < MAX_COUNT`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81ef56703a14ade77f1560c8d531da79b730b72a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->