### PR TITLE
MOD-14615 - run valgrind suite serially (fix CPU-oversubscription flake)

### DIFF
--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -453,6 +453,10 @@ PARALLEL=${PARALLEL:-1}
 # due to Python "Can't pickle local object" problem in RLTest
 [[ $OS == macos ]] && PARALLEL=0
 
+# run Valgrind serially: at --parallelism nproc the runner oversubscribes CPU
+# (redis-server is ~30x slower under Valgrind), starving shards past LibMR's max-idle
+[[ $VG == 1 ]] && PARALLEL=0
+
 [[ $EXT == 1 || $EXT == run || $BB == 1 || $GDB == 1 ]] && PARALLEL=0
 
 if [[ -n $PARALLEL && $PARALLEL != 0 ]]; then


### PR DESCRIPTION
## Summary
`test_asm:test_asm_with_data_and_queries_during_migrations` intermittently failed on the **valgrind `oss_cluster`** nightly with `A multi-keys command failed because at least one shard did not reply within the given timeframe`.

## Root cause
The flow suite runs at `--parallelism nproc`, and each `redis-server` is ~30x slower under valgrind. On the hosted runner that **oversubscribes the CPU** — many concurrent test clusters (each several redis processes) contend for a few cores, so a shard is starved past LibMR's **5s** max-idle during migration churn and the multi-shard query "times out". It is **not a product bug**: in production each shard runs on its own CPU/node, so 5s is ample. (macOS already forces serial for a related reason.)

## Fix
One line in `tests.sh`: run valgrind serially (`[[ $VG == 1 ]] && PARALLEL=0`) so each shard gets a core and the **default 5s holds** — no product change, no timeout bump, no config.

## Verification
With `PARALLEL=0` the valgrind `oss_cluster` shard went **435/435 green at the default 5s** ([run 28498734942](https://github.com/RedisTimeSeries/RedisTimeSeries/actions/runs/28498734942)), with the parallelism confirmed off. (Contrast: at `--parallelism nproc` the same test flaked ~nightly.)

## Notes
- De-linked from MOD-15307 (fork drain) / MOD-14239 (sanitizer ghost-lock) — different issues.
- The same serial run also covers the sibling slow-env-timeout tests (`test_filterby` / MOD-14289, `test_ts_bget`).
- Tradeoff: the valgrind shards run serially, so they're slower — measured at **~2.5h**, which is under the macOS leg (~3h) that already gates the nightly, so there is **no net nightly wall-clock regression**. Accepted as fine for the nightly.

Fixes MOD-14615.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness-only change in `tests.sh`; no runtime or product behavior changes.
> 
> **Overview**
> **Forces serial RLTest execution when `VG=1`**, matching the existing macOS and `SLOW` behavior, so Valgrind nightly runs no longer use `--parallelism nproc`.
> 
> Under Valgrind, `redis-server` is much slower; parallel test clusters were oversubscribing CI CPUs and occasionally tripping LibMR multi-shard idle timeouts during migrations (CI flake, not a product change). **Tradeoff:** Valgrind shards take longer (~2.5h serial vs parallel), but stay within the nightly wall-clock budget already set by the macOS leg.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a53bf498382cfadf2eaa11302c7b5d1a13c7142. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->