### PR TITLE
ci: run nightly valgrind shards on a 16-core larger runner

### DIFF
--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -136,6 +136,12 @@ jobs:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       beta-version: ${{needs.prepare-values.outputs.beta-version}}
       run_valgrind: true
+      # Valgrind is ~20-30x slower and the pole shard (oss_cluster) takes ~3h on
+      # the 4-vCPU default runner. RLTest parallelism scales with nproc, so a
+      # 16-core larger runner cuts that to roughly the longest single test
+      # (test_max_extensive, ~1h under valgrind). Label must match a GitHub-hosted
+      # larger runner configured in the org.
+      runner: ubuntu-latest-16-cores
     secrets: inherit
   linux-sanitizer:
     uses: ./.github/workflows/flow-linux.yml

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -41,6 +41,11 @@ on:
         description: 'Run each test topology as a separate parallel job (one per topology)'
         type: boolean
         default: false
+      runner:
+        description: 'Runner label override (empty = ubuntu-latest / ubuntu-24.04-arm; e.g. ubuntu-latest-16-cores for slow valgrind runs)'
+        type: string
+        required: false
+        default: ''
       beta-version:
         description: 'Beta version for S3 uploads'
         type: string
@@ -81,6 +86,11 @@ on:
         description: 'Run each test topology as a separate parallel job (one per topology)'
         type: boolean
         default: false
+      runner:
+        description: 'Runner label override (empty = ubuntu-latest / ubuntu-24.04-arm; e.g. ubuntu-latest-16-cores for slow valgrind runs)'
+        type: string
+        required: false
+        default: ''
       beta-version:
         description: 'Beta version for S3 uploads'
         type: string
@@ -111,8 +121,14 @@ jobs:
         id: set-runner
         env:
           ARCH: ${{ inputs.arch }}
+          RUNNER_OVERRIDE: ${{ inputs.runner }}
         run: |
-          if [ "$ARCH" == "arm64" ]; then
+          # tests.sh runs RLTest with --parallelism $(nproc), so test throughput
+          # scales with runner cores: callers may override the runner with a
+          # larger-runner label (e.g. ubuntu-latest-16-cores) for slow suites.
+          if [ -n "$RUNNER_OVERRIDE" ]; then
+            echo "runner=$RUNNER_OVERRIDE" >> $GITHUB_OUTPUT
+          elif [ "$ARCH" == "arm64" ]; then
             echo "runner=ubuntu-24.04-arm" >> $GITHUB_OUTPUT
           else
             echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What

Run the nightly valgrind shards on a `ubuntu-latest-16-cores` GitHub-hosted larger runner instead of the default 4-vCPU `ubuntu-latest`.

- `flow-linux.yml` gains an optional `runner` input (both `workflow_dispatch` and `workflow_call`); empty keeps today's behaviour, so PR CI and all other callers are unaffected.
- `event-nightly.yml` passes `runner: ubuntu-latest-16-cores` for the `linux-valgrind` job only.

## Why

The valgrind suite is already sharded one topology per job, so nightly wall-clock is set by the slowest shard. From the 2026-07-08 nightly:

| shard | duration |
|---|---|
| oss_cluster | **3h01m** |
| aof_slaves | 2h20m |
| slaves | 2h17m |
| gen | 1h42m |
| aof | 1h12m |

`tests.sh` runs RLTest with `--parallelism $(nproc)` (uncapped), so test throughput scales directly with runner cores — no harness changes needed. Going 4→16 vCPU should cut the pole shard to roughly the longest single test (`test_max_extensive`, ~1h under valgrind, see the `TEST_TIMEOUT` comment in `tests/flow/tests.sh`). Beyond 16 cores that single-test tail dominates, so larger sizes buy little while doubling cost.

## Prerequisite

An org admin must create a GitHub-hosted larger runner named `ubuntu-latest-16-cores` (Linux x64, 16-core / 64 GB) in this org, with **public repositories enabled** on its runner group (off by default — without it the jobs queue forever). Larger runners are always billed ($0.064/min for 16-core Linux); estimated ~250–300 runner-min/night ≈ $16–19/night after the speedup.

## Verification

Dispatched `flow-linux.yml` on this branch with `run_valgrind=true` and `runner=ubuntu-latest-16-cores` — the shards being picked up (rather than sitting "waiting for a runner") proves the label resolves; the run itself shows the new wall-clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change with an opt-in runner label; production code and default PR CI paths are unchanged aside from nightly valgrind targeting a larger runner (requires org runner configuration).
> 
> **Overview**
> Adds an optional **`runner`** input to **`flow-linux.yml`** (manual dispatch and reusable workflow). When set, it overrides the default `ubuntu-latest` / `ubuntu-24.04-arm` choice in the **Set runner** step; leaving it empty keeps current behavior for all existing callers.
> 
> The nightly **`linux-valgrind`** job in **`event-nightly.yml`** now passes **`runner: ubuntu-latest-16-cores`** so valgrind topology shards run on a 16-vCPU GitHub-hosted larger runner instead of the default 4-vCPU label, with inline notes on expected wall-clock and org runner setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7373590569d48f59b724dcf222bbb14002f82361. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->