### PR TITLE
[8.6] MOD-15749 Short-form CLUSTERSET: RAMP capability + LibMR error-return

### DIFF
--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -26,6 +26,7 @@ capabilities:
     - flash
     - ipv6
     - asm
+    - short_form_clusterset
 exclude_commands:
     - timeseries.REFRESHCLUSTER
     - timeseries.INFOCLUSTER


### PR DESCRIPTION
Cherry-pick of [#2065](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2065) to `8.6`.

**What:**
- Adds `short_form_clusterset` to `pack/ramp.yml` capabilities.
- Bumps `deps/LibMR` `44d5025` → `a37b672` ([RedisGears/LibMR#99](https://github.com/RedisGears/LibMR/pull/99)): the short form of CLUSTERSET now replies with an error instead of a silent `+OK` when `RedisModule_GetClusterNodeSlotRanges` is unavailable — enabling DMC's try-then-fallback safety guard.

**LibMR ride-along:** the bump also pulls in LibMR #96 (Linux SSL CI hang / testUnevenWork timeout fix) and #98 (detect oss cluster at MR_ClusterInit), aligning `8.6`'s LibMR with master and the 99.99 beta currently under test.

Cherry-pick applied cleanly (ramp.yml + submodule pointer only); corp-authored, no extra trailers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging capability flag only; no runtime logic in this diff.
> 
> **Overview**
> Declares **`short_form_clusterset`** in `pack/ramp.yml` so RedisTimeSeries advertises support for the short-form CLUSTERSET flow to Redis Enterprise / RAMP.
> 
> This pairs with the LibMR update (short-form CLUSTERSET returns an error when `RedisModule_GetClusterNodeSlotRanges` is missing instead of a silent `+OK`), so DMC can try short form and fall back safely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a4c6ace4afcc1ae59517d5b56b61cd71eabf651. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->