### PR TITLE
[8.4] MOD-15749 Short-form CLUSTERSET: RAMP capability + LibMR error-return

### DIFF
--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -26,6 +26,7 @@ capabilities:
     - flash
     - ipv6
     - asm
+    - short_form_clusterset
 exclude_commands:
     - timeseries.REFRESHCLUSTER
     - timeseries.INFOCLUSTER


### PR DESCRIPTION
Cherry-pick of [#2065](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2065) to `8.4`.

**What:**
- Adds `short_form_clusterset` to `pack/ramp.yml` capabilities.
- Bumps `deps/LibMR` `44d5025` → `a37b672` ([RedisGears/LibMR#99](https://github.com/RedisGears/LibMR/pull/99)): the short form of CLUSTERSET now replies with an error instead of a silent `+OK` when `RedisModule_GetClusterNodeSlotRanges` is unavailable — enabling DMC's try-then-fallback safety guard.

**LibMR ride-along:** the bump also pulls in LibMR #96 (Linux SSL CI hang / testUnevenWork timeout fix) and #98 (detect oss cluster at MR_ClusterInit), aligning `8.4`'s LibMR with master and the 99.99 beta currently under test.

Cherry-pick applied cleanly (ramp.yml + submodule pointer only); corp-authored, no extra trailers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging metadata only; no runtime logic changes in the diff itself.
> 
> **Overview**
> Declares **`short_form_clusterset`** in `pack/ramp.yml` so RedisTimeSeries advertises support for the short-form **CLUSTERSET** flow in Redis Enterprise / RAMP packaging.
> 
> This pairs with the LibMR update (cherry-picked alongside this change) where short-form CLUSTERSET returns an error when slot-range APIs are missing, so proxies such as DMC can detect unsupported paths and fall back safely instead of treating a silent `+OK` as success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d93f36f2670f2306ede51de2a192c3eaab96099. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->