### PR TITLE
MOD-6409 - TS.INFO memoryUsage (and MEMORY USAGE, via the mem_usage callback)

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -303,6 +303,12 @@ int IsKeyIndexed(RedisModuleString *ts_key) {
 //
 // Dict sizes come from RedisModule_MallocSizeDict(), which is itself an approximation,
 // so the result is an estimate.
+//
+// Note: the per-key number is not static — it shifts as other keys with the same
+// label are added or removed, because entries (the denominator) changes. This is
+// intentional: the 1/N slice keeps the sum-over-all-keys invariant correct, which
+// is what matters for capacity estimates. Individual MEMORY USAGE calls on a live
+// system will show small fluctuations as the keyspace changes.
 size_t IndexMemUsage(RedisModuleString *ts_key) {
     if (ts_key == NULL) {
         return 0;

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -287,6 +287,52 @@ int IsKeyIndexed(RedisModuleString *ts_key) {
     return !nokey;
 }
 
+// Estimates the label-index memory attributable to a single time series (MOD-6409 #6).
+//
+// The index is global module state rather than part of the value object, but the
+// ticket lists it as a memUsage() fix, so it is summed into SeriesMemUsage() and thus
+// reported by both TS.INFO and MEMORY USAGE. Apportioning the shared leaves by 1/N
+// keeps the property that summing over all keys counts the index exactly once.
+//
+// Two contributions are summed:
+//   1. The inverse-index dict (tsLabelIndex[ts_key]), which is owned exclusively by
+//      this key, is counted in full.
+//   2. Each shared leaf dict in labelsIndex (one per "label=value" / "label" the key
+//      indexes) is shared by every key carrying that same label, so only this key's
+//      per-entry slice (size / entry-count) is attributed to it.
+//
+// Dict sizes come from RedisModule_MallocSizeDict(), which is itself an approximation,
+// so the result is an estimate.
+size_t IndexMemUsage(RedisModuleString *ts_key) {
+    if (ts_key == NULL) {
+        return 0;
+    }
+    int nokey = 0;
+    RedisModuleDict *ts_leaf = RedisModule_DictGet(tsLabelIndex, ts_key, &nokey);
+    if (nokey) { // series has no labels or is not indexed
+        return 0;
+    }
+
+    size_t total = RedisModule_MallocSizeDict(ts_leaf);
+
+    RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(ts_leaf, "^", NULL, 0);
+    RedisModuleString *labelKey;
+    while ((labelKey = RedisModule_DictNext(NULL, iter, NULL)) != NULL) {
+        int leaf_nokey = 0;
+        RedisModuleDict *leaf = RedisModule_DictGet(labelsIndex, labelKey, &leaf_nokey);
+        if (!leaf_nokey && leaf != NULL) {
+            const uint64_t entries = RedisModule_DictSize(leaf);
+            if (entries > 0) {
+                total += RedisModule_MallocSizeDict(leaf) / entries;
+            }
+        }
+        RedisModule_FreeString(NULL, labelKey);
+    }
+    RedisModule_DictIteratorStop(iter);
+
+    return total;
+}
+
 static uint64_t _calc_dicts_total_size(RedisModuleDict **dicts, size_t dict_size) {
     uint64_t total_size = 0;
     for (size_t i = 0; i < dict_size; i++) {

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -68,6 +68,7 @@ void RemoveAllIndexedMetrics();
 void RemoveAllIndexedMetrics_generic(RedisModuleDict *_labelsIndex,
                                      RedisModuleDict **_tsLabelIndex);
 int IsKeyIndexed(RedisModuleString *ts_key);
+size_t IndexMemUsage(RedisModuleString *ts_key);
 RedisModuleDict *QueryIndex(RedisModuleCtx *ctx,
                             QueryPredicate *index_predicate,
                             size_t predicate_count,

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -560,8 +560,9 @@ const char *SeriesGetCStringLabelValue(const Series *series, const char *labelKe
 
 size_t SeriesMemUsage(const void *value) {
     const Series *series = (const Series *)value;
-    return RedisModule_MallocSize((void *)series) + SeriesRulesSize(series) +
-           SeriesLabelsSize(series) + SeriesChunksSize(series);
+    size_t keyNameSize = series->keyName ? RedisModule_MallocSizeString(series->keyName) : 0;
+    return RedisModule_MallocSize((void *)series) + keyNameSize + SeriesRulesSize(series) +
+           SeriesLabelsSize(series) + SeriesChunksSize(series) + IndexMemUsage(series->keyName);
 }
 
 size_t SeriesGetNumSamples(const Series *series) {

--- a/tests/flow/test_ts_info_memory.py
+++ b/tests/flow/test_ts_info_memory.py
@@ -1,0 +1,63 @@
+from includes import *
+from test_helper_classes import _get_ts_info
+
+
+# Regression tests for TS.INFO memoryUsage (and MEMORY USAGE via the mem_usage
+# callback) under-reporting per-key memory.
+#
+# SeriesMemUsage() used to omit:
+#   - the series key name string (Series.keyName)
+#   - the series' share of the global label->series index (IndexMemUsage)
+# As a result TS.INFO reported less memory than the key actually consumes,
+# which skews capacity estimates (size one series, multiply by key count).
+
+
+def test_memory_usage_accounts_for_key_name():
+    # Two series identical except for key-name length: the longer key name
+    # must be reflected in the reported memory.
+    with Env().getClusterConnectionIfNeeded() as r:
+        r.flushall()
+        short_key = '{mem}s'
+        long_key = '{mem}' + ('k' * 512)
+        r.execute_command('TS.CREATE', short_key)
+        r.execute_command('TS.CREATE', long_key)
+
+        short_mem = _get_ts_info(r, short_key).memory_usage
+        long_mem = _get_ts_info(r, long_key).memory_usage
+
+        assert long_mem > short_mem
+        assert long_mem - short_mem >= 256
+
+
+def test_memory_usage_accounts_for_label_index():
+    # A labeled series occupies space in the global label->series index, which
+    # is now attributed back to the key. A labeled series must therefore report
+    # more memory than an otherwise identical unlabeled one.
+    with Env().getClusterConnectionIfNeeded() as r:
+        r.flushall()
+        plain_key = '{idx}plain'
+        labeled_key = '{idx}labeled'
+        r.execute_command('TS.CREATE', plain_key)
+        r.execute_command('TS.CREATE', labeled_key,
+                          'LABELS', 'sensor_id', '1234', 'area_id', '4567')
+
+        plain_mem = _get_ts_info(r, plain_key).memory_usage
+        labeled_mem = _get_ts_info(r, labeled_key).memory_usage
+
+        assert labeled_mem > plain_mem
+
+
+def test_memory_usage_grows_with_more_indexed_labels():
+    # More indexed labels => larger index contribution attributed to the key.
+    with Env().getClusterConnectionIfNeeded() as r:
+        r.flushall()
+        one_label = '{grow}one'
+        many_labels = '{grow}many'
+        r.execute_command('TS.CREATE', one_label, 'LABELS', 'a', '1')
+        r.execute_command('TS.CREATE', many_labels,
+                          'LABELS', 'a', '1', 'b', '2', 'c', '3', 'd', '4')
+
+        one_mem = _get_ts_info(r, one_label).memory_usage
+        many_mem = _get_ts_info(r, many_labels).memory_usage
+
+        assert many_mem > one_mem


### PR DESCRIPTION
under-reported per-key memory, leading to wrong capacity estimates when prospects size one series and multiply by the planned key count.

Resolves the two remaining items of MOD-6409:

- #7 key name: count series->keyName, a value-owned RedisModuleString allocation that was never included.

- #6 label index: add IndexMemUsage(), which estimates a series' share of the global label index — the per-key inverse-index dict (tsLabelIndex) in full, plus a 1/N slice of each shared labelsIndex leaf. Apportioning shared leaves by entry count keeps the property that summing over all keys counts the index exactly once. Dict sizes use MallocSizeDict, so the figure is an estimate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Accounting-only change to memory reporting; no write path, query, or indexing behavior changes beyond what TS.INFO/MEMORY USAGE return.
> 
> **Overview**
> Fixes **under-reported** per-key memory in `TS.INFO` `memoryUsage` and Redis `MEMORY USAGE` (via the `mem_usage` callback), which skewed capacity planning when sizing one series and scaling by key count.
> 
> **`SeriesMemUsage()`** now adds the **`series->keyName`** string allocation and **`IndexMemUsage(series->keyName)`**, which estimates each series’ share of the global label index: the full per-key inverse dict in `tsLabelIndex`, plus a **1/N** slice of each shared `labelsIndex` leaf (dict size ÷ entry count) so summing across keys accounts for the index once.
> 
> New flow tests assert longer key names increase reported memory, labeled series report more than unlabeled ones, and more labels increase the attributed index footprint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0085c87434b88a71e20924a6fd0a998ecc7dd5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->