### PR TITLE
RED-191674 - drop duplicate tests from event-tag, build + upload only

### DIFF
--- a/.github/workflows/event-tag.yml
+++ b/.github/workflows/event-tag.yml
@@ -33,9 +33,10 @@ jobs:
             REDIS_REF="$(.install/get-redis-ref.sh)"
           fi
           echo "redis-ref=${REDIS_REF}" >> $GITHUB_OUTPUT
-  linter:
-    uses: ./.github/workflows/flow-linter.yml
-    secrets: inherit
+  # NOTE: tests (linter, valgrind, sanitizer, full suite) intentionally run in
+  # event-nightly, which the release pipeline executes before tagging. The tag
+  # build only produces and uploads release artifacts (skip_tests: true), so it
+  # does not re-run the duplicate test suite. See RED-191674.
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]
@@ -43,6 +44,7 @@ jobs:
       arch: x64
       os: focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      skip_tests: true
     secrets: inherit
   build-linux-arm64:
     uses: ./.github/workflows/flow-linux.yml
@@ -51,10 +53,12 @@ jobs:
       arch: arm64
       os: focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      skip_tests: true
     secrets: inherit
   macos:
     uses: ./.github/workflows/flow-macos.yml
     needs: [prepare-values]
     with:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      skip_tests: true
     secrets: inherit

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -37,6 +37,10 @@ on:
         description: 'Only build the module (compile smoke); skip tests, pack and S3 upload'
         type: boolean
         default: false
+      skip_tests:
+        description: 'Skip tests but still pack and upload artifacts to S3 (e.g. release tags whose tests already ran in the nightly)'
+        type: boolean
+        default: false
       shard_topologies:
         description: 'Run each test topology as a separate parallel job (one per topology)'
         type: boolean
@@ -75,6 +79,10 @@ on:
         default: false
       build_only:
         description: 'Only build the module (compile smoke); skip tests, pack and S3 upload'
+        type: boolean
+        default: false
+      skip_tests:
+        description: 'Skip tests but still pack and upload artifacts to S3 (e.g. release tags whose tests already ran in the nightly)'
         type: boolean
         default: false
       shard_topologies:
@@ -199,7 +207,7 @@ jobs:
             make build
 
       - name: Run tests
-        if: ${{ !inputs.build_only }}
+        if: ${{ !inputs.build_only && !inputs.skip_tests }}
         env:
           TOPO: ${{ matrix.platform.topo }}
         run: |
@@ -231,20 +239,20 @@ jobs:
               ${TOPO_ARGS} 2>&1 | tee /workspace/test_output.log; exit \${PIPESTATUS[0]}"
 
       - name: Fix test log permissions
-        if: ${{ always() && !inputs.build_only }}
+        if: ${{ always() && !inputs.build_only && !inputs.skip_tests }}
         run: |
           sudo chown -R "$(id -u)":"$(id -g)" tests || true
           sudo chmod -R a+rX tests || true
           sudo chown "$(id -u)":"$(id -g)" test_output.log || true
 
       - name: Capture test results
-        if: ${{ always() && !inputs.build_only }}
+        if: ${{ always() && !inputs.build_only && !inputs.skip_tests }}
         uses: ./.github/actions/capture-test-results
         with:
           os-name: ${{ inputs.arch }}-${{ matrix.platform.os }}${{ matrix.platform.topo && format('-{0}', matrix.platform.topo) || '' }}
 
       - name: Upload test artifacts
-        if: ${{ failure() && !inputs.build_only }}
+        if: ${{ failure() && !inputs.build_only && !inputs.skip_tests }}
         uses: actions/upload-artifact@v6
         with:
           name: test-artifacts-${{ inputs.arch }}-${{ matrix.platform.os }}${{ matrix.platform.topo && format('-{0}', matrix.platform.topo) || '' }}${{ inputs.run_valgrind && '-valgrind' || '' }}${{ inputs.run_sanitizer && '-sanitizer' || '' }}

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -45,6 +45,10 @@ on:
         description: 'Only build the module (compile smoke); skip tests, pack and S3 upload'
         type: boolean
         default: false
+      skip_tests:
+        description: 'Skip tests but still pack and upload artifacts to S3 (e.g. release tags whose tests already ran in the nightly)'
+        type: boolean
+        default: false
       beta-version:
         description: 'Beta version for S3 uploads'
         type: string
@@ -75,6 +79,10 @@ on:
         default: false
       build_only:
         description: 'Only build the module (compile smoke); skip tests, pack and S3 upload'
+        type: boolean
+        default: false
+      skip_tests:
+        description: 'Skip tests but still pack and upload artifacts to S3 (e.g. release tags whose tests already ran in the nightly)'
         type: boolean
         default: false
       beta-version:
@@ -173,18 +181,18 @@ jobs:
         with:
           use-venv: '1'
       - name: Run tests
-        if: ${{ !inputs.build_only }}
+        if: ${{ !inputs.build_only && !inputs.skip_tests }}
         uses: ./.github/actions/run-tests
         with:
           use-venv: '1'
           quick: ${{inputs.quick && '1' || '0'}}
       - name: Capture test results
-        if: ${{ always() && !inputs.build_only }}
+        if: ${{ always() && !inputs.build_only && !inputs.skip_tests }}
         uses: ./.github/actions/capture-test-results
         with:
           os-name: ${{ matrix.os }}
       - name: Upload test artifacts
-        if: ${{ failure() && !inputs.build_only }}
+        if: ${{ failure() && !inputs.build_only && !inputs.skip_tests }}
         uses: ./.github/actions/upload-artifacts
         with:
           image: ${{ matrix.os }}


### PR DESCRIPTION
## What

Removes redundant test execution from the **Event TAG** release workflow. The orchestrated release pipeline already runs `event-nightly` (linter, full test suite, valgrind, sanitizer) before tagging, so re-running tests on the version tag is duplicative and slows the release.

Jira: [RED-191674](https://redislabs.atlassian.net/browse/RED-191674) (part of [RED-182067](https://redislabs.atlassian.net/browse/RED-182067) — RedisTimeSeries Automated Release Pipeline)

## Changes

- **`event-tag.yml`**: removed the `linter` job; pass `skip_tests: true` to the Linux x64 / arm64 and macOS build jobs. Tag trigger (`v[0-9]+.[0-9]+.[0-9]+`) is unchanged.
- **`flow-linux.yml` / `flow-macos.yml`**: added a new `skip_tests` input (default `false`). When true it skips the test / capture-results steps but **still packs and uploads release artifacts to S3**.

Why a new input rather than the existing `build_only`? `build_only` is a compile-only smoke that also skips pack + S3 upload (used by `event-ci`). The tag flow needs build **+ S3 upload, without tests** — no existing flag covered that.

## Impact / safety

- `skip_tests` defaults to `false`, so **`event-ci.yml` and `event-nightly.yml` are unaffected** (neither file is changed here; nothing else passes the input).
- On a tag ref the S3 upload action still runs with `RELEASE=1`, so artifacts land in the production release directory.

## Acceptance criteria
- [x] event-tag builds artifacts for all platforms without running tests
- [x] Artifacts uploaded to S3 release directory
- [x] Duplicate test runs eliminated → faster tag pipeline
- [x] Tag trigger (`v[0-9]+.[0-9]+.[0-9]+`) preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RED-191674]: https://redislabs.atlassian.net/browse/RED-191674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RED-182067]: https://redislabs.atlassian.net/browse/RED-182067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with `skip_tests` defaulting to false; tag builds rely on pre-tag nightly tests instead of re-running validation on the tagged ref.
> 
> **Overview**
> **Event TAG** no longer runs the standalone **linter** job or the full test matrix on version tags. Linux and macOS reusable flows are invoked with **`skip_tests: true`**, so tag pipelines focus on **build, pack, and S3 upload** after **`event-nightly`** has already exercised linter, valgrind, sanitizer, and the full suite.
> 
> **`flow-linux.yml`** and **`flow-macos.yml`** gain a **`skip_tests`** input (default **`false`**). When set, test execution and related steps (log fixes, capture results, failure artifact upload) are skipped, while **pack** and **S3 upload** still run—unlike **`build_only`**, which skips packaging and upload for compile smoke.
> 
> Other callers keep prior behavior because nothing else passes **`skip_tests`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b8aedb454b9190d5e41e695c1e38661bf9284f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->