### PR TITLE
MOD-16160 Fix client-side cache tips for TS.BGET and TS.NRANGE/TS.NREVRANGE

### DIFF
--- a/src/cmd_info/ts_info.c
+++ b/src/cmd_info/ts_info.c
@@ -762,6 +762,7 @@ static const RedisModuleCommandInfo TS_BGET_INFO = {
     .complexity = "O(log(n)+k) where n is the number of samples in the series and k is the number "
                   "of returned samples",
     .since = "8.10.0",
+    .tips = "dont_cache",
     .arity = -4,
     .key_specs = (RedisModuleCommandKeySpec *)TS_BGET_KEYSPECS,
     .args = (RedisModuleCommandArg *)TS_BGET_ARGS,
@@ -1077,7 +1078,6 @@ static const RedisModuleCommandInfo TS_NREVRANGE_INFO = {
     .complexity = "O(numkeys*(n/m+k)) where n = Number of samples, m = Chunk size (samples "
                   "per chunk), k = Number of samples that are in the requested range",
     .since = "8.10.0",
-    .tips = "dont_cache",
     .arity = -5,
     .key_specs = (RedisModuleCommandKeySpec *)TS_NREVRANGE_KEYSPECS,
     .args = (RedisModuleCommandArg *)TS_NREVRANGE_ARGS,
@@ -1187,7 +1187,6 @@ static const RedisModuleCommandInfo TS_NRANGE_INFO = {
     .complexity = "O(numkeys*(n/m+k)) where n = Number of samples, m = Chunk size (samples "
                   "per chunk), k = Number of samples that are in the requested range",
     .since = "8.10.0",
-    .tips = "dont_cache",
     .arity = -5,
     .key_specs = (RedisModuleCommandKeySpec *)TS_NRANGE_KEYSPECS,
     .args = (RedisModuleCommandArg *)TS_NRANGE_ARGS,


### PR DESCRIPTION
Corrects the `dont_cache` command tips for the new commands per the caching decision with product: add it to `TS.BGET`, remove it from `TS.NRANGE`/`TS.NREVRANGE`.

- `TS.BGET` gets `dont_cache`: the `$` cursor resolves to `lastTimestamp + 1` at command-receipt time, so a cached reply can be served after the cursor should have advanced, with no key modification in between to invalidate it.
- `TS.NRANGE`/`TS.NREVRANGE` lose `dont_cache`: they take explicit keys (keynum keyspec), so `CLIENT TRACKING` can track and invalidate them correctly, making their replies safe to cache.
- Filter-based `MRANGE`/`MREVRANGE` intentionally keep `dont_cache` (their keys are not known to the client).
- Follow-up to #2052 and #2054.

Test plan:
- `COMMAND INFO ts.bget` lists the `dont_cache` tip.
- `COMMAND INFO ts.nrange` / `ts.nrevrange` no longer list `dont_cache`.
- `COMMAND INFO ts.mrange` / `ts.mrevrange` still list `dont_cache` (unchanged).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only changes to command tips with no runtime query logic modified; caching safety relies on existing keynum key specs and unchanged MRANGE/MREVRANGE exclusions.
> 
> **Overview**
> **TS.NRANGE** and **TS.NREVRANGE** no longer advertise the `dont_cache` command tip in `RedisModuleCommandInfo`, so Redis clients can treat their replies as eligible for **client-side caching** when using `CLIENT TRACKING`.
> 
> The change is limited to command metadata in `ts_info.c`; command handlers are unchanged. Filter-based **TS.MRANGE** / **TS.MREVRANGE** still use `dont_cache` because keys are not declared up front. The diff also sets **`dont_cache`** on **TS.BGET** (blocking / non-deterministic behavior relative to caching).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ea5b2b042bcba214ac837ebe2390edbca540475. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->