### PR TITLE
MOD-16399 Bump LibMR: skip rebuilds for unchanged CLUSTERSET topologies

### DIFF
--- a/tests/flow/test_clusterset_noop.py
+++ b/tests/flow/test_clusterset_noop.py
@@ -1,0 +1,43 @@
+from includes import Env
+
+
+def _run_id(conn):
+    # INFOCLUSTER layout: ["MyId", <id>, "MyRunId", <run id>, ...]
+    return conn.execute_command("timeseries.INFOCLUSTER")[3]
+
+
+def _long_form_clusterset(my_port, second_shard_port):
+    return [
+        "HASHFUNC", "CRC16", "NUMSLOTS", "16384", "MYID", "1", "RANGES", "2",
+        "SHARD", "1", "SLOTRANGE", "0", "8191",
+        "ADDR", f"@127.0.0.1:{my_port}", "MASTER",
+        "SHARD", "2", "SLOTRANGE", "8192", "16383",
+        "ADDR", f"@127.0.0.1:{second_shard_port}", "MASTER",
+    ]
+
+
+def test_identical_long_form_clusterset_is_noop():
+    env = Env(decodeResponses=True, moduleArgs="ts-topology-events no")
+    env.skipOnCluster()
+    env.skipOnSlave()
+
+    conn = env.getConnection()
+    try:
+        conn.execute_command("debug", "MARK-INTERNAL-CLIENT")
+    except Exception:
+        pass  # INFOCLUSTER is not internal-only on older Redis versions.
+
+    my_port = conn.connection_pool.connection_kwargs["port"]
+    initial = _long_form_clusterset(my_port, my_port + 1)
+
+    assert conn.execute_command("timeseries.CLUSTERSET", *initial) == "OK"
+    run_id = _run_id(conn)
+
+    # A DMC no-op re-broadcast must preserve the existing LibMR cluster.
+    assert conn.execute_command("timeseries.CLUSTERSET", *initial) == "OK"
+    assert _run_id(conn) == run_id
+
+    # A real endpoint change must still replace it.
+    changed = _long_form_clusterset(my_port, my_port + 2)
+    assert conn.execute_command("timeseries.CLUSTERSET", *changed) == "OK"
+    assert _run_id(conn) != run_id

--- a/tests/flow/test_clusterset_noop.py
+++ b/tests/flow/test_clusterset_noop.py
@@ -33,7 +33,9 @@ def test_identical_long_form_clusterset_is_noop():
     assert conn.execute_command("timeseries.CLUSTERSET", *initial) == "OK"
     run_id = _run_id(conn)
 
-    # A DMC no-op re-broadcast must preserve the existing LibMR cluster.
+    # LibMR generates a run ID when it builds the cluster, so preserving that
+    # externally visible ID proves the DMC re-broadcast did not rebuild it
+    # (and therefore did not drop connections or abort in-flight executions).
     assert conn.execute_command("timeseries.CLUSTERSET", *initial) == "OK"
     assert _run_id(conn) == run_id
 


### PR DESCRIPTION
## Summary

- Pin LibMR to [RedisGears/LibMR#104](https://github.com/RedisGears/LibMR/pull/104), commit `c6a5ed62bc7d7b5ddaa8adf99d2cf6fb5a7d527c`.
- Add RedisTimeSeries flow coverage for the DMC-style long-form `CLUSTERSET` path with topology events explicitly disabled.
- Verify that an identical long-form command preserves the LibMR run ID, while a real endpoint change replaces it.

The active LibMR #104 implementation uses a lightweight pre-parse argument guard for long form only. Short form and the Redis core topology-event mechanism remain unchanged, and the previously published LibMR commit history is preserved.

## Verification

- `gmake build DEPS=1`
- `gmake flow_tests TEST=test_clusterset_noop.py:test_identical_long_form_clusterset_is_noop QUICK=1` — 1 passed, 0 failed.

LibMR #104 is merged; this PR now pins its canonical commit on LibMR `master`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: dependency pin plus integration test; behavior change is scoped to unchanged long-form CLUSTERSET and real topology updates still rebuild.
> 
> **Overview**
> Pins **LibMR** to the commit that adds a **long-form `CLUSTERSET` pre-parse guard** so an identical topology re-broadcast does not tear down and rebuild the LibMR cluster (preserving run ID, connections, and in-flight work). Short-form `CLUSTERSET` and Redis topology-event paths are unchanged.
> 
> Adds flow coverage **`test_identical_long_form_clusterset_is_noop`**: with `ts-topology-events no`, it checks that repeating the same DMC-style long-form `timeseries.CLUSTERSET` leaves **`INFOCLUSTER` run ID** unchanged, while a real shard address change still produces a new run ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85a35cc2d43c79e9218ba6c84413bc91f06f8f8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


