### PR TITLE
Fix event-nightly CI on 8.10: read Redis ref from dedicated redis_ref field

### DIFF
--- a/.install/get-redis-ref.sh
+++ b/.install/get-redis-ref.sh
@@ -42,8 +42,7 @@ fi
 
 # The dev/unreleased placeholder (99.99 or 99.99.99) means we track the
 # 'unstable' branch; a real version is used as the git ref directly.
-# 8.10 is also mapped to 'unstable' because the upstream redis/redis repo does
-# not yet have an 8.10 branch/tag; update this once it is released.
+# TODO: remove 8.10 once redis core branches out to 8.10
 case "$COMPAT_VERSION" in
 	99.99 | 99.99.99 | 8.10) REDIS_REF="unstable" ;;
 	*)                        REDIS_REF="$COMPAT_VERSION" ;;

--- a/.install/get-redis-ref.sh
+++ b/.install/get-redis-ref.sh
@@ -42,9 +42,11 @@ fi
 
 # The dev/unreleased placeholder (99.99 or 99.99.99) means we track the
 # 'unstable' branch; a real version is used as the git ref directly.
+# 8.10 is also mapped to 'unstable' because the upstream redis/redis repo does
+# not yet have an 8.10 branch/tag; update this once it is released.
 case "$COMPAT_VERSION" in
-	99.99 | 99.99.99) REDIS_REF="unstable" ;;
-	*)                REDIS_REF="$COMPAT_VERSION" ;;
+	99.99 | 99.99.99 | 8.10) REDIS_REF="unstable" ;;
+	*)                        REDIS_REF="$COMPAT_VERSION" ;;
 esac
 
 echo "$REDIS_REF"

--- a/.install/get-redis-ref.sh
+++ b/.install/get-redis-ref.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 # Print the Redis git ref that redistimeseries is built/tested against.
 #
-# The ref is derived from the `compatible_redis_version` field of the RAMP
-# manifest (pack/ramp.yml), so the version lives in a single place and is not
-# duplicated across Dockerfiles and CI workflows:
-#   * the dev/unreleased placeholder 99.99 (or 99.99.99) -> "unstable" branch
-#   * any real version (e.g. "8.8") is used as the git ref verbatim
+# The ref is read from the `redis_ref` field of the RAMP manifest
+# (pack/ramp.yml), so it lives in a single place and is not duplicated across
+# Dockerfiles and CI workflows. Set it to "unstable" to track the Redis
+# development branch, or to a specific tag/branch (e.g. "8.8") for a release.
 # The value may be quoted or unquoted; an inline '#' comment, if any, is stripped.
 #
 # It lives under .install/ (not sbin/) so it is copied into the Docker build
@@ -30,22 +29,14 @@ if [[ ! -f "$RAMP_FILE" ]]; then
 	exit 1
 fi
 
-# Value of the top-level `compatible_redis_version:` key, with inline comment,
+# Value of the top-level `redis_ref:` key, with inline comment,
 # surrounding whitespace and quotes stripped.
-COMPAT_VERSION="$(sed -nE 's/^compatible_redis_version:[[:space:]]*(.*)$/\1/p' "$RAMP_FILE" | head -n1 \
+REDIS_REF="$(sed -nE 's/^redis_ref:[[:space:]]*(.*)$/\1/p' "$RAMP_FILE" | head -n1 \
 	| sed -E 's/[[:space:]]*#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//; s/^"(.*)"$/\1/; s/^'\''(.*)'\''$/\1/')"
 
-if [[ -z "$COMPAT_VERSION" ]]; then
-	echo "Error: 'compatible_redis_version' is not defined in $RAMP_FILE" >&2
+if [[ -z "$REDIS_REF" ]]; then
+	echo "Error: 'redis_ref' is not defined in $RAMP_FILE" >&2
 	exit 1
 fi
-
-# The dev/unreleased placeholder (99.99 or 99.99.99) means we track the
-# 'unstable' branch; a real version is used as the git ref directly.
-# TODO: remove 8.10 once redis core branches out to 8.10
-case "$COMPAT_VERSION" in
-	99.99 | 99.99.99 | 8.10) REDIS_REF="unstable" ;;
-	*)                        REDIS_REF="$COMPAT_VERSION" ;;
-esac
 
 echo "$REDIS_REF"

--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -8,6 +8,7 @@ license: Redis Source Available License 2.0 (RSALv2) or the Server Side Public L
 command_line_args: ""
 compatible_redis_version: "8.10"
 min_redis_version: "8.10"
+redis_ref: "unstable"
 min_redis_pack_version: "7.2.0"
 capabilities:
     - types


### PR DESCRIPTION
## Problem

The Event Nightly workflow on the `8.10` branch failed on **all 22 jobs** with:

```
fatal: couldn't find remote ref 8.10
```

When the `8.10` branch was cut, `pack/ramp.yml` was set to `compatible_redis_version: "8.10"`. `.install/get-redis-ref.sh` derived the Redis git ref from that field and passed it verbatim to `install_redis.sh`, which tried to clone `redis/redis` at ref `8.10`. The upstream `redis/redis` repo has no `8.10` branch or tag yet, so every Docker build failed at the Redis install step before any test ran.

## Fix

Introduce a dedicated `redis_ref` field in `pack/ramp.yml` and read it directly, instead of overloading `compatible_redis_version` (which carries RAMP / Redis Enterprise packaging semantics, not CI test targets).

- **`pack/ramp.yml`** — add `redis_ref: "unstable"` so Docker/CI track the Redis development branch. `compatible_redis_version` / `min_redis_version` stay at `8.10` for packaging.
- **`.install/get-redis-ref.sh`** — read `redis_ref` directly and drop the version-mapping logic (the `99.99` → `unstable` placeholder handling and the `8.10` workaround).

This matches the intent already documented in the `event-nightly.yml` `workflow_dispatch` input ("use `redis_ref` from `pack/ramp.yml`"); the script now actually reads that field.

Released branches should set `redis_ref` to the matching upstream tag/branch (e.g. `"8.8"`); set it back to `"unstable"` (or to `8.10` once upstream publishes it) as appropriate.

## Follow-up

`master` still reads `compatible_redis_version`; a companion PR forward-ports this change there so the mechanism is consistent across branches.