### PR TITLE
Use dedicated redis_ref field in ramp.yml for CI git ref

### DIFF
--- a/.install/get-redis-ref.sh
+++ b/.install/get-redis-ref.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 # Print the Redis git ref that redistimeseries is built/tested against.
 #
-# The ref is derived from the `compatible_redis_version` field of the RAMP
-# manifest (pack/ramp.yml), so the version lives in a single place and is not
-# duplicated across Dockerfiles and CI workflows:
-#   * the dev/unreleased placeholder 99.99 (or 99.99.99) -> "unstable" branch
-#   * any real version (e.g. "8.8") is used as the git ref verbatim
+# The ref is read from the `redis_ref` field of the RAMP manifest
+# (pack/ramp.yml), so it lives in a single place and is not duplicated across
+# Dockerfiles and CI workflows. Set it to "unstable" to track the Redis
+# development branch, or to a specific tag/branch (e.g. "8.8") for a release.
 # The value may be quoted or unquoted; an inline '#' comment, if any, is stripped.
 #
 # It lives under .install/ (not sbin/) so it is copied into the Docker build
@@ -30,21 +29,14 @@ if [[ ! -f "$RAMP_FILE" ]]; then
 	exit 1
 fi
 
-# Value of the top-level `compatible_redis_version:` key, with inline comment,
+# Value of the top-level `redis_ref:` key, with inline comment,
 # surrounding whitespace and quotes stripped.
-COMPAT_VERSION="$(sed -nE 's/^compatible_redis_version:[[:space:]]*(.*)$/\1/p' "$RAMP_FILE" | head -n1 \
+REDIS_REF="$(sed -nE 's/^redis_ref:[[:space:]]*(.*)$/\1/p' "$RAMP_FILE" | head -n1 \
 	| sed -E 's/[[:space:]]*#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//; s/^"(.*)"$/\1/; s/^'\''(.*)'\''$/\1/')"
 
-if [[ -z "$COMPAT_VERSION" ]]; then
-	echo "Error: 'compatible_redis_version' is not defined in $RAMP_FILE" >&2
+if [[ -z "$REDIS_REF" ]]; then
+	echo "Error: 'redis_ref' is not defined in $RAMP_FILE" >&2
 	exit 1
 fi
-
-# The dev/unreleased placeholder (99.99 or 99.99.99) means we track the
-# 'unstable' branch; a real version is used as the git ref directly.
-case "$COMPAT_VERSION" in
-	99.99 | 99.99.99) REDIS_REF="unstable" ;;
-	*)                REDIS_REF="$COMPAT_VERSION" ;;
-esac
 
 echo "$REDIS_REF"

--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -8,6 +8,7 @@ license: Redis Source Available License 2.0 (RSALv2) or the Server Side Public L
 command_line_args: ""
 compatible_redis_version: "99.99"
 min_redis_version: "99.99"
+redis_ref: "unstable"
 min_redis_pack_version: "7.2.0"
 capabilities:
     - types


### PR DESCRIPTION
## Summary

Read the Redis git ref used for builds/tests from a dedicated `redis_ref` field in `pack/ramp.yml`, instead of overloading `compatible_redis_version` (which carries RAMP / Redis Enterprise packaging semantics, not CI test targets).

This is the forward-port to `master` of the fix in #2058 (on the `8.10` branch), so the mechanism is consistent across branches. On the `8.10` branch this resolved an Event Nightly failure where `compatible_redis_version: "8.10"` was passed verbatim as a git ref and `redis/redis` has no `8.10` branch/tag yet (`fatal: couldn't find remote ref 8.10`).

## Changes

- **`pack/ramp.yml`** — add `redis_ref: "unstable"` so Docker/CI track the Redis development branch. `compatible_redis_version` / `min_redis_version` stay at `99.99` for packaging.
- **`.install/get-redis-ref.sh`** — read `redis_ref` directly and drop the version-mapping logic (the `99.99` / `99.99.99` → `unstable` placeholder handling and verbatim-version refs).

This matches the intent already documented in the `event-nightly.yml` `workflow_dispatch` input ("use `redis_ref` from `pack/ramp.yml`"); the script now actually reads that field. Release branches should set `redis_ref` to the matching upstream tag/branch (e.g. `"8.8"`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3PvE6uwbJJPoq86DzHrLK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/CI configuration only; no runtime module logic. Release branches must set `redis_ref` explicitly when packaging version differs from the upstream git ref.
> 
> **Overview**
> **CI and Docker builds** now take the upstream Redis git ref from a dedicated **`redis_ref`** field in `pack/ramp.yml`, instead of deriving it from **`compatible_redis_version`**.
> 
> `pack/ramp.yml` adds **`redis_ref: "unstable"`** so master tracks the Redis dev branch while packaging fields (`compatible_redis_version` / `min_redis_version`) stay at **`99.99`**. **`.install/get-redis-ref.sh`** parses **`redis_ref`** directly and **drops** the old logic that mapped **`99.99`** to **`unstable`** or used a real version string as the git ref—avoiding failures when a packaging version (e.g. **`8.10`**) is not a valid **`redis/redis`** branch or tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31c4b84958bd6d1f7446f250cb57a94ad789a60e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->