### PR TITLE
MOD-16172 - support exclude empty in mrange commands

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -1188,6 +1188,13 @@
                         "name": "reducer"
                     }
                 ]
+            },
+            {
+                "name": "excludeempty",
+                "type": "pure-token",
+                "token": "EXCLUDEEMPTY",
+                "optional": true,
+                "since": "8.10.0"
             }
         ],
         "since": "1.0.0",
@@ -1365,6 +1372,13 @@
                         "name": "reducer"
                     }
                 ]
+            },
+            {
+                "name": "excludeempty",
+                "type": "pure-token",
+                "token": "EXCLUDEEMPTY",
+                "optional": true,
+                "since": "8.10.0"
             }
         ],
         "group": "timeseries"

--- a/src/cmd_info/ts_info.c
+++ b/src/cmd_info/ts_info.c
@@ -1454,6 +1454,11 @@ static const RedisModuleCommandArg TS_MRANGE_ARGS[] = {
                 .type = REDISMODULE_ARG_TYPE_ONEOF,
                 .subargs = (RedisModuleCommandArg *)AGGREGATOR_OPTIONS },
               { 0 } } },
+    { .name = "EXCLUDEEMPTY",
+      .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+      .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+      .token = "EXCLUDEEMPTY",
+      .since = "8.10.0" },
     { 0 }
 };
 
@@ -1597,6 +1602,11 @@ static const RedisModuleCommandArg TS_MREVRANGE_ARGS[] = {
                 .type = REDISMODULE_ARG_TYPE_ONEOF,
                 .subargs = (RedisModuleCommandArg *)AGGREGATOR_OPTIONS },
               { 0 } } },
+    { .name = "EXCLUDEEMPTY",
+      .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+      .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+      .token = "EXCLUDEEMPTY",
+      .since = "8.10.0" },
     { 0 }
 };
 

--- a/src/libmr_commands.c
+++ b/src/libmr_commands.c
@@ -226,7 +226,9 @@ static void mrange_done_internal(ExecutionCtx *eCtx, RedisModuleCtx *ctx, MRange
                                     args->numLimitLabels,
                                     replyArgs,
                                     args->reverse,
-                                    false);
+                                    false,
+                                    NULL,
+                                    NULL);
             }
         }
     });
@@ -308,9 +310,13 @@ static void mrange_done_gears(ExecutionCtx *eCtx, RedisModuleCtx *ctx, MRangeDat
             Series *s = SeriesRecord_IntoSeries((SeriesRecord *)raw_record);
             tempSeries = array_append(tempSeries, s);
 
-            if (data->args.excludeEmpty &&
-                !SeriesHasSamplesInRange(s, &data->args.rangeArgs, data->args.reverse)) {
-                continue;
+            EnrichedChunk *first_chunk = NULL;
+            AbstractIterator *probe = NULL;
+            if (data->args.excludeEmpty) {
+                probe = SeriesQueryIfNonEmpty(
+                    s, &data->args.rangeArgs, data->args.reverse, &first_chunk);
+                if (!probe)
+                    continue;
             }
 
             if (data->args.groupByLabel) {
@@ -323,7 +329,9 @@ static void mrange_done_gears(ExecutionCtx *eCtx, RedisModuleCtx *ctx, MRangeDat
                                     data->args.numLimitLabels,
                                     &data->args.rangeArgs,
                                     data->args.reverse,
-                                    false);
+                                    false,
+                                    probe,
+                                    first_chunk);
             }
         }
     }

--- a/src/libmr_commands.c
+++ b/src/libmr_commands.c
@@ -275,20 +275,12 @@ static void mrange_done_gears(ExecutionCtx *eCtx, RedisModuleCtx *ctx, MRangeDat
         resultset = ResultSet_Create();
         ResultSet_GroupbyLabel(resultset, data->args.groupByLabel);
     } else {
-        size_t total_len = 0;
-        for (int i = 0; i < len; i++) {
-            Record *raw_listRecord = MR_ExecutionCtxGetResult(eCtx, i);
-            if (raw_listRecord->recordType != GetListRecordType()) {
-                RedisModule_Log(ctx,
-                                "warning",
-                                "Unexpected record type: %s",
-                                raw_listRecord->recordType->type.type);
-                continue;
-            }
-            total_len += ListRecord_GetLen((ListRecord *)raw_listRecord);
-        }
-        ReplyWithMapOrArray(ctx, total_len, false);
+        // ponytail: postponed length — EXCLUDEEMPTY may skip series, so the real
+        // count is only known after emission (see ReplySetMapOrArrayLength below).
+        ReplyWithMapOrArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN, false);
     }
+
+    long long replylen = 0;
 
     Series **tempSeries = array_new(Record *, len); // calloc(len, sizeof(Series *));
     for (int i = 0; i < len; i++) {
@@ -332,8 +324,13 @@ static void mrange_done_gears(ExecutionCtx *eCtx, RedisModuleCtx *ctx, MRangeDat
                                     false,
                                     probe,
                                     first_chunk);
+                replylen++;
             }
         }
+    }
+
+    if (!data->args.groupByLabel) {
+        ReplySetMapOrArrayLength(ctx, replylen, false);
     }
 
     if (data->args.groupByLabel) {

--- a/src/libmr_commands.c
+++ b/src/libmr_commands.c
@@ -630,6 +630,7 @@ int TSDB_mrange_MR(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool
     }
 
     queryArg->userName = CopyCurrentUserName(ctx);
+    queryArg->excludeEmpty = args.excludeEmpty;
     // Always send FILTERBY to shards; they apply it regardless of aggregation.
     queryArg->filterByValueArgs = args.rangeArgs.filterByValueArgs;
     queryArg->filterByTSArgs = args.rangeArgs.filterByTSArgs;

--- a/src/libmr_commands.c
+++ b/src/libmr_commands.c
@@ -308,6 +308,11 @@ static void mrange_done_gears(ExecutionCtx *eCtx, RedisModuleCtx *ctx, MRangeDat
             Series *s = SeriesRecord_IntoSeries((SeriesRecord *)raw_record);
             tempSeries = array_append(tempSeries, s);
 
+            if (data->args.excludeEmpty &&
+                !SeriesHasSamplesInRange(s, &data->args.rangeArgs, data->args.reverse)) {
+                continue;
+            }
+
             if (data->args.groupByLabel) {
                 ResultSet_AddSeries(resultset, s, RedisModule_StringPtrLen(s->keyName, NULL));
             } else {

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -221,6 +221,7 @@ static void QueryPredicates_ArgSerialize(WriteSerializationCtx *sctx, void *arg,
             MR_SerializationCtxWriteLongLong(sctx, predicate_list->filterByTSArgs.values[i], error);
         }
     }
+    MR_SerializationCtxWriteLongLong(sctx, predicate_list->excludeEmpty, error);
 }
 
 static void SerializationCtxWriteRedisString(WriteSerializationCtx *sctx,
@@ -356,6 +357,7 @@ static void *QueryPredicates_ArgDeserialize_impl(ReaderSerializationCtx *sctx,
             predicates->filterByTSArgs.values[i] = MR_SerializationCtxReadLongLong(sctx, error);
         }
     }
+    predicates->excludeEmpty = MR_SerializationCtxReadLongLong(sctx, error);
 
     if (unlikely(expect_resp && *error)) {
         goto err;
@@ -846,6 +848,7 @@ static void TS_INTERNAL_MRANGE_impl(RedisModuleCtx *ctx, void *args) {
     mrangeArgs.groupByReducerArgs.aggregationClass = NULL;
     mrangeArgs.groupByReducerArgs.agg_type = TS_AGG_NONE;
     mrangeArgs.reverse = false;
+    mrangeArgs.excludeEmpty = queryArg->excludeEmpty;
 
     AggregationClass *aggClasses[TS_AGG_TYPES_MAX] = { 0 };
     if (queryArg->numAggClasses > 0) {

--- a/src/libmr_integration.h
+++ b/src/libmr_integration.h
@@ -41,6 +41,7 @@ typedef struct QueryPredicates_Arg
     timestamp_t timestampAlignment;
     FilterByValueArgs filterByValueArgs;
     FilterByTSArgs filterByTSArgs;
+    bool excludeEmpty;
 } QueryPredicates_Arg;
 
 typedef struct StringRecord

--- a/src/module.c
+++ b/src/module.c
@@ -463,6 +463,12 @@ int replyUngroupedMultiRange(RedisModuleCtx *ctx, RedisModuleDict *result, const
             continue;
         }
 
+        if (args->excludeEmpty &&
+            !SeriesHasSamplesInRange(series, &args->rangeArgs, args->reverse)) {
+            RedisModule_CloseKey(key);
+            RedisModule_FreeString(ctx, currentKey);
+            continue;
+        }
         ReplySeriesArrayPos(ctx,
                             series,
                             args->withLabels,

--- a/src/module.c
+++ b/src/module.c
@@ -463,11 +463,15 @@ int replyUngroupedMultiRange(RedisModuleCtx *ctx, RedisModuleDict *result, const
             continue;
         }
 
-        if (args->excludeEmpty &&
-            !SeriesHasSamplesInRange(series, &args->rangeArgs, args->reverse)) {
-            RedisModule_CloseKey(key);
-            RedisModule_FreeString(ctx, currentKey);
-            continue;
+        EnrichedChunk *first_chunk = NULL;
+        AbstractIterator *probe = NULL;
+        if (args->excludeEmpty) {
+            probe = SeriesQueryIfNonEmpty(series, &args->rangeArgs, args->reverse, &first_chunk);
+            if (!probe) {
+                RedisModule_CloseKey(key);
+                RedisModule_FreeString(ctx, currentKey);
+                continue;
+            }
         }
         ReplySeriesArrayPos(ctx,
                             series,
@@ -476,7 +480,9 @@ int replyUngroupedMultiRange(RedisModuleCtx *ctx, RedisModuleDict *result, const
                             args->numLimitLabels,
                             &args->rangeArgs,
                             args->reverse,
-                            false);
+                            false,
+                            probe,
+                            first_chunk);
         replylen++;
         RedisModule_CloseKey(key);
         RedisModule_FreeString(ctx, currentKey);

--- a/src/query_language.c
+++ b/src/query_language.c
@@ -19,6 +19,9 @@
 #define stringify2(x) #x
 
 #define QUERY_TOKEN_SIZE 10
+
+// Offset of the GROUPBY label token relative to the GROUPBY keyword position.
+#define GROUPBY_LABEL_OFFSET 1
 static const char *QUERY_TOKENS[] = {
     "WITHLABELS", "AGGREGATION",     "LIMIT",        "GROUPBY", "REDUCE",
     "FILTER",     "FILTER_BY_VALUE", "FILTER_BY_TS", "COUNT",   "EXCLUDEEMPTY",
@@ -968,6 +971,8 @@ int parseMRangeCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, 
     }
 
     const int groupby_location = RMUtil_ArgIndex("GROUPBY", argv, argc);
+    // The GROUPBY label is the token immediately following the GROUPBY keyword.
+    const int groupby_label_location = groupby_location + GROUPBY_LABEL_OFFSET;
 
     if (groupby_location > 0 && groupby_location < filter_location) {
         RTS_ReplyGeneralError(ctx, "TSDB: GROUPBY should always come after filter");
@@ -990,15 +995,24 @@ int parseMRangeCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, 
     }
     args.queryPredicates = queries;
 
-    args.excludeEmpty = RMUtil_ArgIndex("EXCLUDEEMPTY", argv, argc) > 0;
+    const int excludeEmptyPos = RMUtil_ArgIndex("EXCLUDEEMPTY", argv, argc);
+    // ponytail: ignore a GROUPBY label literally named EXCLUDEEMPTY (the only
+    // unconstrained token slot); otherwise it falsely trips the guard below.
+    args.excludeEmpty =
+        excludeEmptyPos > 0 && !(groupby_location > 0 && excludeEmptyPos == groupby_label_location);
+
+    if (args.excludeEmpty && groupby_location > 0) {
+        RTS_ReplyGeneralError(ctx, "TSDB: EXCLUDEEMPTY is not allowed with GROUPBY");
+        goto error_free_all;
+    }
 
     if (groupby_location > 0) {
-        if (groupby_location + 1 >= argc) {
+        if (groupby_label_location >= argc) {
             // GROUP BY without any argument
             RedisModule_WrongArity(ctx);
             goto error_free_all;
         }
-        args.groupByLabel = RedisModule_StringPtrLen(argv[groupby_location + 1], NULL);
+        args.groupByLabel = RedisModule_StringPtrLen(argv[groupby_label_location], NULL);
 
         const int reduce_location = RMUtil_ArgIndex("REDUCE", argv, argc);
         // If we've detected a groupby but not a reduce
@@ -1017,11 +1031,6 @@ int parseMRangeCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, 
                 ctx, "TSDB: GROUPBY is not allowed when multiple aggregators are specified");
             goto error_free_all;
         }
-    }
-
-    if (args.excludeEmpty && args.groupByLabel != NULL) {
-        RTS_ReplyGeneralError(ctx, "TSDB: EXCLUDEEMPTY is not allowed with GROUPBY");
-        goto error_free_all;
     }
 
     *out = args;

--- a/src/query_language.c
+++ b/src/query_language.c
@@ -18,10 +18,10 @@
 #define stringify(x) stringify2(x)
 #define stringify2(x) #x
 
-#define QUERY_TOKEN_SIZE 9
+#define QUERY_TOKEN_SIZE 10
 static const char *QUERY_TOKENS[] = {
     "WITHLABELS", "AGGREGATION",     "LIMIT",        "GROUPBY", "REDUCE",
-    "FILTER",     "FILTER_BY_VALUE", "FILTER_BY_TS", "COUNT",
+    "FILTER",     "FILTER_BY_VALUE", "FILTER_BY_TS", "COUNT",   "EXCLUDEEMPTY",
 };
 
 static int parseTimestamp(RedisModuleString *string, timestamp_t *out) {
@@ -990,6 +990,8 @@ int parseMRangeCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, 
     }
     args.queryPredicates = queries;
 
+    args.excludeEmpty = RMUtil_ArgIndex("EXCLUDEEMPTY", argv, argc) > 0;
+
     if (groupby_location > 0) {
         if (groupby_location + 1 >= argc) {
             // GROUP BY without any argument
@@ -1016,6 +1018,12 @@ int parseMRangeCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, 
             goto error_free_all;
         }
     }
+
+    if (args.excludeEmpty && args.groupByLabel != NULL) {
+        RTS_ReplyGeneralError(ctx, "TSDB: EXCLUDEEMPTY is not allowed with GROUPBY");
+        goto error_free_all;
+    }
+
     *out = args;
     return REDISMODULE_OK;
 

--- a/src/query_language.h
+++ b/src/query_language.h
@@ -92,6 +92,7 @@ typedef struct MRangeArgs
     const char *groupByLabel;
     ReducerArgs groupByReducerArgs;
     bool reverse;
+    bool excludeEmpty;
 } MRangeArgs;
 
 typedef struct MGetArgs

--- a/src/reply.c
+++ b/src/reply.c
@@ -136,6 +136,16 @@ int ReplySeriesArrayPos(RedisModuleCtx *ctx,
     return REDISMODULE_OK;
 }
 
+bool SeriesHasSamplesInRange(Series *series, const RangeArgs *args, bool reverse) {
+    RangeArgs oneArgs = *args;
+    oneArgs.count = 1;
+    AbstractIterator *iter = SeriesQuery(series, &oneArgs, reverse, true);
+    EnrichedChunk *chunk = iter->GetNext(iter);
+    bool hasData = chunk && chunk->samples.num_samples > 0;
+    iter->Close(iter);
+    return hasData;
+}
+
 int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args, bool reverse) {
     long long arraylen = 0;
     long long _count = LLONG_MAX;

--- a/src/reply.c
+++ b/src/reply.c
@@ -137,9 +137,7 @@ int ReplySeriesArrayPos(RedisModuleCtx *ctx,
 }
 
 bool SeriesHasSamplesInRange(Series *series, const RangeArgs *args, bool reverse) {
-    RangeArgs oneArgs = *args;
-    oneArgs.count = 1;
-    AbstractIterator *iter = SeriesQuery(series, &oneArgs, reverse, true);
+    AbstractIterator *iter = SeriesQuery(series, args, reverse, true);
     EnrichedChunk *chunk = iter->GetNext(iter);
     bool hasData = chunk && chunk->samples.num_samples > 0;
     iter->Close(iter);

--- a/src/reply.c
+++ b/src/reply.c
@@ -79,7 +79,9 @@ int ReplySeriesArrayPos(RedisModuleCtx *ctx,
                         uint16_t limitLabelsSize,
                         const RangeArgs *args,
                         bool rev,
-                        bool print_reduced) {
+                        bool print_reduced,
+                        AbstractIterator *iter,
+                        EnrichedChunk *first_chunk) {
     if (!_ReplyMap(ctx)) {
         RedisModule_ReplyWithArray(ctx, MRANGE_RESP2_ENTRY_ELEMENTS);
     }
@@ -132,31 +134,47 @@ int ReplySeriesArrayPos(RedisModuleCtx *ctx,
             }
         }
     }
-    ReplySeriesRange(ctx, s, args, rev);
+    if (iter) {
+        ReplySeriesRangeFromIter(ctx, iter, first_chunk, args);
+    } else {
+        ReplySeriesRange(ctx, s, args, rev);
+    }
     return REDISMODULE_OK;
 }
 
-bool SeriesHasSamplesInRange(Series *series, const RangeArgs *args, bool reverse) {
+AbstractIterator *SeriesQueryIfNonEmpty(Series *series,
+                                        const RangeArgs *args,
+                                        bool reverse,
+                                        EnrichedChunk **first_chunk_out) {
     AbstractIterator *iter = SeriesQuery(series, args, reverse, true);
-    EnrichedChunk *chunk = iter->GetNext(iter);
-    bool hasData = chunk && chunk->samples.num_samples > 0;
+    EnrichedChunk *chunk;
+    while ((chunk = iter->GetNext(iter)) != NULL) {
+        if (chunk->samples.num_samples > 0) {
+            *first_chunk_out = chunk;
+            return iter;
+        }
+    }
     iter->Close(iter);
-    return hasData;
+    return NULL;
 }
 
-int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args, bool reverse) {
+int ReplySeriesRangeFromIter(RedisModuleCtx *ctx,
+                             AbstractIterator *iter,
+                             EnrichedChunk *first_chunk,
+                             const RangeArgs *args) {
     long long arraylen = 0;
-    long long _count = LLONG_MAX;
+    long long _count = (args->count != -1) ? args->count : LLONG_MAX;
     unsigned int n;
-    if (args->count != -1) {
-        _count = args->count;
-    }
+    EnrichedChunk *enrichedChunk = first_chunk;
 
-    AbstractIterator *iter = SeriesQuery(series, args, reverse, true);
-    EnrichedChunk *enrichedChunk;
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
 
-    while ((arraylen < _count) && (enrichedChunk = iter->GetNext(iter))) {
+    while (arraylen < _count) {
+        if (!enrichedChunk) {
+            enrichedChunk = iter->GetNext(iter);
+            if (!enrichedChunk)
+                break;
+        }
         n = (unsigned int)min(_count - arraylen, enrichedChunk->samples.num_samples);
         size_t vps = enrichedChunk->samples.values_per_sample;
         for (size_t i = 0; i < n; ++i) {
@@ -172,11 +190,16 @@ int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args,
             }
         }
         arraylen += n;
+        enrichedChunk = NULL;
     }
     iter->Close(iter);
 
     RedisModule_ReplySetArrayLength(ctx, arraylen);
     return REDISMODULE_OK;
+}
+
+int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args, bool reverse) {
+    return ReplySeriesRangeFromIter(ctx, SeriesQuery(series, args, reverse, true), NULL, args);
 }
 
 void ReplyWithSeriesLabelsWithLimit(RedisModuleCtx *ctx,

--- a/src/reply.h
+++ b/src/reply.h
@@ -39,10 +39,20 @@ int ReplySeriesArrayPos(RedisModuleCtx *ctx,
                         uint16_t limitLabelsSize,
                         const RangeArgs *args,
                         bool rev,
-                        bool print_reduced);
+                        bool print_reduced,
+                        AbstractIterator *iter,
+                        EnrichedChunk *first_chunk);
+
+AbstractIterator *SeriesQueryIfNonEmpty(Series *series,
+                                        const RangeArgs *args,
+                                        bool reverse,
+                                        EnrichedChunk **first_chunk_out);
 
 int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args, bool rev);
-bool SeriesHasSamplesInRange(Series *series, const RangeArgs *args, bool reverse);
+int ReplySeriesRangeFromIter(RedisModuleCtx *ctx,
+                             AbstractIterator *iter,
+                             EnrichedChunk *first_chunk,
+                             const RangeArgs *args);
 
 // Reply one pivoted row: [timestamp, [value_0, value_1, ..., value_{num_values-1}]].
 void ReplyWithPivotSample(RedisModuleCtx *ctx,

--- a/src/reply.h
+++ b/src/reply.h
@@ -42,6 +42,7 @@ int ReplySeriesArrayPos(RedisModuleCtx *ctx,
                         bool print_reduced);
 
 int ReplySeriesRange(RedisModuleCtx *ctx, Series *series, const RangeArgs *args, bool rev);
+bool SeriesHasSamplesInRange(Series *series, const RangeArgs *args, bool reverse);
 
 // Reply one pivoted row: [timestamp, [value_0, value_1, ..., value_{num_values-1}]].
 void ReplyWithPivotSample(RedisModuleCtx *ctx,

--- a/src/resultset.c
+++ b/src/resultset.c
@@ -109,8 +109,16 @@ void GroupList_ReplyResultSet(RedisModuleCtx *ctx,
                               const RangeArgs *args,
                               bool rev) {
     for (int i = 0; i < group->count; i++) {
-        ReplySeriesArrayPos(
-            ctx, group->list[i], withlabels, limitLabels, limitLabelsSize, args, rev, true);
+        ReplySeriesArrayPos(ctx,
+                            group->list[i],
+                            withlabels,
+                            limitLabels,
+                            limitLabelsSize,
+                            args,
+                            rev,
+                            true,
+                            NULL,
+                            NULL);
     }
 }
 

--- a/tests/flow/test_ts_mrange.py
+++ b/tests/flow/test_ts_mrange.py
@@ -1054,3 +1054,304 @@ def test_mrange_empty_fill_range_ends_after_last_sample():
                                             'FILTER', _EMPTY_FILL_LABEL)
             assert _mrange_key_samples(mrange_res, 'ef_after') == range_res, \
                 f'after-last-sample mismatch for agg={agg}'
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# EXCLUDEEMPTY tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _excl_keys(res):
+    """Return sorted list of key names from RESP2 or RESP3 MRANGE result."""
+    if isinstance(res, dict):
+        return sorted(k.decode() if isinstance(k, bytes) else k for k in res.keys())
+    return sorted(s[0].decode() if isinstance(s[0], bytes) else s[0] for s in res)
+
+
+def _excl_samples(res, key):
+    """Return sample list for key from RESP2 or RESP3 MRANGE result."""
+    key_b = key.encode() if isinstance(key, str) else key
+    if isinstance(res, dict):
+        entry = res.get(key_b) or res.get(key)
+        return entry[-1]  # last element is always samples
+    for s in res:
+        if s[0] == key_b or s[0] == key:
+            return s[2]
+    raise AssertionError(repr(key) + ' not found in result')
+
+
+def test_excludeempty_basic(env):
+    """Series with no samples in range are excluded; series with data are returned."""
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', 'xeb1', 'LABELS', 'g', 'xeb')
+        r.execute_command('TS.CREATE', 'xeb2', 'LABELS', 'g', 'xeb')
+        r.execute_command('TS.CREATE', 'xeb3', 'LABELS', 'g', 'xeb')
+        r.execute_command('TS.ADD', 'xeb1', 10, 1.0)
+        r.execute_command('TS.ADD', 'xeb1', 20, 2.0)
+        r.execute_command('TS.ADD', 'xeb2', 1000, 99.0)   # outside range
+        r.execute_command('TS.ADD', 'xeb3', 15, 3.0)
+
+        res = r1.execute_command('TS.MRANGE', 1, 100, 'EXCLUDEEMPTY', 'FILTER', 'g=xeb')
+        assert _excl_keys(res) == ['xeb1', 'xeb3']
+
+        res_all = r1.execute_command('TS.MRANGE', 1, 100, 'FILTER', 'g=xeb')
+        assert len(res_all) == 3
+
+
+def test_excludeempty_all_empty(env):
+    """When every series is empty in range the reply is an empty array."""
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', 'xee1', 'LABELS', 'g', 'xee')
+        r.execute_command('TS.CREATE', 'xee2', 'LABELS', 'g', 'xee')
+        r.execute_command('TS.ADD', 'xee1', 9999, 1.0)
+        r.execute_command('TS.ADD', 'xee2', 9999, 2.0)
+
+        res = r1.execute_command('TS.MRANGE', 1, 100, 'EXCLUDEEMPTY', 'FILTER', 'g=xee')
+        assert res == [] or res == {}
+
+
+def test_excludeempty_all_have_data(env):
+    """When every series has data the result matches a plain MRANGE."""
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', 'xea1', 'LABELS', 'g', 'xea')
+        r.execute_command('TS.CREATE', 'xea2', 'LABELS', 'g', 'xea')
+        r.execute_command('TS.ADD', 'xea1', 10, 1.0)
+        r.execute_command('TS.ADD', 'xea2', 20, 2.0)
+
+        res_excl = r1.execute_command('TS.MRANGE', 1, 100, 'EXCLUDEEMPTY', 'FILTER', 'g=xea')
+        res_plain = r1.execute_command('TS.MRANGE', 1, 100, 'FILTER', 'g=xea')
+        assert _excl_keys(res_excl) == _excl_keys(res_plain)
+
+
+def test_excludeempty_single_series_empty(env):
+    """Only series: empty → reply is []."""
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', 'xes1', 'LABELS', 'g', 'xes1')
+        r.execute_command('TS.ADD', 'xes1', 500, 7.0)
+
+        res = r1.execute_command('TS.MRANGE', 1, 10, 'EXCLUDEEMPTY', 'FILTER', 'g=xes1')
+        assert res == [] or res == {}
+
+
+def test_excludeempty_single_series_nonempty(env):
+    """Only series: has data → returned normally."""
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', 'xes2', 'LABELS', 'g', 'xes2')
+        r.execute_command('TS.ADD', 'xes2', 5, 7.0)
+
+        res = r1.execute_command('TS.MRANGE', 1, 10, 'EXCLUDEEMPTY', 'FILTER', 'g=xes2')
+        assert _excl_keys(res) == ['xes2']
+
+
+def test_excludeempty_withlabels(env):
+    """EXCLUDEEMPTY + WITHLABELS: non-empty series include their labels."""
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', 'xewl1', 'LABELS', 'g', 'xewl', 'name', 'alpha')
+        r.execute_command('TS.CREATE', 'xewl2', 'LABELS', 'g', 'xewl', 'name', 'beta')
+        r.execute_command('TS.ADD', 'xewl1', 5, 1.0)
+        r.execute_command('TS.ADD', 'xewl2', 5000, 2.0)   # outside range
+
+        res = r1.execute_command('TS.MRANGE', 1, 100, 'WITHLABELS', 'EXCLUDEEMPTY', 'FILTER', 'g=xewl')
+        assert _excl_keys(res) == ['xewl1']
+        labels = dict(next(s[1] for s in res if s[0] == b'xewl1'))
+        assert labels[b'name'] == b'alpha'
+
+
+def test_excludeempty_with_count(env):
+    """EXCLUDEEMPTY + COUNT: count applies to samples within the kept series."""
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', 'xec1', 'LABELS', 'g', 'xec')
+        r.execute_command('TS.CREATE', 'xec2', 'LABELS', 'g', 'xec')
+        for i in range(1, 11):
+            r.execute_command('TS.ADD', 'xec1', i, float(i))
+        r.execute_command('TS.ADD', 'xec2', 9999, 1.0)
+
+        res = r1.execute_command('TS.MRANGE', 1, 100, 'COUNT', 3, 'EXCLUDEEMPTY', 'FILTER', 'g=xec')
+        assert _excl_keys(res) == ['xec1']
+        assert len(_excl_samples(res, 'xec1')) == 3
+
+
+def test_excludeempty_with_aggregation(env):
+    """EXCLUDEEMPTY + AGGREGATION: series with no raw samples in range are excluded."""
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', 'xeag1', 'LABELS', 'g', 'xeag')
+        r.execute_command('TS.CREATE', 'xeag2', 'LABELS', 'g', 'xeag')
+        for i in range(0, 100, 10):
+            r.execute_command('TS.ADD', 'xeag1', i, float(i))
+        r.execute_command('TS.ADD', 'xeag2', 9999, 1.0)
+
+        res = r1.execute_command(
+            'TS.MRANGE', 0, 99, 'AGGREGATION', 'avg', 50, 'EXCLUDEEMPTY', 'FILTER', 'g=xeag')
+        assert _excl_keys(res) == ['xeag1']
+
+
+def test_excludeempty_with_filter_by_value(env):
+    """EXCLUDEEMPTY + FILTER_BY_VALUE: series whose values all fall outside the filter are excluded."""
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', 'xefv1', 'LABELS', 'g', 'xefv')
+        r.execute_command('TS.CREATE', 'xefv2', 'LABELS', 'g', 'xefv')
+        r.execute_command('TS.ADD', 'xefv1', 10, 5.0)
+        r.execute_command('TS.ADD', 'xefv1', 20, 15.0)
+        r.execute_command('TS.ADD', 'xefv2', 10, 100.0)
+        r.execute_command('TS.ADD', 'xefv2', 20, 200.0)
+
+        res = r1.execute_command(
+            'TS.MRANGE', 1, 100, 'FILTER_BY_VALUE', 0, 20, 'EXCLUDEEMPTY', 'FILTER', 'g=xefv')
+        assert _excl_keys(res) == ['xefv1']
+
+
+def test_excludeempty_with_filter_by_ts(env):
+    """EXCLUDEEMPTY + FILTER_BY_TS: series with no matching timestamps are excluded."""
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', 'xeft1', 'LABELS', 'g', 'xeft')
+        r.execute_command('TS.CREATE', 'xeft2', 'LABELS', 'g', 'xeft')
+        r.execute_command('TS.ADD', 'xeft1', 10, 1.0)
+        r.execute_command('TS.ADD', 'xeft1', 20, 2.0)
+        r.execute_command('TS.ADD', 'xeft2', 30, 3.0)   # not in FILTER_BY_TS list
+
+        res = r1.execute_command(
+            'TS.MRANGE', 1, 100, 'FILTER_BY_TS', 10, 20, 'EXCLUDEEMPTY', 'FILTER', 'g=xeft')
+        assert _excl_keys(res) == ['xeft1']
+
+
+def test_excludeempty_mrevrange(env):
+    """EXCLUDEEMPTY works with TS.MREVRANGE and returns samples in reverse order."""
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', 'xer1', 'LABELS', 'g', 'xer')
+        r.execute_command('TS.CREATE', 'xer2', 'LABELS', 'g', 'xer')
+        r.execute_command('TS.ADD', 'xer1', 10, 1.0)
+        r.execute_command('TS.ADD', 'xer1', 20, 2.0)
+        r.execute_command('TS.ADD', 'xer1', 30, 3.0)
+        r.execute_command('TS.ADD', 'xer2', 9999, 1.0)
+
+        res = r1.execute_command('TS.MREVRANGE', 1, 100, 'EXCLUDEEMPTY', 'FILTER', 'g=xer')
+        assert _excl_keys(res) == ['xer1']
+        timestamps = [s[0] for s in _excl_samples(res, 'xer1')]
+        assert timestamps == sorted(timestamps, reverse=True)
+
+
+def test_excludeempty_boundary_timestamps(env):
+    """Series with a sample exactly at the range boundary is included."""
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', 'xebt1', 'LABELS', 'g', 'xebt')
+        r.execute_command('TS.CREATE', 'xebt2', 'LABELS', 'g', 'xebt')
+        r.execute_command('TS.ADD', 'xebt1', 1, 1.0)    # exactly at start
+        r.execute_command('TS.ADD', 'xebt2', 100, 2.0)  # exactly at end
+
+        res = r1.execute_command('TS.MRANGE', 1, 100, 'EXCLUDEEMPTY', 'FILTER', 'g=xebt')
+        assert _excl_keys(res) == ['xebt1', 'xebt2']
+
+        res_out = r1.execute_command('TS.MRANGE', 2, 99, 'EXCLUDEEMPTY', 'FILTER', 'g=xebt')
+        assert res_out == [] or res_out == {}
+
+
+def test_excludeempty_error_with_groupby(env):
+    """EXCLUDEEMPTY combined with GROUPBY must return an error."""
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', 'xegb1', 'LABELS', 'g', 'xegb')
+        with pytest.raises(redis.ResponseError) as exc:
+            r1.execute_command(
+                'TS.MRANGE', 1, 100,
+                'EXCLUDEEMPTY',
+                'FILTER', 'g=xegb',
+                'GROUPBY', 'g', 'REDUCE', 'sum')
+        assert 'EXCLUDEEMPTY' in str(exc.value)
+
+
+def test_excludeempty_mixed_large(env):
+    """10 series: alternating empty/non-empty — exactly the non-empty ones come back."""
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        expected = []
+        for i in range(10):
+            key = f'xeml{i}'
+            r.execute_command('TS.CREATE', key, 'LABELS', 'g', 'xeml')
+            if i % 2 == 0:
+                r.execute_command('TS.ADD', key, 50, float(i))
+                expected.append(key)
+            else:
+                r.execute_command('TS.ADD', key, 9999, float(i))
+
+        res = r1.execute_command('TS.MRANGE', 1, 100, 'EXCLUDEEMPTY', 'FILTER', 'g=xeml')
+        assert _excl_keys(res) == sorted(expected)
+
+
+def _run_excludeempty_agg_type(env, agg_type):
+    label_val = f'xeat_{agg_type}'
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', f'xeat1_{agg_type}', 'LABELS', 'g', label_val)
+        r.execute_command('TS.CREATE', f'xeat2_{agg_type}', 'LABELS', 'g', label_val)
+        r.execute_command('TS.ADD', f'xeat1_{agg_type}', 10, 3.0)
+        r.execute_command('TS.ADD', f'xeat1_{agg_type}', 20, 5.0)
+        r.execute_command('TS.ADD', f'xeat2_{agg_type}', 9999, 1.0)
+        res = r1.execute_command(
+            'TS.MRANGE', 1, 100, 'AGGREGATION', agg_type, 100, 'EXCLUDEEMPTY', 'FILTER', f'g={label_val}')
+        assert _excl_keys(res) == [f'xeat1_{agg_type}'], f'agg={agg_type}'
+        assert len(_excl_samples(res, f'xeat1_{agg_type}')) == 1, f'agg={agg_type}'
+
+
+def test_excludeempty_agg_type_avg(env):
+    _run_excludeempty_agg_type(env, 'avg')
+
+def test_excludeempty_agg_type_sum(env):
+    _run_excludeempty_agg_type(env, 'sum')
+
+def test_excludeempty_agg_type_min(env):
+    _run_excludeempty_agg_type(env, 'min')
+
+def test_excludeempty_agg_type_max(env):
+    _run_excludeempty_agg_type(env, 'max')
+
+def test_excludeempty_agg_type_count(env):
+    _run_excludeempty_agg_type(env, 'count')
+
+def test_excludeempty_agg_type_first(env):
+    _run_excludeempty_agg_type(env, 'first')
+
+def test_excludeempty_agg_type_last(env):
+    _run_excludeempty_agg_type(env, 'last')
+
+
+def test_excludeempty_agg_empty_flag_both_sides(env):
+    """AGGREGATION EMPTY + data on BOTH sides of range: NaN buckets are produced →
+    reply is non-empty → series is KEPT by EXCLUDEEMPTY (reply-level semantics)."""
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', 'xebs', 'LABELS', 'g', 'xebs')
+        r.execute_command('TS.ADD', 'xebs', 10, 1.0)     # before range
+        r.execute_command('TS.ADD', 'xebs', 9999, 2.0)   # after range
+
+        # No raw samples in [1000, 5000], but EMPTY fills NaN buckets because
+        # there's data on both sides → reply is non-empty → series must be kept.
+        res = r1.execute_command(
+            'TS.MRANGE', 1000, 5000, 'AGGREGATION', 'avg', 1000, 'EMPTY', 'EXCLUDEEMPTY', 'FILTER', 'g=xebs')
+        assert _excl_keys(res) == ['xebs']
+        samples = _excl_samples(res, 'xebs')
+        assert len(samples) > 0
+        assert all(math.isnan(float(v)) for _, v in samples)
+
+
+def test_excludeempty_agg_empty_flag_one_side(env):
+    """AGGREGATION EMPTY + data on ONE side only: edge buckets dropped → no NaN buckets
+    in range → series is EXCLUDED by EXCLUDEEMPTY."""
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', 'xeos', 'LABELS', 'g', 'xeos')
+        r.execute_command('TS.ADD', 'xeos', 9999, 2.0)   # after range only
+
+        res = r1.execute_command(
+            'TS.MRANGE', 1000, 5000, 'AGGREGATION', 'avg', 1000, 'EMPTY', 'EXCLUDEEMPTY', 'FILTER', 'g=xeos')
+        assert res == [] or res == {}
+
+
+def test_excludeempty_resp3(env):
+    """EXCLUDEEMPTY returns correct keys under RESP3 (map reply)."""
+    from utils import is_resp3_possible
+    if not is_resp3_possible(env):
+        env.skip()
+    env3 = Env(protocol=3)
+    with env3.getClusterConnectionIfNeeded() as r, env3.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', 'xr3a', 'LABELS', 'g', 'xr3')
+        r.execute_command('TS.CREATE', 'xr3b', 'LABELS', 'g', 'xr3')
+        r.execute_command('TS.ADD', 'xr3a', 10, 1.0)
+        r.execute_command('TS.ADD', 'xr3b', 9999, 2.0)   # outside range
+
+        res = r1.execute_command('TS.MRANGE', 1, 100, 'EXCLUDEEMPTY', 'FILTER', 'g=xr3')
+        assert isinstance(res, dict)
+        assert _excl_keys(res) == ['xr3a']


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes multi-key range query reply shape and cluster merge behavior; incorrect filtering or reply lengths could break clients relying on MRANGE semantics.
> 
> **Overview**
> Adds optional **`EXCLUDEEMPTY`** (since 8.10.0) to **`TS.MRANGE`** and **`TS.MREVRANGE`**, documented in `commands.json` and command info.
> 
> When set, matching series that would return **no samples** for the query (range, filters, aggregation, etc.) are **omitted** from the multi-series reply instead of appearing with empty sample arrays. Parsing stores the flag on **`MRangeArgs`**, rejects **`EXCLUDEEMPTY` with `GROUPBY`**, and avoids treating a **`GROUPBY`** label literally named `EXCLUDEEMPTY` as the flag.
> 
> Implementation probes each series with **`SeriesQueryIfNonEmpty`** and reuses that iterator via **`ReplySeriesRangeFromIter`** so empty series are skipped without a second scan. Top-level array/map length uses **postponed length** where needed so RESP2/RESP3 counts match the filtered series list.
> 
> The flag is propagated for **cluster/LibMR** (`QueryPredicates_Arg` serialize/deserialize and coordinator shard args). Extensive flow tests cover combinations with labels, count, aggregation, filter-by-value/ts, MREVRANGE, RESP3, and EMPTY aggregation edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cc7c0680c6106be9559ed3b2e19929adc36b6e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->