### PR TITLE
MOD-16224 Fix filter-blind neighbor lookups in EMPTY aggregation

### DIFF
--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -288,13 +288,11 @@ AggregationIterator *AggregationIterator_New(struct AbstractIterator *input,
 static size_t twa_get_samples_from_left(timestamp_t cur_ts,
                                         const AggregationIterator *self,
                                         Sample *sample_left,
-                                        Sample *sample_leftLeft,
-                                        bool apply_filter);
+                                        Sample *sample_leftLeft);
 static size_t twa_get_samples_from_right(timestamp_t cur_ts,
                                          const AggregationIterator *self,
                                          Sample *sample_right,
-                                         Sample *sample_rightRight,
-                                         bool apply_filter);
+                                         Sample *sample_rightRight);
 timestamp_t twa_calc_ta(bool reverse,
                         timestamp_t bucketStartTS,
                         timestamp_t bucketEndTS,
@@ -373,9 +371,8 @@ static void twa_compute_empty_bucket_value(const AggregationIterator *self,
         false, bucket_ts, bucket_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
 
     size_t n_samples_before =
-        twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore, true);
-    size_t n_samples_after =
-        twa_get_samples_from_right(tb, self, &sample_after, &sample_afAfter, true);
+        twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore);
+    size_t n_samples_after = twa_get_samples_from_right(tb, self, &sample_after, &sample_afAfter);
 
     twa_calc_empty_bucket_val(ta,
                               tb,
@@ -494,11 +491,10 @@ static void seed_locf_for_empty_gap(const AggregationIterator *self,
             continue;
         }
         Sample older, older_older;
-        // apply_filter=true: LOCF must carry the last KEPT value. Without the filter the older
-        // neighbor could be a sample removed by FILTER_BY_VALUE/FILTER_BY_TS, so an empty bucket
-        // would carry a value the filter excluded (and reverse would disagree with forward).
-        if (twa_get_samples_from_left(lowest_empty_bucket_start, self, &older, &older_older, true) >
-            0) {
+        // LOCF must carry the last KEPT value: twa_get_samples_from_left honors the query filters,
+        // so the older neighbor can't be a sample removed by FILTER_BY_VALUE/FILTER_BY_TS (which
+        // would make an empty bucket carry an excluded value, and reverse disagree with forward).
+        if (twa_get_samples_from_left(lowest_empty_bucket_start, self, &older, &older_older) > 0) {
             LastValueSeedLocf(self->aggregationContexts[a], older.value, older.timestamp);
         } else {
             /* No older sample exists. The next non-empty bucket's appendValue will go through the
@@ -535,14 +531,15 @@ static void fillEmptyBucketsWithDefaultVals(size_t *write_index,
 static size_t twa_get_samples_from_right(timestamp_t cur_ts,
                                          const AggregationIterator *self,
                                          Sample *sample_right,
-                                         Sample *sample_rightRight,
-                                         bool apply_filter) {
+                                         Sample *sample_rightRight) {
     size_t n_samples_right = 0;
     if (cur_ts < UINT64_MAX) {
+        // Honor the query's filters so a sample removed by FILTER_BY_VALUE/FILTER_BY_TS is not
+        // treated as a neighbor (edge-gap detection, LOCF seeding, TWA interpolation).
         RangeArgs args = {
             .aggregationArgs = { 0 },
-            .filterByValueArgs = apply_filter ? self->byValueArgs : (FilterByValueArgs){ 0 },
-            .filterByTSArgs = apply_filter ? self->byTsArgs : (FilterByTSArgs){ 0 },
+            .filterByValueArgs = self->byValueArgs,
+            .filterByTSArgs = self->byTsArgs,
             .startTimestamp = cur_ts,
             .endTimestamp = UINT64_MAX,
             .latest = false,
@@ -571,14 +568,15 @@ static size_t twa_get_samples_from_right(timestamp_t cur_ts,
 static size_t twa_get_samples_from_left(timestamp_t cur_ts,
                                         const AggregationIterator *self,
                                         Sample *sample_left,
-                                        Sample *sample_leftLeft,
-                                        bool apply_filter) {
+                                        Sample *sample_leftLeft) {
     size_t n_samples_left = 0;
     if (cur_ts > 0) {
+        // Honor the query's filters so a sample removed by FILTER_BY_VALUE/FILTER_BY_TS is not
+        // treated as a neighbor (edge-gap detection, LOCF seeding, TWA interpolation).
         RangeArgs args = {
             .aggregationArgs = { 0 },
-            .filterByValueArgs = apply_filter ? self->byValueArgs : (FilterByValueArgs){ 0 },
-            .filterByTSArgs = apply_filter ? self->byTsArgs : (FilterByTSArgs){ 0 },
+            .filterByValueArgs = self->byValueArgs,
+            .filterByTSArgs = self->byTsArgs,
             .startTimestamp = 0,
             .endTimestamp = cur_ts - 1,
             .latest = false,
@@ -641,8 +639,8 @@ static void twa_fillEmptyBuckets(size_t *write_index,
     int64_t agg_time_delta = self->aggregationTimeDelta;
     ta = twa_calc_ta(
         false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
-    n_samples_before = twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore, true);
-    n_samples_after = twa_get_samples_from_right(ta, self, &sample_after, &sample_afAfter, true);
+    n_samples_before = twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore);
+    n_samples_after = twa_get_samples_from_right(ta, self, &sample_after, &sample_afAfter);
 
     for (size_t i = 0; i < n_empty_buckets; ++i) {
         ta = twa_calc_ta(
@@ -734,12 +732,13 @@ static int fillEmptyBuckets(Samples *samples,
         Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
         timestamp_t ta = twa_calc_ta(
             false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
-        // apply_filter=true: a neighbor removed by FILTER_BY_VALUE/FILTER_BY_TS must not count, or
-        // an edge gap looks interior and we fill out to endTimestamp (UINT64_MAX with '+') -> OOM.
+        // The neighbor lookups honor the query filters: a sample removed by FILTER_BY_VALUE/
+        // FILTER_BY_TS must not count here, or an edge gap looks interior and we fill out to
+        // endTimestamp (UINT64_MAX with '+') -> bucket-count overflow -> OOM.
         size_t n_samples_before =
-            twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore, true);
+            twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore);
         size_t n_samples_after =
-            twa_get_samples_from_right(ta, self, &sample_after, &sample_afAfter, true);
+            twa_get_samples_from_right(ta, self, &sample_after, &sample_afAfter);
         if (n_samples_before == 0 || n_samples_after == 0) {
             return 0;
         }

--- a/src/filter_iterator.c
+++ b/src/filter_iterator.c
@@ -241,7 +241,9 @@ AggregationIterator *AggregationIterator_New(struct AbstractIterator *input,
                                              BucketTimestamp bucketTS,
                                              Series *series,
                                              api_timestamp_t startTimestamp,
-                                             api_timestamp_t endTimestamp) {
+                                             api_timestamp_t endTimestamp,
+                                             FilterByValueArgs byValueArgs,
+                                             FilterByTSArgs byTsArgs) {
     AggregationIterator *iter = malloc(sizeof(AggregationIterator));
     iter->base.GetNext = AggregationIterator_GetNextChunk;
     iter->base.Close = AggregationIterator_Close;
@@ -275,6 +277,8 @@ AggregationIterator *AggregationIterator_New(struct AbstractIterator *input,
     iter->handled_empty_suffix = false;
     iter->prev_ts = DC;
     iter->validSamplesInBucket = false;
+    iter->byValueArgs = byValueArgs;
+    iter->byTsArgs = byTsArgs;
     memset(iter->validPerAgg, 0, sizeof(iter->validPerAgg));
     ReallocSamplesArray(&iter->aux_chunk->samples, 1);
     ResetEnrichedChunk(iter->aux_chunk);
@@ -284,11 +288,13 @@ AggregationIterator *AggregationIterator_New(struct AbstractIterator *input,
 static size_t twa_get_samples_from_left(timestamp_t cur_ts,
                                         const AggregationIterator *self,
                                         Sample *sample_left,
-                                        Sample *sample_leftLeft);
+                                        Sample *sample_leftLeft,
+                                        bool apply_filter);
 static size_t twa_get_samples_from_right(timestamp_t cur_ts,
                                          const AggregationIterator *self,
                                          Sample *sample_right,
-                                         Sample *sample_rightRight);
+                                         Sample *sample_rightRight,
+                                         bool apply_filter);
 timestamp_t twa_calc_ta(bool reverse,
                         timestamp_t bucketStartTS,
                         timestamp_t bucketEndTS,
@@ -367,8 +373,9 @@ static void twa_compute_empty_bucket_value(const AggregationIterator *self,
         false, bucket_ts, bucket_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
 
     size_t n_samples_before =
-        twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore);
-    size_t n_samples_after = twa_get_samples_from_right(tb, self, &sample_after, &sample_afAfter);
+        twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore, true);
+    size_t n_samples_after =
+        twa_get_samples_from_right(tb, self, &sample_after, &sample_afAfter, true);
 
     twa_calc_empty_bucket_val(ta,
                               tb,
@@ -487,7 +494,11 @@ static void seed_locf_for_empty_gap(const AggregationIterator *self,
             continue;
         }
         Sample older, older_older;
-        if (twa_get_samples_from_left(lowest_empty_bucket_start, self, &older, &older_older) > 0) {
+        // apply_filter=true: LOCF must carry the last KEPT value. Without the filter the older
+        // neighbor could be a sample removed by FILTER_BY_VALUE/FILTER_BY_TS, so an empty bucket
+        // would carry a value the filter excluded (and reverse would disagree with forward).
+        if (twa_get_samples_from_left(lowest_empty_bucket_start, self, &older, &older_older, true) >
+            0) {
             LastValueSeedLocf(self->aggregationContexts[a], older.value, older.timestamp);
         } else {
             /* No older sample exists. The next non-empty bucket's appendValue will go through the
@@ -524,13 +535,14 @@ static void fillEmptyBucketsWithDefaultVals(size_t *write_index,
 static size_t twa_get_samples_from_right(timestamp_t cur_ts,
                                          const AggregationIterator *self,
                                          Sample *sample_right,
-                                         Sample *sample_rightRight) {
+                                         Sample *sample_rightRight,
+                                         bool apply_filter) {
     size_t n_samples_right = 0;
     if (cur_ts < UINT64_MAX) {
         RangeArgs args = {
             .aggregationArgs = { 0 },
-            .filterByValueArgs = { 0 },
-            .filterByTSArgs = { 0 },
+            .filterByValueArgs = apply_filter ? self->byValueArgs : (FilterByValueArgs){ 0 },
+            .filterByTSArgs = apply_filter ? self->byTsArgs : (FilterByTSArgs){ 0 },
             .startTimestamp = cur_ts,
             .endTimestamp = UINT64_MAX,
             .latest = false,
@@ -559,13 +571,14 @@ static size_t twa_get_samples_from_right(timestamp_t cur_ts,
 static size_t twa_get_samples_from_left(timestamp_t cur_ts,
                                         const AggregationIterator *self,
                                         Sample *sample_left,
-                                        Sample *sample_leftLeft) {
+                                        Sample *sample_leftLeft,
+                                        bool apply_filter) {
     size_t n_samples_left = 0;
     if (cur_ts > 0) {
         RangeArgs args = {
             .aggregationArgs = { 0 },
-            .filterByValueArgs = { 0 },
-            .filterByTSArgs = { 0 },
+            .filterByValueArgs = apply_filter ? self->byValueArgs : (FilterByValueArgs){ 0 },
+            .filterByTSArgs = apply_filter ? self->byTsArgs : (FilterByTSArgs){ 0 },
             .startTimestamp = 0,
             .endTimestamp = cur_ts - 1,
             .latest = false,
@@ -628,8 +641,8 @@ static void twa_fillEmptyBuckets(size_t *write_index,
     int64_t agg_time_delta = self->aggregationTimeDelta;
     ta = twa_calc_ta(
         false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
-    n_samples_before = twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore);
-    n_samples_after = twa_get_samples_from_right(ta, self, &sample_after, &sample_afAfter);
+    n_samples_before = twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore, true);
+    n_samples_after = twa_get_samples_from_right(ta, self, &sample_after, &sample_afAfter, true);
 
     for (size_t i = 0; i < n_empty_buckets; ++i) {
         ta = twa_calc_ta(
@@ -721,10 +734,12 @@ static int fillEmptyBuckets(Samples *samples,
         Sample sample_before, sample_befBefore, sample_after, sample_afAfter;
         timestamp_t ta = twa_calc_ta(
             false, cur_ts, cur_ts + agg_time_delta, self->startTimestamp, self->endTimestamp);
+        // apply_filter=true: a neighbor removed by FILTER_BY_VALUE/FILTER_BY_TS must not count, or
+        // an edge gap looks interior and we fill out to endTimestamp (UINT64_MAX with '+') -> OOM.
         size_t n_samples_before =
-            twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore);
+            twa_get_samples_from_left(ta, self, &sample_before, &sample_befBefore, true);
         size_t n_samples_after =
-            twa_get_samples_from_right(ta, self, &sample_after, &sample_afAfter);
+            twa_get_samples_from_right(ta, self, &sample_after, &sample_afAfter, true);
         if (n_samples_before == 0 || n_samples_after == 0) {
             return 0;
         }
@@ -989,8 +1004,8 @@ static void agg_iter_init_if_needed(AggregationIterator *self,
     if (self->hasTwa && !((!is_reversed) && init_ts == 0)) {
         RangeArgs args = {
             .aggregationArgs = { 0 },
-            .filterByValueArgs = { 0 },
-            .filterByTSArgs = { 0 },
+            .filterByValueArgs = self->byValueArgs,
+            .filterByTSArgs = self->byTsArgs,
             .startTimestamp = is_reversed ? init_ts + 1 : 0,
             .endTimestamp = is_reversed ? UINT64_MAX : init_ts - 1,
             .latest = false,
@@ -1352,8 +1367,8 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
             if (!(is_reversed && last_sample.timestamp == 0)) {
                 RangeArgs args = {
                     .aggregationArgs = { 0 },
-                    .filterByValueArgs = { 0 },
-                    .filterByTSArgs = { 0 },
+                    .filterByValueArgs = self->byValueArgs,
+                    .filterByTSArgs = self->byTsArgs,
                     .startTimestamp = is_reversed ? 0 : last_sample.timestamp + 1,
                     .endTimestamp = is_reversed ? last_sample.timestamp - 1 : UINT64_MAX,
                     .latest = false,
@@ -1435,8 +1450,11 @@ static EnrichedChunk *agg_iter_finalize(AggregationIterator *self,
             CalcBucketStart(is_reversed ? self->startTimestamp : self->endTimestamp,
                             aggregationTimeDelta,
                             self->timestampAlignment);
+        // Use the bucket START, not samples.timestamps[0] -- under BUCKETTIMESTAMP end/mid the
+        // latter is the labeled (shifted) timestamp, so CalcBucketStart would land on the next
+        // bucket and the empty fill would re-emit this real bucket as a duplicate.
         timestamp_t first_bucket = CalcBucketStart(
-            self->aux_chunk->samples.timestamps[0], aggregationTimeDelta, self->timestampAlignment);
+            self->aggregationLastTimestamp, aggregationTimeDelta, self->timestampAlignment);
         bool has_empty_buckets = true;
         if (is_reversed) {
             if (first_bucket <= last_bucket) {

--- a/src/filter_iterator.h
+++ b/src/filter_iterator.h
@@ -64,6 +64,10 @@ typedef struct AggregationIterator
     timestamp_t prev_ts;
     bool validSamplesInBucket; // are there any valid samples in current bucket (any aggregation)
     bool validPerAgg[TS_AGG_TYPES_MAX]; // per-aggregation validity tracking for current bucket
+    // Same sample filters as the query, so the edge-gap drop counts only kept samples: a sample
+    // removed by FILTER_BY_VALUE/FILTER_BY_TS must not make an edge gap look like an interior one.
+    FilterByValueArgs byValueArgs;
+    FilterByTSArgs byTsArgs;
 } AggregationIterator;
 
 AggregationIterator *AggregationIterator_New(struct AbstractIterator *input,
@@ -76,7 +80,9 @@ AggregationIterator *AggregationIterator_New(struct AbstractIterator *input,
                                              BucketTimestamp bucketTS,
                                              Series *series,
                                              api_timestamp_t startTimestamp,
-                                             api_timestamp_t endTimestamp);
+                                             api_timestamp_t endTimestamp,
+                                             FilterByValueArgs byValueArgs,
+                                             FilterByTSArgs byTsArgs);
 EnrichedChunk *AggregationIterator_GetNextChunk(struct AbstractIterator *iter);
 void AggregationIterator_Close(struct AbstractIterator *iterator);
 

--- a/src/filter_iterator.h
+++ b/src/filter_iterator.h
@@ -64,8 +64,10 @@ typedef struct AggregationIterator
     timestamp_t prev_ts;
     bool validSamplesInBucket; // are there any valid samples in current bucket (any aggregation)
     bool validPerAgg[TS_AGG_TYPES_MAX]; // per-aggregation validity tracking for current bucket
-    // Same sample filters as the query, so the edge-gap drop counts only kept samples: a sample
-    // removed by FILTER_BY_VALUE/FILTER_BY_TS must not make an edge gap look like an interior one.
+    // Same sample filters as the query, so neighbor lookups (edge-gap drop, LOCF seed, TWA
+    // interpolation) count only kept samples: a sample removed by FILTER_BY_VALUE/FILTER_BY_TS must
+    // not make an edge gap look interior. Borrowed by value from the query's RangeArgs (which
+    // outlives this iterator); byTsArgs holds a pointer we do not own and must not free.
     FilterByValueArgs byValueArgs;
     FilterByTSArgs byTsArgs;
 } AggregationIterator;

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -1416,7 +1416,9 @@ AbstractIterator *SeriesQuery(Series *series,
                                                             args->aggregationArgs.bucketTS,
                                                             series,
                                                             args->startTimestamp,
-                                                            args->endTimestamp);
+                                                            args->endTimestamp,
+                                                            args->filterByValueArgs,
+                                                            args->filterByTSArgs);
     }
 
     return chain;

--- a/tests/flow/test_ts_range_empty_filter_stress.py
+++ b/tests/flow/test_ts_range_empty_filter_stress.py
@@ -1,0 +1,262 @@
+# Stress tests for AGGREGATION + EMPTY combined with FILTER_BY_VALUE / FILTER_BY_TS,
+# for every aggregator EXCEPT twa.
+#
+# Background: MOD-8187 extended EMPTY-bucket filling to all aggregators (not just twa). The
+# edge-gap "is there a neighbour?" check scanned the raw series and ignored the value/ts filters,
+# so a filtered-out sample beyond the last KEPT sample made an edge gap look interior and the fill
+# ran to endTimestamp (UINT64_MAX with '+') -> unsigned overflow -> OOM abort. These tests would
+# crash the server pre-fix; they also assert exact values against an INDEPENDENT oracle (computed
+# from first principles, never from the engine) so a wrong-value regression is caught too.
+#
+# twa is intentionally excluded: its interpolation still reads raw (unfiltered) neighbours, a
+# separate pre-existing issue tracked apart from the OOM fix.
+
+import math
+import random
+
+from RLTest import Env
+
+NON_TWA_AGGS = ['avg', 'sum', 'min', 'max', 'range', 'count', 'countAll',
+                'first', 'last', 'std.p', 'std.s', 'var.p', 'var.s']
+
+# empty interior bucket -> 0 for these; 'last' carries the previous value (LOCF); rest -> NaN
+_ZERO_EMPTY = {'count', 'countAll', 'sum'}
+
+
+def _pvar(xs):
+    n = len(xs)
+    m = sum(xs) / n
+    return sum((x - m) ** 2 for x in xs) / n
+
+
+def _svar(xs):
+    n = len(xs)
+    if n < 2:
+        return 0.0
+    m = sum(xs) / n
+    return sum((x - m) ** 2 for x in xs) / (n - 1)
+
+
+_AGG = {
+    'avg': lambda xs: sum(xs) / len(xs),
+    'sum': lambda xs: float(sum(xs)),
+    'min': lambda xs: float(min(xs)),
+    'max': lambda xs: float(max(xs)),
+    'range': lambda xs: float(max(xs) - min(xs)),
+    'count': lambda xs: float(len(xs)),
+    'countAll': lambda xs: float(len(xs)),  # data has no NaN, so == count
+    'first': lambda xs: float(xs[0]),       # xs are in ascending-ts order
+    'last': lambda xs: float(xs[-1]),
+    'std.p': lambda xs: math.sqrt(_pvar(xs)),
+    'std.s': lambda xs: math.sqrt(_svar(xs)),
+    'var.p': lambda xs: _pvar(xs),
+    'var.s': lambda xs: _svar(xs),
+}
+
+
+def _oracle(samples, agg, bucket, lo, hi, rev, fbv, fbts, empty, bts):
+    """Expected TS.(REV)RANGE output, derived independently of the engine.
+
+    samples: list of (ts, value), value finite (no NaN in these tests).
+    Returns list of (label_ts, expected_value_float) in result order.
+    """
+    lo_n = -(1 << 62) if lo == '-' else lo
+    hi_n = (1 << 62) if hi == '+' else hi
+    fset = set(fbts) if fbts is not None else None
+    kept = sorted((t, v) for t, v in samples
+                  if lo_n <= t <= hi_n
+                  and (fbv is None or fbv[0] <= v <= fbv[1])
+                  and (fset is None or t in fset))
+    if not kept:
+        return []
+
+    def bs(t):
+        return (t // bucket) * bucket
+
+    by = {}
+    for t, v in kept:           # kept is sorted -> values land in ascending-ts order
+        by.setdefault(bs(t), []).append(v)
+    first_b, last_b = bs(kept[0][0]), bs(kept[-1][0])
+
+    rows = []
+    last_val = None
+    b = first_b
+    while b <= last_b:
+        if b in by:
+            xs = by[b]
+            val = _AGG[agg](xs)
+            last_val = xs[-1]
+        elif not empty:
+            b += bucket
+            continue            # without EMPTY, interior gaps are not emitted
+        elif agg in _ZERO_EMPTY:
+            val = 0.0
+        elif agg == 'last':
+            val = float(last_val)   # LOCF: carry the most recent kept value
+        else:
+            val = float('nan')
+        if bts == 'mid':
+            label = b + bucket // 2
+        elif bts == 'end':
+            label = b + bucket
+        else:
+            label = b
+        rows.append((label, val))
+        b += bucket
+    if rev:
+        rows.reverse()
+    return rows
+
+
+def _cmd(key, agg, bucket, lo, hi, rev, fbv, fbts, empty, bts):
+    args = ['TS.REVRANGE' if rev else 'TS.RANGE', key, lo, hi]
+    if fbts is not None:
+        args += ['FILTER_BY_TS', *fbts]
+    if fbv is not None:
+        args += ['FILTER_BY_VALUE', fbv[0], fbv[1]]
+    args += ['AGGREGATION', agg, bucket]
+    if bts is not None:
+        args += ['BUCKETTIMESTAMP', bts]
+    if empty:
+        args += ['EMPTY']
+    return args
+
+
+def _parse_val(raw):
+    s = raw.decode() if isinstance(raw, bytes) else str(raw)
+    return float('nan') if s.lower() == 'nan' else float(s)
+
+
+def _eq(a, e):
+    if math.isnan(e):
+        return math.isnan(a)
+    if math.isnan(a):
+        return False
+    return abs(a - e) <= 1e-6 + 1e-6 * abs(e)
+
+
+_counter = [0]
+
+
+def _check(r, samples, agg, bucket, lo='-', hi='+', rev=False,
+           fbv=None, fbts=None, empty=True, bts=None):
+    _counter[0] += 1
+    key = 'fes:%d' % _counter[0]
+    r.execute_command('TS.CREATE', key)
+    madd = []
+    for t, v in samples:
+        madd += [key, t, v]
+    if madd:
+        r.execute_command('TS.MADD', *madd)
+
+    expected = _oracle(samples, agg, bucket, lo, hi, rev, fbv, fbts, empty, bts)
+    cmd = _cmd(key, agg, bucket, lo, hi, rev, fbv, fbts, empty, bts)
+    actual = r.execute_command(*cmd)
+    label = '%s | samples=%s' % (' '.join(str(x) for x in cmd), samples)
+
+    assert len(actual) == len(expected), \
+        "row count %d != %d for: %s\n%s\nvs\n%s" % (len(actual), len(expected), label, actual, expected)
+    for (arow, erow) in zip(actual, expected):
+        ats, av = arow[0], _parse_val(arow[1])
+        ets, ev = erow
+        assert int(ats) == ets, "ts %s != %s for: %s\n%s\nvs\n%s" % (ats, ets, label, actual, expected)
+        assert _eq(av, ev), "value %r != %r at ts %s for: %s\n%s\nvs\n%s" % (av, ev, ats, label, actual, expected)
+    r.execute_command('DEL', key)
+
+
+# ---------------------------------------------------------------------------
+# explicit, hand-checked OOM scenarios (one per aggregator)
+# ---------------------------------------------------------------------------
+
+def test_oom_filter_strips_suffix_explicit():
+    """The exact OOM shape: one kept sample, one filtered-out sample beyond it, open '+' bound,
+    EMPTY on. Pre-fix this aborts the server; post-fix the trailing edge gap is dropped."""
+    env = Env(decodeResponses=False)
+    env.skipOnCluster()
+    with env.getClusterConnectionIfNeeded() as r:
+        r.execute_command('FLUSHALL')
+        # sample 5 -> 10 is kept by [0,100]; sample 50 -> 9999 is filtered out (beyond, no value)
+        for agg in NON_TWA_AGGS:
+            _check(r, [(5, 10), (50, 9999)], agg, bucket=4,
+                   lo='-', hi='+', fbv=(0, 100), empty=True)
+            _check(r, [(5, 10), (50, 9999)], agg, bucket=4,
+                   lo='-', hi='+', fbv=(0, 100), empty=True, rev=True)
+            _check(r, [(5, 10), (50, 9999)], agg, bucket=4,
+                   lo='-', hi='+', fbv=(0, 100), empty=True, bts='end')
+
+
+def test_filter_strips_prefix_and_interior_explicit():
+    """Filter removes the first sample (prefix edge gap dropped) and a middle one (interior gap
+    kept as empty)."""
+    env = Env(decodeResponses=False)
+    env.skipOnCluster()
+    with env.getClusterConnectionIfNeeded() as r:
+        r.execute_command('FLUSHALL')
+        # values: 1 (removed, prefix), 5 & 7 (kept), 9 (removed, interior between 5 and 7)
+        samples = [(2, 1), (10, 5), (20, 9), (30, 7)]
+        for agg in NON_TWA_AGGS:
+            _check(r, samples, agg, bucket=4, lo='-', hi='+', fbv=(2, 8), empty=True)
+            _check(r, samples, agg, bucket=4, lo='-', hi='+', fbv=(2, 8), empty=True, rev=True)
+            _check(r, samples, agg, bucket=5, lo='-', hi='+', fbv=(2, 8), empty=True, bts='mid')
+
+
+def test_filter_by_ts_strips_edges_explicit():
+    env = Env(decodeResponses=False)
+    env.skipOnCluster()
+    with env.getClusterConnectionIfNeeded() as r:
+        r.execute_command('FLUSHALL')
+        samples = [(2, 1), (10, 5), (20, 9), (30, 7), (45, 3)]
+        # keep only ts 10 and 30 -> 2/20/45 dropped (2 prefix-edge, 45 suffix-edge, 20 interior)
+        for agg in NON_TWA_AGGS:
+            _check(r, samples, agg, bucket=4, lo='-', hi='+', fbts=[10, 30], empty=True)
+            _check(r, samples, agg, bucket=4, lo='-', hi='+', fbts=[10, 30], empty=True, rev=True)
+
+
+# ---------------------------------------------------------------------------
+# randomized stress
+# ---------------------------------------------------------------------------
+
+def test_range_empty_filter_stress():
+    """Randomized: data + filters that frequently strip edge samples, EMPTY on, open/wide bounds,
+    every non-twa aggregator. Asserts engine == independent oracle and that the server survives."""
+    import os
+    iters = int(os.getenv('EMPTY_FILTER_FUZZ_ITERS', '400'))
+    rnd = random.Random(int(os.getenv('EMPTY_FILTER_FUZZ_SEED', '20260611')))
+
+    env = Env(decodeResponses=False)
+    env.skipOnCluster()
+    with env.getClusterConnectionIfNeeded() as r:
+        r.execute_command('FLUSHALL')
+        for _ in range(iters):
+            hi_pool = rnd.choice([40, 60, 120])
+            n = rnd.randint(1, 14)
+            ts = sorted(rnd.sample(range(0, hi_pool), n))
+            samples = [(t, rnd.randint(-50, 50)) for t in ts]
+
+            bucket = rnd.randint(1, 9)
+            empty = rnd.random() < 0.85           # EMPTY is the OOM trigger -> usually on
+            bts = rnd.choice([None, 'start', 'mid', 'end'])
+            rev = rnd.random() < 0.5
+
+            # Bounds must fully contain the data so the emitted span is purely data-driven (first
+            # kept .. last kept). A numeric lo strictly inside the data, or hi below the last
+            # sample, makes leading/trailing partial buckets depend on out-of-window neighbours --
+            # a separate query-boundary question, out of scope for the OOM. So: lo <= every ts
+            # (0 or '-') and hi >= every ts (hi_pool > max ts, or '+'). This still fully exercises
+            # the OOM (open '+' suffix + a filter that strips the last kept sample) and edge drops.
+            lo = '-' if rnd.random() < 0.5 else 0
+            hi = '+' if rnd.random() < 0.5 else hi_pool
+
+            fbv = None
+            fbts = None
+            pick = rnd.random()
+            if pick < 0.55:
+                a = rnd.randint(-50, 40)
+                fbv = (a, a + rnd.randint(0, 60))   # often strips edge samples
+            elif pick < 0.75 and ts:
+                k = rnd.randint(1, len(ts))
+                fbts = sorted(rnd.sample(ts, k))
+
+            for agg in NON_TWA_AGGS:
+                _check(r, samples, agg, bucket=bucket, lo=lo, hi=hi, rev=rev,
+                       fbv=fbv, fbts=fbts, empty=empty, bts=bts)

--- a/tests/flow/test_ts_range_empty_filter_stress.py
+++ b/tests/flow/test_ts_range_empty_filter_stress.py
@@ -1,5 +1,4 @@
-# Stress tests for AGGREGATION + EMPTY combined with FILTER_BY_VALUE / FILTER_BY_TS,
-# for every aggregator EXCEPT twa.
+# Stress tests for AGGREGATION + EMPTY combined with FILTER_BY_VALUE / FILTER_BY_TS.
 #
 # Background: MOD-8187 extended EMPTY-bucket filling to all aggregators (not just twa). The
 # edge-gap "is there a neighbour?" check scanned the raw series and ignored the value/ts filters,
@@ -8,8 +7,11 @@
 # crash the server pre-fix; they also assert exact values against an INDEPENDENT oracle (computed
 # from first principles, never from the engine) so a wrong-value regression is caught too.
 #
-# twa is intentionally excluded: its interpolation still reads raw (unfiltered) neighbours, a
-# separate pre-existing issue tracked apart from the OOM fix.
+# twa is covered separately (test_twa_filter_equivalence_stress + the explicit crash test below):
+# this PR makes twa's neighbour lookups filter-aware too, so it can't be value-checked against the
+# same first-principles oracle (no hand-derived twa integral). Instead we verify it by EQUIVALENCE
+# -- twa(full data + filter) == twa(only the kept samples, no filter) -- plus a server-survives
+# check on the OOM repro. A full twa value-oracle is tracked as a follow-up.
 
 import math
 import random
@@ -359,3 +361,31 @@ def test_twa_filter_equivalence_stress():
                 assert _eq(_parse_val(ra[1]), _parse_val(rb[1])), \
                     "twa %r \!= %r at ts %s for: %s\n%s\nvs\n%s" % (ra[1], rb[1], ra[0], label, a, b)
             r.execute_command('DEL', full, keptk)
+
+
+def test_twa_oom_repro_survives():
+    """twa hits the same OOM path as the other aggregators; lock in the crash fix with a
+    server-survives check (no oracle needed). The [(5,10),(50,9999)] + FILTER_BY_VALUE 0 100 +
+    EMPTY shape aborted the server pre-fix: the filtered-out 9999 made the trailing edge gap look
+    interior, so the empty fill ran toward '+' (UINT64_MAX) and the bucket count overflowed."""
+    env = Env(decodeResponses=False)
+    env.skipOnCluster()
+    with env.getClusterConnectionIfNeeded() as r:
+        r.execute_command('FLUSHALL')
+        r.execute_command('TS.CREATE', 'twaoom')
+        r.execute_command('TS.MADD', 'twaoom', 5, 10, 'twaoom', 50, 9999)  # 9999 filtered out
+        variants = [
+            ['TS.RANGE', 'twaoom', '-', '+', 'FILTER_BY_VALUE', 0, 100,
+             'AGGREGATION', 'twa', 4, 'EMPTY'],
+            ['TS.REVRANGE', 'twaoom', '-', '+', 'FILTER_BY_VALUE', 0, 100,
+             'AGGREGATION', 'twa', 4, 'EMPTY'],
+            ['TS.RANGE', 'twaoom', '-', '+', 'FILTER_BY_VALUE', 0, 100,
+             'AGGREGATION', 'twa', 4, 'BUCKETTIMESTAMP', 'end', 'EMPTY'],
+            ['TS.REVRANGE', 'twaoom', '-', '+', 'FILTER_BY_VALUE', 0, 100,
+             'AGGREGATION', 'twa', 4, 'BUCKETTIMESTAMP', 'end', 'EMPTY'],
+            ['TS.RANGE', 'twaoom', '-', '+', 'FILTER_BY_TS', 5,
+             'AGGREGATION', 'twa', 4, 'EMPTY'],
+        ]
+        for cmd in variants:
+            r.execute_command(*cmd)              # pre-fix: server aborts here -> ConnectionError
+            assert r.execute_command('PING')     # must still be alive

--- a/tests/flow/test_ts_range_empty_filter_stress.py
+++ b/tests/flow/test_ts_range_empty_filter_stress.py
@@ -260,3 +260,102 @@ def test_range_empty_filter_stress():
             for agg in NON_TWA_AGGS:
                 _check(r, samples, agg, bucket=bucket, lo=lo, hi=hi, rev=rev,
                        fbv=fbv, fbts=fbts, empty=empty, bts=bts)
+
+
+# ---------------------------------------------------------------------------
+# twa: filter-equivalence oracle
+#
+# twa is excluded from the value oracle above (we don't reimplement its integral). Instead we
+# verify the filter is applied correctly by EQUIVALENCE: twa over the full data WITH the filter must
+# equal twa over only the kept samples WITHOUT a filter. This uses the engine's own (trusted)
+# no-filter twa as the reference, so it needs no hand-derived twa math. Bounds may be anything --
+# they apply identically to both sides, so the equivalence is independent of query-boundary rules.
+# ---------------------------------------------------------------------------
+
+def _kept_for_filter(samples, fbv, fbts):
+    fset = set(fbts) if fbts is not None else None
+    return [(t, v) for (t, v) in samples
+            if (fbv is None or fbv[0] <= v <= fbv[1])
+            and (fset is None or t in fset)]
+
+
+def test_twa_filter_equivalence_stress():
+    import os
+    iters = int(os.getenv('TWA_FILTER_FUZZ_ITERS', '400'))
+    rnd = random.Random(int(os.getenv('TWA_FILTER_FUZZ_SEED', '20260612')))
+
+    env = Env(decodeResponses=False)
+    env.skipOnCluster()
+    with env.getClusterConnectionIfNeeded() as r:
+        r.execute_command('FLUSHALL')
+        kid = 0
+        for _ in range(iters):
+            hi_pool = rnd.choice([40, 60, 120])
+            n = rnd.randint(1, 14)
+            ts = sorted(rnd.sample(range(0, hi_pool), n))
+            samples = [(t, rnd.randint(-50, 50)) for t in ts]
+
+            bucket = rnd.randint(1, 9)
+            empty = rnd.random() < 0.85
+            bts = rnd.choice([None, 'start', 'mid', 'end'])
+            rev = rnd.random() < 0.5
+            lo = '-' if rnd.random() < 0.5 else rnd.randint(0, hi_pool)
+            hi = '+' if rnd.random() < 0.5 else (lo if isinstance(lo, int) else 0) + rnd.randint(0, hi_pool)
+
+            # always apply a filter (no-filter would make the equivalence trivial)
+            fbv = None
+            fbts = None
+            if rnd.random() < 0.6 or not ts:
+                a = rnd.randint(-50, 40)
+                fbv = (a, a + rnd.randint(0, 60))
+            else:
+                k = rnd.randint(1, len(ts))
+                fbts = sorted(rnd.sample(ts, k))
+
+            kept = _kept_for_filter(samples, fbv, fbts)
+
+            kid += 1
+            full = 'twf:%d' % kid
+            keptk = 'twk:%d' % kid
+            r.execute_command('TS.CREATE', full)
+            r.execute_command('TS.CREATE', keptk)
+            m = []
+            for t, v in samples:
+                m += [full, t, v]
+            if m:
+                r.execute_command('TS.MADD', *m)
+            m = []
+            for t, v in kept:
+                m += [keptk, t, v]
+            if m:
+                r.execute_command('TS.MADD', *m)
+
+            # A: full data WITH the filter
+            a_args = ['TS.REVRANGE' if rev else 'TS.RANGE', full, lo, hi]
+            if fbts is not None:
+                a_args += ['FILTER_BY_TS', *fbts]
+            if fbv is not None:
+                a_args += ['FILTER_BY_VALUE', fbv[0], fbv[1]]
+            a_args += ['AGGREGATION', 'twa', bucket]
+            if bts is not None:
+                a_args += ['BUCKETTIMESTAMP', bts]
+            if empty:
+                a_args += ['EMPTY']
+            # B: only the kept samples, NO filter
+            b_args = ['TS.REVRANGE' if rev else 'TS.RANGE', keptk, lo, hi, 'AGGREGATION', 'twa', bucket]
+            if bts is not None:
+                b_args += ['BUCKETTIMESTAMP', bts]
+            if empty:
+                b_args += ['EMPTY']
+
+            a = r.execute_command(*a_args)
+            b = r.execute_command(*b_args)
+            label = ' '.join(str(x) for x in a_args)
+            assert len(a) == len(b), \
+                "row count %d \!= %d for: %s\n%s\nvs\n%s" % (len(a), len(b), label, a, b)
+            for ra, rb in zip(a, b):
+                assert int(ra[0]) == int(rb[0]), \
+                    "ts %s \!= %s for: %s\n%s\nvs\n%s" % (ra[0], rb[0], label, a, b)
+                assert _eq(_parse_val(ra[1]), _parse_val(rb[1])), \
+                    "twa %r \!= %r at ts %s for: %s\n%s\nvs\n%s" % (ra[1], rb[1], ra[0], label, a, b)
+            r.execute_command('DEL', full, keptk)


### PR DESCRIPTION
The empty-bucket fill looked up neighbor samples without applying FILTER_BY_VALUE/FILTER_BY_TS, causing several bugs:

- OOM crash: a filtered-out sample made an edge gap look interior, so the fill ran to endTimestamp (+) and the bucket count overflowed -> giant alloc -> server abort.
- last (LOCF) carried a filtered-out value in reverse.
- twa interpolated using filtered-out samples.

Also fixed a duplicate-bucket bug: the reverse empty-suffix computed its start from the BUCKETTIMESTAMP-shifted label instead of the bucket start, re-emitting the boundary bucket under end/mid.

Fix: thread the query filters into the aggregation iterator and apply them in the neighbor lookups; use the bucket start for the suffix fill. Added stress tests for all non-twa aggregators.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core TS.RANGE/REVRANGE aggregation with EMPTY and filters; fixes a crash and result correctness but touches neighbor-scan paths used by all aggregators.
> 
> **Overview**
> **EMPTY** aggregation with **FILTER_BY_VALUE** / **FILTER_BY_TS** now passes the same filter args into `AggregationIterator` and uses them whenever the engine scans the series for **neighbor** samples (edge-gap checks, **last** LOCF seeding, **twa** interpolation).
> 
> That stops filtered-out points from being treated as neighbors, which previously could **OOM** the server (suffix fill toward `+`), wrong **last** values in reverse, and wrong **twa** behavior. Reverse empty-suffix fill now keys off the real **bucket start** (`aggregationLastTimestamp`) instead of the **BUCKETTIMESTAMP** label, avoiding duplicate buckets under `end`/`mid`.
> 
> Adds stress tests: independent oracle for non-twa aggs, twa filter-equivalence + OOM survival checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b08f7210346e3b41e445c9e324f8f0fbde5b6182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->