### PR TITLE
MOD-14615 - skip test_asm migration-query test on macos-15-intel (slow-runner flake)

### DIFF
--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -128,6 +128,8 @@ jobs:
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
       TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH}}
       PIP_BREAK_SYSTEM_PACKAGES: 1
+      # Expose the matrix runner label to the tests so they can skip on a specific runner.
+      RUNNER_LABEL: ${{ matrix.os }}
     runs-on: ${{matrix.os}}
     needs: setup-environment
     strategy:

--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -31,6 +31,9 @@ SANITIZER = os.getenv('SANITIZER', '')
 VALGRIND = (os.getenv('VALGRIND', '0') == '1') or (os.getenv('VG', '0') == '1')
 CODE_COVERAGE = os.getenv('CODE_COVERAGE', '0') == '1'
 
+# CI matrix runner label (e.g. "macos-15-intel"), exported by the workflow. Empty locally.
+RUNNER_LABEL = os.getenv('RUNNER_LABEL', '')
+
 # Upper bound on how long a "prompt" wake (e.g. TS.READ woken by a key deletion)
 # may take before we consider it a regression. Scaled up under Valgrind/sanitizer
 # so the slower wake-up callback there can't produce a false failure.

--- a/tests/flow/test_asm.py
+++ b/tests/flow/test_asm.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Optional, Set
 import redis
 
-from includes import Env, VALGRIND, SANITIZER
+from includes import Env, VALGRIND, SANITIZER, RUNNER_LABEL
 from utils import slot_table
 
 
@@ -36,6 +36,13 @@ def test_asm_with_data():
 def test_asm_with_data_and_queries_during_migrations():
     env = Env(shardsCount=2, decodeResponses=True, noLog=False)
     if env.env != "oss-cluster":
+        env.skip()
+
+    # macos-15-intel is the slowest hosted runner and can't reliably serve the
+    # multi-shard query within LibMR's 5s max-idle during migration churn, so it
+    # occasionally trips the max-idle timeout instead of the expected slot-ranges
+    # error (MOD-14615 residual; not a product bug -- other macOS/Linux runners pass).
+    if RUNNER_LABEL == "macos-15-intel":
         env.skip()
 
     number_of_keys = 1000 if not (VALGRIND or SANITIZER) else 100


### PR DESCRIPTION
## Summary
Follow-up to #2083. `test_asm_with_data_and_queries_during_migrations` intermittently fails on the **`macos-15-intel`** nightly runner with `A multi-keys command failed because at least one shard did not reply within the given timeframe` instead of the expected `"Query requires unavailable slots"`, tripping the assert at [test_asm.py:70](tests/flow/test_asm.py#L70).

## Root cause — runner speed, not a product bug
The test runs a multi-shard `TS.MRANGE … GROUPBY label1 REDUCE count` in a loop *during* back-and-forth slot migration. On the slow/old `macos-15-intel` box, a shard occasionally can't reply within LibMR's 5s max-idle during migration churn, so the query returns the timeout rather than the clean slot-ranges error.

Evidence it's the runner, not the product — in nightly [28547152141](https://github.com/RedisTimeSeries/RedisTimeSeries/actions/runs/28547152141), **5 of 6 macOS runners passed the identical test**; only `macos-15-intel` failed:

| runner | result |
|---|---|
| macos-14 / macos-14-large / macos-15 / macos-26 / **macos-26-intel** | ✅ |
| **macos-15-intel** | ❌ max-idle |

macOS already runs the suite serially, so the valgrind-oversubscription fix (#2083) doesn't apply here — there's no parallelism left to remove.

## Change
- `flow-macos.yml`: export the matrix runner label as `RUNNER_LABEL`.
- `includes.py`: add `RUNNER_LABEL` env flag (alongside `VALGRIND`/`SANITIZER`).
- `test_asm.py`: `env.skip()` **only** this one test **only** on `macos-15-intel`.

Coverage is preserved everywhere else — all Linux topologies and the 5 other macOS runners still run the test.

Relates to MOD-14615.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CI env wiring and a targeted test skip; no module or runtime behavior changes.
> 
> **Overview**
> **CI-only workaround for MOD-14615:** the macOS workflow now passes the matrix runner name into tests via `RUNNER_LABEL`, and `test_asm_with_data_and_queries_during_migrations` is skipped when that label is `macos-15-intel`.
> 
> That test runs multi-shard `TS.MRANGE` while slots migrate; on the slow `macos-15-intel` runner it sometimes hits LibMR’s max-idle timeout instead of the expected “unavailable slots” error, causing false failures. Other macOS and Linux runners still run the test unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feff0dfad9c43e498f18d0ad5810365b3166a673. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->