### PR TITLE
pass VG=1 flag to the build as well

### DIFF
--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -146,6 +146,7 @@ jobs:
             -f Dockerfile.${{ matrix.platform.os }} \
             --build-arg REDIS_REF=${{ env.REDIS_REF }} \
             --build-arg SANITIZER=${{ inputs.run_sanitizer && 'address' || '' }} \
+            --build-arg VALGRIND=${{ inputs.run_valgrind && '1' || '' }} \
             -t ${{ env.DOCKER_IMAGE }} \
             .
 

--- a/.install/install_redis.sh
+++ b/.install/install_redis.sh
@@ -38,8 +38,9 @@ if [ -n "${VALGRIND}" ]; then
     echo "Building Redis without _FORTIFY_SOURCE for Valgrind"
     REDIS_EXTRA_CFLAGS="-U_FORTIFY_SOURCE"
 fi
-make SANITIZER=${SANITIZER:-} REDIS_CFLAGS="${REDIS_EXTRA_CFLAGS}" -j$(nproc)
-make SANITIZER=${SANITIZER:-} REDIS_CFLAGS="${REDIS_EXTRA_CFLAGS}" install
+# `install` builds `all` first, so a single invocation keeps the compiler flags
+# consistent and avoids a redundant rebuild.
+make SANITIZER=${SANITIZER:-} REDIS_CFLAGS="${REDIS_EXTRA_CFLAGS}" install -j$(nproc)
 cd ..
 
 echo "Redis installed successfully"

--- a/.install/install_redis.sh
+++ b/.install/install_redis.sh
@@ -29,8 +29,17 @@ cd redis
 git fetch origin ${REDIS_REF}
 git checkout ${REDIS_REF}
 git submodule update --init --recursive
-make SANITIZER=${SANITIZER:-} -j$(nproc)
-make install
+# For Valgrind runs only, build Redis without _FORTIFY_SOURCE. At -O2/-O3 the
+# distro compiler lowers correct memmove() calls into __memcpy_chk(), which
+# Valgrind's direction-agnostic overlap check misreports as errors (e.g. in
+# readSyncBulkPayload). Other builds keep fortification unchanged. See RED-195208.
+REDIS_EXTRA_CFLAGS=""
+if [ -n "${VALGRIND}" ]; then
+    echo "Building Redis without _FORTIFY_SOURCE for Valgrind"
+    REDIS_EXTRA_CFLAGS="-U_FORTIFY_SOURCE"
+fi
+make SANITIZER=${SANITIZER:-} REDIS_CFLAGS="${REDIS_EXTRA_CFLAGS}" -j$(nproc)
+make SANITIZER=${SANITIZER:-} REDIS_CFLAGS="${REDIS_EXTRA_CFLAGS}" install
 cd ..
 
 echo "Redis installed successfully"

--- a/Dockerfile.jammy
+++ b/Dockerfile.jammy
@@ -17,9 +17,12 @@ RUN bash /workspace/.install/install_script.sh
 # Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
 ARG REDIS_REF=
 ARG SANITIZER=
+# VALGRIND=1 builds Redis without _FORTIFY_SOURCE to avoid Valgrind false
+# positives on fortify-lowered memmove() (see install_redis.sh / RED-195208).
+ARG VALGRIND=
 
 COPY pack/ramp.yml /workspace/pack/ramp.yml
-RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} VALGRIND=${VALGRIND} /workspace/.install/install_redis.sh
 
 # Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only Redis compile flags when Valgrind is enabled; release packing is already skipped for Valgrind runs.
> 
> **Overview**
> When **Flow Linux** runs with `run_valgrind`, the Docker image build now receives `VALGRIND=1` (alongside the existing `VG=1` at test time) so the Redis inside the image is compiled for Valgrind-friendly CI.
> 
> **`install_redis.sh`** uses that flag to add `REDIS_CFLAGS=-U_FORTIFY_SOURCE` only for Valgrind builds, avoiding false positives from fortify-lowered `memmove()` / `__memcpy_chk()` (RED-195208). Non-Valgrind installs are unchanged. Redis is built with a single `make … install` instead of separate `make` and `make install`.
> 
> **`Dockerfile.jammy`** declares the `VALGRIND` build arg and forwards it into `install_redis.sh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e2897d9e67c1d2bf79c3d63f94ca71c89f75770. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->