### PR TITLE
[8.10] MOD-15749 Short-form CLUSTERSET: RAMP capability + LibMR error-return

### DIFF
--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -27,6 +27,7 @@ capabilities:
     - flash
     - ipv6
     - asm
+    - short_form_clusterset
 exclude_commands:
     - timeseries.REFRESHCLUSTER
     - timeseries.INFOCLUSTER


### PR DESCRIPTION
Cherry-pick of [#2065](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2065) to `8.10`.

**What:**
- Adds `short_form_clusterset` to `pack/ramp.yml` capabilities.
- Bumps `deps/LibMR` `44d5025` → `a37b672` ([RedisGears/LibMR#99](https://github.com/RedisGears/LibMR/pull/99)): the short form of CLUSTERSET now replies with an error instead of a silent `+OK` when `RedisModule_GetClusterNodeSlotRanges` is unavailable — enabling DMC's try-then-fallback safety guard.

**LibMR ride-along:** also pulls in LibMR #96 (Linux SSL CI hang / testUnevenWork timeout fix) and #98 (detect oss cluster at MR_ClusterInit), aligning `8.10`'s LibMR with master and the 99.99 beta.

Cherry-pick applied cleanly (ramp.yml + submodule pointer only); corp-authored, no extra trailers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pack metadata and clustering integration flag only; no application logic changes in the shown diff.
> 
> **Overview**
> Declares the **`short_form_clusterset`** pack capability in `pack/ramp.yml`, advertising that RedisTimeSeries supports the short-form CLUSTERSET flow used by cluster management (e.g. DMC try-then-fallback when slot-range APIs are missing).
> 
> This cherry-pick aligns **8.10** with master on that capability flag; the behavioral change (short-form CLUSTERSET returning an error instead of silent `+OK` when `RedisModule_GetClusterNodeSlotRanges` is unavailable) comes from the paired **LibMR** submodule update described in the PR, not from edits visible in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7ccab27e8944b0e8e9a8636f028dc2880eff1bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->