### PR TITLE
MOD-16505 - change TS.BGET command to TS.READ

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -1387,8 +1387,8 @@
         "since": "1.0.0",
         "group": "timeseries"
     },
-    "TS.BGET": {
-        "summary": "Blocking GET: wait up to `timeout` milliseconds or until at least `min_count` samples with timestamp >= `timestamp` are available (whichever occurs first), then retrieve up to `max_count` of the oldest qualifying samples in ascending timestamp order. When `timeout` is 0 the command does not block and returns whatever is available now (possibly empty or fewer than `min_count`). Defaults: `min_count` 1, `max_count` unlimited.",
+    "TS.READ": {
+        "summary": "Return up to `max_count` samples with timestamp >= `timestamp` in ascending order. With BLOCK, waits up to `milliseconds` ms until at least `min_count` qualifying samples exist; without BLOCK, returns immediately whatever is available. Defaults: `min_count` 1, `max_count` unlimited.",
         "complexity": "O(log(n)+k) where n is the number of samples in the series and k is the number of returned samples",
         "arguments": [
             {
@@ -1400,14 +1400,20 @@
                 "type": "string"
             },
             {
-                "name": "timeout",
-                "type": "integer"
-            },
-            {
-                "name": "min_count",
-                "token": "MIN_COUNT",
-                "type": "integer",
-                "optional": true
+                "name": "BLOCK",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "milliseconds",
+                        "token": "BLOCK",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "min_count",
+                        "type": "integer"
+                    }
+                ]
             },
             {
                 "name": "max_count",

--- a/src/cmd_info/ts_info.c
+++ b/src/cmd_info/ts_info.c
@@ -742,9 +742,7 @@ static const RedisModuleCommandArg TS_READ_ARGS[] = {
       .flags = REDISMODULE_CMD_ARG_OPTIONAL,
       .subargs =
           (RedisModuleCommandArg[]){
-              { .name = "milliseconds",
-                .type = REDISMODULE_ARG_TYPE_INTEGER,
-                .token = "BLOCK" },
+              { .name = "milliseconds", .type = REDISMODULE_ARG_TYPE_INTEGER, .token = "BLOCK" },
               { .name = "min_count", .type = REDISMODULE_ARG_TYPE_INTEGER },
               { 0 } } },
     { .name = "MAX_COUNT",

--- a/src/cmd_info/ts_info.c
+++ b/src/cmd_info/ts_info.c
@@ -723,9 +723,9 @@ static const RedisModuleCommandInfo TS_GET_INFO = {
 };
 
 // ===============================
-// TS.BGET key timestamp timeout [MIN_COUNT min_count] [MAX_COUNT max_count]
+// TS.READ key timestamp [BLOCK milliseconds min_count] [MAX_COUNT max_count]
 // ===============================
-static const RedisModuleCommandKeySpec TS_BGET_KEYSPECS[] = {
+static const RedisModuleCommandKeySpec TS_READ_KEYSPECS[] = {
     { .flags = REDISMODULE_CMD_KEY_RO,
       .begin_search_type = REDISMODULE_KSPEC_BS_INDEX,
       .bs.index = { .pos = 1 },
@@ -734,16 +734,18 @@ static const RedisModuleCommandKeySpec TS_BGET_KEYSPECS[] = {
     { 0 }
 };
 
-static const RedisModuleCommandArg TS_BGET_ARGS[] = {
+static const RedisModuleCommandArg TS_READ_ARGS[] = {
     { .name = "key", .type = REDISMODULE_ARG_TYPE_KEY, .key_spec_index = 0 },
     { .name = "timestamp", .type = REDISMODULE_ARG_TYPE_STRING },
-    { .name = "timeout", .type = REDISMODULE_ARG_TYPE_INTEGER },
-    { .name = "MIN_COUNT",
+    { .name = "BLOCK",
       .type = REDISMODULE_ARG_TYPE_BLOCK,
       .flags = REDISMODULE_CMD_ARG_OPTIONAL,
       .subargs =
           (RedisModuleCommandArg[]){
-              { .name = "min_count", .type = REDISMODULE_ARG_TYPE_INTEGER, .token = "MIN_COUNT" },
+              { .name = "milliseconds",
+                .type = REDISMODULE_ARG_TYPE_INTEGER,
+                .token = "BLOCK" },
+              { .name = "min_count", .type = REDISMODULE_ARG_TYPE_INTEGER },
               { 0 } } },
     { .name = "MAX_COUNT",
       .type = REDISMODULE_ARG_TYPE_BLOCK,
@@ -755,17 +757,17 @@ static const RedisModuleCommandArg TS_BGET_ARGS[] = {
     { 0 }
 };
 
-static const RedisModuleCommandInfo TS_BGET_INFO = {
+static const RedisModuleCommandInfo TS_READ_INFO = {
     .version = REDISMODULE_COMMAND_INFO_VERSION,
-    .summary = "Blocking GET: wait up to timeout ms or until min_count samples with timestamp >= "
-               "timestamp are available, then return up to max_count of the oldest such samples",
+    .summary = "Read: return up to max_count samples with timestamp >= timestamp. With BLOCK, "
+               "waits up to milliseconds ms until at least min_count qualifying samples exist",
     .complexity = "O(log(n)+k) where n is the number of samples in the series and k is the number "
                   "of returned samples",
     .since = "8.10.0",
     .tips = "dont_cache",
-    .arity = -4,
-    .key_specs = (RedisModuleCommandKeySpec *)TS_BGET_KEYSPECS,
-    .args = (RedisModuleCommandArg *)TS_BGET_ARGS,
+    .arity = -3,
+    .key_specs = (RedisModuleCommandKeySpec *)TS_READ_KEYSPECS,
+    .args = (RedisModuleCommandArg *)TS_READ_ARGS,
 };
 
 // ===============================
@@ -1675,9 +1677,9 @@ int RegisterTSCommandInfos(RedisModuleCtx *ctx) {
     if (!cmd_get || RedisModule_SetCommandInfo(cmd_get, &TS_GET_INFO) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    // Register TS.BGET command info
-    RedisModuleCommand *cmd_bget = RedisModule_GetCommand(ctx, "TS.BGET");
-    if (!cmd_bget || RedisModule_SetCommandInfo(cmd_bget, &TS_BGET_INFO) == REDISMODULE_ERR)
+    // Register TS.READ command info
+    RedisModuleCommand *cmd_read = RedisModule_GetCommand(ctx, "TS.READ");
+    if (!cmd_read || RedisModule_SetCommandInfo(cmd_read, &TS_READ_INFO) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     // Register TS.RANGE command info

--- a/src/module.c
+++ b/src/module.c
@@ -1503,7 +1503,9 @@ typedef struct ReadCtx
     size_t min_count;       ///< unblock threshold: wait until this many samples qualify (default 1)
     long long max_count;    ///< reply cap: max samples to return; -1 = unlimited (default)
     bool blocking_req;      ///< true when BLOCK was specified; false = return immediately
-    long long timeout_ms;   ///< only meaningful when blocking_req; 0 = block forever, >0 = max wait
+    long long timeout_ms;   ///< BLOCK timeout: 0 = block forever, >0 = max wait ms.
+                          ///< Only set when blocking_req; non-blocking paths resolve synchronously
+                          ///< and never reach RTS_BlockClientOnKey.
 } ReadCtx;
 
 /**
@@ -1542,8 +1544,11 @@ static int parse_read_args(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     // can compute the exact expected count and give WrongArity on mismatch.
     // BLOCK takes 3 tokens (keyword + ms + min_count); MAX_COUNT takes 2.
     // Valid argcs: 3, 5 (MAX_COUNT only), 6 (BLOCK only), 8 (both).
-    bool has_block = RMUtil_ArgIndex("BLOCK", argv, argc) >= READ_ARGV_FIRST_OPTION;
-    bool has_max_count = RMUtil_ArgIndex("MAX_COUNT", argv, argc) >= READ_ARGV_FIRST_OPTION;
+    bool has_block =
+        RMUtil_ArgIndex("BLOCK", argv + READ_ARGV_FIRST_OPTION, argc - READ_ARGV_FIRST_OPTION) >= 0;
+    bool has_max_count = RMUtil_ArgIndex("MAX_COUNT",
+                                         argv + READ_ARGV_FIRST_OPTION,
+                                         argc - READ_ARGV_FIRST_OPTION) >= 0;
     int expected_argc = READ_MIN_ARGC + (has_block ? READ_BLOCK_TOKENS : 0) +
                         (has_max_count ? READ_MAX_COUNT_TOKENS : 0);
     if (argc != expected_argc) {
@@ -1556,8 +1561,12 @@ static int parse_read_args(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     long long max_count = READ_DEFAULT_MAX_COUNT;
 
     if (has_block) {
-        if (RMUtil_ParseArgsAfter("BLOCK", argv, argc, "ll", &timeout_ms, &min_count) !=
-                REDISMODULE_OK ||
+        if (RMUtil_ParseArgsAfter("BLOCK",
+                                  argv + READ_ARGV_FIRST_OPTION,
+                                  argc - READ_ARGV_FIRST_OPTION,
+                                  "ll",
+                                  &timeout_ms,
+                                  &min_count) != REDISMODULE_OK ||
             timeout_ms < 0) {
             RedisModule_ReplyWithError(ctx,
                                        "TSDB: BLOCK milliseconds must be a non-negative integer");
@@ -1570,7 +1579,11 @@ static int parse_read_args(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     }
 
     if (has_max_count) {
-        if (RMUtil_ParseArgsAfter("MAX_COUNT", argv, argc, "l", &max_count) != REDISMODULE_OK ||
+        if (RMUtil_ParseArgsAfter("MAX_COUNT",
+                                  argv + READ_ARGV_FIRST_OPTION,
+                                  argc - READ_ARGV_FIRST_OPTION,
+                                  "l",
+                                  &max_count) != REDISMODULE_OK ||
             max_count <= 0) {
             RedisModule_ReplyWithError(ctx, "TSDB: MAX_COUNT must be a positive integer");
             return REDISMODULE_ERR;
@@ -1933,7 +1946,7 @@ int TSDB_read(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         (REDISMODULE_CTX_FLAGS_LUA | REDISMODULE_CTX_FLAGS_MULTI |
          REDISMODULE_CTX_FLAGS_DENY_BLOCKING)) {
         RedisModule_ReplyWithError(ctx,
-                                   "TSDB: blocking TS.READ (with BLOCK) is not allowed"
+                                   "TSDB: blocking TS.READ (with BLOCK) is not allowed "
                                    "inside MULTI, EVAL, or a deny-blocking context");
         return REDISMODULE_OK;
     }
@@ -1944,7 +1957,7 @@ int TSDB_read(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         // surfacing a new deny-blocking flag). Reply with an error so the
         // client doesn't hang on an empty pipeline.
         RedisModule_ReplyWithError(ctx,
-                                   "TSDB: blocking TS.READ (with BLOCK) is not allowed"
+                                   "TSDB: blocking TS.READ (with BLOCK) is not allowed "
                                    "inside MULTI, EVAL, or a deny-blocking context");
     }
     return REDISMODULE_OK;

--- a/src/module.c
+++ b/src/module.c
@@ -904,7 +904,7 @@ static int internalAdd(RedisModuleCtx *ctx,
             handleCompaction(ctx, series, rule, timestamp, value);
         }
     }
-    // Wake any TS.BGET waiters parked on this key. Cheap no-op when no client
+    // Wake any TS.READ waiters parked on this key. Cheap no-op when no client
     // is blocked; harmless extra try_reply when the upsert was an in-place
     // update (the reply_cb will re-check and stay parked if nothing changed).
     RedisModule_SignalKeyAsReady(ctx, series->keyName);
@@ -1441,22 +1441,23 @@ int TSDB_get(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 }
 
 /* ============================================================================
- *  TS.BGET — Blocking GET (cursor-style tailing of a series)
+ *  TS.READ — Blocking GET (cursor-style tailing of a series)
  *
- *  Syntax:  TS.BGET key timestamp timeout [MIN_COUNT min_count] [MAX_COUNT max_count]
+ *  Syntax:  TS.READ key timestamp [BLOCK milliseconds min_count] [MAX_COUNT max_count]
  *
  *  Returns up to `max_count` samples (default unlimited) with sample-ts greater
- *  than or equal to the resolved cursor, sorted ascending. Blocks up to
- *  `timeout` ms waiting until at least `min_count` qualifying samples exist
- *  (default 1). `timestamp` may be a literal UNIX-ms value or one of the
- *  sentinels `-` (earliest) / `+` (latest existing sample, inclusive) /
+ *  than or equal to the resolved cursor, sorted ascending. When BLOCK is given,
+ *  blocks up to `milliseconds` ms waiting until at least `min_count` qualifying
+ *  samples exist (default 1). Without BLOCK, returns immediately. `timestamp`
+ *  may be a literal UNIX-ms value or one of the sentinels `-` (earliest) /
+ *  `+` (latest existing sample, inclusive) /
  *  `$` (latest sample's ts + 1, i.e. only post-command samples qualify).
  *
  *  Wake-up is driven by RedisModule_SignalKeyAsReady() in the sample-append
  *  chokepoint of the engine (covers TS.ADD / TS.MADD / TS.INCRBY / TS.DECRBY
  *  on append, plus compaction-rule writes to the destination key).
  *
- *  Sentinel support (all resolved once inside parse_bget_args):
+ *  Sentinel support (all resolved once inside parse_read_args):
  *    `-` -> cursor=0 (no lower bound).
  *    `+` -> cursor=series->lastTimestamp (latest existing sample qualifies,
  *           aligned with TS.RANGE); missing/empty -> 0; wrong-type -> WRONGTYPE.
@@ -1465,47 +1466,48 @@ int TSDB_get(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
  * ============================================================================
  */
 
-/// TS.BGET MIN_COUNT default: unblock as soon as one sample qualifies.
-#define BGET_DEFAULT_MIN_COUNT 1
-/// TS.BGET MAX_COUNT default: unlimited (maps to RangeArgs.count == -1).
-#define BGET_DEFAULT_MAX_COUNT (-1)
+/// TS.READ BLOCK min_count default: unblock as soon as one sample qualifies.
+#define READ_DEFAULT_MIN_COUNT 1
+/// TS.READ MAX_COUNT default: unlimited (maps to RangeArgs.count == -1).
+#define READ_DEFAULT_MAX_COUNT (-1)
 
-/// TS.BGET fixed argv layout: TS.BGET key timestamp timeout [MIN_COUNT n] [MAX_COUNT n]
-typedef enum BGetArgv
+/// TS.READ fixed argv layout: TS.READ key timestamp [BLOCK ms min_count] [MAX_COUNT n]
+typedef enum ReadArgv
 {
-    BGET_ARGV_COMMAND = 0,     ///< the command name itself
-    BGET_ARGV_KEY = 1,         ///< series key
-    BGET_ARGV_TIMESTAMP = 2,   ///< cursor / '-' / '+' / '$'
-    BGET_ARGV_TIMEOUT = 3,     ///< timeout in ms
-    BGET_ARGV_FIRST_OPTION = 4 ///< first MIN_COUNT/MAX_COUNT keyword (options follow in pairs)
-} BGetArgv;
+    READ_ARGV_COMMAND = 0,     ///< the command name itself
+    READ_ARGV_KEY = 1,         ///< series key
+    READ_ARGV_TIMESTAMP = 2,   ///< cursor / '-' / '+' / '$'
+    READ_ARGV_FIRST_OPTION = 3 ///< first optional keyword (BLOCK or MAX_COUNT)
+} ReadArgv;
 
-#define BGET_OPTION_STRIDE 2 ///< each option is a keyword + value pair
-/// timeout_ms value meaning "do not block": reply with whatever is available now.
-#define BGET_NO_BLOCK_TIMEOUT 0
-/// Min argc: just the fixed args (command key timestamp timeout), no options.
-#define BGET_MIN_ARGC BGET_ARGV_FIRST_OPTION
-/// Max argc: the fixed args plus both MIN_COUNT and MAX_COUNT pairs.
-#define BGET_MAX_ARGC (BGET_ARGV_FIRST_OPTION + 2 * BGET_OPTION_STRIDE)
+/// Token count for the optional BLOCK group: keyword + milliseconds + min_count.
+#define READ_BLOCK_TOKENS 3
+/// Token count for the optional MAX_COUNT group: keyword + value.
+#define READ_MAX_COUNT_TOKENS 2
+/// Min argc: command + key + timestamp, no options.
+#define READ_MIN_ARGC READ_ARGV_FIRST_OPTION
+/// Max argc: fixed args + BLOCK group + MAX_COUNT group.
+#define READ_MAX_ARGC (READ_MIN_ARGC + READ_BLOCK_TOKENS + READ_MAX_COUNT_TOKENS)
 
 /**
- * @brief Parsed TS.BGET arguments, also used as blocked-client privdata.
+ * @brief Parsed TS.READ arguments, also used as blocked-client privdata.
  *
- * Populated once by parse_bget_args() so callbacks never re-parse argv.
- * `key` is borrowed at parse time; TSDB_bget_block() retains it and
- * TSDB_bget_free_privdata() releases it.
+ * Populated once by parse_read_args() so callbacks never re-parse argv.
+ * `key` is borrowed at parse time; TSDB_read_block() retains it and
+ * TSDB_read_free_privdata() releases it.
  */
-typedef struct BGetCtx
+typedef struct ReadCtx
 {
     RedisModuleString *key; ///< series key to read from
     api_timestamp_t cursor; ///< inclusive lower bound: only samples with ts >= cursor qualify
     size_t min_count;       ///< unblock threshold: wait until this many samples qualify (default 1)
     long long max_count;    ///< reply cap: max samples to return; -1 = unlimited (default)
-    long long timeout_ms;   ///< 0 = do not block; >0 = max time to wait
-} BGetCtx;
+    bool blocking_req;      ///< true when BLOCK was specified; false = return immediately
+    long long timeout_ms;   ///< only meaningful when blocking_req; 0 = block forever, >0 = max wait
+} ReadCtx;
 
 /**
- * @brief Parse TS.BGET argv into @p out, including sentinel resolution.
+ * @brief Parse TS.READ argv into @p out, including sentinel resolution.
  *
  * On error, replies to the client with a descriptive error.
  * @p out->key is borrowed from @p argv (not retained).
@@ -1514,60 +1516,60 @@ typedef struct BGetCtx
  *   - literal non-negative integer : @p out->cursor = the integer.
  *   - '-'                          : @p out->cursor = 0 (no lower bound).
  *   - '+'                          : open the series ONCE and snapshot
- *                                    @p out->cursor = lastTimestamp + 1;
- *                                    saturated (lastTimestamp == UINT64_MAX)
- *                                    -> UINT64_MAX to avoid wrap-to-0;
+ *                                    @p out->cursor = lastTimestamp;
  *                                    missing or empty series -> 0; wrong-type
  *                                    key -> reply WRONGTYPE and return ERR.
+ *   - '$'                          : @p out->cursor = lastTimestamp + 1
+ *                                    (saturated at UINT64_MAX); only future
+ *                                    samples qualify.
  *
  * After OK, @p out->cursor is a plain literal for the rest of the lifecycle.
  *
- * Syntax: TS.BGET key timestamp timeout [MIN_COUNT min_count] [MAX_COUNT max_count]
- *   - argv[3] (timeout): non-negative integer milliseconds; 0 means "do not block".
- *   - MIN_COUNT (optional): unblock threshold, positive integer. Default 1.
+ * Syntax: TS.READ key timestamp [BLOCK milliseconds min_count] [MAX_COUNT max_count]
+ *   - BLOCK (optional): milliseconds is non-negative integer ms; 0 = do not block.
+ *                       min_count is positive integer unblock threshold. Default: no block.
  *   - MAX_COUNT (optional): reply cap, positive integer. Default unlimited (-1).
- *   - Requires min_count <= max_count.
+ *   - Requires min_count <= max_count when MAX_COUNT is specified.
  *
  * @param ctx   Redis module context (used to reply on error / WRONGTYPE).
  * @param argv  Command argument vector.
- * @param argc  Number of arguments in @p argv (4 to 8).
+ * @param argc  Number of arguments in @p argv (3, 5, 6, or 8).
  * @param out   Output struct populated on success.
  * @return REDISMODULE_OK on success, REDISMODULE_ERR on any reply written.
  */
-static int parse_bget_args(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, BGetCtx *out) {
-    // Optional args come only as MIN_COUNT/MAX_COUNT keyword+value pairs, so
-    // anything past the fixed args must be a whole number of BGET_OPTION_STRIDE
-    // tokens. This rejects a stray trailing token or a lone keyword (e.g. an
-    // odd argc of 5 or 7) instead of silently ignoring it.
-    if (argc < BGET_MIN_ARGC || argc > BGET_MAX_ARGC ||
-        (argc - BGET_MIN_ARGC) % BGET_OPTION_STRIDE != 0) {
+static int parse_read_args(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, ReadCtx *out) {
+    // Determine which optional blocks are present before validating argc so we
+    // can compute the exact expected count and give WrongArity on mismatch.
+    // BLOCK takes 3 tokens (keyword + ms + min_count); MAX_COUNT takes 2.
+    // Valid argcs: 3, 5 (MAX_COUNT only), 6 (BLOCK only), 8 (both).
+    bool has_block = RMUtil_ArgIndex("BLOCK", argv, argc) >= READ_ARGV_FIRST_OPTION;
+    bool has_max_count = RMUtil_ArgIndex("MAX_COUNT", argv, argc) >= READ_ARGV_FIRST_OPTION;
+    int expected_argc = READ_MIN_ARGC + (has_block ? READ_BLOCK_TOKENS : 0) +
+                        (has_max_count ? READ_MAX_COUNT_TOKENS : 0);
+    if (argc != expected_argc) {
         RedisModule_WrongArity(ctx);
         return REDISMODULE_ERR;
     }
 
-    // timeout_ms: non-negative integer. BGET_NO_BLOCK_TIMEOUT means "do not block".
-    long long timeout_ms = BGET_NO_BLOCK_TIMEOUT;
-    if (RedisModule_StringToLongLong(argv[BGET_ARGV_TIMEOUT], &timeout_ms) != REDISMODULE_OK ||
-        timeout_ms < 0) {
-        RedisModule_ReplyWithError(ctx, "TSDB: timeout must be a non-negative integer");
-        return REDISMODULE_ERR;
-    }
+    long long timeout_ms = 0;
+    long long min_count = READ_DEFAULT_MIN_COUNT;
+    long long max_count = READ_DEFAULT_MAX_COUNT;
 
-    // Optional MIN_COUNT / MAX_COUNT, parsed like every other TS optional
-    // keyword argument: locate the token with RMUtil_ArgIndex and read its
-    // value with RMUtil_ParseArgsAfter.
-    long long min_count = BGET_DEFAULT_MIN_COUNT;
-    long long max_count = BGET_DEFAULT_MAX_COUNT;
-
-    if (RMUtil_ArgIndex("MIN_COUNT", argv, argc) > 0) {
-        if (RMUtil_ParseArgsAfter("MIN_COUNT", argv, argc, "l", &min_count) != REDISMODULE_OK ||
-            min_count <= 0) {
-            RedisModule_ReplyWithError(ctx, "TSDB: MIN_COUNT must be a positive integer");
+    if (has_block) {
+        if (RMUtil_ParseArgsAfter("BLOCK", argv, argc, "ll", &timeout_ms, &min_count) !=
+                REDISMODULE_OK ||
+            timeout_ms < 0) {
+            RedisModule_ReplyWithError(ctx,
+                                       "TSDB: BLOCK milliseconds must be a non-negative integer");
+            return REDISMODULE_ERR;
+        }
+        if (min_count <= 0) {
+            RedisModule_ReplyWithError(ctx, "TSDB: BLOCK min_count must be a positive integer");
             return REDISMODULE_ERR;
         }
     }
 
-    if (RMUtil_ArgIndex("MAX_COUNT", argv, argc) > 0) {
+    if (has_max_count) {
         if (RMUtil_ParseArgsAfter("MAX_COUNT", argv, argc, "l", &max_count) != REDISMODULE_OK ||
             max_count <= 0) {
             RedisModule_ReplyWithError(ctx, "TSDB: MAX_COUNT must be a positive integer");
@@ -1576,8 +1578,8 @@ static int parse_bget_args(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     }
 
     // Unlimited max_count is >= any min_count, so only validate when capped.
-    if (max_count != BGET_DEFAULT_MAX_COUNT && min_count > max_count) {
-        RedisModule_ReplyWithError(ctx, "TSDB: MIN_COUNT must be <= MAX_COUNT");
+    if (max_count != READ_DEFAULT_MAX_COUNT && min_count > max_count) {
+        RedisModule_ReplyWithError(ctx, "TSDB: BLOCK min_count must be <= MAX_COUNT");
         return REDISMODULE_ERR;
     }
 
@@ -1594,12 +1596,12 @@ static int parse_bget_args(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     // lastTs would chase forward and we'd never reply.
     api_timestamp_t cursor = 0;
     size_t ts_len = 0;
-    const char *ts_str = RedisModule_StringPtrLen(argv[BGET_ARGV_TIMESTAMP], &ts_len);
+    const char *ts_str = RedisModule_StringPtrLen(argv[READ_ARGV_TIMESTAMP], &ts_len);
     if (ts_len == 1 && ts_str[0] == '-') {
         cursor = 0;
     } else if (ts_len == 1 && (ts_str[0] == '+' || ts_str[0] == '$')) {
         const bool future_only = (ts_str[0] == '$');
-        RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[BGET_ARGV_KEY], REDISMODULE_READ);
+        RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[READ_ARGV_KEY], REDISMODULE_READ);
         const int kt = key ? RedisModule_KeyType(key) : REDISMODULE_KEYTYPE_EMPTY;
 
         if (kt == REDISMODULE_KEYTYPE_EMPTY) {
@@ -1630,7 +1632,7 @@ static int parse_bget_args(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
         }
     } else {
         long long ts_ll = 0;
-        if (RedisModule_StringToLongLong(argv[BGET_ARGV_TIMESTAMP], &ts_ll) != REDISMODULE_OK ||
+        if (RedisModule_StringToLongLong(argv[READ_ARGV_TIMESTAMP], &ts_ll) != REDISMODULE_OK ||
             ts_ll < 0) {
             RedisModule_ReplyWithError(ctx, "TSDB: invalid timestamp");
             return REDISMODULE_ERR;
@@ -1638,10 +1640,11 @@ static int parse_bget_args(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
         cursor = (api_timestamp_t)ts_ll;
     }
 
-    out->key = argv[BGET_ARGV_KEY];
+    out->key = argv[READ_ARGV_KEY];
     out->cursor = cursor;
     out->min_count = (size_t)min_count;
     out->max_count = max_count;
+    out->blocking_req = has_block;
     out->timeout_ms = timeout_ms;
     return REDISMODULE_OK;
 }
@@ -1671,7 +1674,7 @@ static size_t TSDB_count_samples_up_to(Series *series, const RangeArgs *range, s
 }
 
 /**
- * @brief Try to satisfy a TS.BGET request from current series state.
+ * @brief Try to satisfy a TS.READ request from current series state.
  *
  * Single source of truth for "what should we reply with right now?", shared
  * by the fast path, the wake-up callback, and the timeout callback. In
@@ -1687,7 +1690,7 @@ static size_t TSDB_count_samples_up_to(Series *series, const RangeArgs *range, s
  *     wake-ups.
  *   - flush  (@p require_full_batch == false): always reply (possibly empty
  *     or partial). Used by the timeout callback and by the no-block fast
- *     path when `timeout_ms == 0`.
+ *     path when BLOCK is omitted (`blocking_req == false`).
  *
  * In all reply cases at most @p args->max_count samples are returned.
  *
@@ -1699,12 +1702,12 @@ static size_t TSDB_count_samples_up_to(Series *series, const RangeArgs *range, s
  *                         flush  -> reply (0..max_count samples).
  *
  * @param ctx                Module context for OpenKey/Reply* calls.
- * @param args               Parsed BGET arguments (key, cursor, min/max count).
+ * @param args               Parsed READ arguments (key, cursor, min/max count).
  * @param require_full_batch Strict (true) vs flush (false) mode.
  * @return true if a reply was written, false only in strict mode when caller
  *         should block / stay parked.
  */
-static bool TSDB_bget_try_reply(RedisModuleCtx *ctx, const BGetCtx *args, bool require_full_batch) {
+static bool TSDB_read_try_reply(RedisModuleCtx *ctx, const ReadCtx *args, bool require_full_batch) {
     RedisModuleKey *key = RedisModule_OpenKey(ctx, args->key, REDISMODULE_READ);
     const int keyType = key ? RedisModule_KeyType(key) : REDISMODULE_KEYTYPE_EMPTY;
 
@@ -1771,13 +1774,13 @@ static bool TSDB_bget_try_reply(RedisModuleCtx *ctx, const BGetCtx *args, bool r
  * Must be called from a BlockClientOnKeys callback (reply / timeout) on the
  * unblock path — i.e. right before returning REDISMODULE_OK. Accumulates the
  * elapsed wait into bc->background_duration so slowlog / commandstats /
- * latency-history account for blocked TS.BGET time instead of dropping it.
+ * latency-history account for blocked TS.READ time instead of dropping it.
  *
  * Safe no-op when the Redis build doesn't expose the MeasureTime APIs.
  *
  * @param ctx Module context bound to the blocked client.
  */
-static void TSDB_bget_account_blocked_time(RedisModuleCtx *ctx) {
+static void TSDB_read_account_blocked_time(RedisModuleCtx *ctx) {
     if (CheckVersionForBlockedClientMeasureTime()) {
         RedisModule_BlockedClientMeasureTimeEnd(RedisModule_GetBlockedClientHandle(ctx));
     }
@@ -1795,21 +1798,21 @@ static void TSDB_bget_account_blocked_time(RedisModuleCtx *ctx) {
  * @return REDISMODULE_OK to unblock and commit the reply, REDISMODULE_ERR to
  *         stay parked until the next signal or the timeout.
  */
-static int TSDB_bget_reply_callback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+static int TSDB_read_reply_callback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
-    const BGetCtx *priv = RedisModule_GetBlockedClientPrivateData(ctx);
+    const ReadCtx *priv = RedisModule_GetBlockedClientPrivateData(ctx);
     // If the key was deleted while we were parked (Redis wakes us on
     // DEL/UNLINK/FLUSHDB/FLUSHALL/expire/eviction via the
     // REDISMODULE_BLOCK_UNBLOCK_DELETED flag set in RTS_BlockClientOnKey),
     // flush whatever's available (empty) instead of re-parking until timeout.
     const bool key_gone = !RedisModule_KeyExists(ctx, priv->key);
-    if (!TSDB_bget_try_reply(ctx, priv, /*require_full_batch=*/!key_gone)) {
+    if (!TSDB_read_try_reply(ctx, priv, /*require_full_batch=*/!key_gone)) {
         // Stay parked: keep the background timer running so the eventual
         // unblock (next signal or timeout) accounts for the full wait.
         return REDISMODULE_ERR;
     }
-    TSDB_bget_account_blocked_time(ctx);
+    TSDB_read_account_blocked_time(ctx);
     return REDISMODULE_OK;
 }
 
@@ -1818,36 +1821,36 @@ static int TSDB_bget_reply_callback(RedisModuleCtx *ctx, RedisModuleString **arg
  *
  * Invoked when `timeout_ms` elapses without the client being unblocked.
  * Flushes whatever is available (possibly empty or fewer than count) per
- * the TS.BGET spec.
+ * the TS.READ spec.
  *
  * @param ctx   Module context bound to the blocked client.
  * @param argv  Unused.
  * @param argc  Unused.
  * @return Always REDISMODULE_OK (the client is unblocked unconditionally).
  */
-static int TSDB_bget_timeout_callback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+static int TSDB_read_timeout_callback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
-    const BGetCtx *priv = RedisModule_GetBlockedClientPrivateData(ctx);
-    (void)TSDB_bget_try_reply(ctx, priv, /*require_full_batch=*/false);
-    TSDB_bget_account_blocked_time(ctx);
+    const ReadCtx *priv = RedisModule_GetBlockedClientPrivateData(ctx);
+    (void)TSDB_read_try_reply(ctx, priv, /*require_full_batch=*/false);
+    TSDB_read_account_blocked_time(ctx);
     return REDISMODULE_OK;
 }
 
 /**
- * @brief Release the BGetCtx attached to the blocked client.
+ * @brief Release the ReadCtx attached to the blocked client.
  *
  * Called by Redis once the client is unblocked (via reply, timeout,
  * disconnect, or abort). Frees the retained key and the heap struct.
  *
  * @param ctx       Module context (used for RedisModule_FreeString).
- * @param privdata  BGetCtx* allocated by TSDB_bget_block(); NULL-safe.
+ * @param privdata  ReadCtx* allocated by TSDB_read_block(); NULL-safe.
  */
-static void TSDB_bget_free_privdata(RedisModuleCtx *ctx, void *privdata) {
+static void TSDB_read_free_privdata(RedisModuleCtx *ctx, void *privdata) {
     if (!privdata) {
         return;
     }
-    BGetCtx *priv = privdata;
+    ReadCtx *priv = privdata;
     if (priv->key) {
         RedisModule_FreeString(ctx, priv->key);
     }
@@ -1858,7 +1861,7 @@ static void TSDB_bget_free_privdata(RedisModuleCtx *ctx, void *privdata) {
  * @brief Allocate privdata and park the client on @p args->key.
  *
  * Heap-copies @p args, retains the key for the privdata's lifetime, and
- * registers the BGET reply / timeout / free callbacks. Redis owns the
+ * registers the READ reply / timeout / free callbacks. Redis owns the
  * blocked-client lifecycle thereafter.
  *
  * If Redis refuses to block (MULTI / Lua / deny-blocking context),
@@ -1867,83 +1870,81 @@ static void TSDB_bget_free_privdata(RedisModuleCtx *ctx, void *privdata) {
  * a leak.
  *
  * @param ctx   Module context bound to the calling client.
- * @param args  Parsed BGET arguments to capture into privdata.
+ * @param args  Parsed READ arguments to capture into privdata.
  * @return Handle to the blocked client, or NULL if blocking was refused.
  */
-static RedisModuleBlockedClient *TSDB_bget_block(RedisModuleCtx *ctx, const BGetCtx *args) {
-    BGetCtx *priv = malloc(sizeof(*priv));
+static RedisModuleBlockedClient *TSDB_read_block(RedisModuleCtx *ctx, const ReadCtx *args) {
+    ReadCtx *priv = malloc(sizeof(*priv));
     *priv = *args;
     RedisModule_RetainString(ctx, priv->key);
 
     RedisModuleBlockedClient *bc = RTS_BlockClientOnKey(ctx,
-                                                        TSDB_bget_reply_callback,
-                                                        TSDB_bget_timeout_callback,
-                                                        TSDB_bget_free_privdata,
+                                                        TSDB_read_reply_callback,
+                                                        TSDB_read_timeout_callback,
+                                                        TSDB_read_free_privdata,
                                                         priv->timeout_ms,
                                                         priv->key,
                                                         priv);
     if (!bc) {
-        TSDB_bget_free_privdata(ctx, priv);
+        TSDB_read_free_privdata(ctx, priv);
     }
     return bc;
 }
 
 /**
- * @brief TS.BGET command entry point.
+ * @brief TS.READ command entry point.
  *
- * Parses argv into a BGetCtx. If samples at-or-after the cursor already exist
- * (or the key is unusable / `timeout_ms == 0`), replies inline via
- * TSDB_bget_try_reply(); otherwise parks the client via TSDB_bget_block().
+ * Parses argv into a ReadCtx. If samples at-or-after the cursor already exist
+ * (or the key is unusable / BLOCK omitted), replies inline via
+ * TSDB_read_try_reply(); otherwise parks the client via TSDB_read_block().
  *
  * Blocking refusal in MULTI / EVAL / deny-blocking contexts is handled
- * reactively: BlockClientOnKeys returns NULL, TSDB_bget_block cleans up the
+ * reactively: BlockClientOnKeys returns NULL, TSDB_read_block cleans up the
  * privdata, and we deliver an explanatory error here.
  *
  * @param ctx   Module context.
  * @param argv  Command argument vector:
- *              `TS.BGET key timestamp timeout [MIN_COUNT min_count] [MAX_COUNT max_count]`.
- * @param argc  Argument count (4 to 8).
+ *              `TS.READ key timestamp [BLOCK milliseconds min_count] [MAX_COUNT max_count]`.
+ * @param argc  Argument count (3 to 8).
  * @return Always REDISMODULE_OK — errors (parse, WRONGTYPE, blocking refused)
  *         are delivered through RedisModule_ReplyWithError so the client
  *         always sees a terminal reply.
  */
-int TSDB_bget(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+int TSDB_read(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_AutoMemory(ctx);
 
-    BGetCtx args = { 0 };
-    if (parse_bget_args(ctx, argv, argc, &args) != REDISMODULE_OK) {
-        // parse_bget_args already wrote a reply (validation error, WRONGTYPE
+    ReadCtx args = { 0 };
+    if (parse_read_args(ctx, argv, argc, &args) != REDISMODULE_OK) {
+        // parse_read_args already wrote a reply (validation error, WRONGTYPE
         // during '+' resolution, etc.).
         return REDISMODULE_OK;
     }
 
-    // BGET_NO_BLOCK_TIMEOUT means "do not block" — flush whatever is available
-    // now (possibly empty / partial). A positive timeout uses strict mode; if
-    // we don't have min_count yet, fall through and park the client until a
-    // SignalKeyAsReady wakes us with enough data, or the timeout fires.
-    if (TSDB_bget_try_reply(ctx, &args, args.timeout_ms > BGET_NO_BLOCK_TIMEOUT)) {
+    // Without BLOCK: flush whatever exists now and return immediately.
+    // With BLOCK: use strict mode — if min_count isn't met yet, fall through and park.
+    if (TSDB_read_try_reply(ctx, &args, args.blocking_req)) {
         return REDISMODULE_OK;
     }
 
     // Preemptive refusal in MULTI / EVAL / deny-blocking contexts, mirroring
-    // TSDB_mget. A timeout_ms == 0 request already resolved synchronously
-    // above, so reaching here implies the caller asked to block.
+    // TSDB_mget. A no-BLOCK request already resolved synchronously above,
+    // so reaching here implies the caller issued BLOCK and asked to wait.
     if (RedisModule_GetContextFlags(ctx) &
         (REDISMODULE_CTX_FLAGS_LUA | REDISMODULE_CTX_FLAGS_MULTI |
          REDISMODULE_CTX_FLAGS_DENY_BLOCKING)) {
         RedisModule_ReplyWithError(ctx,
-                                   "TSDB: blocking TS.BGET (timeout > 0) is not allowed "
+                                   "TSDB: blocking TS.READ (with BLOCK) is not allowed"
                                    "inside MULTI, EVAL, or a deny-blocking context");
         return REDISMODULE_OK;
     }
 
-    if (!TSDB_bget_block(ctx, &args)) {
+    if (!TSDB_read_block(ctx, &args)) {
         // Defensive fallback: BlockClientOnKeys refused to park us even
         // though the preemptive context check passed (e.g. a Redis version
         // surfacing a new deny-blocking flag). Reply with an error so the
         // client doesn't hang on an empty pipeline.
         RedisModule_ReplyWithError(ctx,
-                                   "TSDB: blocking TS.BGET (timeout > 0) is not allowed "
+                                   "TSDB: blocking TS.READ (with BLOCK) is not allowed"
                                    "inside MULTI, EVAL, or a deny-blocking context");
     }
     return REDISMODULE_OK;
@@ -2576,8 +2577,8 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
     RegisterCommandWithModesAndAcls(ctx, "ts.info", TSDB_info, "readonly", "read fast");
     RegisterCommandWithModesAndAcls(ctx, "ts.get", TSDB_get, "readonly", "read fast");
-    // TS.BGET may block on the key; intentionally NOT flagged "fast".
-    RegisterCommandWithModesAndAcls(ctx, "ts.bget", TSDB_bget, "readonly", "read");
+    // TS.READ may block on the key; intentionally NOT flagged "fast".
+    RegisterCommandWithModesAndAcls(ctx, "ts.read", TSDB_read, "readonly", "read");
     RegisterCommandWithModesAndAcls(ctx, "ts.del", TSDB_delete, "write", "write");
 
     if (RedisModule_CreateCommand(ctx, "ts.madd", TSDB_madd, "write deny-oom", 1, -1, 3) ==

--- a/src/tsdb.c
+++ b/src/tsdb.c
@@ -609,7 +609,7 @@ static bool RuleSeriesUpsertSample(RedisModuleCtx *ctx,
     } else {
         SeriesUpsertSample(destSeries, start, val, DP_LAST);
     }
-    // Wake any TS.BGET waiters parked on the destination key, so a
+    // Wake any TS.READ waiters parked on the destination key, so a
     // compaction-rule bucket landing here triggers them just like a direct
     // write would.
     RedisModule_SignalKeyAsReady(ctx, rule->destKey);

--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -31,7 +31,7 @@ SANITIZER = os.getenv('SANITIZER', '')
 VALGRIND = (os.getenv('VALGRIND', '0') == '1') or (os.getenv('VG', '0') == '1')
 CODE_COVERAGE = os.getenv('CODE_COVERAGE', '0') == '1'
 
-# Upper bound on how long a "prompt" wake (e.g. TS.BGET woken by a key deletion)
+# Upper bound on how long a "prompt" wake (e.g. TS.READ woken by a key deletion)
 # may take before we consider it a regression. Scaled up under Valgrind/sanitizer
 # so the slower wake-up callback there can't produce a false failure.
 WAKE_TIMEOUT_SECS = 30 if (VALGRIND or SANITIZER) else 5

--- a/tests/flow/test_ts_read.py
+++ b/tests/flow/test_ts_read.py
@@ -38,8 +38,8 @@ def _start_read(env, key, cursor, block_ms=None, min_count=None, max_count=None)
         # first under normal conditions.
         try:
             if block_ms is not None:
-                conn.connection_pool.connection_kwargs["socket_timeout"] = \
-                    max(1.0, (block_ms / 1000.0) + 1.0)
+                timeout = WAKE_TIMEOUT_SECS + 1.0 if block_ms == 0 else max(1.0, (block_ms / 1000.0) + 1.0)
+                conn.connection_pool.connection_kwargs["socket_timeout"] = timeout
         except Exception:
             pass
         t0 = time.time()

--- a/tests/flow/test_ts_read.py
+++ b/tests/flow/test_ts_read.py
@@ -299,6 +299,65 @@ def test_read_timeout_flushes_available_samples():
 
 
 # ---------------------------------------------------------------------------
+# 4b. BLOCK 0 = block forever: client parks with no timeout and only wakes
+#     when a qualifying sample arrives via SignalKeyAsReady.
+# ---------------------------------------------------------------------------
+
+def test_read_block_zero_blocks_forever_until_sample_arrives():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    r.execute_command("FLUSHALL")
+
+    # BLOCK 0 min_count=1: no timeout, must stay parked until first ADD.
+    t, slot = _start_read(env, "ts", "-", block_ms=0, min_count=1)
+    time.sleep(0.3)
+    env.assertTrue(t.is_alive(),
+                   message="BLOCK 0 should park the client indefinitely (no timeout)")
+
+    # Still blocked after another pause — no producer yet.
+    time.sleep(0.5)
+    env.assertTrue(t.is_alive(),
+                   message="BLOCK 0 must still be parked with no data")
+
+    assert r.execute_command("TS.ADD", "ts", 100, "1.0") == 100
+
+    t.join(timeout=WAKE_TIMEOUT_SECS)
+    env.assertFalse(t.is_alive(),
+                    message="BLOCK 0 must wake promptly once a qualifying sample arrives")
+    env.assertEqual(slot["error"], None)
+    env.assertEqual(slot["result"], [[100, b"1"]])
+
+
+def test_read_block_zero_wakes_on_del():
+    """BLOCK 0 (infinite) must also unblock on key deletion, not hang forever."""
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    _seed(r, "ts", [(100, "1.0")])
+
+    t, slot = _start_read(env, "ts", 0, block_ms=0, min_count=5)
+    time.sleep(0.3)
+    env.assertTrue(t.is_alive(), message="BLOCK 0 should be parked")
+
+    t0 = time.time()
+    assert r.execute_command("DEL", "ts") == 1
+
+    t.join(timeout=WAKE_TIMEOUT_SECS)
+    elapsed = time.time() - t0
+    env.assertFalse(t.is_alive(),
+                    message="DEL must wake a BLOCK 0 client (took %.3fs)" % elapsed)
+    env.assertEqual(slot["error"], None)
+    env.assertEqual(slot["result"], [])
+    env.assertTrue(elapsed < WAKE_TIMEOUT_SECS,
+                   message="DEL wake must be immediate, took %.3fs" % elapsed)
+
+
+# ---------------------------------------------------------------------------
 # 5. '-' sentinel: cursor=0, matches every existing sample.
 # ---------------------------------------------------------------------------
 
@@ -599,6 +658,27 @@ def test_read_inside_eval_refuses_with_clear_error():
                    message="unexpected error: %r" % (excinfo.value,))
 
 
+def test_read_block_zero_refused_in_multi():
+    """BLOCK 0 (infinite) must also be refused inside MULTI — it blocks forever."""
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    r.execute_command("FLUSHALL")
+
+    r.execute_command("MULTI")
+    r.execute_command("TS.READ", "ts", 0, "BLOCK", 0, 1)
+    try:
+        res = r.execute_command("EXEC")
+        env.assertEqual(len(res), 1)
+        env.assertTrue(_is_deny_blocking_error(res[0]),
+                       message="unexpected EXEC reply: %r" % (res[0],))
+    except redis.ResponseError as e:
+        env.assertTrue(_is_deny_blocking_error(e),
+                       message="unexpected error: %r" % (e,))
+
+
 # ---------------------------------------------------------------------------
 # 14. Parse / arity validation — every malformed call must surface an error.
 # ---------------------------------------------------------------------------
@@ -653,6 +733,52 @@ def test_read_without_block_returns_partial_immediately():
     env.assertEqual(res, [[100, b"1"], [200, b"2"]])
     env.assertTrue(elapsed < 0.3,
                    message="non-blocking READ must not block, took %.3fs" % elapsed)
+
+
+def test_read_without_block_on_missing_key_returns_empty_immediately():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    r.execute_command("FLUSHALL")
+
+    t0 = time.time()
+    res = r.execute_command("TS.READ", "ts", 0)
+    elapsed = time.time() - t0
+
+    env.assertEqual(res, [])
+    env.assertTrue(elapsed < 0.3,
+                   message="non-blocking READ on missing key must not block, took %.3fs" % elapsed)
+
+
+def test_read_without_block_on_empty_series_returns_empty_immediately():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    assert r.execute_command("TS.CREATE", "ts")
+
+    t0 = time.time()
+    res = r.execute_command("TS.READ", "ts", 0)
+    elapsed = time.time() - t0
+
+    env.assertEqual(res, [])
+    env.assertTrue(elapsed < 0.3,
+                   message="non-blocking READ on empty series must not block, took %.3fs" % elapsed)
+
+
+def test_read_without_block_respects_max_count():
+    env = Env()
+    if env.is_cluster():
+        env.skip()
+
+    r = env.getConnection()
+    _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0"), (400, "4.0")])
+
+    res = r.execute_command("TS.READ", "ts", 0, "MAX_COUNT", 2)
+    env.assertEqual(res, [[100, b"1"], [200, b"2"]])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/flow/test_ts_read.py
+++ b/tests/flow/test_ts_read.py
@@ -8,42 +8,43 @@ from includes import *
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _bget_argv(key, cursor, timeout_ms, min_count=None, max_count=None):
-    """Build a TS.BGET argument list for the
-    `key timestamp timeout [MIN_COUNT n] [MAX_COUNT n]` syntax."""
-    argv = [key, cursor, timeout_ms]
-    if min_count is not None:
-        argv += ["MIN_COUNT", min_count]
+def _read_argv(key, cursor, block_ms=None, min_count=None, max_count=None):
+    """Build a TS.READ argument list for the
+    `key timestamp [BLOCK ms min_count] [MAX_COUNT n]` syntax."""
+    argv = [key, cursor]
+    if block_ms is not None:
+        argv += ["BLOCK", block_ms, min_count if min_count is not None else 1]
     if max_count is not None:
         argv += ["MAX_COUNT", max_count]
     return argv
 
 
-def _start_bget(env, key, cursor, timeout_ms, min_count=None, max_count=None):
-    """Spawn a worker thread that issues TS.BGET on its own connection.
+def _start_read(env, key, cursor, block_ms=None, min_count=None, max_count=None):
+    """Spawn a worker thread that issues TS.READ on its own connection.
 
     Returns (thread, slot) where `slot` is mutated by the worker:
         slot["result"]  -> reply payload (or None if it errored / hasn't returned)
         slot["error"]   -> exception text (or None)
-        slot["elapsed"] -> wall-clock seconds the BGET call took
+        slot["elapsed"] -> wall-clock seconds the READ call took
     """
     slot = {"result": None, "error": None, "elapsed": None}
-    argv = _bget_argv(key, cursor, timeout_ms, min_count, max_count)
+    argv = _read_argv(key, cursor, block_ms, min_count, max_count)
 
     def worker():
         conn = env.getConnection()
-        # Cap the socket read so a stuck server-side BGET cannot keep the
+        # Cap the socket read so a stuck server-side READ cannot keep the
         # thread (daemon or not) alive past a short, predictable bound.
-        # Slightly above timeout_ms to let the server's own timeout fire
+        # Slightly above block_ms to let the server's own timeout fire
         # first under normal conditions.
         try:
-            conn.connection_pool.connection_kwargs["socket_timeout"] = \
-                max(1.0, (timeout_ms / 1000.0) + 1.0)
+            if block_ms is not None:
+                conn.connection_pool.connection_kwargs["socket_timeout"] = \
+                    max(1.0, (block_ms / 1000.0) + 1.0)
         except Exception:
             pass
         t0 = time.time()
         try:
-            slot["result"] = conn.execute_command("TS.BGET", *argv)
+            slot["result"] = conn.execute_command("TS.READ", *argv)
         except Exception as e:
             slot["error"] = str(e)
         finally:
@@ -68,30 +69,30 @@ def _seed(r, key, samples):
 # 1. Immediate reply when enough qualifying samples already exist.
 # ---------------------------------------------------------------------------
 
-def test_bget_returns_immediately_when_min_count_already_satisfied():
+def test_read_returns_immediately_when_min_count_already_satisfied():
     env = Env()
     if env.is_cluster():
-        env.skip()  # BGET is a single-key primitive; cluster routing is orthogonal.
+        env.skip()  # READ is a single-key primitive; cluster routing is orthogonal.
 
     r = env.getConnection()
     _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
 
-    # cursor=101 -> qualifying = {200, 300}; MIN_COUNT 2 is already met, so BGET
-    # should NOT block and return synchronously (MAX_COUNT 2 caps the reply).
+    # cursor=101 -> qualifying = {200, 300}; BLOCK min_count 2 is already met, so
+    # READ should NOT block and return synchronously (MAX_COUNT 2 caps the reply).
     t0 = time.time()
-    res = r.execute_command("TS.BGET", "ts", 101, 1000, "MIN_COUNT", 2, "MAX_COUNT", 2)
+    res = r.execute_command("TS.READ", "ts", 101, "BLOCK", 1000, 2, "MAX_COUNT", 2)
     elapsed = time.time() - t0
 
     env.assertEqual(res, [[200, b"2"], [300, b"3"]])
     # Sanity: nothing close to the 1s timeout.
-    env.assertTrue(elapsed < 0.5, message="BGET should be ~instant, got %.3fs" % elapsed)
+    env.assertTrue(elapsed < 0.5, message="READ should be ~instant, got %.3fs" % elapsed)
 
 
 # ---------------------------------------------------------------------------
 # 2. Blocks until SignalKeyAsReady has pushed qualifying-count to >= min_count.
 # ---------------------------------------------------------------------------
 
-def test_bget_blocks_then_unblocks_when_min_count_is_reached():
+def test_read_blocks_then_unblocks_when_min_count_is_reached():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -99,36 +100,36 @@ def test_bget_blocks_then_unblocks_when_min_count_is_reached():
     r = env.getConnection()
     _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
 
-    # cursor=101 -> initial qualifying = {200, 300} = 2 < 5, so BGET blocks.
+    # cursor=101 -> initial qualifying = {200, 300} = 2 < 5, so READ blocks.
     # NOTE: to reach min_count=5 with cursor=101 we need THREE more samples,
     # not two — the sample at ts=100 doesn't qualify because 100 < 101
     # (cursor is an inclusive lower bound: only ts >= cursor qualifies).
     # Each TS.ADD fires SignalKeyAsReady -> reply_cb runs; only the third
     # add commits because that's when qualifying becomes 5.
-    t, slot = _start_bget(env, "ts", 101, 2_000, min_count=5, max_count=5)
+    t, slot = _start_read(env, "ts", 101, 2_000, min_count=5, max_count=5)
 
     # Give the worker enough time to issue BlockClientOnKeys on the server.
     time.sleep(0.3)
-    env.assertTrue(t.is_alive(), message="BGET should be blocked (2 < 5 qualifying)")
+    env.assertTrue(t.is_alive(), message="READ should be blocked (2 < 5 qualifying)")
 
     # Add #1: qualifying = {200, 300, 400} = 3 < 5 -> stay blocked.
     assert r.execute_command("TS.ADD", "ts", 400, "4.0") == 400
     time.sleep(0.2)
     env.assertTrue(t.is_alive(),
-                   message="BGET should still be blocked after 1st add (3 < 5)")
+                   message="READ should still be blocked after 1st add (3 < 5)")
 
     # Add #2: qualifying = {200, 300, 400, 500} = 4 < 5 -> stay blocked.
     assert r.execute_command("TS.ADD", "ts", 500, "5.0") == 500
     time.sleep(0.2)
     env.assertTrue(t.is_alive(),
-                   message="BGET should still be blocked after 2nd add (4 < 5)")
+                   message="READ should still be blocked after 2nd add (4 < 5)")
 
     # Add #3: qualifying = {200, 300, 400, 500, 600} = 5 -> reply_cb commits.
     assert r.execute_command("TS.ADD", "ts", 600, "6.0") == 600
 
     t.join(timeout=2.0)
     env.assertFalse(t.is_alive(),
-                    message="BGET should have replied once qualifying >= min_count")
+                    message="READ should have replied once qualifying >= min_count")
 
     env.assertEqual(slot["error"], None)
     env.assertEqual(
@@ -137,7 +138,7 @@ def test_bget_blocks_then_unblocks_when_min_count_is_reached():
     )
     # Sanity: well below the 10s timeout — we unblocked on the signal, not on timeout.
     env.assertTrue(slot["elapsed"] < 5.0,
-                   message="BGET took %.2fs, should have unblocked promptly" % slot["elapsed"])
+                   message="READ took %.2fs, should have unblocked promptly" % slot["elapsed"])
 
 
 # ---------------------------------------------------------------------------
@@ -145,7 +146,7 @@ def test_bget_blocks_then_unblocks_when_min_count_is_reached():
 #    oldest `max_count` (so callers can advance the cursor to the last returned ts).
 # ---------------------------------------------------------------------------
 
-def test_bget_returns_oldest_max_count_when_more_qualify():
+def test_read_returns_oldest_max_count_when_more_qualify():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -157,22 +158,22 @@ def test_bget_returns_oldest_max_count_when_more_qualify():
     ])
 
     # cursor=101 -> 4 qualifying (200, 300, 400, 500); MAX_COUNT 2 -> take the OLDEST 2.
-    res = r.execute_command("TS.BGET", "ts", 101, 1000, "MAX_COUNT", 2)
+    res = r.execute_command("TS.READ", "ts", 101, "BLOCK", 1000, 1, "MAX_COUNT", 2)
     env.assertEqual(res, [[200, b"2"], [300, b"3"]])
 
     # The caller pages forward by setting cursor to last_returned_ts + 1
     # (cursor is inclusive: ts >= cursor qualifies, so passing 300 would
     # re-emit the sample we already saw).
-    res = r.execute_command("TS.BGET", "ts", 301, 1000, "MAX_COUNT", 2)
+    res = r.execute_command("TS.READ", "ts", 301, "BLOCK", 1000, 1, "MAX_COUNT", 2)
     env.assertEqual(res, [[400, b"4"], [500, b"5"]])
 
 
 # ---------------------------------------------------------------------------
-# 3b. MIN_COUNT vs MAX_COUNT divergence: wait for min_count, then return the
-#     oldest max_count (which may be fewer than what qualifies).
+# 3b. BLOCK min_count vs MAX_COUNT divergence: wait for min_count, then return
+#     the oldest max_count (which may be fewer than what qualifies).
 # ---------------------------------------------------------------------------
 
-def test_bget_min_below_max_returns_oldest_max_count():
+def test_read_min_below_max_returns_oldest_max_count():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -183,20 +184,20 @@ def test_bget_min_below_max_returns_oldest_max_count():
         (400, "4.0"), (500, "5.0"), (600, "6.0"),
     ])
 
-    # cursor=0 -> 6 qualify; MIN_COUNT 2 already met, MAX_COUNT 4 caps to oldest 4.
-    res = r.execute_command("TS.BGET", "ts", 0, 1000, "MIN_COUNT", 2, "MAX_COUNT", 4)
+    # cursor=0 -> 6 qualify; BLOCK min_count 2 already met, MAX_COUNT 4 caps to oldest 4.
+    res = r.execute_command("TS.READ", "ts", 0, "BLOCK", 1000, 2, "MAX_COUNT", 4)
     env.assertEqual(res, [[100, b"1"], [200, b"2"], [300, b"3"], [400, b"4"]])
 
 
 # ---------------------------------------------------------------------------
-# 3d. Blocking path with MIN_COUNT < MAX_COUNT: the wake-up gate uses min_count,
+# 3d. Blocking path with min_count < MAX_COUNT: the wake-up gate uses min_count,
 #     but the committed reply is still capped to the oldest max_count. A single
 #     TS.MADD lands all samples before the wake-up callback runs, so qualifying
 #     jumps past max_count in one shot — exercising gate vs cap in the async
 #     (reply-callback) path, not just the synchronous fast path (test 3b).
 # ---------------------------------------------------------------------------
 
-def test_bget_blocking_min_gate_max_cap():
+def test_read_blocking_min_gate_max_cap():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -205,10 +206,10 @@ def test_bget_blocking_min_gate_max_cap():
     _seed(r, "ts", [(100, "1.0")])
 
     # cursor = 101 (literal), so the existing sample at 100 doesn't qualify and
-    # BGET blocks (0 < MIN_COUNT 2). MAX_COUNT 3 caps whatever we eventually return.
-    t, slot = _start_bget(env, "ts", 101, 2_000, min_count=2, max_count=3)
+    # READ blocks (0 < min_count 2). MAX_COUNT 3 caps whatever we eventually return.
+    t, slot = _start_read(env, "ts", 101, 2_000, min_count=2, max_count=3)
     time.sleep(0.3)
-    env.assertTrue(t.is_alive(), message="BGET should block until min_count qualifies")
+    env.assertTrue(t.is_alive(), message="READ should block until min_count qualifies")
 
     # One MADD adds 5 new qualifying samples atomically; the wake-up sees 5 >= 2
     # (gate satisfied) and must return the OLDEST 3 (cap), not all 5.
@@ -222,7 +223,7 @@ def test_bget_blocking_min_gate_max_cap():
     ) == [200, 300, 400, 500, 600]
 
     t.join(timeout=2.0)
-    env.assertFalse(t.is_alive(), message="BGET should have unblocked once min_count qualified")
+    env.assertFalse(t.is_alive(), message="READ should have unblocked once min_count qualified")
     env.assertEqual(slot["error"], None)
     env.assertEqual(slot["result"], [[200, b"2"], [300, b"3"], [400, b"4"]])
 
@@ -231,7 +232,7 @@ def test_bget_blocking_min_gate_max_cap():
 # 3e. Keyword matching is case-insensitive (house-style RMUtil_ArgIndex).
 # ---------------------------------------------------------------------------
 
-def test_bget_count_keywords_are_case_insensitive():
+def test_read_count_keywords_are_case_insensitive():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -242,15 +243,15 @@ def test_bget_count_keywords_are_case_insensitive():
     ])
 
     # cursor=0 -> 4 qualify; lower/mixed-case keywords must behave like uppercase.
-    res = r.execute_command("TS.BGET", "ts", 0, 1000, "min_count", 1, "Max_Count", 2)
+    res = r.execute_command("TS.READ", "ts", 0, "block", 1000, 1, "Max_Count", 2)
     env.assertEqual(res, [[100, b"1"], [200, b"2"]])
 
 
 # ---------------------------------------------------------------------------
-# 3c. Defaults: no MIN_COUNT/MAX_COUNT -> min_count=1, max_count=unlimited.
+# 3c. Defaults: no BLOCK/MAX_COUNT -> non-blocking, max_count=unlimited.
 # ---------------------------------------------------------------------------
 
-def test_bget_defaults_min_one_max_unlimited():
+def test_read_defaults_non_blocking_max_unlimited():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -258,9 +259,9 @@ def test_bget_defaults_min_one_max_unlimited():
     r = env.getConnection()
     _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
 
-    # min_count defaults to 1 (already met), max_count defaults to unlimited
-    # so every qualifying sample is returned.
-    res = r.execute_command("TS.BGET", "ts", 0, 1000)
+    # No BLOCK: returns immediately. max_count defaults to unlimited so every
+    # qualifying sample is returned.
+    res = r.execute_command("TS.READ", "ts", 0)
     env.assertEqual(res, [[100, b"1"], [200, b"2"], [300, b"3"]])
 
 
@@ -269,7 +270,7 @@ def test_bget_defaults_min_one_max_unlimited():
 #    flush whatever is available (which may be fewer than min_count).
 # ---------------------------------------------------------------------------
 
-def test_bget_timeout_flushes_available_samples():
+def test_read_timeout_flushes_available_samples():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -280,10 +281,10 @@ def test_bget_timeout_flushes_available_samples():
         (400, "4.0"), (500, "5.0"),
     ])
 
-    # cursor=101 -> 4 qualifying; MIN_COUNT 10 cannot be reached. Nobody else adds.
-    # After timeout_ms expires the timeout_cb flushes the 4 available samples.
+    # cursor=101 -> 4 qualifying; BLOCK min_count 10 cannot be reached. Nobody else adds.
+    # After milliseconds expires the timeout_cb flushes the 4 available samples.
     t0 = time.time()
-    res = r.execute_command("TS.BGET", "ts", 101, 1000, "MIN_COUNT", 10)
+    res = r.execute_command("TS.READ", "ts", 101, "BLOCK", 1000, 10)
     elapsed = time.time() - t0
 
     env.assertEqual(
@@ -301,7 +302,7 @@ def test_bget_timeout_flushes_available_samples():
 # 5. '-' sentinel: cursor=0, matches every existing sample.
 # ---------------------------------------------------------------------------
 
-def test_bget_dash_returns_all_existing_samples():
+def test_read_dash_returns_all_existing_samples():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -310,8 +311,8 @@ def test_bget_dash_returns_all_existing_samples():
     _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
 
     # '-' resolves statically to cursor=0; with ts >= 0 every sample qualifies,
-    # so MIN_COUNT 3 is already met and BGET returns synchronously.
-    res = r.execute_command("TS.BGET", "ts", "-", 5000, "MIN_COUNT", 3, "MAX_COUNT", 3)
+    # so BLOCK min_count 3 is already met and READ returns synchronously.
+    res = r.execute_command("TS.READ", "ts", "-", "BLOCK", 5000, 3, "MAX_COUNT", 3)
     env.assertEqual(res, [[100, b"1"], [200, b"2"], [300, b"3"]])
 
 
@@ -319,7 +320,7 @@ def test_bget_dash_returns_all_existing_samples():
 # 6. '-' on a missing key: cursor=0, blocks until the first qualifying ADD.
 # ---------------------------------------------------------------------------
 
-def test_bget_dash_on_empty_series_blocks_until_first_add():
+def test_read_dash_on_empty_series_blocks_until_first_add():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -327,16 +328,16 @@ def test_bget_dash_on_empty_series_blocks_until_first_add():
     r = env.getConnection()
     r.execute_command("FLUSHALL")  # key "ts" must not exist for this scenario.
 
-    t, slot = _start_bget(env, "ts", "-", 2_000)
+    t, slot = _start_read(env, "ts", "-", 2_000)
     time.sleep(0.3)
     env.assertTrue(t.is_alive(),
-                   message="BGET '-' on missing key should block until ADD")
+                   message="READ '-' on missing key should block until ADD")
 
     assert r.execute_command("TS.ADD", "ts", 100, "1.0") == 100
 
     t.join(timeout=2.0)
     env.assertFalse(t.is_alive(),
-                    message="BGET should have replied once the first sample arrived")
+                    message="READ should have replied once the first sample arrived")
     env.assertEqual(slot["error"], None)
     env.assertEqual(slot["result"], [[100, b"1"]])
 
@@ -345,7 +346,7 @@ def test_bget_dash_on_empty_series_blocks_until_first_add():
 # 7. '+' sentinel on an empty / missing key: cursor=0, behaves like '-'.
 # ---------------------------------------------------------------------------
 
-def test_bget_plus_on_empty_series_blocks_until_first_add():
+def test_read_plus_on_empty_series_blocks_until_first_add():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -353,10 +354,10 @@ def test_bget_plus_on_empty_series_blocks_until_first_add():
     r = env.getConnection()
     r.execute_command("FLUSHALL")
 
-    t, slot = _start_bget(env, "ts", "+", 2_000)
+    t, slot = _start_read(env, "ts", "+", 2_000)
     time.sleep(0.3)
     env.assertTrue(t.is_alive(),
-                   message="BGET '+' on missing key should block until ADD")
+                   message="READ '+' on missing key should block until ADD")
 
     assert r.execute_command("TS.ADD", "ts", 100, "1.0") == 100
 
@@ -372,7 +373,7 @@ def test_bget_plus_on_empty_series_blocks_until_first_add():
 #    qualifies, so the first call returns it immediately without blocking.
 # ---------------------------------------------------------------------------
 
-def test_bget_plus_returns_latest_existing_sample():
+def test_read_plus_returns_latest_existing_sample():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -381,13 +382,13 @@ def test_bget_plus_returns_latest_existing_sample():
     _seed(r, "ts", [(100, "1.0"), (200, "2.0"), (300, "3.0")])
 
     # '+' resolves to lastTs = 300. With inclusive ts >= 300, only the latest
-    # sample qualifies; min_count defaults to 1 so it returns synchronously.
+    # sample qualifies; BLOCK min_count defaults to 1 so it returns synchronously.
     t0 = time.time()
-    res = r.execute_command("TS.BGET", "ts", "+", 1000)
+    res = r.execute_command("TS.READ", "ts", "+", "BLOCK", 1000, 1)
     elapsed = time.time() - t0
 
     env.assertEqual(res, [[300, b"3"]])
-    env.assertTrue(elapsed < 0.5, message="BGET '+' should be ~instant, got %.3fs" % elapsed)
+    env.assertTrue(elapsed < 0.5, message="READ '+' should be ~instant, got %.3fs" % elapsed)
 
 
 # ---------------------------------------------------------------------------
@@ -395,7 +396,7 @@ def test_bget_plus_returns_latest_existing_sample():
 #    (last retrieved ts + 1) has nothing newer and times out with an empty reply.
 # ---------------------------------------------------------------------------
 
-def test_bget_paging_past_latest_times_out_empty():
+def test_read_paging_past_latest_times_out_empty():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -406,7 +407,7 @@ def test_bget_paging_past_latest_times_out_empty():
     # Caller already consumed up to ts=300 and pages forward to 301; no sample
     # has ts >= 301, so the call blocks and flushes empty on timeout.
     t0 = time.time()
-    res = r.execute_command("TS.BGET", "ts", 301, 1000)
+    res = r.execute_command("TS.READ", "ts", 301, "BLOCK", 1000, 1)
     elapsed = time.time() - t0
 
     env.assertEqual(res, [])
@@ -422,7 +423,7 @@ def test_bget_paging_past_latest_times_out_empty():
 #     call blocks until a strictly-newer sample arrives.
 # ---------------------------------------------------------------------------
 
-def test_bget_dollar_only_returns_samples_added_after_command():
+def test_read_dollar_only_returns_samples_added_after_command():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -432,10 +433,10 @@ def test_bget_dollar_only_returns_samples_added_after_command():
 
     # '$' resolves to lastTs + 1 = 301. Existing 100/200/300 must NOT qualify;
     # only a future ADD with ts >= 301 should wake us.
-    t, slot = _start_bget(env, "ts", "$", 2_000)
+    t, slot = _start_read(env, "ts", "$", 2_000)
     time.sleep(0.3)
     env.assertTrue(t.is_alive(),
-                   message="BGET '$' should ignore pre-existing samples and block")
+                   message="READ '$' should ignore pre-existing samples and block")
 
     # Producer adds a strictly newer sample -> wake-up.
     assert r.execute_command("TS.ADD", "ts", 400, "4.0") == 400
@@ -451,7 +452,7 @@ def test_bget_dollar_only_returns_samples_added_after_command():
 #     so it blocks until the first sample is added.
 # ---------------------------------------------------------------------------
 
-def test_bget_dollar_on_empty_series_blocks_until_first_add():
+def test_read_dollar_on_empty_series_blocks_until_first_add():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -459,10 +460,10 @@ def test_bget_dollar_on_empty_series_blocks_until_first_add():
     r = env.getConnection()
     r.execute_command("FLUSHALL")
 
-    t, slot = _start_bget(env, "ts", "$", 2_000)
+    t, slot = _start_read(env, "ts", "$", 2_000)
     time.sleep(0.3)
     env.assertTrue(t.is_alive(),
-                   message="BGET '$' on missing key should block until ADD")
+                   message="READ '$' on missing key should block until ADD")
 
     assert r.execute_command("TS.ADD", "ts", 100, "1.0") == 100
 
@@ -474,10 +475,10 @@ def test_bget_dollar_on_empty_series_blocks_until_first_add():
 
 # ---------------------------------------------------------------------------
 # 10. Multi-client broadcast: every parked client receives the new sample
-#     (TS.BGET semantics — not BLPOP-style first-waiter-wins dequeue).
+#     (TS.READ semantics — not BLPOP-style first-waiter-wins dequeue).
 # ---------------------------------------------------------------------------
 
-def test_bget_broadcasts_to_all_blocked_clients():
+def test_read_broadcasts_to_all_blocked_clients():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -487,7 +488,7 @@ def test_bget_broadcasts_to_all_blocked_clients():
 
     # cursor = 101 (literal): the existing sample at 100 doesn't qualify, so all
     # clients block until a newer sample arrives.
-    workers = [_start_bget(env, "ts", 101, 2_000) for _ in range(4)]
+    workers = [_start_read(env, "ts", 101, 2_000) for _ in range(4)]
     time.sleep(0.3)
     for t, _ in workers:
         env.assertTrue(t.is_alive(), message="all clients should be parked")
@@ -504,11 +505,11 @@ def test_bget_broadcasts_to_all_blocked_clients():
 
 
 # ---------------------------------------------------------------------------
-# 11. Compaction wake-up: BGET parked on a compaction destination unblocks
+# 11. Compaction wake-up: READ parked on a compaction destination unblocks
 #     when a bucket commits into it.
 # ---------------------------------------------------------------------------
 
-def test_bget_on_compaction_destination_wakes_on_bucket_commit():
+def test_read_on_compaction_destination_wakes_on_bucket_commit():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -519,10 +520,10 @@ def test_bget_on_compaction_destination_wakes_on_bucket_commit():
     assert r.execute_command(
         "TS.CREATERULE", "src", "dst", "AGGREGATION", "avg", 10)
 
-    t, slot = _start_bget(env, "dst", "-", 2_000)
+    t, slot = _start_read(env, "dst", "-", 2_000)
     time.sleep(0.3)
     env.assertTrue(t.is_alive(),
-                   message="BGET on empty dst should be parked")
+                   message="READ on empty dst should be parked")
 
     # Two samples in bucket [0,9], then a sample in [10,19] closes the first
     # bucket and writes the aggregated point into dst -> SignalKeyAsReady.
@@ -532,7 +533,7 @@ def test_bget_on_compaction_destination_wakes_on_bucket_commit():
 
     t.join(timeout=2.0)
     env.assertFalse(t.is_alive(),
-                    message="BGET on dst should wake on bucket commit")
+                    message="READ on dst should wake on bucket commit")
     env.assertEqual(slot["error"], None)
     env.assertTrue(len(slot["result"]) >= 1)
 
@@ -541,7 +542,7 @@ def test_bget_on_compaction_destination_wakes_on_bucket_commit():
 # 12. WRONGTYPE on the literal-cursor path.
 # ---------------------------------------------------------------------------
 
-def test_bget_wrongtype_literal_cursor():
+def test_read_wrongtype_literal_cursor():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -549,19 +550,19 @@ def test_bget_wrongtype_literal_cursor():
     r = env.getConnection()
     r.set("not_a_ts", "hello")
     with pytest.raises(redis.ResponseError, match="WRONGTYPE"):
-        r.execute_command("TS.BGET", "not_a_ts", 0, 0)
+        r.execute_command("TS.READ", "not_a_ts", 0)
 
 
 # ---------------------------------------------------------------------------
-# 13. Refusal inside MULTI / EVAL when timeout > 0.
+# 13. Refusal inside MULTI / EVAL when BLOCK ms > 0.
 # ---------------------------------------------------------------------------
 
 def _is_deny_blocking_error(err):
     s = str(err)
-    return "deny" in s.lower() or "MULTI" in s or "EVAL" in s or "BGET" in s
+    return "deny" in s.lower() or "MULTI" in s or "EVAL" in s or "with BLOCK" in s
 
 
-def test_bget_inside_multi_refuses_with_clear_error():
+def test_read_inside_multi_refuses_with_clear_error():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -572,7 +573,7 @@ def test_bget_inside_multi_refuses_with_clear_error():
                                    # branch instead of replying synchronously.
 
     r.execute_command("MULTI")
-    r.execute_command("TS.BGET", "ts", 0, 1000)
+    r.execute_command("TS.READ", "ts", 0, "BLOCK", 1000, 1)
     try:
         res = r.execute_command("EXEC")
         env.assertEqual(len(res), 1)
@@ -583,7 +584,7 @@ def test_bget_inside_multi_refuses_with_clear_error():
                        message="unexpected error: %r" % (e,))
 
 
-def test_bget_inside_eval_refuses_with_clear_error():
+def test_read_inside_eval_refuses_with_clear_error():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -593,7 +594,7 @@ def test_bget_inside_eval_refuses_with_clear_error():
 
     with pytest.raises(redis.ResponseError) as excinfo:
         r.execute_command(
-            "EVAL", "return redis.call('TS.BGET','ts',0,1000)", 1, "ts")
+            "EVAL", "return redis.call('TS.READ','ts',0,'BLOCK',1000,1)", 1, "ts")
     env.assertTrue(_is_deny_blocking_error(excinfo.value),
                    message="unexpected error: %r" % (excinfo.value,))
 
@@ -602,7 +603,7 @@ def test_bget_inside_eval_refuses_with_clear_error():
 # 14. Parse / arity validation — every malformed call must surface an error.
 # ---------------------------------------------------------------------------
 
-def test_bget_parse_errors():
+def test_read_parse_errors():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -611,31 +612,32 @@ def test_bget_parse_errors():
     _seed(r, "ts", [(100, "1.0")])
 
     bad_argv = [
-        ("ts",),                                       # wrong arity (too few)
-        ("ts", 0),                                     # wrong arity (too few)
-        ("ts", 0, 0, "MIN_COUNT", 1, "MAX_COUNT", 1, "x"),  # arity (too many)
-        ("ts", 0, 1000, "MIN_COUNT", 0),               # min_count == 0
-        ("ts", 0, 1000, "MIN_COUNT", -1),              # min_count < 0
-        ("ts", 0, 1000, "MAX_COUNT", 0),               # max_count == 0
-        ("ts", 0, -1),                                 # timeout < 0
-        ("ts", 0, 1000, "MIN_COUNT", "abc"),           # non-integer min_count
-        ("ts", 0, 1000, "MIN_COUNT", "1.5"),           # non-integer min_count
-        ("ts", 0, "abc"),                              # non-integer timeout
-        ("ts", "abc", 1000),                           # non-integer / non-sentinel ts
-        ("ts", -1, 1000),                              # negative literal timestamp
-        ("ts", 0, 1000, "MIN_COUNT", 5, "MAX_COUNT", 2),   # min_count > max_count
-        ("ts", 0, 1000, "MIN_COUNT"),                  # dangling keyword (no value)
+        ("ts",),                                              # wrong arity (too few, missing ts)
+        ("ts", 0, "BLOCK", -1, 1),                           # timeout < 0
+        ("ts", 0, "BLOCK", 1000, 0),                         # min_count == 0
+        ("ts", 0, "BLOCK", 1000, -1),                        # min_count < 0
+        ("ts", 0, "BLOCK", 1000, "abc"),                     # non-integer min_count
+        ("ts", 0, "BLOCK", 1000, "1.5"),                     # non-integer min_count
+        ("ts", 0, "BLOCK", "abc", 1),                        # non-integer timeout
+        ("ts", 0, "BLOCK", 1000),                            # BLOCK without min_count
+        ("ts", 0, "MAX_COUNT", 0),                           # max_count == 0
+        ("ts", 0, "MAX_COUNT", -1),                          # max_count < 0
+        ("ts", 0, "MAX_COUNT"),                              # dangling MAX_COUNT keyword
+        ("ts", "abc", "BLOCK", 1000, 1),                     # non-integer / non-sentinel ts
+        ("ts", -1, "BLOCK", 1000, 1),                        # negative literal timestamp
+        ("ts", 0, "BLOCK", 1000, 5, "MAX_COUNT", 2),         # min_count > max_count
+        ("ts", 0, "BLOCK", 1000, 1, "MAX_COUNT", 1, "x"),    # too many args
     ]
     for argv in bad_argv:
         with pytest.raises(redis.ResponseError):
-            r.execute_command("TS.BGET", *argv)
+            r.execute_command("TS.READ", *argv)
 
 
 # ---------------------------------------------------------------------------
-# 15. timeout_ms == 0: return whatever is available immediately, never block.
+# 15. Without BLOCK: return whatever is available immediately, never block.
 # ---------------------------------------------------------------------------
 
-def test_bget_timeout_zero_returns_partial_without_blocking():
+def test_read_without_block_returns_partial_immediately():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -643,24 +645,24 @@ def test_bget_timeout_zero_returns_partial_without_blocking():
     r = env.getConnection()
     _seed(r, "ts", [(100, "1.0"), (200, "2.0")])
 
-    # MIN_COUNT 10, only 2 qualifying samples; timeout=0 must flush immediately.
+    # Without BLOCK, READ must flush immediately even when only 2 samples exist.
     t0 = time.time()
-    res = r.execute_command("TS.BGET", "ts", 0, 0, "MIN_COUNT", 10)
+    res = r.execute_command("TS.READ", "ts", 0)
     elapsed = time.time() - t0
 
     env.assertEqual(res, [[100, b"1"], [200, b"2"]])
     env.assertTrue(elapsed < 0.3,
-                   message="timeout=0 must not block, took %.3fs" % elapsed)
+                   message="non-blocking READ must not block, took %.3fs" % elapsed)
 
 
 # ---------------------------------------------------------------------------
-# 16. Key deletion unblocks a parked BGET client well before its timeout.
-#     Regression: TS.BGET previously used BlockClientOnKeys (BLPOP-style)
+# 16. Key deletion unblocks a parked READ client well before its timeout.
+#     Regression: TS.READ previously used BlockClientOnKeys (BLPOP-style)
 #     which ignored delete signals, so deleting the key left the client
-#     parked until timeout_ms — leaking the connection and hanging CI.
+#     parked until block_ms — leaking the connection and hanging CI.
 # ---------------------------------------------------------------------------
 
-def test_bget_del_wakes_parked_client():
+def test_read_del_wakes_parked_client():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -671,9 +673,9 @@ def test_bget_del_wakes_parked_client():
     # Server-side block timeout set to 2x the prompt-wake bound so a prompt
     # return is unambiguously the deletion wake, not a timeout flush (both scale
     # for Valgrind via WAKE_TIMEOUT_SECS).
-    t, slot = _start_bget(env, "ts", 0, WAKE_TIMEOUT_SECS * 2 * 1000, min_count=5)
+    t, slot = _start_read(env, "ts", 0, WAKE_TIMEOUT_SECS * 2 * 1000, min_count=5)
     time.sleep(0.3)
-    env.assertTrue(t.is_alive(), message="BGET should be parked waiting for more samples")
+    env.assertTrue(t.is_alive(), message="READ should be parked waiting for more samples")
 
     t0 = time.time()
     assert r.execute_command("DEL", "ts") == 1
@@ -681,14 +683,14 @@ def test_bget_del_wakes_parked_client():
     t.join(timeout=WAKE_TIMEOUT_SECS)
     elapsed = time.time() - t0
     env.assertFalse(t.is_alive(),
-                    message="DEL must wake the parked BGET client (took %.3fs)" % elapsed)
+                    message="DEL must wake the parked READ client (took %.3fs)" % elapsed)
     env.assertEqual(slot["error"], None)
     env.assertEqual(slot["result"], [])
     env.assertTrue(elapsed < WAKE_TIMEOUT_SECS,
                    message="DEL wake must be immediate, took %.3fs" % elapsed)
 
 
-def test_bget_unlink_wakes_parked_client():
+def test_read_unlink_wakes_parked_client():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -696,9 +698,9 @@ def test_bget_unlink_wakes_parked_client():
     r = env.getConnection()
     _seed(r, "ts", [(100, "1.0")])
 
-    t, slot = _start_bget(env, "ts", 0, WAKE_TIMEOUT_SECS * 2 * 1000, min_count=5)
+    t, slot = _start_read(env, "ts", 0, WAKE_TIMEOUT_SECS * 2 * 1000, min_count=5)
     time.sleep(0.3)
-    env.assertTrue(t.is_alive(), message="BGET should be parked")
+    env.assertTrue(t.is_alive(), message="READ should be parked")
 
     t0 = time.time()
     assert r.execute_command("UNLINK", "ts") == 1
@@ -706,14 +708,14 @@ def test_bget_unlink_wakes_parked_client():
     t.join(timeout=WAKE_TIMEOUT_SECS)
     elapsed = time.time() - t0
     env.assertFalse(t.is_alive(),
-                    message="UNLINK must wake the parked BGET client (took %.3fs)" % elapsed)
+                    message="UNLINK must wake the parked READ client (took %.3fs)" % elapsed)
     env.assertEqual(slot["error"], None)
     env.assertEqual(slot["result"], [])
     env.assertTrue(elapsed < WAKE_TIMEOUT_SECS,
                    message="UNLINK wake must be immediate, took %.3fs" % elapsed)
 
 
-def test_bget_flushall_wakes_parked_client():
+def test_read_flushall_wakes_parked_client():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -721,9 +723,9 @@ def test_bget_flushall_wakes_parked_client():
     r = env.getConnection()
     _seed(r, "ts", [(100, "1.0")])
 
-    t, slot = _start_bget(env, "ts", 0, WAKE_TIMEOUT_SECS * 2 * 1000, min_count=5)
+    t, slot = _start_read(env, "ts", 0, WAKE_TIMEOUT_SECS * 2 * 1000, min_count=5)
     time.sleep(0.3)
-    env.assertTrue(t.is_alive(), message="BGET should be parked")
+    env.assertTrue(t.is_alive(), message="READ should be parked")
 
     t0 = time.time()
     r.execute_command("FLUSHALL")
@@ -731,14 +733,14 @@ def test_bget_flushall_wakes_parked_client():
     t.join(timeout=WAKE_TIMEOUT_SECS)
     elapsed = time.time() - t0
     env.assertFalse(t.is_alive(),
-                    message="FLUSHALL must wake the parked BGET client (took %.3fs)" % elapsed)
+                    message="FLUSHALL must wake the parked READ client (took %.3fs)" % elapsed)
     env.assertEqual(slot["error"], None)
     env.assertEqual(slot["result"], [])
     env.assertTrue(elapsed < WAKE_TIMEOUT_SECS,
                    message="FLUSHALL wake must be immediate, took %.3fs" % elapsed)
 
 
-def test_bget_flushdb_wakes_parked_client():
+def test_read_flushdb_wakes_parked_client():
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -746,9 +748,9 @@ def test_bget_flushdb_wakes_parked_client():
     r = env.getConnection()
     _seed(r, "ts", [(100, "1.0")])
 
-    t, slot = _start_bget(env, "ts", 0, WAKE_TIMEOUT_SECS * 2 * 1000, min_count=5)
+    t, slot = _start_read(env, "ts", 0, WAKE_TIMEOUT_SECS * 2 * 1000, min_count=5)
     time.sleep(0.3)
-    env.assertTrue(t.is_alive(), message="BGET should be parked")
+    env.assertTrue(t.is_alive(), message="READ should be parked")
 
     t0 = time.time()
     r.execute_command("FLUSHDB")
@@ -756,16 +758,16 @@ def test_bget_flushdb_wakes_parked_client():
     t.join(timeout=WAKE_TIMEOUT_SECS)
     elapsed = time.time() - t0
     env.assertFalse(t.is_alive(),
-                    message="FLUSHDB must wake the parked BGET client (took %.3fs)" % elapsed)
+                    message="FLUSHDB must wake the parked READ client (took %.3fs)" % elapsed)
     env.assertEqual(slot["error"], None)
     env.assertEqual(slot["result"], [])
     env.assertTrue(elapsed < WAKE_TIMEOUT_SECS,
                    message="FLUSHDB wake must be immediate, took %.3fs" % elapsed)
 
 
-def test_bget_multiple_parked_clients_all_wake_on_del():
+def test_read_multiple_parked_clients_all_wake_on_del():
     """Every client parked on the same key must wake on a single DEL,
-    not just one — TS.BGET is broadcast, not BLPOP-style dequeue."""
+    not just one — TS.READ is broadcast, not BLPOP-style dequeue."""
     env = Env()
     if env.is_cluster():
         env.skip()
@@ -773,16 +775,16 @@ def test_bget_multiple_parked_clients_all_wake_on_del():
     r = env.getConnection()
     _seed(r, "ts", [(100, "1.0")])
 
-    workers = [_start_bget(env, "ts", 0, WAKE_TIMEOUT_SECS * 2 * 1000, min_count=5) for _ in range(4)]
+    workers = [_start_read(env, "ts", 0, WAKE_TIMEOUT_SECS * 2 * 1000, min_count=5) for _ in range(4)]
     time.sleep(0.3)
     for t, _ in workers:
-        env.assertTrue(t.is_alive(), message="each BGET should be parked")
+        env.assertTrue(t.is_alive(), message="each READ should be parked")
 
     assert r.execute_command("DEL", "ts") == 1
 
     for t, slot in workers:
         t.join(timeout=WAKE_TIMEOUT_SECS)
         env.assertFalse(t.is_alive(),
-                        message="every parked BGET must wake on DEL")
+                        message="every parked READ must wake on DEL")
         env.assertEqual(slot["error"], None)
         env.assertEqual(slot["result"], [])


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Breaking API rename (`TS.BGET` removed) and changed blocking semantics affect any client using the old command; core blocking/read logic is largely preserved under new parsing.
> 
> **Overview**
> **Renames `TS.BGET` to `TS.READ`** and reshapes the command surface so blocking is opt-in instead of a required timeout argument.
> 
> The new form is `TS.READ key timestamp [BLOCK milliseconds min_count] [MAX_COUNT max_count]`. **Without `BLOCK`**, the command returns immediately with whatever samples qualify (replacing the old `timeout 0` behavior). **With `BLOCK`**, it waits up to `milliseconds` until at least `min_count` samples exist; `BLOCK 0` means wait indefinitely until data or key deletion. The former standalone `MIN_COUNT` keyword is folded into the `BLOCK` group as its second argument.
> 
> Implementation is a straight rename (`BGetCtx` → `ReadCtx`, `TSDB_bget_*` → `TSDB_read_*`, registration as `ts.read`) with updated arity validation for the new optional blocks. Command metadata in `commands.json` and `ts_info.c` is aligned. Flow tests move from `test_ts_bget` patterns to `test_ts_read`, including new coverage for non-blocking reads, `BLOCK 0`, and MULTI refusal for infinite block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1879235bbbcbbfeed987997632e6e44cf85775ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->