### PR TITLE
MOD-16514 - fix bootstrap & build for all os

### DIFF
--- a/.install/install_cmake.sh
+++ b/.install/install_cmake.sh
@@ -5,6 +5,15 @@ processor=$(uname -m)
 OS_TYPE=$(uname -s)
 MODE="${1:-}" # whether to install using sudo or not (empty when already root)
 
+# Skip when an adequate cmake is already on PATH (distro package or another
+# module's bootstrap on the same host): re-running must be a no-op, and
+# blindly re-installing would overwrite /usr/local under other checkouts.
+have_ver="$(cmake --version 2>/dev/null | awk '/cmake version/ {print $3; exit}' || true)"
+if [[ -n "$have_ver" ]] && printf '%s\n' "$version" "$have_ver" | sort -V -C 2>/dev/null; then
+    echo "cmake $have_ver already installed (>= required $version) - skipping"
+    exit 0
+fi
+
 if [[ $OS_TYPE = 'Darwin' ]]
 then
     brew install cmake
@@ -16,8 +25,10 @@ else
         filename=cmake-${version}-linux-aarch64.sh
     fi
 
-    wget https://github.com/Kitware/CMake/releases/download/v${version}/${filename}
-    chmod u+x ./${filename}
-    $MODE ./${filename} --skip-license --prefix=/usr/local --exclude-subdir
+    tmpdir=$(mktemp -d)
+    wget -P "$tmpdir" https://github.com/Kitware/CMake/releases/download/v${version}/${filename}
+    chmod u+x "$tmpdir/$filename"
+    $MODE "$tmpdir/$filename" --skip-license --prefix=/usr/local --exclude-subdir
+    rm -rf "$tmpdir"
     cmake --version
 fi

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -17,7 +17,7 @@ install_aws_cli() {
     arch=$(uname -m)
     local url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
     [ "$arch" = "aarch64" ] && url="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
-    curl "$url" -o /tmp/awscliv2.zip
+    curl -fSL --retry 3 "$url" -o /tmp/awscliv2.zip
     unzip -o /tmp/awscliv2.zip -d /tmp/awscli-install
     /tmp/awscli-install/aws/install
     rm -rf /tmp/awscliv2.zip /tmp/awscli-install

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -19,7 +19,7 @@ install_aws_cli() {
     [ "$arch" = "aarch64" ] && url="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
     curl -fSL --retry 3 "$url" -o /tmp/awscliv2.zip
     unzip -o /tmp/awscliv2.zip -d /tmp/awscli-install
-    /tmp/awscli-install/aws/install
+    $SUDO /tmp/awscli-install/aws/install
     rm -rf /tmp/awscliv2.zip /tmp/awscli-install
 }
 

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -18,7 +18,7 @@ install_aws_cli() {
     local url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
     [ "$arch" = "aarch64" ] && url="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
     curl "$url" -o /tmp/awscliv2.zip
-    unzip /tmp/awscliv2.zip -d /tmp/awscli-install
+    unzip -o /tmp/awscliv2.zip -d /tmp/awscli-install
     /tmp/awscli-install/aws/install
     rm -rf /tmp/awscliv2.zip /tmp/awscli-install
 }

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -17,9 +17,10 @@ install_aws_cli() {
     arch=$(uname -m)
     local url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
     [ "$arch" = "aarch64" ] && url="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
-    curl "$url" -o "awscliv2.zip"
-    unzip awscliv2.zip
-    ./aws/install
+    curl "$url" -o /tmp/awscliv2.zip
+    unzip /tmp/awscliv2.zip -d /tmp/awscli-install
+    /tmp/awscli-install/aws/install
+    rm -rf /tmp/awscliv2.zip /tmp/awscli-install
 }
 
 # ----------------------------------------------------------------------------

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -7,6 +7,21 @@
 # Sourced by os/<osnick>.sh after lib/pm.sh. All variables here are plain
 # space-separated strings so callers can splat them with `apt_install $SET`.
 
+# Install AWS CLI v2 from the official installer (arch-aware). Skips if
+# already present — handles pre-installed AMIs without failing.
+install_aws_cli() {
+    if command -v aws &>/dev/null; then
+        return 0
+    fi
+    local arch
+    arch=$(uname -m)
+    local url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+    [ "$arch" = "aarch64" ] && url="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
+    curl "$url" -o "awscliv2.zip"
+    unzip awscliv2.zip
+    ./aws/install
+}
+
 # ----------------------------------------------------------------------------
 # Debian family (apt)
 # ----------------------------------------------------------------------------

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -176,6 +176,11 @@ el8_default_install() {
         gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel \
         python3.11 python3.11-devel python3.11-pip xz
     $SUDO cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh 2>/dev/null || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/gcc  /usr/local/bin/gcc  || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/g++  /usr/local/bin/g++  || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/cc   /usr/local/bin/cc   || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/as   /usr/local/bin/as   || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/make /usr/local/bin/make || true
     $SUDO update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 2000000
     $SUDO update-alternatives --set python3 /usr/bin/python3.11
     export SETUP_PYTHON_VERSION="${SETUP_PYTHON_VERSION:-3.11}"
@@ -188,4 +193,9 @@ el9_default_install() {
     dnf_install \
         gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ gcc-toolset-13-libatomic-devel
     $SUDO cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh 2>/dev/null || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/gcc  /usr/local/bin/gcc  || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/g++  /usr/local/bin/g++  || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/cc   /usr/local/bin/cc   || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/as   /usr/local/bin/as   || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/make /usr/local/bin/make || true
 }

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -174,8 +174,10 @@ el8_default_install() {
     rhel_default_install
     dnf_install \
         gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel \
-        python3.11 python3.11-devel xz
+        python3.11 python3.11-devel python3.11-pip xz
     $SUDO cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh 2>/dev/null || true
+    $SUDO update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 2000000
+    $SUDO update-alternatives --set python3 /usr/bin/python3.11
     export SETUP_PYTHON_VERSION="${SETUP_PYTHON_VERSION:-3.11}"
 }
 

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -48,7 +48,11 @@ apt_install() {
         $SUDO apt-get update -qq
         _pm_apt_updated=1
     fi
-    $SUDO apt-get install -yqq --no-install-recommends "$@"
+    # env goes THROUGH $SUDO: sudo's env_reset strips exported variables, so a
+    # plain export upstream never reaches dpkg — debconf (e.g. tzdata on focal,
+    # which the base image doesn't preinstall) then blocks on an interactive
+    # prompt and the bootstrap hangs.
+    $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends "$@"
 }
 
 # `--allowerasing` lets dnf pick our `curl` over the slimmer `curl-minimal`
@@ -102,22 +106,12 @@ brew_install() {
 
 debian_default_install() {
     apt_install $DEBIAN_BASE
-    # apt install clang on some Debian-family distros registers clang as the
-    # highest-priority alternative for cc/gcc/g++, causing the clang blocks
-    # path to be chosen in our defer/errdefer macros (requires -fblocks) and
-    # mixing LTO formats at link time. Explicitly pin all three to the highest
-    # real GCC installed by build-essential so the toolchain is consistent.
-    _GCC=$(ls /usr/bin/gcc-[0-9]* 2>/dev/null | sort -V | tail -1)
-    [ -n "$_GCC" ] || { echo "ERROR: no gcc binary found after apt install" >&2; exit 1; }
-    $SUDO update-alternatives --install /usr/bin/cc  cc  "$_GCC" 100
-    $SUDO update-alternatives --set     cc  "$_GCC"
-    $SUDO update-alternatives --install /usr/bin/gcc gcc "$_GCC" 100
-    $SUDO update-alternatives --set     gcc "$_GCC"
-    _GPP="${_GCC/gcc/g++}"
-    if [ -x "$_GPP" ]; then
-        $SUDO update-alternatives --install /usr/bin/g++ g++ "$_GPP" 100
-        $SUDO update-alternatives --set     g++ "$_GPP"
-    fi
+    # No update-alternatives here: pinning cc/gcc/g++ to "the highest gcc on
+    # the system" made the outcome depend on what OTHER checkouts' bootstraps
+    # had installed side-by-side (e.g. RediSearch's gcc-12 flipped the global
+    # default for everyone on the host). Distro defaults stay untouched; the
+    # one distro whose clang packaging hijacks cc (bullseye) restores its own
+    # fixed distro default in os/bullseye.sh.
 }
 
 rhel_default_install() {

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -102,6 +102,22 @@ brew_install() {
 
 debian_default_install() {
     apt_install $DEBIAN_BASE
+    # apt install clang on some Debian-family distros registers clang as the
+    # highest-priority alternative for cc/gcc/g++, causing the clang blocks
+    # path to be chosen in our defer/errdefer macros (requires -fblocks) and
+    # mixing LTO formats at link time. Explicitly pin all three to the highest
+    # real GCC installed by build-essential so the toolchain is consistent.
+    _GCC=$(ls /usr/bin/gcc-[0-9]* 2>/dev/null | sort -V | tail -1)
+    [ -n "$_GCC" ] || { echo "ERROR: no gcc binary found after apt install" >&2; exit 1; }
+    $SUDO update-alternatives --install /usr/bin/cc  cc  "$_GCC" 100
+    $SUDO update-alternatives --set     cc  "$_GCC"
+    $SUDO update-alternatives --install /usr/bin/gcc gcc "$_GCC" 100
+    $SUDO update-alternatives --set     gcc "$_GCC"
+    _GPP="${_GCC/gcc/g++}"
+    if [ -x "$_GPP" ]; then
+        $SUDO update-alternatives --install /usr/bin/g++ g++ "$_GPP" 100
+        $SUDO update-alternatives --set     g++ "$_GPP"
+    fi
 }
 
 rhel_default_install() {

--- a/.install/os/amazonlinux2.sh
+++ b/.install/os/amazonlinux2.sh
@@ -27,3 +27,4 @@ $SUDO ln -sf "$(command -v cmake3)" /usr/bin/cmake
 $SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/make /usr/local/bin/make
 $SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/gcc /usr/local/bin/gcc
 $SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/g++ /usr/local/bin/g++
+$SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/cc /usr/local/bin/cc

--- a/.install/os/amazonlinux2.sh
+++ b/.install/os/amazonlinux2.sh
@@ -24,7 +24,9 @@ $SUDO yum -y install --nogpgcheck --skip-broken \
 
 rhel_default_install
 $SUDO ln -sf "$(command -v cmake3)" /usr/bin/cmake
-$SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/make /usr/local/bin/make
-$SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/gcc /usr/local/bin/gcc
-$SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/g++ /usr/local/bin/g++
-$SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/cc /usr/local/bin/cc
+if [ -f /opt/rh/devtoolset-11/root/usr/bin/gcc ]; then
+    $SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/make /usr/local/bin/make
+    $SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/gcc /usr/local/bin/gcc
+    $SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/g++ /usr/local/bin/g++
+    $SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/cc /usr/local/bin/cc
+fi

--- a/.install/os/amazonlinux2.sh
+++ b/.install/os/amazonlinux2.sh
@@ -24,3 +24,6 @@ $SUDO yum -y install --nogpgcheck --skip-broken \
 
 rhel_default_install
 $SUDO ln -sf "$(command -v cmake3)" /usr/bin/cmake
+$SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/make /usr/local/bin/make
+$SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/gcc /usr/local/bin/gcc
+$SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/g++ /usr/local/bin/g++

--- a/.install/os/azurelinux3.sh
+++ b/.install/os/azurelinux3.sh
@@ -8,6 +8,4 @@
 tdnf_default_install
 
 # Install aws-cli for uploading artifacts to s3
-curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-unzip awscliv2.zip
-./aws/install
+install_aws_cli

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -7,21 +7,25 @@
 . "$LIB/packages.sh"
 
 apt_install software-properties-common lsb-core binfmt-support zlib1g-dev
-$SUDO add-apt-repository ppa:ubuntu-toolchain-r/test -y || true
+echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | $SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list
+$SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F || true
+$SUDO apt-get update -qq
 debian_default_install
 apt_install gcc-10 g++-10 awscli
 $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
     --slave /usr/bin/g++ g++ /usr/bin/g++-10
 
-cd /tmp
-wget -q https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz
-tar -xzf cmake-3.28.0.tar.gz
-cd cmake-3.28.0
-./configure
-make -j"$(nproc)"
-$SUDO make install
-cd /
-rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz
-$SUDO ln -sf /usr/local/bin/cmake /usr/bin/cmake
+if ! cmake --version 2>/dev/null | grep -qE 'cmake version 3\.(2[89]|[3-9][0-9])'; then
+    cd /tmp
+    wget -q https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz
+    tar -xzf cmake-3.28.0.tar.gz
+    cd cmake-3.28.0
+    ./configure
+    make -j"$(nproc)"
+    $SUDO make install
+    cd /
+    rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz
+    $SUDO ln -sf /usr/local/bin/cmake /usr/bin/cmake
+fi
 
 pip3 install dataclasses

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -17,6 +17,7 @@ apt_install gnupg wget
 wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r.gpg || true
 wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2C277A0A352154E5" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r-2.gpg || true
 echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | $SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list
+$SUDO apt-get update -qq
 apt_install software-properties-common lsb-core binfmt-support zlib1g-dev
 debian_default_install
 apt_install gcc-10 g++-10

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -10,7 +10,10 @@ export DEBIAN_FRONTEND=noninteractive
 echo 'debconf debconf/frontend select Noninteractive' | $SUDO debconf-set-selections 2>/dev/null || true
 echo 'tzdata tzdata/Areas select Etc' | $SUDO debconf-set-selections 2>/dev/null || true
 echo 'tzdata tzdata/Zones/Etc select UTC' | $SUDO debconf-set-selections 2>/dev/null || true
-$SUDO apt-get install -y --no-install-recommends gnupg wget 2>/dev/null || true
+# apt_install (not a raw apt-get call) so this runs apt-get update first —
+# on a fresh base image with no apt index yet, a raw "apt-get install"
+# here can fail silently and leave gnupg/wget missing for the next step.
+apt_install gnupg wget
 wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r.gpg || true
 wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2C277A0A352154E5" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r-2.gpg || true
 echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | $SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list
@@ -22,8 +25,11 @@ install_aws_cli
 # may have already pinned something newer in this shared build container.
 _cur=$(gcc -dumpversion | cut -d. -f1)
 if [ "$_cur" -lt 10 ]; then
-    # g++ is registered as its own independent master by debian_default_install,
-    # not as a slave of gcc — --slave-grouping it here would conflict with that.
+    # cc/gcc/g++ are each registered as their own independent master by
+    # debian_default_install, not slaves of each other — --slave-grouping
+    # would conflict with that.
+    $SUDO update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-10 60
+    $SUDO update-alternatives --set     cc  /usr/bin/gcc-10
     $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
     $SUDO update-alternatives --set     gcc /usr/bin/gcc-10
     $SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
-# Ubuntu 18.04 (bionic). gcc-10 is available in the ESM repos directly
-# (no toolchain-r PPA needed). cmake 3.28 built from source — apt cmake is 3.10.
+# Ubuntu 18.04 (bionic). cmake 3.28 built from source — apt cmake is 3.10.
+# gcc-10 via toolchain-r PPA; || true so launchpad failures are non-fatal
+# (ESM repos already carry gcc-10 on Ubuntu Pro machines).
 
 # shellcheck source=../lib/packages.sh
 . "$LIB/packages.sh"
 
+apt_install software-properties-common lsb-core binfmt-support zlib1g-dev
+$SUDO add-apt-repository ppa:ubuntu-toolchain-r/test -y || true
 debian_default_install
-apt_install lsb-core binfmt-support zlib1g-dev gcc-10 g++-10 awscli
+apt_install gcc-10 g++-10 awscli
 $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
     --slave /usr/bin/g++ g++ /usr/bin/g++-10
 

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -6,10 +6,15 @@
 # shellcheck source=../lib/packages.sh
 . "$LIB/packages.sh"
 
-apt_install software-properties-common lsb-core binfmt-support zlib1g-dev
+export DEBIAN_FRONTEND=noninteractive
+echo 'debconf debconf/frontend select Noninteractive' | $SUDO debconf-set-selections 2>/dev/null || true
+echo 'tzdata tzdata/Areas select Etc' | $SUDO debconf-set-selections 2>/dev/null || true
+echo 'tzdata tzdata/Zones/Etc select UTC' | $SUDO debconf-set-selections 2>/dev/null || true
+$SUDO apt-get install -y --no-install-recommends gnupg wget 2>/dev/null || true
+wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r.gpg
+wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2C277A0A352154E5" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r-2.gpg
 echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | $SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list
-$SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F || true
-$SUDO apt-get update -qq
+apt_install software-properties-common lsb-core binfmt-support zlib1g-dev
 debian_default_install
 apt_install gcc-10 g++-10 awscli
 $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -33,3 +33,5 @@ $SUDO make install
 cd /
 rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz
 $SUDO ln -sf /usr/local/bin/cmake /usr/bin/cmake
+
+pip3 install dataclasses

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -1,25 +1,12 @@
 #!/usr/bin/env bash
-# Ubuntu 18.04 (bionic). Two distinct quirks beyond the Debian default:
-#
-#   1. Apt's default gcc is 7.x — too old for our C++. Pull gcc-10/g++-10
-#      from the toolchain-r/test PPA and switch /usr/bin/{gcc,g++} to them.
-#
-#   2. Apt's cmake is 3.10 — too old for our CMakeLists. Build cmake 3.28
-#      from source (~5 minutes on a typical CI runner) and symlink it as
-#      /usr/bin/cmake so the older apt cmake is shadowed.
-#
-# We deliberately do *not* call debian_default_install before adding the PPA
-# because software-properties-common (which provides add-apt-repository) is
-# not in the base image and pulling it via apt_install lets us populate the
-# apt cache in a single update pass.
+# Ubuntu 18.04 (bionic). gcc-10 is available in the ESM repos directly
+# (no toolchain-r PPA needed). cmake 3.28 built from source — apt cmake is 3.10.
 
 # shellcheck source=../lib/packages.sh
 . "$LIB/packages.sh"
 
-apt_install software-properties-common lsb-core binfmt-support zlib1g-dev
-$SUDO add-apt-repository ppa:ubuntu-toolchain-r/test -y
 debian_default_install
-apt_install gcc-10 g++-10 awscli
+apt_install lsb-core binfmt-support zlib1g-dev gcc-10 g++-10 awscli
 $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
     --slave /usr/bin/g++ g++ /usr/bin/g++-10
 

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -11,14 +11,24 @@ echo 'debconf debconf/frontend select Noninteractive' | $SUDO debconf-set-select
 echo 'tzdata tzdata/Areas select Etc' | $SUDO debconf-set-selections 2>/dev/null || true
 echo 'tzdata tzdata/Zones/Etc select UTC' | $SUDO debconf-set-selections 2>/dev/null || true
 $SUDO apt-get install -y --no-install-recommends gnupg wget 2>/dev/null || true
-wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r.gpg
-wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2C277A0A352154E5" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r-2.gpg
+wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r.gpg || true
+wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2C277A0A352154E5" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r-2.gpg || true
 echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | $SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list
 apt_install software-properties-common lsb-core binfmt-support zlib1g-dev
 debian_default_install
-apt_install gcc-10 g++-10 awscli
-$SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
-    --slave /usr/bin/g++ g++ /usr/bin/g++-10
+apt_install gcc-10 g++-10
+install_aws_cli
+# Only move the active compiler up, never down — another module's bootstrap
+# may have already pinned something newer in this shared build container.
+_cur=$(gcc -dumpversion | cut -d. -f1)
+if [ "$_cur" -lt 10 ]; then
+    # g++ is registered as its own independent master by debian_default_install,
+    # not as a slave of gcc — --slave-grouping it here would conflict with that.
+    $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
+    $SUDO update-alternatives --set     gcc /usr/bin/gcc-10
+    $SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60
+    $SUDO update-alternatives --set     g++ /usr/bin/g++-10
+fi
 
 if ! cmake --version 2>/dev/null | grep -qE 'cmake version 3\.(2[89]|[3-9][0-9])'; then
     cd /tmp

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -13,7 +13,7 @@ echo 'tzdata tzdata/Zones/Etc select UTC' | $SUDO debconf-set-selections 2>/dev/
 # apt_install (not a raw apt-get call) so this runs apt-get update first —
 # on a fresh base image with no apt index yet, a raw "apt-get install"
 # here can fail silently and leave gnupg/wget missing for the next step.
-apt_install gnupg wget
+apt_install gnupg wget curl ca-certificates
 wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r.gpg || true
 wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2C277A0A352154E5" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r-2.gpg || true
 echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | $SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list

--- a/.install/os/bullseye.sh
+++ b/.install/os/bullseye.sh
@@ -5,3 +5,16 @@
 . "$LIB/packages.sh"
 
 debian_default_install
+
+# Bullseye's clang packaging registers clang as the highest-priority
+# alternative for cc, which breaks the defer/errdefer macros (clang blocks
+# need -fblocks) and mixes LTO formats at link time. Restore the DISTRO
+# default (gcc-10 is bullseye's system gcc) — a fixed target, so every
+# module's bootstrap converges on the same state regardless of order or of
+# whatever newer side-by-side gcc another checkout installed.
+$SUDO update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-10 100
+$SUDO update-alternatives --set     cc  /usr/bin/gcc-10
+$SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
+$SUDO update-alternatives --set     gcc /usr/bin/gcc-10
+$SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
+$SUDO update-alternatives --set     g++ /usr/bin/g++-10

--- a/.install/os/focal.sh
+++ b/.install/os/focal.sh
@@ -5,6 +5,7 @@
 # shellcheck source=../lib/packages.sh
 . "$LIB/packages.sh"
 
+$SUDO update-alternatives --remove-all g++ 2>/dev/null || true
 debian_default_install
 apt_install gcc-10 g++-10
 $SUDO update-alternatives --remove-all g++ 2>/dev/null || true

--- a/.install/os/focal.sh
+++ b/.install/os/focal.sh
@@ -7,5 +7,12 @@
 
 debian_default_install
 apt_install gcc-10 g++-10
-$SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
-$SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60
+# Only move the active compiler up, never down — another module's bootstrap
+# may have already pinned something newer in this shared build container.
+_cur=$(gcc -dumpversion | cut -d. -f1)
+if [ "$_cur" -lt 10 ]; then
+    $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
+    $SUDO update-alternatives --set     gcc /usr/bin/gcc-10
+    $SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60
+    $SUDO update-alternatives --set     g++ /usr/bin/g++-10
+fi

--- a/.install/os/focal.sh
+++ b/.install/os/focal.sh
@@ -5,9 +5,7 @@
 # shellcheck source=../lib/packages.sh
 . "$LIB/packages.sh"
 
-$SUDO update-alternatives --remove-all g++ 2>/dev/null || true
 debian_default_install
 apt_install gcc-10 g++-10
-$SUDO update-alternatives --remove-all g++ 2>/dev/null || true
-$SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
-    --slave /usr/bin/g++ g++ /usr/bin/g++-10
+$SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
+$SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60

--- a/.install/os/focal.sh
+++ b/.install/os/focal.sh
@@ -7,5 +7,6 @@
 
 debian_default_install
 apt_install gcc-10 g++-10
+$SUDO update-alternatives --remove-all g++ 2>/dev/null || true
 $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
     --slave /usr/bin/g++ g++ /usr/bin/g++-10

--- a/.install/os/focal.sh
+++ b/.install/os/focal.sh
@@ -11,6 +11,8 @@ apt_install gcc-10 g++-10
 # may have already pinned something newer in this shared build container.
 _cur=$(gcc -dumpversion | cut -d. -f1)
 if [ "$_cur" -lt 10 ]; then
+    $SUDO update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-10 60
+    $SUDO update-alternatives --set     cc  /usr/bin/gcc-10
     $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
     $SUDO update-alternatives --set     gcc /usr/bin/gcc-10
     $SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60

--- a/.install/os/mariner2.sh
+++ b/.install/os/mariner2.sh
@@ -8,6 +8,4 @@
 tdnf_default_install
 
 # Install aws-cli for uploading artifacts to s3
-curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-unzip awscliv2.zip
-./aws/install
+install_aws_cli

--- a/.install/os/rocky8.sh
+++ b/.install/os/rocky8.sh
@@ -8,6 +8,4 @@
 el8_default_install
 
 # Install aws-cli for uploading artifacts to s3
-curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-unzip awscliv2.zip
-./aws/install
+install_aws_cli

--- a/.install/os/rocky9.sh
+++ b/.install/os/rocky9.sh
@@ -7,12 +7,5 @@
 
 el9_default_install
 
-# Install aws-cli for uploading artifacts to s3 (arch-aware: x86_64 / aarch64)
-ARCH=$(uname -m)
-if [[ $ARCH == "aarch64" ]]; then
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
-else
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-fi
-unzip awscliv2.zip
-./aws/install
+# Install aws-cli for uploading artifacts to s3
+install_aws_cli


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes global compiler and python3 defaults on EL8 and several Ubuntu/Debian images, which can affect all builds on a shared host; apt/sudo and download-from-network paths add operational surface but are scoped to bootstrap scripts.
> 
> **Overview**
> Makes `.install` bootstraps **safe to re-run** on shared build machines and fixes hangs and compiler drift across distros.
> 
> **CMake** (`install_cmake.sh`) exits early when PATH already has cmake ≥ 3.25.1, and downloads the Kitware installer into a temp directory instead of the current checkout.
> 
> **APT** (`pm.sh`) passes `DEBIAN_FRONTEND=noninteractive` through `sudo env` on `apt-get install` so debconf (e.g. `tzdata` on focal) cannot block non-interactive runs.
> 
> **Compilers** stop fighting between modules: `debian_default_install` no longer pins global `cc`/`gcc`/`g++`. **Bullseye** always resets to distro **gcc-10** (fixes clang owning `cc`). **Focal** and **Bionic** only raise the default to gcc-10 when the active major version is &lt; 10. **EL8/EL9** and **Amazon Linux 2** add `/usr/local/bin` symlinks into gcc/devtoolset toolsets; EL8 also installs `python3.11-pip` and sets `python3` to 3.11.
> 
> **AWS CLI v2** is centralized in `install_aws_cli()` (arch-aware, no-op if `aws` exists) and replaces duplicated curl/unzip blocks on Rocky/Azure/Mariner OS scripts.
> 
> **Bionic** gains debconf/tzdata preseeding, manual toolchain PPA key/repo setup (with `apt_install` before wget), conditional cmake 3.28 source build, `install_aws_cli`, and `pip3 install dataclasses`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 309c14f63c4cf7dae7ee81e7a17a0f900816bd5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->