### PR TITLE
ci: add code coverage to CI — PR + nightly (lcov -> Codecov)

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -100,3 +100,16 @@ jobs:
       quick: false
       run_sanitizer: true
     secrets: inherit
+  # Code coverage (instrumented build + lcov -> Codecov). Runs on PRs too, so
+  # Codecov posts a per-PR diff-coverage comment. Skipped on draft PRs; toggle
+  # off via the repo variable ENABLE_CODE_COVERAGE='false'. Uploads require the
+  # CODECOV_TOKEN repo secret.
+  coverage:
+    if: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && !github.event.pull_request.draft }}
+    uses: ./.github/workflows/flow-coverage.yml
+    needs: [prepare-values]
+    with:
+      redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      test-config: QUICK=1
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -156,6 +156,19 @@ jobs:
       quick: false
     secrets: inherit
 
+  coverage:
+    # Code coverage: instrumented build (COV=1 -> gcov) + tests -> lcov -> Codecov.
+    # Toggle off via the repo variable ENABLE_CODE_COVERAGE='false'. Uploads
+    # require the CODECOV_TOKEN repo secret.
+    if: ${{ vars.ENABLE_CODE_COVERAGE != 'false' }}
+    uses: ./.github/workflows/flow-coverage.yml
+    needs: [prepare-values]
+    with:
+      redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      test-config: QUICK=1
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   notify-results:
     name: Aggregate Results & Notify
     runs-on: ubuntu-latest

--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -1,0 +1,123 @@
+name: Flow Coverage
+# Builds the module instrumented for coverage (COV=1 -> gcov), runs the flow +
+# unit tests, collects an lcov report (bin/<platform>/cov.info) and uploads it
+# to Codecov. Intended for the nightly; coverage is a slow instrumented build so
+# it is not run on the PR gate.
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      redis-ref:
+        description: 'Redis ref to checkout (empty -> pack/ramp.yml default)'
+        type: string
+        required: false
+        default: ''
+      test-config:
+        description: 'Topology selection for the coverage run (default QUICK=1 -> GEN only)'
+        type: string
+        required: false
+        default: 'QUICK=1'
+  workflow_call:
+    inputs:
+      redis-ref:
+        description: 'Redis ref to checkout'
+        type: string
+        required: true
+      test-config:
+        description: 'Topology selection for the coverage run (default QUICK=1 -> GEN only)'
+        type: string
+        required: false
+        default: 'QUICK=1'
+    secrets:
+      CODECOV_TOKEN:
+        description: 'Codecov upload token (repo secret)'
+        required: false
+
+jobs:
+  coverage:
+    name: coverage (jammy, x64)
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_IMAGE: redistimeseries-jammy-cov:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: 'recursive'
+
+      - name: Resolve redis-ref
+        id: redis
+        env:
+          INPUT_REDIS_REF: ${{ inputs.redis-ref }}
+        run: |
+          REF="$INPUT_REDIS_REF"
+          [ -z "$REF" ] && REF="$(.install/get-redis-ref.sh)"
+          echo "ref=$REF" >> $GITHUB_OUTPUT
+
+      - name: Build Docker Image
+        env:
+          REDIS_REF: ${{ steps.redis.outputs.ref }}
+        run: |
+          docker build -f Dockerfile.jammy --build-arg REDIS_REF="$REDIS_REF" -t "$DOCKER_IMAGE" .
+
+      - name: Run coverage
+        env:
+          TEST_CONFIG: ${{ inputs.test-config }}
+        run: |
+          # `make coverage COV=1` = build COV=1 (instrumented debug) + reset
+          # counters + run tests COV=1 + lcov collect -> bin/<platform>/cov.info.
+          # COV=1 must be set at the top level: the lcov reset/collect macros in
+          # readies/mk/coverage.defs are guarded by `ifeq ($(COV),1)`, so without
+          # it the build is instrumented but no report is produced. The test step
+          # is prefixed with `-` in the Makefile, so the report is still produced
+          # even if some tests fail.
+          docker run --rm \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace \
+            --cap-add=SYS_PTRACE \
+            --security-opt seccomp=unconfined \
+            "$DOCKER_IMAGE" \
+            bash -c "make coverage COV=1 ${TEST_CONFIG} 2>&1 | tee /workspace/coverage_output.log; exit \${PIPESTATUS[0]}"
+
+      - name: Fix permissions
+        if: always()
+        run: |
+          sudo chown -R "$(id -u)":"$(id -g)" bin tests || true
+
+      - name: Locate coverage report
+        id: cov
+        if: always()
+        run: |
+          f="$(find bin -name cov.info 2>/dev/null | head -1)"
+          echo "file=$f" >> $GITHUB_OUTPUT
+          if [ -n "$f" ]; then
+            echo "Found coverage report: $f"
+            lcov --summary "$f" 2>/dev/null || true
+          else
+            echo "::warning::No cov.info produced by 'make coverage'"
+          fi
+
+      - name: Upload coverage to Codecov
+        if: ${{ always() && steps.cov.outputs.file != '' }}
+        uses: codecov/codecov-action@v5
+        with:
+          files: ${{ steps.cov.outputs.file }}
+          disable_search: true
+          flags: flow
+          # Keep nightly green if the upload hiccups / token is not yet set; flip
+          # to true once CODECOV_TOKEN is confirmed in the repo secrets.
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload coverage artifact
+        if: ${{ always() && steps.cov.outputs.file != '' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-report
+          path: |
+            ${{ steps.cov.outputs.file }}
+            coverage_output.log

--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -48,6 +48,9 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: 'recursive'
+          # Full history so Codecov can resolve the PR base for accurate
+          # diff-coverage (the per-PR comment).
+          fetch-depth: 0
 
       - name: Resolve redis-ref
         id: redis


### PR DESCRIPTION
## What

Wire code coverage into CI — on **PRs and the nightly** (like RedisJSON), so Codecov posts a per-PR **diff-coverage comment**. The repo already had the plumbing (`make coverage`, `COV=1` → gcov, `codecov.yml`, `lcov` in the build image, Codecov badge) but no workflow ran it.

- **New reusable `flow-coverage.yml`**: builds the `jammy` image, runs `make coverage COV=1 QUICK=1` (instrumented debug build + GEN tests + `lcov` collect → `bin/<platform>/cov.info`), uploads to Codecov via `codecov/codecov-action@v5`, and keeps a `cov.info` artifact. Checks out with `fetch-depth: 0` so Codecov can resolve the PR base for accurate diff coverage.
- **`event-ci.yml`**: a `coverage` job on every PR (skips draft PRs), so the Codecov diff comment shows on the PR.
- **`event-nightly.yml`**: the same `coverage` job for trend/whole-tree coverage.
- Both gated by the repo variable `ENABLE_CODE_COVERAGE` (defaults on; set `'false'` to disable everywhere).

## Notes

- `COV=1` is passed at the **top level** deliberately: the lcov reset/collect macros in `deps/readies/mk/coverage.defs` are guarded by `ifeq ($(COV),1)`, so without it the build is instrumented but no report is collected. (RedisJSON's Makefile implies COV from the target; RTS's does not.)
- Coverage uses `QUICK=1` (GEN topology) to keep the instrumented run reasonable; it runs in parallel with the other PR jobs.
- `CODECOV_TOKEN` is passed **explicitly** to the reusable workflow (not `secrets: inherit`).
- `fail_ci_if_error: false` for now so a missing token / transient Codecov hiccup doesn't fail PRs; flip to `true` once the token is confirmed.

## ⚠️ Repo config required for the Codecov comment to appear

1. **`CODECOV_TOKEN`** repo secret — required for the upload + PR comment (project is already on codecov.io per the README badge).
2. **`ENABLE_CODE_COVERAGE`** repo variable — optional; coverage runs unless this is `'false'`.

## Validation

The coverage job runs on this PR's own CI (`coverage / coverage (jammy, x64)`), validating the instrumented build → `lcov` → `cov.info` path end-to-end. The Codecov diff comment will appear once `CODECOV_TOKEN` is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions wiring around existing `make coverage`; no application or security logic is modified.
> 
> **Overview**
> Adds **instrumented coverage** to CI by introducing a reusable **`flow-coverage.yml`** workflow and calling it from **PR** (`event-ci.yml`) and **nightly** (`event-nightly.yml`) pipelines.
> 
> The new flow builds the jammy Docker image, runs **`make coverage COV=1`** with **`QUICK=1`** (GEN topology), collects **`cov.info`**, uploads to **Codecov** (`codecov-action@v5`, `fail_ci_if_error: false`), and stores a coverage artifact. Checkout uses **`fetch-depth: 0`** so Codecov can compute PR diff coverage. Jobs are gated by **`ENABLE_CODE_COVERAGE`** (off when set to `'false'`); PR coverage skips **draft** PRs and passes **`CODECOV_TOKEN`** explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9906596ad31437d2611ce9632d44812379b4b52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->