### PR TITLE
ci: add timeouts to nightly jobs to prevent 6-hour hangs

### DIFF
--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -123,6 +123,12 @@ jobs:
     name: ${{ inputs.arch }}-${{ matrix.platform.os }}, ${{ needs.setup-environment.outputs.redis-ref }}
     runs-on: ${{ needs.setup-environment.outputs.runner }}
     needs: setup-environment
+    # Safety net so a hung step (e.g. a test that leaves an orphan process
+    # keeping the `docker run` open) fails fast instead of running until
+    # GitHub's 360-minute default and stalling the whole nightly.
+    # Valgrind runs are legitimately much slower (~3.5h) so they get a
+    # larger budget than regular/sanitizer builds (~1h).
+    timeout-minutes: ${{ inputs.run_valgrind && 300 || 90 }}
     strategy:
       fail-fast: false
       matrix:
@@ -159,6 +165,11 @@ jobs:
             make build
 
       - name: Run tests
+        # Tight per-step timeout on the step that has been observed to hang
+        # (tests finish and pass, but an orphaned process keeps `docker run`
+        # alive). A step-level timeout lets the always()/failure() steps below
+        # still run so test logs/artifacts are captured for diagnosis.
+        timeout-minutes: ${{ inputs.run_valgrind && 270 || 60 }}
         run: |
           # Capture test output to file for parsing by capture-test-results action
           # The workspace is mounted, so test_output.log will be accessible outside the container

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -116,6 +116,9 @@ jobs:
       PIP_BREAK_SYSTEM_PACKAGES: 1
     runs-on: ${{matrix.os}}
     needs: setup-environment
+    # macOS runs are legitimately slow (~3.5h) but should never hang for the
+    # full 360-minute default and stall the nightly.
+    timeout-minutes: 300
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/flow-random-traffic.yml
+++ b/.github/workflows/flow-random-traffic.yml
@@ -54,6 +54,9 @@ jobs:
     name: random-traffic (${{ needs.pick-os.outputs.os }})
     needs: pick-os
     runs-on: ubuntu-latest
+    # Random traffic normally completes in ~20m; cap it so a hung redis-server
+    # or generator can't run until the 360-minute default and stall the nightly.
+    timeout-minutes: 60
     env:
       DOCKER_IMAGE: redistimeseries-${{ needs.pick-os.outputs.os }}:latest
       REDIS_REF: ${{ inputs.redis-ref || 'unstable' }}

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -349,10 +349,24 @@ run_tests() {
 	[[ -z "$RLTEST_PY" ]] && RLTEST_PY="$(pick_rltest_python)"
 
 	local E=0
-	if [[ $NOP != 1 ]]; then
-		{ $OP "$RLTEST_PY" -m RLTest @$rltest_config; (( E |= $? )); } || true
-	else
+	if [[ $NOP == 1 ]]; then
 		$OP "$RLTEST_PY" -m RLTest @$rltest_config
+	elif [[ $OS == linux && $GDB != 1 && $RLTEST_CONSOLE != 1 ]]; then
+		# Run RLTest in its own session/process group (setsid) so we can
+		# reliably reap its entire process tree once it returns. RLTest
+		# occasionally leaves an orphaned redis-server behind (e.g. a replica,
+		# AOF-rewrite or cluster node that wasn't shut down). Such an orphan
+		# inherits RLTest's stdout, which under CI is the write end of the
+		# `make test ... | tee` pipe; while it holds that pipe open `tee` never
+		# sees EOF and the job hangs until the CI timeout, even though every
+		# test has already passed and the summary was printed.
+		setsid "$RLTEST_PY" -m RLTest @$rltest_config &
+		local rltest_pid=$!
+		{ wait "$rltest_pid"; (( E |= $? )); } || true
+		# Reap anything still alive in RLTest's process group (-pid == pgid).
+		kill -9 -- -"$rltest_pid" 2>/dev/null || true
+	else
+		{ $OP "$RLTEST_PY" -m RLTest @$rltest_config; (( E |= $? )); } || true
 	fi
 
 	[[ $KEEP != 1 ]] && rm -f $rltest_config


### PR DESCRIPTION
The nightly workflow on master intermittently ran for ~6 hours and then
timed out. Root cause: a build-linux matrix job (random OS) hung in the
'Run tests' step. Logs show the test suite actually finished and passed,
but an orphaned process kept the 'docker run' pipe open so the step never
returned. With no timeout-minutes set, the job sat until GitHub Actions'
360-minute default cancelled it, blocking the whole nightly.

Add explicit timeouts so a hung job fails fast instead of consuming 6h:
- flow-linux: job-level backstop and a tight step-level timeout on
  'Run tests' (larger budget for valgrind, which is legitimately ~3.5h).
  The step-level timeout lets the always()/failure() capture steps run so
  diagnostics are preserved.
- flow-macos: job-level timeout (macOS is slow but bounded).
- flow-random-traffic: job-level timeout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and test-runner hardening only; Linux RLTest uses process-group cleanup but skips GDB/interactive modes, with macOS and other paths unchanged.
> 
> **Overview**
> Adds **explicit GitHub Actions timeouts** on nightly-style flows so jobs fail in ~1–5 hours instead of sitting on the **360-minute default** when a step never exits.
> 
> **`flow-linux`**: job-level cap (**90m** normal / **300m** valgrind) plus a tighter **`Run tests`** step timeout (**60m** / **270m** valgrind) so hung `docker run` still allows **`always()`** log capture steps to run.
> 
> **`flow-macos`** (**300m**) and **`flow-random-traffic`** (**60m**) get job-level caps for the same stall reason.
> 
> **`tests/flow/tests.sh`**: on **Linux** (non-GDB, non-interactive RLTest), RLTest runs under **`setsid`** and the script **`kill -9`s the process group** after `wait`, targeting orphaned **redis-server** processes that keep the CI **`tee`** pipe open after tests pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1256ef51f16af137b9fe932ca96c9a6631c9ab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->