### PR TITLE
MOD-15749 Short-form CLUSTERSET: RAMP capability + LibMR error-return

### DIFF
--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -27,6 +27,7 @@ capabilities:
     - flash
     - ipv6
     - asm
+    - short_form_clusterset
 exclude_commands:
     - timeseries.REFRESHCLUSTER
     - timeseries.INFOCLUSTER


### PR DESCRIPTION
## What

Two coupled changes for the short-form `CLUSTERSET` rollout:

1. **RAMP capability** — adds `short_form_clusterset` to `pack/ramp.yml` `capabilities:`.
2. **LibMR pin bump** — bumps `deps/LibMR` to [RedisGears/LibMR#99](https://github.com/RedisGears/LibMR/pull/99), which makes the short form reply with an **error** instead of a silent `+OK` when `RedisModule_GetClusterNodeSlotRanges` ([redis/redis#14953](https://github.com/redis/redis/pull/14953)) is unavailable.

## Why

The zero-arg short form of `CLUSTERSET` depends on the slot-ranges module API. Previously, on a build whose host Redis lacks that API, LibMR logged a warning but still replied `+OK`, leaving the cluster unconfigured while the caller believed it had succeeded.

Together these two changes give Redis Enterprise / DMC two complementary, robust paths:
- **capability-aware** — discover support via `module.capabilities()` (same mechanism as `asm`, `intershard_tls`) and only send the short form to builds that advertise it; no patch-version parsing.
- **capability-unaware** — try the short form and fall back to the long form on error (now safe, since the short form returns a clean error when the API is missing).

## Local verification

Built `macos-arm64v8-release` with the new LibMR pin and ran against Redis **8.2.1** (which lacks the slot-ranges API):

| Command | Reply |
|---|---|
| `timeseries.CLUSTERSET` (short, argc=1) | `-ERRCLUSTER Failed to set cluster topology` |
| `timeseries.CLUSTERSET AUTH` (argc=2, bad arity) | `-Could not parse cluster set arguments` |
| `timeseries.CLUSTERSET AUTH <pwd>` (short, argc=3) | `-ERRCLUSTER Failed to set cluster topology` |

Redis log confirmed the real path was exercised:
```
# <timeseries> Short-form CLUSTERSET received, but RedisModule_GetClusterNodeSlotRanges
  is not available in this Redis build. Use long-form CLUSTERSET or REFRESHCLUSTER ...
```
The success path (API present → `+OK`) is covered end-to-end by `tests/flow/test_asm.py::test_short_form_clusterset` (oss-cluster).

## Notes / follow-up

- The LibMR pin is a **temporary** pin to the PR branch commit; re-pin to LibMR master once #99 merges.
- Lands on `master`. For the in-flight enterprise beta (private tags v8.4.10 / v8.6.3 / v8.8.1), the capability + LibMR fix need back-porting to the 8.4/8.6/8.8 release branches, re-tagging, and re-pinning in Redis-Enterprise's module generator, plus the matching `KNOWN_MODULE_CAPABILITIES` entry. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pack metadata only—no runtime module logic in this diff; low impact aside from downstream capability gating behavior.
> 
> **Overview**
> Adds **`short_form_clusterset`** to the Time Series module’s **`pack/ramp.yml`** `capabilities` list so Redis Enterprise / DMC can detect support via `module.capabilities()` (same pattern as `asm` and `intershard_tls`) and only issue the zero-arg short **`CLUSTERSET`** on builds that advertise it.
> 
> This pairs with the LibMR change (not in this diff) that returns an error instead of silent **`+OK`** when `RedisModule_GetClusterNodeSlotRanges` is missing, so callers without capability checks can safely fall back to long-form **`CLUSTERSET`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2829f1f21b522740601ffdd57761f16501e05706. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->