### PR TITLE
MOD-16266 - fix ci hang 

### DIFF
--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -1,7 +1,8 @@
 
 import sys
 import os
-from RLTest import Env, Defaults
+from includes import Env
+from RLTest import Defaults
 from redis import ResponseError
 from packaging import version
 

--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -46,6 +46,38 @@ HANG_TIMEOUT_SECS = 600 if (VALGRIND or SANITIZER) else 60
 # slower wake-up callback there can't produce a false failure.
 WAKE_TIMEOUT_SECS = 30 if (VALGRIND or SANITIZER) else 5
 
+# Give EVERY test connection a default socket read timeout. If the server wedges
+# (e.g. a module deadlock), a command would otherwise block the client forever
+# and hang the whole CI job for hours; with this, the blocked read raises a
+# TimeoutError after HANG_TIMEOUT_SECS, failing the test fast with a traceback
+# that points at the exact stuck command instead of a silent multi-hour hang.
+# setdefault() preserves any explicit per-connection timeout (e.g. TS.BGET tests).
+# RLTest builds all its clients via redis.Redis/StrictRedis, so patching __init__
+# covers master/slave/TLS/unix connections.
+if not getattr(redis.Redis, "_rts_default_socket_timeout_patched", False):
+    _rts_orig_redis_init = redis.Redis.__init__
+
+    def _rts_redis_init(self, *args, **kwargs):
+        kwargs.setdefault("socket_timeout", HANG_TIMEOUT_SECS)
+        _rts_orig_redis_init(self, *args, **kwargs)
+
+    redis.Redis.__init__ = _rts_redis_init
+    redis.Redis._rts_default_socket_timeout_patched = True
+
+# Same default for cluster-wide connections: env.getClusterConnectionIfNeeded()
+# returns a redis.RedisCluster, which is NOT a redis.Redis subclass, so the patch
+# above doesn't cover it. Without this, a wedged server reached via a multi-shard
+# RedisCluster client would still hang forever.
+if hasattr(redis, "RedisCluster") and not getattr(redis.RedisCluster, "_rts_default_socket_timeout_patched", False):
+    _rts_orig_cluster_init = redis.RedisCluster.__init__
+
+    def _rts_cluster_init(self, *args, **kwargs):
+        kwargs.setdefault("socket_timeout", HANG_TIMEOUT_SECS)
+        _rts_orig_cluster_init(self, *args, **kwargs)
+
+    redis.RedisCluster.__init__ = _rts_cluster_init
+    redis.RedisCluster._rts_default_socket_timeout_patched = True
+
 # Use generous terminate patience for all configurations. RLTest polls and
 # returns as soon as the process exits, so a high retry count costs nothing
 # when shutdown is fast, but prevents force-kills under Valgrind/sanitizer

--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -31,6 +31,21 @@ SANITIZER = os.getenv('SANITIZER', '')
 VALGRIND = (os.getenv('VALGRIND', '0') == '1') or (os.getenv('VG', '0') == '1')
 CODE_COVERAGE = os.getenv('CODE_COVERAGE', '0') == '1'
 
+# Wall-clock ceiling for "give up so a hang can't run into the CI job timeout"
+# bounds. A healthy run finishes far below this and never reaches it; it fires
+# only on a genuine hang. Under Valgrind/sanitizer everything is many times
+# slower (a normal op can take minutes), so scale the ceiling way up — it must
+# never trip on a slow-but-healthy run, while still staying far under the CI
+# job timeout (hours).
+HANG_TIMEOUT_SECS = 600 if (VALGRIND or SANITIZER) else 60
+
+# Upper bound on how long a "prompt" wake (e.g. TS.BGET woken by a key deletion)
+# may take before we consider it a regression. Must stay well below the parked
+# client's block timeout (HANG_TIMEOUT_SECS) so a wake that only happened via
+# that block timeout is still caught. Scaled up under Valgrind/sanitizer so the
+# slower wake-up callback there can't produce a false failure.
+WAKE_TIMEOUT_SECS = 30 if (VALGRIND or SANITIZER) else 5
+
 # Use generous terminate patience for all configurations. RLTest polls and
 # returns as soon as the process exits, so a high retry count costs nothing
 # when shutdown is fast, but prevents force-kills under Valgrind/sanitizer
@@ -73,7 +88,11 @@ def verifyClusterInitialized(env):
         except Exception:
             pass # in case we run on older version of redis
         allConnected = False
+        deadline = time.time() + HANG_TIMEOUT_SECS
         while not allConnected:
+            if time.time() > deadline:
+                print("[HANG-GUARD] verifyClusterInitialized exceeded %ss deadline" % HANG_TIMEOUT_SECS, flush=True)
+                raise RuntimeError("verifyClusterInitialized timed out after %ss" % HANG_TIMEOUT_SECS)
             res = conn.execute_command('timeseries.INFOCLUSTER')
             nodes = res[4]
             allConnected = True

--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -31,52 +31,10 @@ SANITIZER = os.getenv('SANITIZER', '')
 VALGRIND = (os.getenv('VALGRIND', '0') == '1') or (os.getenv('VG', '0') == '1')
 CODE_COVERAGE = os.getenv('CODE_COVERAGE', '0') == '1'
 
-# Wall-clock ceiling for "give up so a hang can't run into the CI job timeout"
-# bounds. A healthy run finishes far below this and never reaches it; it fires
-# only on a genuine hang. Under Valgrind/sanitizer everything is many times
-# slower (a normal op can take minutes), so scale the ceiling way up — it must
-# never trip on a slow-but-healthy run, while still staying far under the CI
-# job timeout (hours).
-HANG_TIMEOUT_SECS = 600 if (VALGRIND or SANITIZER) else 60
-
 # Upper bound on how long a "prompt" wake (e.g. TS.BGET woken by a key deletion)
-# may take before we consider it a regression. Must stay well below the parked
-# client's block timeout (HANG_TIMEOUT_SECS) so a wake that only happened via
-# that block timeout is still caught. Scaled up under Valgrind/sanitizer so the
-# slower wake-up callback there can't produce a false failure.
+# may take before we consider it a regression. Scaled up under Valgrind/sanitizer
+# so the slower wake-up callback there can't produce a false failure.
 WAKE_TIMEOUT_SECS = 30 if (VALGRIND or SANITIZER) else 5
-
-# Give EVERY test connection a default socket read timeout. If the server wedges
-# (e.g. a module deadlock), a command would otherwise block the client forever
-# and hang the whole CI job for hours; with this, the blocked read raises a
-# TimeoutError after HANG_TIMEOUT_SECS, failing the test fast with a traceback
-# that points at the exact stuck command instead of a silent multi-hour hang.
-# setdefault() preserves any explicit per-connection timeout (e.g. TS.BGET tests).
-# RLTest builds all its clients via redis.Redis/StrictRedis, so patching __init__
-# covers master/slave/TLS/unix connections.
-if not getattr(redis.Redis, "_rts_default_socket_timeout_patched", False):
-    _rts_orig_redis_init = redis.Redis.__init__
-
-    def _rts_redis_init(self, *args, **kwargs):
-        kwargs.setdefault("socket_timeout", HANG_TIMEOUT_SECS)
-        _rts_orig_redis_init(self, *args, **kwargs)
-
-    redis.Redis.__init__ = _rts_redis_init
-    redis.Redis._rts_default_socket_timeout_patched = True
-
-# Same default for cluster-wide connections: env.getClusterConnectionIfNeeded()
-# returns a redis.RedisCluster, which is NOT a redis.Redis subclass, so the patch
-# above doesn't cover it. Without this, a wedged server reached via a multi-shard
-# RedisCluster client would still hang forever.
-if hasattr(redis, "RedisCluster") and not getattr(redis.RedisCluster, "_rts_default_socket_timeout_patched", False):
-    _rts_orig_cluster_init = redis.RedisCluster.__init__
-
-    def _rts_cluster_init(self, *args, **kwargs):
-        kwargs.setdefault("socket_timeout", HANG_TIMEOUT_SECS)
-        _rts_orig_cluster_init(self, *args, **kwargs)
-
-    redis.RedisCluster.__init__ = _rts_cluster_init
-    redis.RedisCluster._rts_default_socket_timeout_patched = True
 
 # Use generous terminate patience for all configurations. RLTest polls and
 # returns as soon as the process exits, so a high retry count costs nothing
@@ -120,11 +78,7 @@ def verifyClusterInitialized(env):
         except Exception:
             pass # in case we run on older version of redis
         allConnected = False
-        deadline = time.time() + HANG_TIMEOUT_SECS
         while not allConnected:
-            if time.time() > deadline:
-                print("[HANG-GUARD] verifyClusterInitialized exceeded %ss deadline" % HANG_TIMEOUT_SECS, flush=True)
-                raise RuntimeError("verifyClusterInitialized timed out after %ss" % HANG_TIMEOUT_SECS)
             res = conn.execute_command('timeseries.INFOCLUSTER')
             nodes = res[4]
             allConnected = True

--- a/tests/flow/test_acls.py
+++ b/tests/flow/test_acls.py
@@ -3,7 +3,7 @@ import time
 
 import pytest
 import redis
-from RLTest import Env
+from includes import Env
 import redis.exceptions
 from includes import *
 

--- a/tests/flow/test_asm.py
+++ b/tests/flow/test_asm.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Optional, Set
 import redis
 
-from includes import Env, VALGRIND, SANITIZER
+from includes import Env, VALGRIND, SANITIZER, HANG_TIMEOUT_SECS
 from utils import slot_table
 
 
@@ -43,6 +43,13 @@ def test_asm_with_data_and_queries_during_migrations():
     fill_some_data(env, number_of_keys, samples_per_key, label1=17, label2=19)
 
     conn = env.getConnection(0)
+    # Bound the read so a command that stalls mid-migration can't block the
+    # validator thread forever (which would hang the ThreadPoolExecutor join).
+    try:
+        conn.connection_pool.connection_kwargs["socket_timeout"] = HANG_TIMEOUT_SECS
+        print("[HANG-GUARD] asm validator socket_timeout set to %ss" % HANG_TIMEOUT_SECS, flush=True)
+    except Exception:
+        pass
     command = "TS.MRANGE - + FILTER label1=17 GROUPBY label1 REDUCE count"
 
     def validate_result(result):

--- a/tests/flow/test_asm.py
+++ b/tests/flow/test_asm.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Optional, Set
 import redis
 
-from includes import Env, VALGRIND, SANITIZER, HANG_TIMEOUT_SECS
+from includes import Env, VALGRIND, SANITIZER
 from utils import slot_table
 
 
@@ -43,13 +43,6 @@ def test_asm_with_data_and_queries_during_migrations():
     fill_some_data(env, number_of_keys, samples_per_key, label1=17, label2=19)
 
     conn = env.getConnection(0)
-    # Bound the read so a command that stalls mid-migration can't block the
-    # validator thread forever (which would hang the ThreadPoolExecutor join).
-    try:
-        conn.connection_pool.connection_kwargs["socket_timeout"] = HANG_TIMEOUT_SECS
-        print("[HANG-GUARD] asm validator socket_timeout set to %ss" % HANG_TIMEOUT_SECS, flush=True)
-    except Exception:
-        pass
     command = "TS.MRANGE - + FILTER label1=17 GROUPBY label1 REDUCE count"
 
     def validate_result(result):

--- a/tests/flow/test_borken_rdb.py
+++ b/tests/flow/test_borken_rdb.py
@@ -3,7 +3,7 @@ Test that verifies RDB load failure handling for corrupted/broken RDB files.
 This test creates various types of broken RDB files and ensures they fail to load properly.
 """
 
-from RLTest import Env
+from includes import Env
 from includes import *
 
 def _crc_reflect64(x: int) -> int:

--- a/tests/flow/test_broken_rdb.py
+++ b/tests/flow/test_broken_rdb.py
@@ -3,7 +3,7 @@ Test that verifies RDB load failure handling for corrupted/broken RDB files.
 This test creates various types of broken RDB files and ensures they fail to load properly.
 """
 
-from RLTest import Env
+from includes import Env
 from includes import *
 
 

--- a/tests/flow/test_ignore.py
+++ b/tests/flow/test_ignore.py
@@ -1,5 +1,5 @@
 
-from RLTest import Env
+from includes import Env
 from test_helper_classes import _get_ts_info
 from includes import *
 

--- a/tests/flow/test_lazy_del.py
+++ b/tests/flow/test_lazy_del.py
@@ -1,6 +1,6 @@
 import pytest
 import redis
-from RLTest import Env
+from includes import Env
 from test_helper_classes import TSInfo, ALLOWED_ERROR, _insert_data, _get_ts_info, \
     _insert_agg_data
 from includes import *

--- a/tests/flow/test_ooo.py
+++ b/tests/flow/test_ooo.py
@@ -2,7 +2,7 @@ import random
 
 import pytest
 import redis
-from RLTest import Env
+from includes import Env
 from test_helper_classes import _get_ts_info
 from includes import *
 

--- a/tests/flow/test_persistency.py
+++ b/tests/flow/test_persistency.py
@@ -1,4 +1,4 @@
-from RLTest import Env
+from includes import Env
 from test_helper_classes import ALLOWED_ERROR, _insert_data, _get_ts_info
 from includes import *
 

--- a/tests/flow/test_rdbs.py
+++ b/tests/flow/test_rdbs.py
@@ -1,6 +1,6 @@
 import os
 
-from RLTest import Env
+from includes import Env
 from create_test_rdb_file import load_into_redis
 from test_helper_classes import _get_ts_info, TSInfo
 from includes import *

--- a/tests/flow/test_short_read.py
+++ b/tests/flow/test_short_read.py
@@ -9,7 +9,7 @@ import subprocess
 import tempfile
 import zipfile
 from RLTest import Defaults
-from RLTest import Env
+from includes import Env
 import shutil
 import platform
 from test_helper_classes import SAMPLE_SIZE, _get_ts_info, TSInfo

--- a/tests/flow/test_ts_add.py
+++ b/tests/flow/test_ts_add.py
@@ -2,7 +2,7 @@ import time
 
 import pytest
 import redis
-from RLTest import Env
+from includes import Env
 from test_helper_classes import _get_ts_info, TSInfo
 from includes import *
 import random 

--- a/tests/flow/test_ts_bget.py
+++ b/tests/flow/test_ts_bget.py
@@ -668,22 +668,23 @@ def test_bget_del_wakes_parked_client():
     r = env.getConnection()
     _seed(r, "ts", [(100, "1.0")])
 
-    # 30s server-side timeout so a sub-second return is unambiguously the
-    # deletion wake, not a timeout flush.
-    t, slot = _start_bget(env, "ts", 0, 30_000, min_count=5)
+    # Server-side block timeout set to 2x the prompt-wake bound so a prompt
+    # return is unambiguously the deletion wake, not a timeout flush (both scale
+    # for Valgrind via WAKE_TIMEOUT_SECS).
+    t, slot = _start_bget(env, "ts", 0, WAKE_TIMEOUT_SECS * 2 * 1000, min_count=5)
     time.sleep(0.3)
     env.assertTrue(t.is_alive(), message="BGET should be parked waiting for more samples")
 
     t0 = time.time()
     assert r.execute_command("DEL", "ts") == 1
 
-    t.join(timeout=1.5)
+    t.join(timeout=WAKE_TIMEOUT_SECS)
     elapsed = time.time() - t0
     env.assertFalse(t.is_alive(),
                     message="DEL must wake the parked BGET client (took %.3fs)" % elapsed)
     env.assertEqual(slot["error"], None)
     env.assertEqual(slot["result"], [])
-    env.assertTrue(elapsed < 1.0,
+    env.assertTrue(elapsed < WAKE_TIMEOUT_SECS,
                    message="DEL wake must be immediate, took %.3fs" % elapsed)
 
 
@@ -695,20 +696,20 @@ def test_bget_unlink_wakes_parked_client():
     r = env.getConnection()
     _seed(r, "ts", [(100, "1.0")])
 
-    t, slot = _start_bget(env, "ts", 0, 30_000, min_count=5)
+    t, slot = _start_bget(env, "ts", 0, WAKE_TIMEOUT_SECS * 2 * 1000, min_count=5)
     time.sleep(0.3)
     env.assertTrue(t.is_alive(), message="BGET should be parked")
 
     t0 = time.time()
     assert r.execute_command("UNLINK", "ts") == 1
 
-    t.join(timeout=1.5)
+    t.join(timeout=WAKE_TIMEOUT_SECS)
     elapsed = time.time() - t0
     env.assertFalse(t.is_alive(),
                     message="UNLINK must wake the parked BGET client (took %.3fs)" % elapsed)
     env.assertEqual(slot["error"], None)
     env.assertEqual(slot["result"], [])
-    env.assertTrue(elapsed < 1.0,
+    env.assertTrue(elapsed < WAKE_TIMEOUT_SECS,
                    message="UNLINK wake must be immediate, took %.3fs" % elapsed)
 
 
@@ -720,20 +721,20 @@ def test_bget_flushall_wakes_parked_client():
     r = env.getConnection()
     _seed(r, "ts", [(100, "1.0")])
 
-    t, slot = _start_bget(env, "ts", 0, 30_000, min_count=5)
+    t, slot = _start_bget(env, "ts", 0, WAKE_TIMEOUT_SECS * 2 * 1000, min_count=5)
     time.sleep(0.3)
     env.assertTrue(t.is_alive(), message="BGET should be parked")
 
     t0 = time.time()
     r.execute_command("FLUSHALL")
 
-    t.join(timeout=1.5)
+    t.join(timeout=WAKE_TIMEOUT_SECS)
     elapsed = time.time() - t0
     env.assertFalse(t.is_alive(),
                     message="FLUSHALL must wake the parked BGET client (took %.3fs)" % elapsed)
     env.assertEqual(slot["error"], None)
     env.assertEqual(slot["result"], [])
-    env.assertTrue(elapsed < 1.0,
+    env.assertTrue(elapsed < WAKE_TIMEOUT_SECS,
                    message="FLUSHALL wake must be immediate, took %.3fs" % elapsed)
 
 
@@ -745,20 +746,20 @@ def test_bget_flushdb_wakes_parked_client():
     r = env.getConnection()
     _seed(r, "ts", [(100, "1.0")])
 
-    t, slot = _start_bget(env, "ts", 0, 30_000, min_count=5)
+    t, slot = _start_bget(env, "ts", 0, WAKE_TIMEOUT_SECS * 2 * 1000, min_count=5)
     time.sleep(0.3)
     env.assertTrue(t.is_alive(), message="BGET should be parked")
 
     t0 = time.time()
     r.execute_command("FLUSHDB")
 
-    t.join(timeout=1.5)
+    t.join(timeout=WAKE_TIMEOUT_SECS)
     elapsed = time.time() - t0
     env.assertFalse(t.is_alive(),
                     message="FLUSHDB must wake the parked BGET client (took %.3fs)" % elapsed)
     env.assertEqual(slot["error"], None)
     env.assertEqual(slot["result"], [])
-    env.assertTrue(elapsed < 1.0,
+    env.assertTrue(elapsed < WAKE_TIMEOUT_SECS,
                    message="FLUSHDB wake must be immediate, took %.3fs" % elapsed)
 
 
@@ -772,7 +773,7 @@ def test_bget_multiple_parked_clients_all_wake_on_del():
     r = env.getConnection()
     _seed(r, "ts", [(100, "1.0")])
 
-    workers = [_start_bget(env, "ts", 0, 30_000, min_count=5) for _ in range(4)]
+    workers = [_start_bget(env, "ts", 0, WAKE_TIMEOUT_SECS * 2 * 1000, min_count=5) for _ in range(4)]
     time.sleep(0.3)
     for t, _ in workers:
         env.assertTrue(t.is_alive(), message="each BGET should be parked")
@@ -780,7 +781,7 @@ def test_bget_multiple_parked_clients_all_wake_on_del():
     assert r.execute_command("DEL", "ts") == 1
 
     for t, slot in workers:
-        t.join(timeout=1.5)
+        t.join(timeout=WAKE_TIMEOUT_SECS)
         env.assertFalse(t.is_alive(),
                         message="every parked BGET must wake on DEL")
         env.assertEqual(slot["error"], None)

--- a/tests/flow/test_ts_create.py
+++ b/tests/flow/test_ts_create.py
@@ -3,7 +3,7 @@ import time
 
 import pytest
 import redis
-from RLTest import Env
+from includes import Env
 from test_helper_classes import SAMPLE_SIZE, _get_ts_info, TSInfo
 from includes import *
 

--- a/tests/flow/test_ts_createrule.py
+++ b/tests/flow/test_ts_createrule.py
@@ -4,7 +4,7 @@ import statistics
 
 import pytest
 import redis
-from RLTest import Env
+from includes import Env
 from test_helper_classes import _get_series_value, calc_rule, ALLOWED_ERROR, _insert_data, \
     _get_ts_info, _insert_agg_data
 from includes import *

--- a/tests/flow/test_ts_delete.py
+++ b/tests/flow/test_ts_delete.py
@@ -1,4 +1,4 @@
-from RLTest import Env
+from includes import Env
 import pytest
 import redis
 from test_helper_classes import _get_ts_info, TSInfo

--- a/tests/flow/test_ts_deleterule.py
+++ b/tests/flow/test_ts_deleterule.py
@@ -1,6 +1,6 @@
 import pytest
 import redis
-from RLTest import Env
+from includes import Env
 from test_helper_classes import _get_ts_info
 from includes import *
 

--- a/tests/flow/test_ts_keyspace.py
+++ b/tests/flow/test_ts_keyspace.py
@@ -1,6 +1,6 @@
 import time
 
-from RLTest import Env
+from includes import Env
 import time
 from includes import *
 

--- a/tests/flow/test_ts_libmr_failiure.py
+++ b/tests/flow/test_ts_libmr_failiure.py
@@ -21,7 +21,11 @@ def verifyClusterInitialized(env):
         except Exception:
             pass # in case we run on older version of redis
         allConnected = False
+        deadline = time.time() + HANG_TIMEOUT_SECS
         while not allConnected:
+            if time.time() > deadline:
+                print("[HANG-GUARD] verifyClusterInitialized exceeded %ss deadline" % HANG_TIMEOUT_SECS, flush=True)
+                raise RuntimeError("verifyClusterInitialized timed out after %ss" % HANG_TIMEOUT_SECS)
             res = conn.execute_command('timeseries.INFOCLUSTER')
             nodes = res[4]
             allConnected = True
@@ -115,14 +119,17 @@ def testLibmr_client_disconnect():
         for i in range(0,20):
             # expect a new connection to arrive
             cons.append(env.getConnection(random.randint(0, env.shardsCount - 1)))
-            threads.append(Thread(target=libmr_query, args=(cons[i], env, start_ts, samples_count)))
+            threads.append(Thread(target=libmr_query, args=(cons[i], env, start_ts, samples_count), daemon=True))
 
         for i in range(len(threads)):
             threads[i].start()
             cons[i].close()
 
-        # wait for processes to join
-        [th.join() for th in threads]
+        # wait for processes to join (bounded so a stuck worker can't hang CI)
+        for th in threads:
+            th.join(timeout=HANG_TIMEOUT_SECS)
+            if th.is_alive():
+                print("[HANG-GUARD] libmr_query worker still alive after %ss join timeout" % HANG_TIMEOUT_SECS, flush=True)
 
         # make sure we did not crash
         r.ping()
@@ -178,12 +185,12 @@ def test_libmr_topology_change_during_mrange():
             pass
 
     # 1. Block remote shard so it can't process internal commands
-    t_sleep = Thread(target=do_sleep_remote)
+    t_sleep = Thread(target=do_sleep_remote, daemon=True)
     t_sleep.start()
     time.sleep(0.3)
 
     # 2. Fire MRANGE — it will block waiting for the sleeping shard
-    t_mrange = Thread(target=do_mrange)
+    t_mrange = Thread(target=do_mrange, daemon=True)
     t_mrange.start()
     time.sleep(0.3)
 
@@ -193,8 +200,12 @@ def test_libmr_topology_change_during_mrange():
     except Exception:
         pass
 
-    t_mrange.join(timeout=30)
-    t_sleep.join(timeout=30)
+    t_mrange.join(timeout=HANG_TIMEOUT_SECS)
+    if t_mrange.is_alive():
+        print("[HANG-GUARD] do_mrange still alive after %ss join timeout" % HANG_TIMEOUT_SECS, flush=True)
+    t_sleep.join(timeout=HANG_TIMEOUT_SECS)
+    if t_sleep.is_alive():
+        print("[HANG-GUARD] do_sleep_remote still alive after %ss join timeout" % HANG_TIMEOUT_SECS, flush=True)
 
     env.assertEqual(
         mrange_error[0],

--- a/tests/flow/test_ts_libmr_failiure.py
+++ b/tests/flow/test_ts_libmr_failiure.py
@@ -21,11 +21,7 @@ def verifyClusterInitialized(env):
         except Exception:
             pass # in case we run on older version of redis
         allConnected = False
-        deadline = time.time() + HANG_TIMEOUT_SECS
         while not allConnected:
-            if time.time() > deadline:
-                print("[HANG-GUARD] verifyClusterInitialized exceeded %ss deadline" % HANG_TIMEOUT_SECS, flush=True)
-                raise RuntimeError("verifyClusterInitialized timed out after %ss" % HANG_TIMEOUT_SECS)
             res = conn.execute_command('timeseries.INFOCLUSTER')
             nodes = res[4]
             allConnected = True
@@ -119,17 +115,14 @@ def testLibmr_client_disconnect():
         for i in range(0,20):
             # expect a new connection to arrive
             cons.append(env.getConnection(random.randint(0, env.shardsCount - 1)))
-            threads.append(Thread(target=libmr_query, args=(cons[i], env, start_ts, samples_count), daemon=True))
+            threads.append(Thread(target=libmr_query, args=(cons[i], env, start_ts, samples_count)))
 
         for i in range(len(threads)):
             threads[i].start()
             cons[i].close()
 
-        # wait for processes to join (bounded so a stuck worker can't hang CI)
-        for th in threads:
-            th.join(timeout=HANG_TIMEOUT_SECS)
-            if th.is_alive():
-                print("[HANG-GUARD] libmr_query worker still alive after %ss join timeout" % HANG_TIMEOUT_SECS, flush=True)
+        # wait for processes to join
+        [th.join() for th in threads]
 
         # make sure we did not crash
         r.ping()
@@ -185,12 +178,12 @@ def test_libmr_topology_change_during_mrange():
             pass
 
     # 1. Block remote shard so it can't process internal commands
-    t_sleep = Thread(target=do_sleep_remote, daemon=True)
+    t_sleep = Thread(target=do_sleep_remote)
     t_sleep.start()
     time.sleep(0.3)
 
     # 2. Fire MRANGE — it will block waiting for the sleeping shard
-    t_mrange = Thread(target=do_mrange, daemon=True)
+    t_mrange = Thread(target=do_mrange)
     t_mrange.start()
     time.sleep(0.3)
 
@@ -200,12 +193,8 @@ def test_libmr_topology_change_during_mrange():
     except Exception:
         pass
 
-    t_mrange.join(timeout=HANG_TIMEOUT_SECS)
-    if t_mrange.is_alive():
-        print("[HANG-GUARD] do_mrange still alive after %ss join timeout" % HANG_TIMEOUT_SECS, flush=True)
-    t_sleep.join(timeout=HANG_TIMEOUT_SECS)
-    if t_sleep.is_alive():
-        print("[HANG-GUARD] do_sleep_remote still alive after %ss join timeout" % HANG_TIMEOUT_SECS, flush=True)
+    t_mrange.join(timeout=30)
+    t_sleep.join(timeout=30)
 
     env.assertEqual(
         mrange_error[0],

--- a/tests/flow/test_ts_madd.py
+++ b/tests/flow/test_ts_madd.py
@@ -2,7 +2,8 @@ import os
 import time
 import aof_parser
 
-from RLTest import Env, StandardEnv
+from includes import Env
+from RLTest import StandardEnv
 from includes import *
 
 

--- a/tests/flow/test_ts_madd.py
+++ b/tests/flow/test_ts_madd.py
@@ -134,8 +134,7 @@ def test_madd_some_failed_replicas():
         r.execute_command("ts.madd", "test_key3", -222, 11, "test_key1", 123, 11, "test_key1", 124, 12, "test_key1", 125, 12)
         r.execute_command("ts.madd", "test_key3", -222, "bbbbbbb", "test_key1", 123, 11, "test_key1", 124, 12, "test_key1", 125, 12)
 
-        _acked = r.execute_command("wait", 1, HANG_TIMEOUT_SECS * 1000)  # finite timeout so a missing replica ack can't block forever
-        print("[HANG-GUARD] WAIT for 1 replica returned acked=%s (timeout %ss)" % (_acked, HANG_TIMEOUT_SECS), flush=True)
+        r.execute_command("wait", 1, 0)
         env.assertEqual(r.execute_command("ts.range", "test_key1", "-", "+"), [[122, b'11'], [123, b'11'], [124, b'12'], [125, b'12']])
         assert r.execute_command("ts.range", "test_key4", "-", "+") == [[110, b'500.5']]
 

--- a/tests/flow/test_ts_madd.py
+++ b/tests/flow/test_ts_madd.py
@@ -134,7 +134,8 @@ def test_madd_some_failed_replicas():
         r.execute_command("ts.madd", "test_key3", -222, 11, "test_key1", 123, 11, "test_key1", 124, 12, "test_key1", 125, 12)
         r.execute_command("ts.madd", "test_key3", -222, "bbbbbbb", "test_key1", 123, 11, "test_key1", 124, 12, "test_key1", 125, 12)
 
-        r.execute_command("wait", 1, 0)
+        _acked = r.execute_command("wait", 1, HANG_TIMEOUT_SECS * 1000)  # finite timeout so a missing replica ack can't block forever
+        print("[HANG-GUARD] WAIT for 1 replica returned acked=%s (timeout %ss)" % (_acked, HANG_TIMEOUT_SECS), flush=True)
         env.assertEqual(r.execute_command("ts.range", "test_key1", "-", "+"), [[122, b'11'], [123, b'11'], [124, b'12'], [125, b'12']])
         assert r.execute_command("ts.range", "test_key4", "-", "+") == [[110, b'500.5']]
 

--- a/tests/flow/test_ts_range_empty_filter_stress.py
+++ b/tests/flow/test_ts_range_empty_filter_stress.py
@@ -16,7 +16,14 @@
 import math
 import random
 
-from RLTest import Env
+# Use the includes Env wrapper (NOT `from RLTest import Env`). RLTest's raw Env
+# constructor assigns terminateRetries directly with no Defaults fallback, so a
+# raw Env gets terminateRetries=None -> _stopProcess() takes the unbounded
+# "send one SIGTERM, then wait forever" branch. If a replica is slow to exit on
+# shutdown, env teardown then hangs until the per-test timeout (~30 min) and the
+# job fails. The includes wrapper passes terminateRetries=20, so teardown
+# escalates to SIGKILL after ~20s instead of hanging.
+from includes import Env
 
 NON_TWA_AGGS = ['avg', 'sum', 'min', 'max', 'range', 'count', 'countAll',
                 'first', 'last', 'std.p', 'std.s', 'var.p', 'var.s']

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -186,6 +186,21 @@ setup_rltest() {
 		RLTEST_ARGS+=" -i"
 	fi
 	RLTEST_ARGS+=" --enable-debug-command --enable-protected-configs"
+
+	# Per-test wall-clock timeout: RLTest fails any test that runs longer than
+	# this, printing the stuck thread's traceback, instead of letting a hung or
+	# pathologically-slow test run into the multi-hour CI job timeout. It's a
+	# catch-all (deadlock, infinite loop, thread block, runaway-slow test).
+	# Valgrind/sanitizer are far slower, so scale the limit way up there.
+	# Override with TEST_TIMEOUT=<seconds> (0 disables).
+	if [[ -z $TEST_TIMEOUT ]]; then
+		if [[ $VG == 1 || -n $SAN ]]; then
+			TEST_TIMEOUT=1800
+		else
+			TEST_TIMEOUT=300
+		fi
+	fi
+	RLTEST_ARGS+=" --test-timeout $TEST_TIMEOUT"
 }
 
 #----------------------------------------------------------------------------------------------

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -197,7 +197,7 @@ setup_rltest() {
 		if [[ $VG == 1 || -n $SAN ]]; then
 			TEST_TIMEOUT=1800
 		else
-			TEST_TIMEOUT=300
+			TEST_TIMEOUT=600
 		fi
 	fi
 	RLTEST_ARGS+=" --test-timeout $TEST_TIMEOUT"

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -197,7 +197,7 @@ setup_rltest() {
 		if [[ $VG == 1 || -n $SAN ]]; then
 			TEST_TIMEOUT=1800
 		else
-			TEST_TIMEOUT=600
+			TEST_TIMEOUT=1800
 		fi
 	fi
 	RLTEST_ARGS+=" --test-timeout $TEST_TIMEOUT"

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -191,12 +191,17 @@ setup_rltest() {
 	# this, printing the stuck thread's traceback, instead of letting a hung or
 	# pathologically-slow test run into the multi-hour CI job timeout. It's a
 	# catch-all (deadlock, infinite loop, thread block, runaway-slow test).
-	# Valgrind/sanitizer are far slower, so scale the limit way up there.
 	# Override with TEST_TIMEOUT=<seconds> (0 disables).
 	if [[ -z $TEST_TIMEOUT ]]; then
-		if [[ $VG == 1 || -n $SAN ]]; then
-			TEST_TIMEOUT=1800
+		if [[ $VG == 1 ]]; then
+			# Valgrind is ~20-30x slower. The exhaustive test_max_extensive issues
+			# ~1.6M ops and takes roughly an hour under Valgrind, so give a large
+			# ceiling that lets it complete instead of tripping the timeout, while
+			# still bounding a genuine hang far below the CI job limit.
+			TEST_TIMEOUT=10800
 		else
+			# normal + sanitizer (sanitizer is far less slow than Valgrind, and was
+			# already completing within this limit).
 			TEST_TIMEOUT=1800
 		fi
 	fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to test infrastructure and timeouts; no production module or runtime behavior is modified.
> 
> **Overview**
> Addresses **CI hangs** by tightening how flow tests start/stop Redis and how long they may run.
> 
> **Test harness:** Flow tests that imported `Env` from RLTest directly now use **`includes.Env`**, which always passes `terminateRetries=20` so slow teardown (Valgrind/sanitizer/replicas) escalates to SIGKILL instead of waiting indefinitely. `common.py` follows the same import split (`Env` from `includes`, `Defaults` from RLTest).
> 
> **RLTest runner:** `tests.sh` passes **`--test-timeout`** (default 1800s; 10800s under Valgrind, overridable via `TEST_TIMEOUT`) so stuck tests fail with a traceback instead of burning the full job timeout.
> 
> **BGET wake tests:** `includes.py` adds **`WAKE_TIMEOUT_SECS`** (5s normally, 30s under Valgrind/sanitizer). `test_ts_bget.py` deletion/flush wake cases use it for `thread.join` and elapsed assertions, and set server block timeout to `2 × WAKE_TIMEOUT_SECS` so slow instrumented runs do not flake.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e81b9ff713f36e9a35d3e63eccd40ef7c7ca14e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->