### PR TITLE
MOD-15764 - Update Ci to work with the new flow - event ci time reduce

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -49,7 +49,7 @@ jobs:
     needs: [prepare-values]
     with:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-      quick: false
+      quick: true
     secrets: inherit
   linux-valgrind:
     uses: ./.github/workflows/flow-linux.yml
@@ -58,7 +58,7 @@ jobs:
       arch: x64
       os: jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-      quick: false
+      quick: true
       run_valgrind: true
     secrets: inherit
   linux-sanitizer:
@@ -68,6 +68,6 @@ jobs:
       arch: x64
       os: jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-      quick: false
+      quick: true
       run_sanitizer: true
     secrets: inherit

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -174,7 +174,7 @@ jobs:
               VG=${{ inputs.run_valgrind && '1' || '0' }} \
               SAN=${{ inputs.run_sanitizer && 'addr' || '' }} \
               QUICK=${{ inputs.quick && '1' || '0' }} \
-              PARALLEL=10 2>&1 | tee /workspace/test_output.log; exit \${PIPESTATUS[0]}"
+              PARALLEL=${{ (inputs.run_valgrind || inputs.run_sanitizer) && '1' || '10' }} 2>&1 | tee /workspace/test_output.log; exit \${PIPESTATUS[0]}"
 
       - name: Fix test log permissions
         if: always()

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -173,7 +173,8 @@ jobs:
             bash -c "make test \
               VG=${{ inputs.run_valgrind && '1' || '0' }} \
               SAN=${{ inputs.run_sanitizer && 'addr' || '' }} \
-              QUICK=${{ inputs.quick && '1' || '0' }} 2>&1 | tee /workspace/test_output.log; exit \${PIPESTATUS[0]}"
+              QUICK=${{ inputs.quick && '1' || '0' }} \
+              PARALLEL=10 2>&1 | tee /workspace/test_output.log; exit \${PIPESTATUS[0]}"
 
       - name: Fix test log permissions
         if: always()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI-only changes reduce test coverage on several PR jobs (quick mode) and alter parallelism for Valgrind/sanitizer, which could miss regressions that full parallel Linux builds would catch.
> 
> **Overview**
> **Event CI** runs a smaller test suite on macOS, Valgrind, and AddressSanitizer jobs by passing **`quick: true`** (was `false`). Full **`quick: false`** coverage is unchanged on the main Linux x64/arm64 build jobs.
> 
> **Linux flow** test runs now set **`PARALLEL=10`** by default and **`PARALLEL=1`** when Valgrind or sanitizer is enabled, so heavy debug jobs stay less parallel while normal matrix runs use more concurrency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 920df9c603ae7149007f956fec1bf0f237ef1860. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->