### PR TITLE
MOD-16370 Introduce `TS.QUERYLABELS`: Get a list of labels and label-…

### DIFF
--- a/src/cmd_info/ts_info.c
+++ b/src/cmd_info/ts_info.c
@@ -1213,6 +1213,53 @@ static const RedisModuleCommandInfo TS_QUERYINDEX_INFO = {
 };
 
 // ===============================
+// TS.QUERYLABELS <LABELS | VALUES label> [FILTER filterExpr...]
+// ===============================
+static const RedisModuleCommandArg TS_QUERYLABELS_VALUES_ARGS[] = {
+    { .name = "VALUES", .type = REDISMODULE_ARG_TYPE_PURE_TOKEN, .token = "VALUES" },
+    { .name = "label", .type = REDISMODULE_ARG_TYPE_STRING },
+    { 0 }
+};
+
+static const RedisModuleCommandArg TS_QUERYLABELS_SUBTYPE_OPTIONS[] = {
+    { .name = "LABELS", .type = REDISMODULE_ARG_TYPE_PURE_TOKEN, .token = "LABELS" },
+    { .name = "VALUES",
+      .type = REDISMODULE_ARG_TYPE_BLOCK,
+      .subargs = (RedisModuleCommandArg *)TS_QUERYLABELS_VALUES_ARGS },
+    { 0 }
+};
+
+static const RedisModuleCommandArg TS_QUERYLABELS_ARGS[] = {
+    { .name = "subtype",
+      .type = REDISMODULE_ARG_TYPE_ONEOF,
+      .subargs = (RedisModuleCommandArg *)TS_QUERYLABELS_SUBTYPE_OPTIONS },
+    { .name = "FILTER",
+      .type = REDISMODULE_ARG_TYPE_BLOCK,
+      .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+      .subargs =
+          (RedisModuleCommandArg[]){
+              { .name = "FILTER", .type = REDISMODULE_ARG_TYPE_PURE_TOKEN, .token = "FILTER" },
+              { .name = "filterExpr",
+                .type = REDISMODULE_ARG_TYPE_STRING,
+                .flags = REDISMODULE_CMD_ARG_MULTIPLE },
+              { 0 } } },
+    { 0 }
+};
+
+static const RedisModuleCommandInfo TS_QUERYLABELS_INFO = {
+    .version = REDISMODULE_COMMAND_INFO_VERSION,
+    .summary = "Get all label names, or all values of a given label, for time series matching a "
+              "filter list, or all series",
+    .complexity = "O(n) where n is the number of time-series that match the filters (all "
+                  "indexed series when FILTER is omitted)",
+    .since = "8.10.0",
+    .tips = "dont_cache",
+    .arity = -2,
+    .key_specs = NULL,
+    .args = (RedisModuleCommandArg *)TS_QUERYLABELS_ARGS,
+};
+
+// ===============================
 // TS.INFO key [DEBUG]
 // ===============================
 static const RedisModuleCommandKeySpec TS_INFO_KEYSPECS[] = {
@@ -1716,6 +1763,12 @@ int RegisterTSCommandInfos(RedisModuleCtx *ctx) {
     RedisModuleCommand *cmd_queryindex = RedisModule_GetCommand(ctx, "TS.QUERYINDEX");
     if (!cmd_queryindex ||
         RedisModule_SetCommandInfo(cmd_queryindex, &TS_QUERYINDEX_INFO) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    // Register TS.QUERYLABELS command info
+    RedisModuleCommand *cmd_querylabels = RedisModule_GetCommand(ctx, "TS.QUERYLABELS");
+    if (!cmd_querylabels ||
+        RedisModule_SetCommandInfo(cmd_querylabels, &TS_QUERYLABELS_INFO) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     // Register TS.INFO command info

--- a/src/cmd_info/ts_info.c
+++ b/src/cmd_info/ts_info.c
@@ -1249,7 +1249,7 @@ static const RedisModuleCommandArg TS_QUERYLABELS_ARGS[] = {
 static const RedisModuleCommandInfo TS_QUERYLABELS_INFO = {
     .version = REDISMODULE_COMMAND_INFO_VERSION,
     .summary = "Get all label names, or all values of a given label, for time series matching a "
-              "filter list, or all series",
+               "filter list, or all series",
     .complexity = "O(n) where n is the number of time-series that match the filters (all "
                   "indexed series when FILTER is omitted)",
     .since = "8.10.0",

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -13,7 +13,6 @@
 #include "consts.h"
 #include "utils/overflow.h"
 
-#include <assert.h>
 #include <limits.h>
 #include <stdint.h>
 #include <string.h>
@@ -571,10 +570,19 @@ RedisModuleDict *GetAllIndexedSeriesKeys(RedisModuleCtx *ctx) {
     return res;
 }
 
+RedisModuleString *QueryLabelsBuildPrefix(QueryLabelsSubtype subtype,
+                                          RedisModuleString *labelFilter) {
+    return subtype == QueryLabelsSubtype_Labels
+               ? RedisModule_CreateStringPrintf(NULL, K_PREFIX, "")
+               : RedisModule_CreateStringPrintf(
+                     NULL, KV_PREFIX, RedisModule_StringPtrLen(labelFilter, NULL), "");
+}
+
 void QueryLabelsFromIndex(const char *tsKey,
                           size_t tsKeyLen,
                           QueryLabelsSubtype subtype,
-                          RedisModuleString *labelFilter,
+                          const char *prefixBuf,
+                          size_t prefixLen,
                           void (*emit)(void *userData, const char *buf, size_t len),
                           void *userData) {
     int nokey = 0;
@@ -582,14 +590,6 @@ void QueryLabelsFromIndex(const char *tsKey,
     if (nokey) {
         return;
     }
-
-    RedisModuleString *prefix =
-        subtype == QueryLabelsSubtype_Labels
-            ? RedisModule_CreateStringPrintf(NULL, K_PREFIX, "")
-            : RedisModule_CreateStringPrintf(
-                  NULL, KV_PREFIX, RedisModule_StringPtrLen(labelFilter, NULL), "");
-    size_t prefixLen;
-    const char *prefixBuf = RedisModule_StringPtrLen(prefix, &prefixLen);
 
     RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(leaf, "^", NULL, 0);
     char *entryBuf;
@@ -604,8 +604,6 @@ void QueryLabelsFromIndex(const char *tsKey,
         }
     }
     RedisModule_DictIteratorStop(iter);
-
-    RedisModule_FreeString(NULL, prefix);
 }
 
 void QueryPredicate_Free(QueryPredicate *predicate_list, size_t count) {
@@ -624,12 +622,11 @@ void QueryPredicate_Free(QueryPredicate *predicate_list, size_t count) {
 }
 
 void QueryPredicateList_Free(QueryPredicateList *list) {
-    if (list->ref > 1) {
-        --list->ref;
+    // Atomic: this can race with LibMR's dispose thread freeing the same list
+    // (see QueryLabelsArg_ObjectFree and friends) once a cluster execution completes.
+    if (__atomic_sub_fetch(&list->ref, 1, __ATOMIC_RELAXED) > 0) {
         return;
     }
-
-    assert(list->ref == 1);
 
     for (size_t i = 0; i < list->count; i++) {
         QueryPredicate_Free(&list->list[i], 1);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -629,8 +629,7 @@ void QueryLabelsFromIndex(const char *tsKey,
     }
 
     size_t kvLitLen = strlen(KV_PREFIX_LITERAL);
-    size_t candidateLabelLen =
-        subtype == QueryLabelsSubtype_Values ? prefixLen - kvLitLen - 1 : 0;
+    size_t candidateLabelLen = subtype == QueryLabelsSubtype_Values ? prefixLen - kvLitLen - 1 : 0;
 
     RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(leaf, "^", NULL, 0);
     char *entryBuf;

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -481,8 +481,11 @@ static inline bool OwnKeyDuringASM(RedisModuleString *key) { // ASM version
     return RedisModule_ClusterCanAccessKeysInSlot(slot);
 }
 
-// During resharding/ASM trimming/importing, modules might see keys whose slots are no
-// longer (or not yet) owned by the current shard, so we need to filter them out of the results.
+// Results here come from our in-memory label index, not the Redis keyspace, so core's
+// per-slot ownership filtering never applies to them. The index is cleaned lazily (via
+// unlink/keyspace notifications), so during a slot migration it still contains keys for
+// slots this shard no longer owns (reshard/ASM trim) or does not own yet (ASM import).
+// Drop those so we don't report series that aren't this shard's responsibility.
 static void TrimUnownedKeysDuringReshard(RedisModuleDict *res) {
     if (likely(!(isReshardTrimming || isAsmTrimming || isAsmImporting))) {
         return;
@@ -667,8 +670,11 @@ void QueryPredicate_Free(QueryPredicate *predicate_list, size_t count) {
 }
 
 void QueryPredicateList_Free(QueryPredicateList *list) {
-    // Atomic: this can race with LibMR's dispose thread freeing the same list
-    // (see QueryLabelsArg_ObjectFree and friends) once a cluster execution completes.
+    // Atomic: LibMR duplicates/frees the QueryPredicates_Arg/QueryLabelsArg holding this list
+    // from its own execution threads (QueryPredicates_Duplicate/ObjectFree, QueryLabelsArg_*),
+    // concurrently with whichever thread drops this module's own reference. Every touch of
+    // `ref` - increments in libmr_commands.c included - has to be atomic for the count spread
+    // across those threads to stay consistent.
     if (__atomic_sub_fetch(&list->ref, 1, __ATOMIC_RELAXED) > 0) {
         return;
     }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -22,8 +22,10 @@ RedisModuleDict *labelsIndex;  // maps label to it's ts keys.
 RedisModuleDict *tsLabelIndex; // maps ts_key to it's dict in labelsIndex
 extern bool isReshardTrimming, isAsmTrimming, isAsmImporting;
 
-#define KV_PREFIX "__index_%s=%s"
-#define K_PREFIX "__key_index_%s"
+#define KV_PREFIX_LITERAL "__index_"
+#define K_PREFIX_LITERAL "__key_index_"
+#define KV_PREFIX KV_PREFIX_LITERAL "%s=%s"
+#define K_PREFIX K_PREFIX_LITERAL "%s"
 
 typedef enum
 {
@@ -503,9 +505,13 @@ RedisModuleDict *QueryIndex(RedisModuleCtx *ctx,
                             QueryPredicate *index_predicate,
                             size_t predicate_count,
                             bool *hasPermissionError) {
+    RedisModuleDict *res = RedisModule_CreateDict(ctx);
+    if (predicate_count == 0) {
+        return res;
+    }
+
     PromoteSmallestPredicateToFront(ctx, index_predicate, predicate_count);
 
-    RedisModuleDict *res = RedisModule_CreateDict(ctx);
     QueryPredicate *predicate = &index_predicate[0];
 
     if (!IS_INCLUSION(predicate->type)) {
@@ -578,6 +584,37 @@ RedisModuleString *QueryLabelsBuildPrefix(QueryLabelsSubtype subtype,
                      NULL, KV_PREFIX, RedisModule_StringPtrLen(labelFilter, NULL), "");
 }
 
+// Label keys can no longer contain '=' (parseLabelsFromArgs rejects it at creation), but
+// series indexed before that existed. For such a series, a KV entry's "key=value" content
+// is ambiguous: e.g. key "a=b" value "c" and key "a" value "b=c" both flatten differently,
+// but a VALUES(a) lookup can't tell "a=b=c" (real key "a=b") from a genuine key "a" without
+// cross-checking. A real key always has an exact "__key_index_"-prefixed leaf entry, so if
+// some OTHER real key strictly longer than candidateLabel is itself a "key=" prefix of this
+// entry's content, the content truly belongs to that longer key, not to candidateLabel.
+static bool ValuesMatchShadowedByLongerKey(RedisModuleDict *leaf,
+                                           const char *content,
+                                           size_t contentLen,
+                                           size_t candidateLabelLen) {
+    size_t kLitLen = strlen(K_PREFIX_LITERAL);
+    bool shadowed = false;
+    RedisModuleDictIter *kiter = RedisModule_DictIteratorStartC(leaf, "^", NULL, 0);
+    char *kEntryBuf;
+    size_t kEntryLen;
+    while (!shadowed && (kEntryBuf = RedisModule_DictNextC(kiter, &kEntryLen, NULL)) != NULL) {
+        if (kEntryLen <= kLitLen || memcmp(kEntryBuf, K_PREFIX_LITERAL, kLitLen) != 0) {
+            continue;
+        }
+        const char *otherKey = kEntryBuf + kLitLen;
+        size_t otherKeyLen = kEntryLen - kLitLen;
+        if (otherKeyLen > candidateLabelLen && otherKeyLen < contentLen &&
+            memcmp(content, otherKey, otherKeyLen) == 0 && content[otherKeyLen] == '=') {
+            shadowed = true;
+        }
+    }
+    RedisModule_DictIteratorStop(kiter);
+    return shadowed;
+}
+
 void QueryLabelsFromIndex(const char *tsKey,
                           size_t tsKeyLen,
                           QueryLabelsSubtype subtype,
@@ -591,11 +628,20 @@ void QueryLabelsFromIndex(const char *tsKey,
         return;
     }
 
+    size_t kvLitLen = strlen(KV_PREFIX_LITERAL);
+    size_t candidateLabelLen =
+        subtype == QueryLabelsSubtype_Values ? prefixLen - kvLitLen - 1 : 0;
+
     RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(leaf, "^", NULL, 0);
     char *entryBuf;
     size_t entryLen;
     while ((entryBuf = RedisModule_DictNextC(iter, &entryLen, NULL)) != NULL) {
         if (entryLen < prefixLen || memcmp(entryBuf, prefixBuf, prefixLen) != 0) {
+            continue;
+        }
+        if (subtype == QueryLabelsSubtype_Values &&
+            ValuesMatchShadowedByLongerKey(
+                leaf, entryBuf + kvLitLen, entryLen - kvLitLen, candidateLabelLen)) {
             continue;
         }
         emit(userData, entryBuf + prefixLen, entryLen - prefixLen);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -480,6 +480,26 @@ static inline bool OwnKeyDuringASM(RedisModuleString *key) { // ASM version
     return RedisModule_ClusterCanAccessKeysInSlot(slot);
 }
 
+// During resharding/ASM trimming/importing, modules might see keys whose slots are no
+// longer (or not yet) owned by the current shard, so we need to filter them out of the results.
+static void TrimUnownedKeysDuringReshard(RedisModuleDict *res) {
+    if (likely(!(isReshardTrimming || isAsmTrimming || isAsmImporting))) {
+        return;
+    }
+    RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(res, "^", NULL, 0);
+    RedisModuleString *currentKey;
+    while ((currentKey = RedisModule_DictNext(NULL, iter, NULL)) != NULL) {
+        bool ownCurrentKey =
+            (isReshardTrimming ? OwnKeyDuringSharding : OwnKeyDuringASM)(currentKey);
+        if (!ownCurrentKey) {
+            RedisModule_DictDel(res, currentKey, NULL);
+            RedisModule_DictIteratorReseek(iter, ">", currentKey);
+        }
+        RedisModule_FreeString(NULL, currentKey);
+    }
+    RedisModule_DictIteratorStop(iter);
+}
+
 RedisModuleDict *QueryIndex(RedisModuleCtx *ctx,
                             QueryPredicate *index_predicate,
                             size_t predicate_count,
@@ -531,22 +551,7 @@ RedisModuleDict *QueryIndex(RedisModuleCtx *ctx,
     FreeUser(&userCtx);
     free(dicts);
 
-    if (unlikely(isReshardTrimming || isAsmTrimming || isAsmImporting)) {
-        // During those periods modules might see keys whose slots are no longer
-        // (or not yet) owned by the current shard, so we need to filter them out of the results
-        RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(res, "^", NULL, 0);
-        RedisModuleString *currentKey;
-        while ((currentKey = RedisModule_DictNext(NULL, iter, NULL)) != NULL) {
-            bool ownCurrentKey =
-                (isReshardTrimming ? OwnKeyDuringSharding : OwnKeyDuringASM)(currentKey);
-            if (!ownCurrentKey) {
-                RedisModule_DictDel(res, currentKey, NULL);
-                RedisModule_DictIteratorReseek(iter, ">", currentKey);
-            }
-            RedisModule_FreeString(NULL, currentKey);
-        }
-        RedisModule_DictIteratorStop(iter);
-    }
+    TrimUnownedKeysDuringReshard(res);
 
     return res;
 }
@@ -560,25 +565,29 @@ RedisModuleDict *GetAllIndexedSeriesKeys(RedisModuleCtx *ctx) {
         RedisModule_DictSetC(res, currentKey, currentKeyLen, (void *)1);
     }
     RedisModule_DictIteratorStop(iter);
+
+    TrimUnownedKeysDuringReshard(res);
+
     return res;
 }
 
 void QueryLabelsFromIndex(const char *tsKey,
-                         size_t tsKeyLen,
-                         QueryLabelsSubtype subtype,
-                         RedisModuleString *labelFilter,
-                         void (*emit)(void *userData, const char *buf, size_t len),
-                         void *userData) {
+                          size_t tsKeyLen,
+                          QueryLabelsSubtype subtype,
+                          RedisModuleString *labelFilter,
+                          void (*emit)(void *userData, const char *buf, size_t len),
+                          void *userData) {
     int nokey = 0;
     RedisModuleDict *leaf = RedisModule_DictGetC(tsLabelIndex, (void *)tsKey, tsKeyLen, &nokey);
     if (nokey) {
         return;
     }
 
-    RedisModuleString *prefix = subtype == QueryLabelsSubtype_Labels
-                                     ? RedisModule_CreateStringPrintf(NULL, K_PREFIX, "")
-                                     : RedisModule_CreateStringPrintf(
-                                           NULL, KV_PREFIX, RedisModule_StringPtrLen(labelFilter, NULL), "");
+    RedisModuleString *prefix =
+        subtype == QueryLabelsSubtype_Labels
+            ? RedisModule_CreateStringPrintf(NULL, K_PREFIX, "")
+            : RedisModule_CreateStringPrintf(
+                  NULL, KV_PREFIX, RedisModule_StringPtrLen(labelFilter, NULL), "");
     size_t prefixLen;
     const char *prefixBuf = RedisModule_StringPtrLen(prefix, &prefixLen);
 

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -551,6 +551,54 @@ RedisModuleDict *QueryIndex(RedisModuleCtx *ctx,
     return res;
 }
 
+RedisModuleDict *GetAllIndexedSeriesKeys(RedisModuleCtx *ctx) {
+    RedisModuleDict *res = RedisModule_CreateDict(ctx);
+    RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(tsLabelIndex, "^", NULL, 0);
+    char *currentKey;
+    size_t currentKeyLen;
+    while ((currentKey = RedisModule_DictNextC(iter, &currentKeyLen, NULL)) != NULL) {
+        RedisModule_DictSetC(res, currentKey, currentKeyLen, (void *)1);
+    }
+    RedisModule_DictIteratorStop(iter);
+    return res;
+}
+
+void QueryLabelsFromIndex(const char *tsKey,
+                         size_t tsKeyLen,
+                         QueryLabelsSubtype subtype,
+                         RedisModuleString *labelFilter,
+                         void (*emit)(void *userData, const char *buf, size_t len),
+                         void *userData) {
+    int nokey = 0;
+    RedisModuleDict *leaf = RedisModule_DictGetC(tsLabelIndex, (void *)tsKey, tsKeyLen, &nokey);
+    if (nokey) {
+        return;
+    }
+
+    RedisModuleString *prefix = subtype == QueryLabelsSubtype_Labels
+                                     ? RedisModule_CreateStringPrintf(NULL, K_PREFIX, "")
+                                     : RedisModule_CreateStringPrintf(
+                                           NULL, KV_PREFIX, RedisModule_StringPtrLen(labelFilter, NULL), "");
+    size_t prefixLen;
+    const char *prefixBuf = RedisModule_StringPtrLen(prefix, &prefixLen);
+
+    RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(leaf, "^", NULL, 0);
+    char *entryBuf;
+    size_t entryLen;
+    while ((entryBuf = RedisModule_DictNextC(iter, &entryLen, NULL)) != NULL) {
+        if (entryLen < prefixLen || memcmp(entryBuf, prefixBuf, prefixLen) != 0) {
+            continue;
+        }
+        emit(userData, entryBuf + prefixLen, entryLen - prefixLen);
+        if (subtype == QueryLabelsSubtype_Values) {
+            break; // a series has at most one value for a given label name
+        }
+    }
+    RedisModule_DictIteratorStop(iter);
+
+    RedisModule_FreeString(NULL, prefix);
+}
+
 void QueryPredicate_Free(QueryPredicate *predicate_list, size_t count) {
     for (size_t predicate_index = 0; predicate_index < count; predicate_index++) {
         QueryPredicate *predicate = &predicate_list[predicate_index];

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -20,6 +20,12 @@ typedef struct
     RedisModuleString *value;
 } Label;
 
+typedef enum QueryLabelsSubtype
+{
+    QueryLabelsSubtype_Labels = 0,
+    QueryLabelsSubtype_Values,
+} QueryLabelsSubtype;
+
 typedef enum
 {
     EQ,
@@ -73,6 +79,20 @@ RedisModuleDict *QueryIndex(RedisModuleCtx *ctx,
                             QueryPredicate *index_predicate,
                             size_t predicate_count,
                             bool *hasPermissionError);
+
+// Returns a fresh dict of every currently-indexed series key (ts_key -> dummy).
+// Used by TS.QUERYLABELS when no FILTER is given ("all series").
+RedisModuleDict *GetAllIndexedSeriesKeys(RedisModuleCtx *ctx);
+
+// Reads ts_key's label names (LABELS) or the value of the label named by `labelFilter` (VALUES).
+// Calls `emit` once per match: once per label name for LABELS, at most once for VALUES (a series
+// has at most one value per label name). No-op if ts_key isn't indexed.
+void QueryLabelsFromIndex(const char *tsKey,
+                         size_t tsKeyLen,
+                         QueryLabelsSubtype subtype,
+                         RedisModuleString *labelFilter,
+                         void (*emit)(void *userData, const char *buf, size_t len),
+                         void *userData);
 
 int CountPredicateType(QueryPredicateList *queries, PredicateType type);
 #endif

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -84,13 +84,21 @@ RedisModuleDict *QueryIndex(RedisModuleCtx *ctx,
 // Used by TS.QUERYLABELS when no FILTER is given ("all series").
 RedisModuleDict *GetAllIndexedSeriesKeys(RedisModuleCtx *ctx);
 
-// Reads ts_key's label names (LABELS) or the value of the label named by `labelFilter` (VALUES).
-// Calls `emit` once per match: once per label name for LABELS, at most once for VALUES (a series
-// has at most one value per label name). No-op if ts_key isn't indexed.
+// Builds the index-entry prefix for a LABELS or VALUES query (see QueryLabelsFromIndex).
+// Caller owns the returned string and must free it with RedisModule_FreeString(NULL, ...).
+RedisModuleString *QueryLabelsBuildPrefix(QueryLabelsSubtype subtype,
+                                          RedisModuleString *labelFilter);
+
+// Reads ts_key's label names (LABELS) or the value of the label named by the prefix built via
+// QueryLabelsBuildPrefix (VALUES). Calls `emit` once per match: once per label name for LABELS,
+// at most once for VALUES (a series has at most one value per label name). No-op if ts_key isn't
+// indexed. `prefixBuf`/`prefixLen` are loop-invariant across candidate series, so callers scanning
+// many series should build the prefix once and reuse it.
 void QueryLabelsFromIndex(const char *tsKey,
                           size_t tsKeyLen,
                           QueryLabelsSubtype subtype,
-                          RedisModuleString *labelFilter,
+                          const char *prefixBuf,
+                          size_t prefixLen,
                           void (*emit)(void *userData, const char *buf, size_t len),
                           void *userData);
 

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -88,11 +88,11 @@ RedisModuleDict *GetAllIndexedSeriesKeys(RedisModuleCtx *ctx);
 // Calls `emit` once per match: once per label name for LABELS, at most once for VALUES (a series
 // has at most one value per label name). No-op if ts_key isn't indexed.
 void QueryLabelsFromIndex(const char *tsKey,
-                         size_t tsKeyLen,
-                         QueryLabelsSubtype subtype,
-                         RedisModuleString *labelFilter,
-                         void (*emit)(void *userData, const char *buf, size_t len),
-                         void *userData);
+                          size_t tsKeyLen,
+                          QueryLabelsSubtype subtype,
+                          RedisModuleString *labelFilter,
+                          void (*emit)(void *userData, const char *buf, size_t len),
+                          void *userData);
 
 int CountPredicateType(QueryPredicateList *queries, PredicateType type);
 #endif

--- a/src/libmr_commands.c
+++ b/src/libmr_commands.c
@@ -812,8 +812,11 @@ int TSDB_querylabels_MR(RedisModuleCtx *ctx,
         RedisModule_ReplyWithError(ctx, MR_ErrorGetMessage(err));
         // MR_CreateExecution always allocates and returns exec, even on error (it copies
         // and dups every step's args before checking the error) - free it or exec plus its
-        // duplicated QueryLabelsArg reference leak on every failed call.
+        // duplicated QueryLabelsArg reference leak on every failed call. That only drops
+        // the execution's dup'd reference though - also drop our own original reference
+        // (which in turn releases the extra QueryPredicateList ref taken above for FILTER).
         MR_FreeExecution(exec);
+        QueryLabelsArg_ObjectFree(queryArg);
         MR_FreeExecutionBuilder(builder);
         return REDISMODULE_OK;
     }

--- a/src/libmr_commands.c
+++ b/src/libmr_commands.c
@@ -628,6 +628,10 @@ int TSDB_mrange_MR(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool
     queryArg->startTimestamp = args.rangeArgs.startTimestamp;
     queryArg->endTimestamp = args.rangeArgs.endTimestamp;
     queryArg->latest = args.rangeArgs.latest;
+    // Atomic even though this call site is main-thread-only: LibMR's own Duplicate/ObjectFree
+    // step-arg callbacks (QueryPredicates_Duplicate/QueryPredicates_ObjectFree) touch this same
+    // ref from their own execution threads over the object's life, so every mutation site has
+    // to stay atomic for the count to be consistent (see QueryPredicateList_Free in indexer.c).
     __atomic_add_fetch(&args.queryPredicates->ref, 1, __ATOMIC_RELAXED);
     queryArg->predicates = args.queryPredicates;
     queryArg->withLabels = args.withLabels;
@@ -707,7 +711,7 @@ int TSDB_queryindex_MR(RedisModuleCtx *ctx, QueryPredicateList *queries) {
     queryArg->count = queries->count;
     queryArg->startTimestamp = 0;
     queryArg->endTimestamp = 0;
-    __atomic_add_fetch(&queries->ref, 1, __ATOMIC_RELAXED);
+    __atomic_add_fetch(&queries->ref, 1, __ATOMIC_RELAXED); // see rationale in TSDB_mrange_MR above
     queryArg->predicates = queries;
     queryArg->withLabels = false;
     queryArg->limitLabelsSize = 0;
@@ -752,27 +756,21 @@ int TSDB_queryindex_MR(RedisModuleCtx *ctx, QueryPredicateList *queries) {
     return REDISMODULE_OK;
 }
 
-static void querylabels_done_internal(ExecutionCtx *eCtx, RedisModuleCtx *ctx) {
-    ARR(ARR(RedisModuleString *)) nodesResults = collect_node_results(eCtx, ctx);
-    if (!nodesResults) {
-        return;
-    }
-
-    RedisModuleDict *agg = RedisModule_CreateDict(NULL);
-    array_foreach(nodesResults, stringList, {
-        array_foreach(stringList, s, { RedisModule_DictSet(agg, s, NULL); });
-    });
-    array_free(nodesResults);
-
-    ReplyWithKeySetFromDict(ctx, agg);
-    RedisModule_FreeDict(NULL, agg);
-}
-
 static void querylabels_done(ExecutionCtx *eCtx, void *privateData) {
     RedisModuleBlockedClient *bc = privateData;
     RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(bc);
 
-    querylabels_done_internal(eCtx, ctx);
+    ARR(ARR(RedisModuleString *)) nodesResults = collect_node_results(eCtx, ctx);
+    if (nodesResults) {
+        RedisModuleDict *agg = RedisModule_CreateDict(NULL);
+        array_foreach(nodesResults, stringList, {
+            array_foreach(stringList, s, { RedisModule_DictSet(agg, s, NULL); });
+        });
+        array_free(nodesResults);
+
+        ReplyWithKeySetFromDict(ctx, agg);
+        RedisModule_FreeDict(NULL, agg);
+    }
 
     RTS_UnblockClient(bc, ctx);
 }
@@ -797,7 +795,7 @@ int TSDB_querylabels_MR(RedisModuleCtx *ctx,
         queryArg->label = RedisModule_CreateStringFromString(NULL, label);
     }
     if (queries != NULL) {
-        __atomic_add_fetch(&queries->ref, 1, __ATOMIC_RELAXED);
+        __atomic_add_fetch(&queries->ref, 1, __ATOMIC_RELAXED); // see rationale in TSDB_mrange_MR above
         queryArg->predicates = queries;
         queryArg->hasFilter = true;
     }

--- a/src/libmr_commands.c
+++ b/src/libmr_commands.c
@@ -5,6 +5,7 @@
 #include "LibMR/src/cluster.h"
 #include "consts.h"
 #include "libmr_integration.h"
+#include "module.h"
 #include "query_language.h"
 #include "reply.h"
 #include "resultset.h"
@@ -744,6 +745,76 @@ int TSDB_queryindex_MR(RedisModuleCtx *ctx, QueryPredicateList *queries) {
 
     RedisModuleBlockedClient *bc = RTS_BlockClient(ctx, rts_free_rctx);
     MR_ExecutionSetOnDoneHandler(exec, queryindex_done, bc);
+
+    MR_Run(exec);
+    MR_FreeExecution(exec);
+    MR_FreeExecutionBuilder(builder);
+    return REDISMODULE_OK;
+}
+
+static void querylabels_done_internal(ExecutionCtx *eCtx, RedisModuleCtx *ctx) {
+    ARR(ARR(RedisModuleString *)) nodesResults = collect_node_results(eCtx, ctx);
+    if (!nodesResults) {
+        return;
+    }
+
+    RedisModuleDict *agg = RedisModule_CreateDict(NULL);
+    array_foreach(nodesResults, stringList, {
+        array_foreach(stringList, s, { RedisModule_DictSet(agg, s, NULL); });
+    });
+    array_free(nodesResults);
+
+    ReplyWithKeySetFromDict(ctx, agg);
+    RedisModule_FreeDict(NULL, agg);
+}
+
+static void querylabels_done(ExecutionCtx *eCtx, void *privateData) {
+    RedisModuleBlockedClient *bc = privateData;
+    RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(bc);
+
+    querylabels_done_internal(eCtx, ctx);
+
+    RTS_UnblockClient(bc, ctx);
+}
+
+int TSDB_querylabels_MR(RedisModuleCtx *ctx,
+                        QueryLabelsSubtype subtype,
+                        RedisModuleString *label,
+                        QueryPredicateList *queries) {
+    // Since this command will be supported only in newer versions.
+    if (TSGlobalConfig.libmrProtocol != LIBMR_PROTOCOL_INTERNAL) {
+        RedisModule_ReplyWithError(
+            ctx, "TS.QUERYLABELS multi-shard fan-out requires the INTERNAL LibMR protocol");
+        return REDISMODULE_OK;
+    }
+
+    QueryLabelsArg *queryArg = calloc(1, sizeof(QueryLabelsArg));
+    queryArg->refCount = 1;
+    queryArg->subtype = subtype;
+    queryArg->userName = CopyCurrentUserName(ctx);
+    if (label != NULL) {
+        queryArg->label = RedisModule_CreateStringFromString(NULL, label);
+    }
+    if (queries != NULL) {
+        queries->ref++;
+        queryArg->predicates = queries;
+        queryArg->hasFilter = true;
+    }
+
+    ExecutionBuilder *builder = MR_CreateEmptyExecutionBuilder();
+    MR_ExecutionBuilderInternalCommand(builder, "TS.INTERNAL_SLOT_RANGES", NULL);
+    MR_ExecutionBuilderInternalCommand(builder, "TS.INTERNAL_QUERYLABELS", queryArg);
+
+    MRError *err = NULL;
+    Execution *exec = MR_CreateExecution(builder, &err);
+    if (err) {
+        RedisModule_ReplyWithError(ctx, MR_ErrorGetMessage(err));
+        MR_FreeExecutionBuilder(builder);
+        return REDISMODULE_OK;
+    }
+
+    RedisModuleBlockedClient *bc = RTS_BlockClient(ctx, rts_free_rctx);
+    MR_ExecutionSetOnDoneHandler(exec, querylabels_done, bc);
 
     MR_Run(exec);
     MR_FreeExecution(exec);

--- a/src/libmr_commands.c
+++ b/src/libmr_commands.c
@@ -756,20 +756,63 @@ int TSDB_queryindex_MR(RedisModuleCtx *ctx, QueryPredicateList *queries) {
     return REDISMODULE_OK;
 }
 
+static void querylabels_done_gears(ExecutionCtx *eCtx, RedisModuleCtx *ctx) {
+    if (unlikely(check_and_reply_on_error(eCtx, ctx))) {
+        return;
+    }
+
+    RedisModuleDict *agg = RedisModule_CreateDict(NULL);
+    size_t len = MR_ExecutionCtxGetResultsLen(eCtx);
+    for (size_t i = 0; i < len; i++) {
+        Record *raw_listRecord = MR_ExecutionCtxGetResult(eCtx, i);
+        if (raw_listRecord->recordType != GetListRecordType()) {
+            RedisModule_Log(ctx,
+                            "warning",
+                            "Unexpected record type: %s",
+                            raw_listRecord->recordType->type.type);
+            continue;
+        }
+        size_t list_len = ListRecord_GetLen((ListRecord *)raw_listRecord);
+        for (size_t j = 0; j < list_len; j++) {
+            StringRecord *sr =
+                (StringRecord *)ListRecord_GetRecord((ListRecord *)raw_listRecord, j);
+            RedisModule_DictSetC(agg, sr->str, sr->len, NULL);
+        }
+    }
+
+    ReplyWithKeySetFromDict(ctx, agg);
+    RedisModule_FreeDict(NULL, agg);
+}
+
+static void querylabels_done_internal(ExecutionCtx *eCtx, RedisModuleCtx *ctx) {
+    ARR(ARR(RedisModuleString *)) nodesResults = collect_node_results(eCtx, ctx);
+    if (!nodesResults) {
+        return;
+    }
+
+    RedisModuleDict *agg = RedisModule_CreateDict(NULL);
+    array_foreach(nodesResults, stringList, {
+        array_foreach(stringList, s, { RedisModule_DictSet(agg, s, NULL); });
+    });
+    array_free(nodesResults);
+
+    ReplyWithKeySetFromDict(ctx, agg);
+    RedisModule_FreeDict(NULL, agg);
+}
+
 static void querylabels_done(ExecutionCtx *eCtx, void *privateData) {
     RedisModuleBlockedClient *bc = privateData;
     RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(bc);
 
-    ARR(ARR(RedisModuleString *)) nodesResults = collect_node_results(eCtx, ctx);
-    if (nodesResults) {
-        RedisModuleDict *agg = RedisModule_CreateDict(NULL);
-        array_foreach(nodesResults, stringList, {
-            array_foreach(stringList, s, { RedisModule_DictSet(agg, s, NULL); });
-        });
-        array_free(nodesResults);
-
-        ReplyWithKeySetFromDict(ctx, agg);
-        RedisModule_FreeDict(NULL, agg);
+    switch (TSGlobalConfig.libmrProtocol) {
+        case LIBMR_PROTOCOL_GEARS:
+            querylabels_done_gears(eCtx, ctx);
+            break;
+        case LIBMR_PROTOCOL_INTERNAL:
+            querylabels_done_internal(eCtx, ctx);
+            break;
+        default:
+            RedisModule_ReplyWithError(ctx, "Unknown LibMR protocol");
     }
 
     RTS_UnblockClient(bc, ctx);
@@ -779,15 +822,8 @@ int TSDB_querylabels_MR(RedisModuleCtx *ctx,
                         QueryLabelsSubtype subtype,
                         RedisModuleString *label,
                         QueryPredicateList *queries) {
-    // Since this command will be supported only in newer versions.
-    if (TSGlobalConfig.libmrProtocol != LIBMR_PROTOCOL_INTERNAL) {
-        RedisModule_ReplyWithError(ctx,
-                                   "TS.QUERYLABELS multi-shard fan-out requires "
-                                   "'ts-libmr-protocol INTERNAL' (GEARS protocol unsupported)");
-        return REDISMODULE_OK;
-    }
-
     QueryLabelsArg *queryArg = calloc(1, sizeof(QueryLabelsArg));
+    queryArg->shouldReturnNull = false;
     queryArg->refCount = 1;
     queryArg->subtype = subtype;
     queryArg->userName = CopyCurrentUserName(ctx);
@@ -801,9 +837,24 @@ int TSDB_querylabels_MR(RedisModuleCtx *ctx,
         queryArg->hasFilter = true;
     }
 
-    ExecutionBuilder *builder = MR_CreateEmptyExecutionBuilder();
-    MR_ExecutionBuilderInternalCommand(builder, "TS.INTERNAL_SLOT_RANGES", NULL);
-    MR_ExecutionBuilderInternalCommand(builder, "TS.INTERNAL_QUERYLABELS", queryArg);
+    ExecutionBuilder *builder = NULL;
+    switch (TSGlobalConfig.libmrProtocol) {
+        case LIBMR_PROTOCOL_GEARS: {
+            builder = MR_CreateExecutionBuilder("ShardQuerylabelsMapper", queryArg);
+            MR_ExecutionBuilderCollect(builder);
+            break;
+        }
+        case LIBMR_PROTOCOL_INTERNAL: {
+            builder = MR_CreateEmptyExecutionBuilder();
+            MR_ExecutionBuilderInternalCommand(builder, "TS.INTERNAL_SLOT_RANGES", NULL);
+            MR_ExecutionBuilderInternalCommand(builder, "TS.INTERNAL_QUERYLABELS", queryArg);
+            break;
+        }
+        default: {
+            RedisModule_ReplyWithError(ctx, "Unknown LibMR protocol");
+            return REDISMODULE_OK;
+        }
+    }
 
     MRError *err = NULL;
     Execution *exec = MR_CreateExecution(builder, &err);

--- a/src/libmr_commands.c
+++ b/src/libmr_commands.c
@@ -628,7 +628,7 @@ int TSDB_mrange_MR(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool
     queryArg->startTimestamp = args.rangeArgs.startTimestamp;
     queryArg->endTimestamp = args.rangeArgs.endTimestamp;
     queryArg->latest = args.rangeArgs.latest;
-    args.queryPredicates->ref++;
+    __atomic_add_fetch(&args.queryPredicates->ref, 1, __ATOMIC_RELAXED);
     queryArg->predicates = args.queryPredicates;
     queryArg->withLabels = args.withLabels;
     queryArg->limitLabelsSize = args.numLimitLabels;
@@ -707,7 +707,7 @@ int TSDB_queryindex_MR(RedisModuleCtx *ctx, QueryPredicateList *queries) {
     queryArg->count = queries->count;
     queryArg->startTimestamp = 0;
     queryArg->endTimestamp = 0;
-    queries->ref++;
+    __atomic_add_fetch(&queries->ref, 1, __ATOMIC_RELAXED);
     queryArg->predicates = queries;
     queryArg->withLabels = false;
     queryArg->limitLabelsSize = 0;
@@ -783,8 +783,9 @@ int TSDB_querylabels_MR(RedisModuleCtx *ctx,
                         QueryPredicateList *queries) {
     // Since this command will be supported only in newer versions.
     if (TSGlobalConfig.libmrProtocol != LIBMR_PROTOCOL_INTERNAL) {
-        RedisModule_ReplyWithError(
-            ctx, "TS.QUERYLABELS multi-shard fan-out requires the INTERNAL LibMR protocol");
+        RedisModule_ReplyWithError(ctx,
+                                   "TS.QUERYLABELS multi-shard fan-out requires "
+                                   "'ts-libmr-protocol INTERNAL' (GEARS protocol unsupported)");
         return REDISMODULE_OK;
     }
 
@@ -796,7 +797,7 @@ int TSDB_querylabels_MR(RedisModuleCtx *ctx,
         queryArg->label = RedisModule_CreateStringFromString(NULL, label);
     }
     if (queries != NULL) {
-        queries->ref++;
+        __atomic_add_fetch(&queries->ref, 1, __ATOMIC_RELAXED);
         queryArg->predicates = queries;
         queryArg->hasFilter = true;
     }
@@ -809,6 +810,10 @@ int TSDB_querylabels_MR(RedisModuleCtx *ctx,
     Execution *exec = MR_CreateExecution(builder, &err);
     if (err) {
         RedisModule_ReplyWithError(ctx, MR_ErrorGetMessage(err));
+        // MR_CreateExecution always allocates and returns exec, even on error (it copies
+        // and dups every step's args before checking the error) - free it or exec plus its
+        // duplicated QueryLabelsArg reference leak on every failed call.
+        MR_FreeExecution(exec);
         MR_FreeExecutionBuilder(builder);
         return REDISMODULE_OK;
     }

--- a/src/libmr_commands.c
+++ b/src/libmr_commands.c
@@ -795,7 +795,8 @@ int TSDB_querylabels_MR(RedisModuleCtx *ctx,
         queryArg->label = RedisModule_CreateStringFromString(NULL, label);
     }
     if (queries != NULL) {
-        __atomic_add_fetch(&queries->ref, 1, __ATOMIC_RELAXED); // see rationale in TSDB_mrange_MR above
+        __atomic_add_fetch(
+            &queries->ref, 1, __ATOMIC_RELAXED); // see rationale in TSDB_mrange_MR above
         queryArg->predicates = queries;
         queryArg->hasFilter = true;
     }

--- a/src/libmr_commands.h
+++ b/src/libmr_commands.h
@@ -22,5 +22,9 @@ typedef struct MData
 int TSDB_mget_MR(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int TSDB_queryindex_MR(RedisModuleCtx *ctx, QueryPredicateList *queries);
 int TSDB_mrange_MR(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool reverse);
+int TSDB_querylabels_MR(RedisModuleCtx *ctx,
+                        QueryLabelsSubtype subtype,
+                        RedisModuleString *label,
+                        QueryPredicateList *queries);
 
 #endif // REDIS_TIMESERIES_CLEAN_MR_COMMANDS_H

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -453,7 +453,7 @@ static void QueryLabelsArg_CleanupFailedDeserialization(QueryLabelsArg *a) {
                 }
                 if (predicate->valuesList) {
                     for (size_t j = 0; j < predicate->valueListCount && predicate->valuesList[j];
-                        j++) {
+                         j++) {
                         RedisModule_FreeString(NULL, predicate->valuesList[j]);
                     }
                     free(predicate->valuesList);
@@ -1307,11 +1307,11 @@ static void TS_INTERNAL_QUERYLABELS(RedisModuleCtx *ctx, void *args) {
             continue;
         }
         QueryLabelsFromIndex(currentKey,
-                            currentKeyLen,
-                            queryArg->subtype,
-                            queryArg->label,
-                            QueryLabelsEmitReply,
-                            &replyCtx);
+                             currentKeyLen,
+                             queryArg->subtype,
+                             queryArg->label,
+                             QueryLabelsEmitReply,
+                             &replyCtx);
     }
     RedisModule_DictIteratorStop(iter);
     FreeUser(&userCtx);
@@ -1354,11 +1354,11 @@ int register_mr(RedisModuleCtx *ctx, long long numThreads) {
     }
 
     MRObjectType *QueryLabelsArgType = MR_CreateType("QueryLabelsArgType",
-                                                      QueryLabelsArg_ObjectFree,
-                                                      QueryLabelsArg_Duplicate,
-                                                      QueryLabelsArg_Serialize,
-                                                      QueryLabelsArg_Deserialize,
-                                                      QueryLabelsArg_ToString);
+                                                     QueryLabelsArg_ObjectFree,
+                                                     QueryLabelsArg_Duplicate,
+                                                     QueryLabelsArg_Serialize,
+                                                     QueryLabelsArg_Deserialize,
+                                                     QueryLabelsArg_ToString);
 
     if (MR_RegisterObject(QueryLabelsArgType) != REDISMODULE_OK) {
         return REDISMODULE_ERR;

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -377,7 +377,7 @@ static void *QueryPredicates_ArgDeserialize(ReaderSerializationCtx *sctx, MRErro
                ?: QueryPredicates_ArgDeserialize_impl(sctx, error, false);
 }
 
-static void QueryLabelsArg_ObjectFree(void *arg) {
+void QueryLabelsArg_ObjectFree(void *arg) {
     QueryLabelsArg *a = arg;
     if (__atomic_sub_fetch(&a->refCount, 1, __ATOMIC_RELAXED) > 0) {
         return;
@@ -467,6 +467,8 @@ static void QueryLabelsArg_CleanupFailedDeserialization(QueryLabelsArg *a) {
     free(a);
 }
 
+#define QUERYLABELS_MAX_FILTER_ITEMS 4096
+
 static void *QueryLabelsArg_Deserialize(ReaderSerializationCtx *sctx, MRError **error) {
     QueryLabelsArg *a = calloc(1, sizeof(*a));
     a->refCount = 1;
@@ -487,8 +489,11 @@ static void *QueryLabelsArg_Deserialize(ReaderSerializationCtx *sctx, MRError **
     if (*error) {
         goto err;
     }
+    if (a->predicates->count == 0 || a->predicates->count > QUERYLABELS_MAX_FILTER_ITEMS) {
+        goto err;
+    }
     a->predicates->list = calloc(a->predicates->count, sizeof(*a->predicates->list));
-    if (a->predicates->count && !a->predicates->list) {
+    if (!a->predicates->list) {
         goto err;
     }
     for (size_t i = 0; i < a->predicates->count; i++) {
@@ -503,6 +508,9 @@ static void *QueryLabelsArg_Deserialize(ReaderSerializationCtx *sctx, MRError **
         }
         predicate->valueListCount = MR_SerializationCtxReadLongLong(sctx, error);
         if (*error) {
+            goto err;
+        }
+        if (predicate->valueListCount > QUERYLABELS_MAX_FILTER_ITEMS) {
             goto err;
         }
         predicate->valuesList = calloc(predicate->valueListCount, sizeof(*predicate->valuesList));

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -885,6 +885,45 @@ Record *ShardQueryindexMapper(ExecutionCtx *rctx, void *arg) {
     return series_list;
 }
 
+Record *ShardQuerylabelsMapper(ExecutionCtx *rctx, void *arg) {
+    QueryLabelsArg *queryArg = arg;
+
+    if (queryArg->shouldReturnNull) {
+        return NULL;
+    }
+    queryArg->shouldReturnNull = true;
+
+    RedisModule_ThreadSafeContextLock(rts_staticCtx);
+    ApplyCtxUser(rts_staticCtx, queryArg->userName);
+
+    RedisModuleDict *candidates =
+        queryArg->hasFilter
+            ? QueryIndex(
+                  rts_staticCtx, queryArg->predicates->list, queryArg->predicates->count, NULL)
+            : GetAllIndexedSeriesKeys(rts_staticCtx);
+
+    RedisModuleDict *agg = RedisModule_CreateDict(NULL);
+    QueryLabelsAggregateFromCandidates(
+        rts_staticCtx, queryArg->subtype, queryArg->label, candidates, agg);
+
+    Record *result_list = ListRecord_Create(0);
+    RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(agg, "^", NULL, 0);
+    char *currentKey;
+    size_t currentKeyLen;
+    while ((currentKey = RedisModule_DictNextC(iter, &currentKeyLen, NULL)) != NULL) {
+        ListRecord_Add(result_list,
+                       StringRecord_Create(strndup(currentKey, currentKeyLen), currentKeyLen));
+    }
+    RedisModule_DictIteratorStop(iter);
+
+    RedisModule_FreeDict(NULL, agg);
+    RedisModule_FreeDict(rts_staticCtx, candidates);
+    ReleaseCtxUser(rts_staticCtx);
+    RedisModule_ThreadSafeContextUnlock(rts_staticCtx);
+
+    return result_list;
+}
+
 static MRObjectType *MR_CreateType(char *type,
                                    ObjectFree free,
                                    ObjectDuplicate dup,
@@ -1482,6 +1521,8 @@ int register_mr(RedisModuleCtx *ctx, long long numThreads) {
     MR_RegisterReader("ShardMgetMapper", ShardMgetMapper, QueryPredicatesType);
 
     MR_RegisterReader("ShardQueryindexMapper", ShardQueryindexMapper, QueryPredicatesType);
+
+    MR_RegisterReader("ShardQuerylabelsMapper", ShardQuerylabelsMapper, QueryLabelsArgType);
     mr_initialized = true;
 
     return REDISMODULE_OK;

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -488,6 +488,9 @@ static void *QueryLabelsArg_Deserialize(ReaderSerializationCtx *sctx, MRError **
         goto err;
     }
     a->predicates->list = calloc(a->predicates->count, sizeof(*a->predicates->list));
+    if (a->predicates->count && !a->predicates->list) {
+        goto err;
+    }
     for (size_t i = 0; i < a->predicates->count; i++) {
         QueryPredicate *predicate = &a->predicates->list[i];
         predicate->type = MR_SerializationCtxReadLongLong(sctx, error);
@@ -503,6 +506,9 @@ static void *QueryLabelsArg_Deserialize(ReaderSerializationCtx *sctx, MRError **
             goto err;
         }
         predicate->valuesList = calloc(predicate->valueListCount, sizeof(*predicate->valuesList));
+        if (predicate->valueListCount && !predicate->valuesList) {
+            goto err;
+        }
         for (size_t value_index = 0; value_index < predicate->valueListCount; value_index++) {
             predicate->valuesList[value_index] = SerializationCtxReadRedisString(sctx, error);
             if (*error) {
@@ -513,6 +519,7 @@ static void *QueryLabelsArg_Deserialize(ReaderSerializationCtx *sctx, MRError **
     return a;
 
 err:
+    *error = NULL;
     QueryLabelsArg_CleanupFailedDeserialization(a);
     return NULL;
 }
@@ -1274,18 +1281,6 @@ static Record *StringListReplyParser(const redisReply *reply) {
 static InternalCommandCallbacks QueryIndexCallbacks = { .command = TS_INTERNAL_QUERYINDEX,
                                                         .replyParser = StringListReplyParser };
 
-typedef struct QueryLabelsReplyCtx
-{
-    RedisModuleCtx *ctx;
-    long long replylen;
-} QueryLabelsReplyCtx;
-
-static void QueryLabelsEmitReply(void *userData, const char *buf, size_t len) {
-    QueryLabelsReplyCtx *rc = userData;
-    RedisModule_ReplyWithStringBuffer(rc->ctx, buf, len);
-    rc->replylen++;
-}
-
 static void TS_INTERNAL_QUERYLABELS(RedisModuleCtx *ctx, void *args) {
     QueryLabelsArg *queryArg = args;
     ApplyCtxUser(ctx, queryArg->userName);
@@ -1295,28 +1290,24 @@ static void TS_INTERNAL_QUERYLABELS(RedisModuleCtx *ctx, void *args) {
             ? QueryIndex(ctx, queryArg->predicates->list, queryArg->predicates->count, NULL)
             : GetAllIndexedSeriesKeys(ctx);
 
-    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
-    QueryLabelsReplyCtx replyCtx = { .ctx = ctx, .replylen = 0 };
+    // Aggregate into a dict (shared with the non-cluster path) so per-shard duplicates
+    // (e.g. a label shared by many series) are collapsed before crossing the wire.
+    RedisModuleDict *agg = RedisModule_CreateDict(NULL);
+    QueryLabelsAggregateFromCandidates(ctx, queryArg->subtype, queryArg->label, candidates, agg);
 
-    User_Ctx_t userCtx = GetUserFromContext(ctx);
-    RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(candidates, "^", NULL, 0);
+    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
+    RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(agg, "^", NULL, 0);
     char *currentKey;
     size_t currentKeyLen;
+    long long replylen = 0;
     while ((currentKey = RedisModule_DictNextC(iter, &currentKeyLen, NULL)) != NULL) {
-        if (!CheckKeyIsAllowedToReadC(ctx, userCtx.user, currentKey, currentKeyLen)) {
-            continue;
-        }
-        QueryLabelsFromIndex(currentKey,
-                             currentKeyLen,
-                             queryArg->subtype,
-                             queryArg->label,
-                             QueryLabelsEmitReply,
-                             &replyCtx);
+        RedisModule_ReplyWithStringBuffer(ctx, currentKey, currentKeyLen);
+        replylen++;
     }
     RedisModule_DictIteratorStop(iter);
-    FreeUser(&userCtx);
-    RedisModule_ReplySetArrayLength(ctx, replyCtx.replylen);
+    RedisModule_ReplySetArrayLength(ctx, replylen);
 
+    RedisModule_FreeDict(NULL, agg);
     RedisModule_FreeDict(ctx, candidates);
     ReleaseCtxUser(ctx);
 }

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -467,8 +467,6 @@ static void QueryLabelsArg_CleanupFailedDeserialization(QueryLabelsArg *a) {
     free(a);
 }
 
-#define QUERYLABELS_MAX_FILTER_ITEMS 4096
-
 static void *QueryLabelsArg_Deserialize(ReaderSerializationCtx *sctx, MRError **error) {
     QueryLabelsArg *a = calloc(1, sizeof(*a));
     a->refCount = 1;
@@ -489,10 +487,10 @@ static void *QueryLabelsArg_Deserialize(ReaderSerializationCtx *sctx, MRError **
     if (*error) {
         goto err;
     }
-    if (a->predicates->count == 0 || a->predicates->count > QUERYLABELS_MAX_FILTER_ITEMS) {
+    if (a->predicates->count == 0) {
         goto err;
     }
-    a->predicates->list = calloc(a->predicates->count, sizeof(*a->predicates->list));
+    a->predicates->list = rts_try_calloc(a->predicates->count, sizeof(*a->predicates->list));
     if (!a->predicates->list) {
         goto err;
     }
@@ -510,10 +508,8 @@ static void *QueryLabelsArg_Deserialize(ReaderSerializationCtx *sctx, MRError **
         if (*error) {
             goto err;
         }
-        if (predicate->valueListCount > QUERYLABELS_MAX_FILTER_ITEMS) {
-            goto err;
-        }
-        predicate->valuesList = calloc(predicate->valueListCount, sizeof(*predicate->valuesList));
+        predicate->valuesList =
+            rts_try_calloc(predicate->valueListCount, sizeof(*predicate->valuesList));
         if (predicate->valueListCount && !predicate->valuesList) {
             goto err;
         }

--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -377,6 +377,146 @@ static void *QueryPredicates_ArgDeserialize(ReaderSerializationCtx *sctx, MRErro
                ?: QueryPredicates_ArgDeserialize_impl(sctx, error, false);
 }
 
+static void QueryLabelsArg_ObjectFree(void *arg) {
+    QueryLabelsArg *a = arg;
+    if (__atomic_sub_fetch(&a->refCount, 1, __ATOMIC_RELAXED) > 0) {
+        return;
+    }
+    if (a->predicates) {
+        QueryPredicateList_Free(a->predicates);
+    }
+    if (a->userName) {
+        RedisModule_FreeString(NULL, a->userName);
+    }
+    if (a->label) {
+        RedisModule_FreeString(NULL, a->label);
+    }
+    free(a);
+}
+
+static void *QueryLabelsArg_Duplicate(void *arg) {
+    QueryLabelsArg *a = (QueryLabelsArg *)arg;
+    __atomic_add_fetch(&a->refCount, 1, __ATOMIC_RELAXED);
+    return arg;
+}
+
+static char *QueryLabelsArg_ToString(void *arg) {
+    QueryLabelsArg *a = arg;
+    char out[64];
+    snprintf(out, sizeof(out), "QueryLabelsArg: subtype=%d", (int)a->subtype);
+    return strdup(out);
+}
+
+static void QueryLabelsArg_Serialize(WriteSerializationCtx *sctx, void *arg, MRError **error) {
+    QueryLabelsArg *a = arg;
+    if (a->userName) {
+        SerializationCtxWriteRedisString(sctx, a->userName, error);
+    } else {
+        /* For empty string, we write a single byte of 0. */
+        MR_SerializationCtxWriteBuffer(sctx, "", 1, error);
+    }
+    MR_SerializationCtxWriteLongLong(sctx, a->subtype, error);
+    if (a->label) {
+        SerializationCtxWriteRedisString(sctx, a->label, error);
+    } else {
+        MR_SerializationCtxWriteBuffer(sctx, "", 1, error);
+    }
+    MR_SerializationCtxWriteLongLong(sctx, a->hasFilter, error);
+    if (!a->hasFilter) {
+        return;
+    }
+    MR_SerializationCtxWriteLongLong(sctx, a->predicates->count, error);
+    for (size_t i = 0; i < a->predicates->count; i++) {
+        QueryPredicate *predicate = a->predicates->list + i;
+        MR_SerializationCtxWriteLongLong(sctx, predicate->type, error);
+        SerializationCtxWriteRedisString(sctx, predicate->key, error);
+        MR_SerializationCtxWriteLongLong(sctx, predicate->valueListCount, error);
+        for (size_t value_index = 0; value_index < predicate->valueListCount; value_index++) {
+            SerializationCtxWriteRedisString(sctx, predicate->valuesList[value_index], error);
+        }
+    }
+}
+
+static void QueryLabelsArg_CleanupFailedDeserialization(QueryLabelsArg *a) {
+    if (a->userName) {
+        RedisModule_FreeString(NULL, a->userName);
+    }
+    if (a->label) {
+        RedisModule_FreeString(NULL, a->label);
+    }
+    if (a->predicates) {
+        if (a->predicates->list) {
+            for (size_t i = 0; i < a->predicates->count; i++) {
+                QueryPredicate *predicate = &a->predicates->list[i];
+                if (!predicate->key) {
+                    break;
+                }
+                if (predicate->valuesList) {
+                    for (size_t j = 0; j < predicate->valueListCount && predicate->valuesList[j];
+                        j++) {
+                        RedisModule_FreeString(NULL, predicate->valuesList[j]);
+                    }
+                    free(predicate->valuesList);
+                }
+                RedisModule_FreeString(NULL, predicate->key);
+            }
+            free(a->predicates->list);
+        }
+        free(a->predicates);
+    }
+    free(a);
+}
+
+static void *QueryLabelsArg_Deserialize(ReaderSerializationCtx *sctx, MRError **error) {
+    QueryLabelsArg *a = calloc(1, sizeof(*a));
+    a->refCount = 1;
+    a->userName = SerializationCtxReadRedisString(sctx, error);
+    a->subtype = MR_SerializationCtxReadLongLong(sctx, error);
+    a->label = SerializationCtxReadRedisString(sctx, error);
+    a->hasFilter = MR_SerializationCtxReadLongLong(sctx, error);
+    if (*error) {
+        goto err;
+    }
+    if (!a->hasFilter) {
+        return a;
+    }
+
+    a->predicates = calloc(1, sizeof(*a->predicates));
+    a->predicates->ref = 1;
+    a->predicates->count = MR_SerializationCtxReadLongLong(sctx, error);
+    if (*error) {
+        goto err;
+    }
+    a->predicates->list = calloc(a->predicates->count, sizeof(*a->predicates->list));
+    for (size_t i = 0; i < a->predicates->count; i++) {
+        QueryPredicate *predicate = &a->predicates->list[i];
+        predicate->type = MR_SerializationCtxReadLongLong(sctx, error);
+        if (*error) {
+            goto err;
+        }
+        predicate->key = SerializationCtxReadRedisString(sctx, error);
+        if (*error) {
+            goto err;
+        }
+        predicate->valueListCount = MR_SerializationCtxReadLongLong(sctx, error);
+        if (*error) {
+            goto err;
+        }
+        predicate->valuesList = calloc(predicate->valueListCount, sizeof(*predicate->valuesList));
+        for (size_t value_index = 0; value_index < predicate->valueListCount; value_index++) {
+            predicate->valuesList[value_index] = SerializationCtxReadRedisString(sctx, error);
+            if (*error) {
+                goto err;
+            }
+        }
+    }
+    return a;
+
+err:
+    QueryLabelsArg_CleanupFailedDeserialization(a);
+    return NULL;
+}
+
 static Record *StringRecord_Create(char *val, size_t len);
 static Record *ListRecord_Create(size_t initSize);
 static Record *MapRecord_Create(size_t initSize);
@@ -1134,6 +1274,56 @@ static Record *StringListReplyParser(const redisReply *reply) {
 static InternalCommandCallbacks QueryIndexCallbacks = { .command = TS_INTERNAL_QUERYINDEX,
                                                         .replyParser = StringListReplyParser };
 
+typedef struct QueryLabelsReplyCtx
+{
+    RedisModuleCtx *ctx;
+    long long replylen;
+} QueryLabelsReplyCtx;
+
+static void QueryLabelsEmitReply(void *userData, const char *buf, size_t len) {
+    QueryLabelsReplyCtx *rc = userData;
+    RedisModule_ReplyWithStringBuffer(rc->ctx, buf, len);
+    rc->replylen++;
+}
+
+static void TS_INTERNAL_QUERYLABELS(RedisModuleCtx *ctx, void *args) {
+    QueryLabelsArg *queryArg = args;
+    ApplyCtxUser(ctx, queryArg->userName);
+
+    RedisModuleDict *candidates =
+        queryArg->hasFilter
+            ? QueryIndex(ctx, queryArg->predicates->list, queryArg->predicates->count, NULL)
+            : GetAllIndexedSeriesKeys(ctx);
+
+    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
+    QueryLabelsReplyCtx replyCtx = { .ctx = ctx, .replylen = 0 };
+
+    User_Ctx_t userCtx = GetUserFromContext(ctx);
+    RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(candidates, "^", NULL, 0);
+    char *currentKey;
+    size_t currentKeyLen;
+    while ((currentKey = RedisModule_DictNextC(iter, &currentKeyLen, NULL)) != NULL) {
+        if (!CheckKeyIsAllowedToReadC(ctx, userCtx.user, currentKey, currentKeyLen)) {
+            continue;
+        }
+        QueryLabelsFromIndex(currentKey,
+                            currentKeyLen,
+                            queryArg->subtype,
+                            queryArg->label,
+                            QueryLabelsEmitReply,
+                            &replyCtx);
+    }
+    RedisModule_DictIteratorStop(iter);
+    FreeUser(&userCtx);
+    RedisModule_ReplySetArrayLength(ctx, replyCtx.replylen);
+
+    RedisModule_FreeDict(ctx, candidates);
+    ReleaseCtxUser(ctx);
+}
+
+static InternalCommandCallbacks QueryLabelsCallbacks = { .command = TS_INTERNAL_QUERYLABELS,
+                                                         .replyParser = StringListReplyParser };
+
 static bool mr_initialized = false;
 
 bool LibMR_IsInitialized() {
@@ -1160,6 +1350,17 @@ int register_mr(RedisModuleCtx *ctx, long long numThreads) {
                                                       QueryPredicates_ToString);
 
     if (MR_RegisterObject(QueryPredicatesType) != REDISMODULE_OK) {
+        return REDISMODULE_ERR;
+    }
+
+    MRObjectType *QueryLabelsArgType = MR_CreateType("QueryLabelsArgType",
+                                                      QueryLabelsArg_ObjectFree,
+                                                      QueryLabelsArg_Duplicate,
+                                                      QueryLabelsArg_Serialize,
+                                                      QueryLabelsArg_Deserialize,
+                                                      QueryLabelsArg_ToString);
+
+    if (MR_RegisterObject(QueryLabelsArgType) != REDISMODULE_OK) {
         return REDISMODULE_ERR;
     }
 
@@ -1280,6 +1481,8 @@ int register_mr(RedisModuleCtx *ctx, long long numThreads) {
     MR_RegisterInternalCommand("TS.INTERNAL_MRANGE", &MrangeCallbacks, QueryPredicatesType);
     MR_RegisterInternalCommand("TS.INTERNAL_MGET", &MgetCallbacks, QueryPredicatesType);
     MR_RegisterInternalCommand("TS.INTERNAL_QUERYINDEX", &QueryIndexCallbacks, QueryPredicatesType);
+    MR_RegisterInternalCommand(
+        "TS.INTERNAL_QUERYLABELS", &QueryLabelsCallbacks, QueryLabelsArgType);
 
     MR_RegisterReader("ShardMgetMapper", ShardMgetMapper, QueryPredicatesType);
 

--- a/src/libmr_integration.h
+++ b/src/libmr_integration.h
@@ -117,6 +117,7 @@ typedef struct StringListRecord
 // unrelated variant would only make more fragile.
 typedef struct QueryLabelsArg
 {
+    bool shouldReturnNull; // GEARS reader one-shot guard; unused by the INTERNAL protocol path
     size_t refCount;
     QueryLabelsSubtype subtype;
     RedisModuleString *userName;

--- a/src/libmr_integration.h
+++ b/src/libmr_integration.h
@@ -125,6 +125,9 @@ typedef struct QueryLabelsArg
     QueryPredicateList *predicates; // NULL when hasFilter is false
 } QueryLabelsArg;
 
+// Drops a reference; frees the arg (and its predicates/strings) once refCount hits 0.
+void QueryLabelsArg_ObjectFree(void *arg);
+
 MRRecordType *GetMapRecordType();
 MRRecordType *GetListRecordType();
 MRRecordType *GetSeriesRecordType();

--- a/src/libmr_integration.h
+++ b/src/libmr_integration.h
@@ -111,6 +111,20 @@ typedef struct StringListRecord
     ARR(RedisModuleString *) stringList;
 } StringListRecord;
 
+// Arg for TS.INTERNAL_QUERYLABELS. Kept separate from QueryPredicates_Arg (used by
+// mget/mrange/queryindex) rather than adding a subtype field to it, since that type's
+// (de)serialization already carries a two-variant rolling-upgrade fallback that a third
+// unrelated variant would only make more fragile.
+typedef struct QueryLabelsArg
+{
+    size_t refCount;
+    QueryLabelsSubtype subtype;
+    RedisModuleString *userName;
+    RedisModuleString *label; // target label name for VALUES; NULL for LABELS
+    bool hasFilter;
+    QueryPredicateList *predicates; // NULL when hasFilter is false
+} QueryLabelsArg;
+
 MRRecordType *GetMapRecordType();
 MRRecordType *GetListRecordType();
 MRRecordType *GetSeriesRecordType();

--- a/src/module.c
+++ b/src/module.c
@@ -336,6 +336,134 @@ int TSDB_queryindex(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return REDISMODULE_OK;
 }
 
+static int ParseQueryLabelsSubtype(RedisModuleCtx *ctx,
+                                   RedisModuleString *token,
+                                   QueryLabelsSubtype *out) {
+    static const struct
+    {
+        const char *name;
+        QueryLabelsSubtype value;
+    } subtypes[] = {
+        { "LABELS", QueryLabelsSubtype_Labels },
+        { "VALUES", QueryLabelsSubtype_Values },
+    };
+    const char *str = RedisModule_StringPtrLen(token, NULL);
+    for (size_t i = 0; i < sizeof(subtypes) / sizeof(subtypes[0]); i++) {
+        if (strcasecmp(str, subtypes[i].name) == 0) {
+            *out = subtypes[i].value;
+            return REDISMODULE_OK;
+        }
+    }
+    RTS_ReplyGeneralError(ctx, "TSDB: unknown subtype, must be one of LABELS|VALUES");
+    return REDISMODULE_ERR;
+}
+
+static void QueryLabelsEmitToDict(void *userData, const char *buf, size_t len) {
+    RedisModule_DictSetC((RedisModuleDict *)userData, (void *)buf, len, NULL);
+}
+
+// ACL: skips candidates the caller can't read.
+static void QueryLabelsAggregateFromCandidates(RedisModuleCtx *ctx,
+                                               QueryLabelsSubtype subtype,
+                                               RedisModuleString *labelFilter,
+                                               RedisModuleDict *candidates,
+                                               RedisModuleDict *agg) {
+    User_Ctx_t userCtx = GetUserFromContext(ctx);
+    RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(candidates, "^", NULL, 0);
+    char *currentKey;
+    size_t currentKeyLen;
+    while ((currentKey = RedisModule_DictNextC(iter, &currentKeyLen, NULL)) != NULL) {
+        if (!CheckKeyIsAllowedToReadC(ctx, userCtx.user, currentKey, currentKeyLen)) {
+            continue;
+        }
+        QueryLabelsFromIndex(
+            currentKey, currentKeyLen, subtype, labelFilter, QueryLabelsEmitToDict, agg);
+    }
+    RedisModule_DictIteratorStop(iter);
+    FreeUser(&userCtx);
+}
+
+static void _TSDB_querylabels_impl(RedisModuleCtx *ctx,
+                                   QueryLabelsSubtype subtype,
+                                   RedisModuleString *label,
+                                   QueryPredicateList *queries) {
+    RedisModuleDict *candidates = queries != NULL
+                                      ? QueryIndex(ctx, queries->list, queries->count, NULL)
+                                      : GetAllIndexedSeriesKeys(ctx);
+
+    RedisModuleDict *agg = RedisModule_CreateDict(NULL);
+    QueryLabelsAggregateFromCandidates(ctx, subtype, label, candidates, agg);
+    ReplyWithKeySetFromDict(ctx, agg);
+    RedisModule_FreeDict(NULL, agg);
+    RedisModule_FreeDict(ctx, candidates);
+}
+
+int TSDB_querylabels(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+
+    if (argc < 2) {
+        return RedisModule_WrongArity(ctx);
+    }
+
+    QueryLabelsSubtype subtype;
+    if (ParseQueryLabelsSubtype(ctx, argv[1], &subtype) != REDISMODULE_OK) {
+        return REDISMODULE_ERR;
+    }
+
+    RedisModuleString *label = NULL;
+    int filter_start = 2;
+    if (subtype == QueryLabelsSubtype_Values) {
+        if (argc < 3) {
+            return RedisModule_WrongArity(ctx);
+        }
+        label = argv[2];
+        filter_start = 3;
+    }
+
+    const int filter_location = RMUtil_ArgIndex("FILTER", argv, argc);
+    if (filter_location != -1 && filter_location != filter_start) {
+        return RTS_ReplyGeneralError(ctx, "TSDB: FILTER must immediately follow the subtype");
+    }
+    if (filter_location == -1 && argc > filter_start) {
+        return RTS_ReplyGeneralError(ctx, "TSDB: unknown argument, expected FILTER");
+    }
+
+    QueryPredicateList *queries = NULL;
+    if (filter_location != -1) {
+        const int query_count = argc - 1 - filter_location;
+        if (query_count <= 0) {
+            return RTS_ReplyGeneralError(ctx, "TSDB: FILTER given with no filter expressions");
+        }
+        if (parseFilter(ctx, argv, argc, filter_location, query_count, &queries) !=
+            REDISMODULE_OK) {
+            return REDISMODULE_ERR;
+        }
+    }
+
+    if (IsMRCluster()) {
+        int ctxFlags = RedisModule_GetContextFlags(ctx);
+
+        if (ctxFlags & (REDISMODULE_CTX_FLAGS_LUA | REDISMODULE_CTX_FLAGS_MULTI |
+                        REDISMODULE_CTX_FLAGS_DENY_BLOCKING)) {
+            RedisModule_ReplyWithError(ctx,
+                                       "Can not run multi sharded command inside a multi exec, "
+                                       "lua, or when blocking is not allowed");
+            if (queries != NULL) {
+                QueryPredicateList_Free(queries);
+            }
+            return REDISMODULE_OK;
+        }
+        TSDB_querylabels_MR(ctx, subtype, label, queries);
+    } else {
+        _TSDB_querylabels_impl(ctx, subtype, label, queries);
+    }
+
+    if (queries != NULL) {
+        QueryPredicateList_Free(queries);
+    }
+    return REDISMODULE_OK;
+}
+
 // multi-series groupby logic
 static int replyGroupedMultiRange(RedisModuleCtx *ctx,
                                   TS_ResultSet *resultset,
@@ -2598,6 +2726,15 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     }
 
     SetCommandAcls(ctx, "ts.queryindex", "read");
+
+    if (RedisModule_CreateCommand(ctx, "ts.querylabels", TSDB_querylabels, "readonly", 0, 0, -1) ==
+        REDISMODULE_ERR) {
+        FreeConfigAndStaticCtx();
+
+        return REDISMODULE_ERR;
+    }
+
+    SetCommandAcls(ctx, "ts.querylabels", "read");
 
     RegisterCommandWithModesAndAcls(ctx, "ts.info", TSDB_info, "readonly", "read fast");
     RegisterCommandWithModesAndAcls(ctx, "ts.get", TSDB_get, "readonly", "read fast");

--- a/src/module.c
+++ b/src/module.c
@@ -362,12 +362,16 @@ static void QueryLabelsEmitToDict(void *userData, const char *buf, size_t len) {
     RedisModule_DictSetC((RedisModuleDict *)userData, (void *)buf, len, NULL);
 }
 
-// ACL: skips candidates the caller can't read.
-static void QueryLabelsAggregateFromCandidates(RedisModuleCtx *ctx,
-                                               QueryLabelsSubtype subtype,
-                                               RedisModuleString *labelFilter,
-                                               RedisModuleDict *candidates,
-                                               RedisModuleDict *agg) {
+// ACL: skips candidates the caller can't read. Shared by the local and cluster-fanout paths.
+void QueryLabelsAggregateFromCandidates(RedisModuleCtx *ctx,
+                                        QueryLabelsSubtype subtype,
+                                        RedisModuleString *labelFilter,
+                                        RedisModuleDict *candidates,
+                                        RedisModuleDict *agg) {
+    RedisModuleString *prefix = QueryLabelsBuildPrefix(subtype, labelFilter);
+    size_t prefixLen;
+    const char *prefixBuf = RedisModule_StringPtrLen(prefix, &prefixLen);
+
     User_Ctx_t userCtx = GetUserFromContext(ctx);
     RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(candidates, "^", NULL, 0);
     char *currentKey;
@@ -377,10 +381,12 @@ static void QueryLabelsAggregateFromCandidates(RedisModuleCtx *ctx,
             continue;
         }
         QueryLabelsFromIndex(
-            currentKey, currentKeyLen, subtype, labelFilter, QueryLabelsEmitToDict, agg);
+            currentKey, currentKeyLen, subtype, prefixBuf, prefixLen, QueryLabelsEmitToDict, agg);
     }
     RedisModule_DictIteratorStop(iter);
     FreeUser(&userCtx);
+
+    RedisModule_FreeString(NULL, prefix);
 }
 
 static void _TSDB_querylabels_impl(RedisModuleCtx *ctx,
@@ -420,22 +426,16 @@ int TSDB_querylabels(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         filter_start = 3;
     }
 
-    const int filter_location = RMUtil_ArgIndex("FILTER", argv, argc);
-    if (filter_location != -1 && filter_location != filter_start) {
-        return RTS_ReplyGeneralError(ctx, "TSDB: FILTER must immediately follow the subtype");
-    }
-    if (filter_location == -1 && argc > filter_start) {
-        return RTS_ReplyGeneralError(ctx, "TSDB: unknown argument, expected FILTER");
-    }
-
     QueryPredicateList *queries = NULL;
-    if (filter_location != -1) {
-        const int query_count = argc - 1 - filter_location;
+    if (argc > filter_start) {
+        if (!RMUtil_StringEqualsCaseC(argv[filter_start], "FILTER")) {
+            return RTS_ReplyGeneralError(ctx, "TSDB: unknown argument, expected FILTER");
+        }
+        const int query_count = argc - 1 - filter_start;
         if (query_count <= 0) {
             return RTS_ReplyGeneralError(ctx, "TSDB: FILTER given with no filter expressions");
         }
-        if (parseFilter(ctx, argv, argc, filter_location, query_count, &queries) !=
-            REDISMODULE_OK) {
+        if (parseFilter(ctx, argv, argc, filter_start, query_count, &queries) != REDISMODULE_OK) {
             return REDISMODULE_ERR;
         }
     }

--- a/src/module.h
+++ b/src/module.h
@@ -177,6 +177,14 @@ GetSeriesResult CheckDictSeriesPermissions(RedisModuleCtx *ctx,
 
 int replyUngroupedMultiRange(RedisModuleCtx *ctx, RedisModuleDict *result, const MRangeArgs *args);
 
+// ACL: skips candidates the caller can't read. Shared by the local and cluster-fanout
+// TS.QUERYLABELS paths (see libmr_integration.c).
+void QueryLabelsAggregateFromCandidates(RedisModuleCtx *ctx,
+                                        QueryLabelsSubtype subtype,
+                                        RedisModuleString *labelFilter,
+                                        RedisModuleDict *candidates,
+                                        RedisModuleDict *agg);
+
 extern int persistence_in_progress;
 
 #endif // MODULE_H

--- a/src/query_language.c
+++ b/src/query_language.c
@@ -61,13 +61,11 @@ int parseLabelsFromArgs(RedisModuleString **argv,
             // Verify Label Key or Value are not empty strings (also not nulls, if those are not
             // allowed)
             size_t keyLen = 0, valueLen = 0;
-            const char *keyStr = RedisModule_StringPtrLen(key, &keyLen);
+            RedisModule_StringPtrLen(key, &keyLen);
             const char *valueStr = NULL;
             if (value != NULL)
                 valueStr = RedisModule_StringPtrLen(value, &valueLen);
-            // '=' is rejected here too: the filter language already can't address a label
-            // whose key contains it (it always splits on the first '=' as the operator).
-            bool legalKey = keyLen > 0 && strchr(keyStr, '=') == NULL;
+            bool legalKey = keyLen > 0;
             bool legalValue = (allow_null_values && value == NULL) ||
                               (valueLen > 0 && strpbrk(valueStr, "(),") == NULL);
             if (!(legalKey && legalValue)) {

--- a/src/query_language.c
+++ b/src/query_language.c
@@ -61,11 +61,13 @@ int parseLabelsFromArgs(RedisModuleString **argv,
             // Verify Label Key or Value are not empty strings (also not nulls, if those are not
             // allowed)
             size_t keyLen = 0, valueLen = 0;
-            RedisModule_StringPtrLen(key, &keyLen);
+            const char *keyStr = RedisModule_StringPtrLen(key, &keyLen);
             const char *valueStr = NULL;
             if (value != NULL)
                 valueStr = RedisModule_StringPtrLen(value, &valueLen);
-            bool legalKey = keyLen > 0;
+            // '=' is rejected here too: the filter language already can't address a label
+            // whose key contains it (it always splits on the first '=' as the operator).
+            bool legalKey = keyLen > 0 && strchr(keyStr, '=') == NULL;
             bool legalValue = (allow_null_values && value == NULL) ||
                               (valueLen > 0 && strpbrk(valueStr, "(),") == NULL);
             if (!(legalKey && legalValue)) {

--- a/src/query_language.h
+++ b/src/query_language.h
@@ -160,6 +160,13 @@ int parseLabelQuery(RedisModuleCtx *ctx,
                     RedisModuleString **limitLabels,
                     unsigned short *limitLabelsSize);
 
+int parseFilter(RedisModuleCtx *ctx,
+                RedisModuleString **argv,
+                int argc,
+                int filter_location,
+                int query_count,
+                QueryPredicateList **out);
+
 int parseAggregationArgs(RedisModuleCtx *ctx,
                          RedisModuleString **argv,
                          int argc,

--- a/src/reply.c
+++ b/src/reply.c
@@ -72,6 +72,20 @@ void ReplyWithSetOrArray(RedisModuleCtx *ctx, long len) {
     }
 }
 
+void ReplyWithKeySetFromDict(RedisModuleCtx *ctx, RedisModuleDict *keySet) {
+    ReplyWithSetOrArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
+    RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(keySet, "^", NULL, 0);
+    char *currentKey;
+    size_t currentKeyLen;
+    long long replylen = 0;
+    while ((currentKey = RedisModule_DictNextC(iter, &currentKeyLen, NULL)) != NULL) {
+        RedisModule_ReplyWithStringBuffer(ctx, currentKey, currentKeyLen);
+        replylen++;
+    }
+    RedisModule_DictIteratorStop(iter);
+    ReplySetSetOrArrayLength(ctx, replylen);
+}
+
 int ReplySeriesArrayPos(RedisModuleCtx *ctx,
                         Series *s,
                         bool withlabels,

--- a/src/reply.h
+++ b/src/reply.h
@@ -32,6 +32,9 @@ static inline bool _is_resp3(RedisModuleCtx *ctx) {
 #define _ReplyMap(ctx) (RedisModule_ReplyWithMap != NULL && _is_resp3(ctx))
 #define _ReplySet(ctx) (RedisModule_ReplyWithSet != NULL && _is_resp3(ctx))
 
+// Reply a set/array of raw dict keys as strings (e.g. a set of ts_keys or label values).
+void ReplyWithKeySetFromDict(RedisModuleCtx *ctx, RedisModuleDict *keySet);
+
 int ReplySeriesArrayPos(RedisModuleCtx *ctx,
                         Series *series,
                         bool withlabels,

--- a/tests/flow/test_ts_querylabels.py
+++ b/tests/flow/test_ts_querylabels.py
@@ -103,7 +103,9 @@ def test_querylabels_acl_filters_unreadable_keys(env):
         r.execute_command('TS.CREATE', 'allowed_key', 'LABELS', 'group', 'acltest', 'onlyallowed', 'x')
         r.execute_command('TS.CREATE', 'blocked_key', 'LABELS', 'group', 'acltest', 'onlyblocked', 'y')
 
-        r.execute_command('ACL', 'SETUSER', 'ql_acl_user', 'on', '>pass', '+@all', '~allowed_key*')
+        for i in range(env.shardsCount):
+            env.getConnection(i).execute_command(
+                'ACL', 'SETUSER', 'ql_acl_user', 'on', '>pass', '+@all', '~allowed_key*')
         r1.execute_command('AUTH', 'ql_acl_user', 'pass')
         try:
             res = r1.execute_command('TS.QUERYLABELS', 'LABELS', 'FILTER', 'group=acltest')
@@ -120,4 +122,5 @@ def test_querylabels_acl_filters_unreadable_keys(env):
             assert sorted(res) == sorted([b'group', b'onlyallowed'])
         finally:
             r1.execute_command('AUTH', 'default', '')
-            r.execute_command('ACL', 'DELUSER', 'ql_acl_user')
+            for i in range(env.shardsCount):
+                env.getConnection(i).execute_command('ACL', 'DELUSER', 'ql_acl_user')

--- a/tests/flow/test_ts_querylabels.py
+++ b/tests/flow/test_ts_querylabels.py
@@ -1,0 +1,123 @@
+import pytest
+import redis
+from includes import *
+from utils import is_resp3_possible
+
+
+def _make_fixture(r):
+    assert r.execute_command('TS.CREATE', 'tester1', 'LABELS', 'name', 'bob', 'class', 'middle', 'generation', 'x')
+    assert r.execute_command('TS.CREATE', 'tester2', 'LABELS', 'name', 'rudy', 'class', 'junior', 'generation', 'x')
+    assert r.execute_command('TS.CREATE', 'tester3', 'LABELS', 'name', 'fabi', 'class', 'top', 'generation', 'x',
+                             'x', '2')
+    assert r.execute_command('TS.CREATE', 'tester4', 'LABELS', 'name', 'anybody', 'class', 'top', 'type', 'noone',
+                             'x', '2', 'z', '3')
+
+
+def test_querylabels_labels():
+    env = Env()
+    env.flush()
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        _make_fixture(r)
+
+        res = r1.execute_command('TS.QUERYLABELS', 'LABELS', 'FILTER', 'generation=x')
+        assert sorted(res) == sorted([b'name', b'class', b'generation', b'x'])
+
+
+def test_querylabels_values():
+    env = Env()
+    env.flush()
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        _make_fixture(r)
+
+        res = r1.execute_command('TS.QUERYLABELS', 'VALUES', 'name', 'FILTER', 'generation=x')
+        assert sorted(res) == sorted([b'bob', b'rudy', b'fabi'])
+
+        res = r1.execute_command('TS.QUERYLABELS', 'VALUES', 'class', 'FILTER', 'generation=x')
+        assert sorted(res) == sorted([b'middle', b'junior', b'top'])
+
+        res = r1.execute_command('TS.QUERYLABELS', 'VALUES', 'x', 'FILTER', 'generation=x')
+        assert sorted(res) == sorted([b'2'])
+
+        # A label that exists but has no matching series under this filter -> empty result.
+        res = r1.execute_command('TS.QUERYLABELS', 'VALUES', 'type', 'FILTER', 'generation=x')
+        assert res == []
+
+        # A label that doesn't exist at all -> empty result, not an error.
+        res = r1.execute_command('TS.QUERYLABELS', 'VALUES', 'nosuchlabel', 'FILTER', 'generation=x')
+        assert res == []
+
+
+def test_querylabels_no_filter():
+    env = Env()
+    env.flush()
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        _make_fixture(r)
+
+        res = r1.execute_command('TS.QUERYLABELS', 'LABELS')
+        assert sorted(res) == sorted([b'name', b'class', b'generation', b'x', b'type', b'z'])
+
+        res = r1.execute_command('TS.QUERYLABELS', 'VALUES', 'class')
+        assert sorted(res) == sorted([b'middle', b'junior', b'top'])
+
+
+def test_querylabels_errors():
+    env = Env()
+    env.flush()
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        _make_fixture(r)
+
+        with pytest.raises(redis.ResponseError):
+            r1.execute_command('TS.QUERYLABELS')
+
+        with pytest.raises(redis.ResponseError):
+            r1.execute_command('TS.QUERYLABELS', 'NOT_A_SUBTYPE')
+
+        with pytest.raises(redis.ResponseError):
+            r1.execute_command('TS.QUERYLABELS', 'VALUES')
+
+        with pytest.raises(redis.ResponseError):
+            r1.execute_command('TS.QUERYLABELS', 'LABELS', 'FILTER')
+
+        with pytest.raises(redis.ResponseError):
+            r1.execute_command('TS.QUERYLABELS', 'LABELS', 'garbage', 'FILTER', 'generation=x')
+
+        with pytest.raises(redis.ResponseError):
+            r1.execute_command('TS.QUERYLABELS', 'VALUES', 'name', 'garbage', 'FILTER', 'generation=x')
+
+
+def test_querylabels_resp3():
+    env = Env(protocol=3)
+    if not is_resp3_possible(env):
+        env.skip()
+    env.flush()
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        _make_fixture(r)
+        res = r1.execute_command('TS.QUERYLABELS', 'VALUES', 'name', 'FILTER', 'generation=x')
+        assert set(res) == {b'bob', b'rudy', b'fabi'}
+
+
+@skip(onVersionLowerThan='7.4.0')
+def test_querylabels_acl_filters_unreadable_keys(env):
+    env.flush()
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        r.execute_command('TS.CREATE', 'allowed_key', 'LABELS', 'group', 'acltest', 'onlyallowed', 'x')
+        r.execute_command('TS.CREATE', 'blocked_key', 'LABELS', 'group', 'acltest', 'onlyblocked', 'y')
+
+        r.execute_command('ACL', 'SETUSER', 'ql_acl_user', 'on', '>pass', '+@all', '~allowed_key*')
+        r1.execute_command('AUTH', 'ql_acl_user', 'pass')
+        try:
+            res = r1.execute_command('TS.QUERYLABELS', 'LABELS', 'FILTER', 'group=acltest')
+            assert sorted(res) == sorted([b'group', b'onlyallowed'])
+
+            res = r1.execute_command('TS.QUERYLABELS', 'VALUES', 'group', 'FILTER', 'group=acltest')
+            assert res == [b'acltest']
+
+            res = r1.execute_command('TS.QUERYLABELS', 'VALUES', 'onlyblocked', 'FILTER', 'group=acltest')
+            assert res == []
+
+            # No FILTER at all must still work (never error), silently omitting blocked_key.
+            res = r1.execute_command('TS.QUERYLABELS', 'LABELS')
+            assert sorted(res) == sorted([b'group', b'onlyallowed'])
+        finally:
+            r1.execute_command('AUTH', 'default', '')
+            r.execute_command('ACL', 'DELUSER', 'ql_acl_user')

--- a/tests/flow/test_ts_querylabels_mr.py
+++ b/tests/flow/test_ts_querylabels_mr.py
@@ -1,0 +1,48 @@
+from includes import *
+from utils import slot_table
+
+
+def test_querylabels_split_merge():
+    # Pin two keys to two different shards (slot 0 and the top slot) so the same label
+    # name+value is spread across shards. The coordinator must dedup them into a single
+    # entry, not report duplicates -- this is the multi-shard merge's main correctness case.
+    env = Env(shardsCount=3)
+    env.flush()
+    keyA = 'keyA{%s}' % slot_table[0]
+    keyB = 'keyB{%s}' % slot_table[16383]
+
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        assert r.execute_command('TS.CREATE', keyA, 'LABELS', 'commonlabel', 'sharedvalue', 'onlyA', 'x')
+        assert r.execute_command('TS.CREATE', keyB, 'LABELS', 'commonlabel', 'sharedvalue', 'onlyB', 'y')
+
+        # LABELS: both shards contribute 'commonlabel'; must be deduped to one entry, and both
+        # shard-local labels ('onlyA'/'onlyB') must still show up.
+        res = r1.execute_command('TS.QUERYLABELS', 'LABELS', 'FILTER', 'commonlabel=sharedvalue')
+        assert sorted(res) == sorted([b'commonlabel', b'onlyA', b'onlyB'])
+
+        # VALUES: the shared value is deduped across shards, not duplicated.
+        res = r1.execute_command('TS.QUERYLABELS', 'VALUES', 'commonlabel', 'FILTER', 'commonlabel=sharedvalue')
+        assert res == [b'sharedvalue']
+
+        res = r1.execute_command('TS.QUERYLABELS', 'VALUES', 'onlyA', 'FILTER', 'commonlabel=sharedvalue')
+        assert res == [b'x']
+
+        res = r1.execute_command('TS.QUERYLABELS', 'VALUES', 'onlyB', 'FILTER', 'commonlabel=sharedvalue')
+        assert res == [b'y']
+
+
+def test_querylabels_no_filter_multishard():
+    env = Env(shardsCount=3)
+    env.flush()
+    keyA = 'keyA{%s}' % slot_table[0]
+    keyB = 'keyB{%s}' % slot_table[16383]
+
+    with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:
+        assert r.execute_command('TS.CREATE', keyA, 'LABELS', 'region', 'us')
+        assert r.execute_command('TS.CREATE', keyB, 'LABELS', 'region', 'eu')
+
+        res = r1.execute_command('TS.QUERYLABELS', 'LABELS')
+        assert sorted(res) == sorted([b'region'])
+
+        res = r1.execute_command('TS.QUERYLABELS', 'VALUES', 'region')
+        assert sorted(res) == sorted([b'us', b'eu'])


### PR DESCRIPTION
…values

`TS.QUERYLABELS <LABELS | VALUES label> [FILTER filterExpr...]
`
Retrieve labels/values/keys information for matching time-series.

Examples: each sensor has a location and a sensor type.

LABELS
`TS.QUERYLABELS LABELS FILTER type=sensor
`


```
1) "location"       <-- list of labels, each associated with at least one matching time-series
2) "sensortype"
3) "type"
```


VALUES label
```

TS.QUERYLABELS VALUES location FILTER type=sensor



1) "LivingRoom"     <-- list of label values, each assigned to this label in at least one matching time-series
2) "Kitchen"
3) "BedRoom"
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New multi-shard blocking command and concurrent ref-counting on shared filter lists; correctness depends on cluster dedup and resharding trim logic, but scope is read-only metadata discovery with tests.
> 
> **Overview**
> Introduces **`TS.QUERYLABELS`** (`LABELS` or `VALUES label`, optional **`FILTER`**) to return deduplicated label names or values for matching indexed series, or all indexed series when **`FILTER`** is omitted. The handler reuses **`parseFilter`**, applies **ACL** on candidate keys, and fans out via **LibMR** (Gears mapper + **`TS.INTERNAL_QUERYLABELS`**) with coordinator-side deduplication; **RESP3** replies use sets via **`ReplyWithKeySetFromDict`**.
> 
> The label **indexer** gains **`GetAllIndexedSeriesKeys`**, **`QueryLabelsFromIndex`** / prefix helpers, refactored **reshard slot trimming** shared with **`QueryIndex`**, and **`VALUES`** disambiguation for pre-validation label names containing **`=`**. **`QueryPredicateList`** reference counting is made **atomic** for LibMR thread safety.
> 
> Command registration, ACLs, and **`TS_QUERYLABELS_INFO`** (since 8.10.0) are wired in; flow tests cover local, cluster merge, RESP3, and ACL behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ff57445f48d48b8e91ec5cc3089036ab3eb3641. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->