### PR TITLE
ci: speed up event PR CI (~4h → ~40m) + reuse Redis env across tests

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -28,28 +28,35 @@ jobs:
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit
+  # PR builds run a representative OS subset (glibc/RHEL/musl/Debian) and the
+  # QUICK test suite (general topology only). The exhaustive OS matrix and the
+  # full topology suite (slaves/AOF/AOF+slaves/OSS-cluster) run in
+  # event-nightly.yml.
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]
     with:
       arch: x64
+      os: jammy rocky9 alpine bookworm
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-      quick: false
+      quick: true
     secrets: inherit
   build-linux-arm64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]
     with:
       arch: arm64
+      os: jammy rocky9
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-      quick: false
+      quick: true
     secrets: inherit
   macos:
     uses: ./.github/workflows/flow-macos.yml
     needs: [prepare-values]
     with:
+      os: macos-15
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-      quick: false
+      quick: true
     secrets: inherit
   linux-valgrind:
     uses: ./.github/workflows/flow-linux.yml
@@ -58,7 +65,7 @@ jobs:
       arch: x64
       os: jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-      quick: false
+      quick: true
       run_valgrind: true
     secrets: inherit
   linux-sanitizer:
@@ -68,6 +75,6 @@ jobs:
       arch: x64
       os: jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-      quick: false
+      quick: true
       run_sanitizer: true
     secrets: inherit

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -156,6 +156,73 @@ jobs:
       quick: false
     secrets: inherit
 
+  # Coverage analysis on a single platform. `make coverage` builds the module
+  # instrumented (COV=1, lcov/gcov), runs the full test suite, and produces an
+  # lcov report (bin/**/cov.info) plus an HTML report (bin/**/cov/). The report
+  # is uploaded to Codecov (see codecov.yml) and attached as a build artifact.
+  coverage:
+    name: Coverage (x64-jammy)
+    runs-on: ubuntu-latest
+    needs: [prepare-values]
+    timeout-minutes: 240
+    env:
+      REDIS_REF: ${{ needs.prepare-values.outputs.redis-ref }}
+      DOCKER_IMAGE: redistimeseries-jammy-cov:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Build Docker Image
+        run: |
+          docker build \
+            -f Dockerfile.jammy \
+            --build-arg REDIS_REF=${{ env.REDIS_REF }} \
+            -t ${{ env.DOCKER_IMAGE }} \
+            .
+
+      - name: Build and test with coverage
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace \
+            --cap-add=SYS_PTRACE \
+            --security-opt seccomp=unconfined \
+            ${{ env.DOCKER_IMAGE }} \
+            make coverage SHOW=1
+
+      - name: Fix coverage file permissions
+        if: always()
+        run: |
+          sudo chown -R "$(id -u)":"$(id -g)" bin tests || true
+
+      - name: Locate coverage report
+        if: always()
+        id: cov
+        run: |
+          INFO=$(find bin -name 'cov.info' | head -1)
+          echo "info=${INFO}" >> $GITHUB_OUTPUT
+          echo "Coverage info file: ${INFO:-<not found>}"
+
+      - name: Upload coverage to Codecov
+        if: always() && steps.cov.outputs.info != ''
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ steps.cov.outputs.info }}
+          flags: nightly
+          fail_ci_if_error: false
+          verbose: true
+
+      - name: Upload HTML coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html-x64-jammy
+          path: bin/**/cov/
+          if-no-files-found: warn
+
   notify-results:
     name: Aggregate Results & Notify
     runs-on: ubuntu-latest

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -123,6 +123,8 @@ jobs:
     name: ${{ inputs.arch }}-${{ matrix.platform.os }}, ${{ needs.setup-environment.outputs.redis-ref }}
     runs-on: ${{ needs.setup-environment.outputs.runner }}
     needs: setup-environment
+    # Hang backstop. Healthy legs finish well inside this; valgrind is far slower.
+    timeout-minutes: ${{ inputs.run_valgrind && 300 || 120 }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -103,7 +103,11 @@ jobs:
           if [ -z "${OS}" ]; then
             OS='["macos-14", "macos-15", "macos-26", "macos-14-large", "macos-15-intel", "macos-26-intel"]'
           else
-            OS='["${OS}"]'
+            # Build a JSON array from a space-separated list (e.g. "macos-15"
+            # or "macos-14 macos-15"). Quotes must expand ${OS}, so no single quotes.
+            ARR="["
+            for o in ${OS}; do ARR="${ARR}\"${o}\","; done
+            OS="${ARR%,}]"
           fi
           echo "${OS}"
           echo "os=${OS}" >> $GITHUB_OUTPUT
@@ -116,6 +120,11 @@ jobs:
       PIP_BREAK_SYSTEM_PACKAGES: 1
     runs-on: ${{matrix.os}}
     needs: setup-environment
+    # Hang backstop; only kills genuine hangs. macOS now runs tests in parallel
+    # (RLTest forces the 'fork' start method, so the old "can't pickle local
+    # object" limitation no longer applies). Kept generous for now because the
+    # pinned RLTest predates the parallel-coordinator hang fix (RLTest #248).
+    timeout-minutes: 300
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Why
Event CI took **~4h on every PR** (last green run: 4h14m). The PR workflow ran the **same exhaustive matrix as the nightly** — 43 build/test legs, each running the full 5-topology suite (`quick: false`: general + slaves + AOF + AOF+slaves + OSS-cluster).

## What
- **PR scope** (`event-ci.yml`): `quick: true` (general topology only) + a representative OS subset (x64 `jammy rocky9 alpine bookworm`, arm64 `jammy rocky9`, macOS `macos-15`) — **9 legs instead of 43**. The full OS matrix and full 5-topology suite remain in `event-nightly.yml`.
- **Hang backstops**: `timeout-minutes` on Linux (120, valgrind 300) and macOS (300) legs.
- **macOS matrix fix** (`flow-macos.yml`): building the matrix JSON for an explicit `os` input was broken (single-quoted, `${OS}` never expanded) — latent because all callers previously passed an empty `os`.
- **Coverage** (`event-nightly.yml`): new nightly job runs `make coverage` (lcov build + full suite) → Codecov + HTML artifact.

## Expected impact
PR wall-clock **~4h → ~40m** (9 legs, single topology).

## Tradeoff / notes
- PRs now test only the **general** topology; slaves/AOF/OSS-cluster coverage moves to the nightly. Tunable per-leg via `quick:` if more PR coverage is wanted.
- Nightly coverage upload needs a `CODECOV_TOKEN` repo secret (job won't fail without it).
- I first also enabled RLTest `--env-reuse` to cut per-test server startup, but CI proved it breaks ~22 tests that assume a fresh server (decodeResponses mismatch; `test_borken_rdb` deliberately crashes the server). Reverted — making the suite env-reuse-safe is a separate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
