### PR TITLE
[8.8] MOD-15749 Short-form CLUSTERSET: RAMP capability + LibMR error-return

### DIFF
--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -26,6 +26,7 @@ capabilities:
     - flash
     - ipv6
     - asm
+    - short_form_clusterset
 exclude_commands:
     - timeseries.REFRESHCLUSTER
     - timeseries.INFOCLUSTER


### PR DESCRIPTION
Cherry-pick of [#2065](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2065) to `8.8`.

**What:**
- Adds `short_form_clusterset` to `pack/ramp.yml` capabilities.
- Bumps `deps/LibMR` `44d5025` → `a37b672` ([RedisGears/LibMR#99](https://github.com/RedisGears/LibMR/pull/99)): the short form of CLUSTERSET now replies with an error instead of a silent `+OK` when `RedisModule_GetClusterNodeSlotRanges` is unavailable — enabling DMC's try-then-fallback safety guard.

**LibMR ride-along:** the bump also pulls in LibMR #96 (Linux SSL CI hang / testUnevenWork timeout fix) and #98 (detect oss cluster at MR_ClusterInit), aligning `8.8`'s LibMR with master and the 99.99 beta currently under test.

Cherry-pick applied cleanly (ramp.yml + submodule pointer only); corp-authored, no extra trailers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates module capability metadata in ramp.yml with no runtime code changes in this diff.
> 
> **Overview**
> Adds **`short_form_clusterset`** to the module’s **`pack/ramp.yml`** capabilities list so Redis Enterprise / RAMP knows RedisTimeSeries supports the short-form **CLUSTERSET** flow used with DMC’s try-then-fallback when cluster slot-range APIs are missing.
> 
> This is a packaging/metadata change only in the provided diff; it aligns the 8.8 release manifest with the short-form CLUSTERSET behavior (error instead of silent **+OK** when unsupported) described for the paired LibMR update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 623d31134dc9df8e19c8286051aa7ee02eafa5ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->