### PR TITLE
fix(alpine): use the distro python3 for the test venv

### DIFF
--- a/.install/os/alpine.sh
+++ b/.install/os/alpine.sh
@@ -12,3 +12,12 @@
 
 alpine_default_install
 apk_install py3-cryptography py3-numpy py3-psutil openblas-dev xsimd
+
+# uv's standalone musl CPython is clang-built and bakes clang-only flags
+# (--rtlib=compiler-rt) into its sysconfig, so setup-python.sh's `uv venv`
+# then fails to compile sdist-only test deps that lack musl wheels (psutil,
+# via rltest) with Alpine's gcc. Use Alpine's own python3 (installed above
+# with python3-dev) and forbid uv from downloading a managed interpreter.
+export SETUP_PYTHON_VERSION="${SETUP_PYTHON_VERSION:-$(command -v python3)}"
+export UV_PYTHON_DOWNLOADS=never
+echo "==> [redistimeseries] alpine: SETUP_PYTHON_VERSION=$SETUP_PYTHON_VERSION UV_PYTHON_DOWNLOADS=never"


### PR DESCRIPTION
## Problem

On Alpine, `make bootstrap` fails building the Python test environment:

```
cc: error: unrecognized command-line option '--rtlib=compiler-rt'
psutil could not be installed from sources
error: command '/usr/bin/cc' failed with exit code 1
hint: `psutil` (v5.9.8) was included because `rltest` depends on `psutil`
```

`.install/lib/setup-python.sh` creates the venv with `uv venv --python ${SETUP_PYTHON_VERSION:-3.12}`. On Alpine, uv downloads its **standalone musl CPython**, which is **clang-built** and bakes clang-only flags (`--rtlib=compiler-rt`) into its `sysconfig`. Test deps that are sdist-only on musl (`psutil==5.9.8`, via rltest) then inherit those flags and fail to compile with Alpine's **gcc**.

`SETUP_PYTHON_VERSION` is pinned for EL8 (`pm.sh`) but not for Alpine, so Alpine falls through to the download.

Reproduced on current `master` in a clean `alpine:3` container (`.install/install_script.sh` with `/.dockerenv` removed to force venv setup).

## Fix

In `.install/os/alpine.sh`, pin the venv to Alpine's own `python3` (already installed with `python3-dev` via `ALPINE_BASE`) and forbid uv downloads — same intent as the existing EL8 pin, expressed as a path so uv uses the system interpreter:

```sh
export SETUP_PYTHON_VERSION="${SETUP_PYTHON_VERSION:-$(command -v python3)}"
export UV_PYTHON_DOWNLOADS=never
```

## Verified

Clean `alpine:3` container, `.install/install_script.sh` with `/.dockerenv` removed:
- **Before:** `uv venv` uses `cpython-3.12.13-linux-aarch64-musl` (downloaded standalone) → psutil sdist build fails with `--rtlib=compiler-rt`.
- **After:** `Using CPython 3.14.5 interpreter at: /usr/bin/python3`, all packages install, bootstrap exits 0.

Found while wiring Alpine into the redis/redis bundled-modules nightly (redis/redis#15253).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Alpine install/bootstrap environment variables; no runtime or auth changes.
> 
> **Overview**
> **Alpine bootstrap** now forces the install script’s test venv to use the system `python3` and blocks `uv` from fetching its own interpreter.
> 
> After `apk` installs the usual Alpine packages, `alpine.sh` exports `SETUP_PYTHON_VERSION` to `$(command -v python3)` (unless already set) and `UV_PYTHON_DOWNLOADS=never`, plus a log line for visibility. That steers `setup-python.sh`’s `uv venv --python …` away from uv’s standalone musl CPython—which embeds clang-only link flags that break sdist builds (e.g. `psutil` via `rltest`) under Alpine’s gcc—and mirrors the EL8 “pin system Python” approach, but with a path instead of a version number.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84399f288972913b95829f933964ff8d8b428695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->