### PR TITLE
Tal.ba/feat/upload image

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -40,8 +40,7 @@ jobs:
       os: jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       quick: false
-      build_images: ${{ contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}
-      use_prebuilt_images: ${{ !contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}
+      use_prebuilt_images: true
       shard_topologies: true
     secrets: inherit
   build-linux-arm64-full:
@@ -52,8 +51,7 @@ jobs:
       os: jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       quick: false
-      build_images: ${{ contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}
-      use_prebuilt_images: ${{ !contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}
+      use_prebuilt_images: true
       shard_topologies: true
     secrets: inherit
   # Remaining OSes are a small, toolchain-diverse compile-only smoke set
@@ -65,8 +63,7 @@ jobs:
       arch: x64
       os: alpine amazonlinux2 azurelinux3 rocky9
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-      build_images: ${{ contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}
-      use_prebuilt_images: ${{ !contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}
+      use_prebuilt_images: true
       build_only: true
     secrets: inherit
   build-linux-arm64-smoke:
@@ -76,8 +73,7 @@ jobs:
       arch: arm64
       os: alpine amazonlinux2023 azurelinux3 rocky9
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-      build_images: ${{ contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}
-      use_prebuilt_images: ${{ !contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}
+      use_prebuilt_images: true
       build_only: true
     secrets: inherit
   macos:
@@ -107,7 +103,6 @@ jobs:
       # this adds replication/AOF/cluster/LibMR ASAN coverage without raising
       # the overall PR wall-clock.
       quick: false
-      build_images: ${{ contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}
-      use_prebuilt_images: ${{ !contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}
+      use_prebuilt_images: true
       run_sanitizer: true
     secrets: inherit

--- a/.github/workflows/flow-random-traffic.yml
+++ b/.github/workflows/flow-random-traffic.yml
@@ -1,5 +1,9 @@
 name: Flow Random Traffic
 
+permissions:
+  contents: read
+  packages: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -55,7 +59,6 @@ jobs:
     needs: pick-os
     runs-on: ubuntu-latest
     env:
-      DOCKER_IMAGE: redistimeseries-${{ needs.pick-os.outputs.os }}:latest
       REDIS_REF: ${{ inputs.redis-ref || 'unstable' }}
     steps:
       - name: Checkout
@@ -63,10 +66,33 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Build Docker Image
+      - name: Set Docker Image
         env:
           SELECTED_OS: ${{ needs.pick-os.outputs.os }}
         run: |
+          repo="$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')"
+          image_tag="$(.install/get-image-tag.sh)"
+          echo "DOCKER_IMAGE=ghcr.io/${repo}/redistimeseries-x86-${SELECTED_OS}:${image_tag}" >> "$GITHUB_ENV"
+
+      - name: Pull Docker Image
+        id: pull-image
+        continue-on-error: true
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "::notice title=Docker image::Trying to pull prebuilt image ${DOCKER_IMAGE}"
+          docker pull "${DOCKER_IMAGE}"
+
+      - name: Use Pulled Docker Image
+        if: ${{ steps.pull-image.outcome == 'success' }}
+        run: |
+          echo "::notice title=Docker image::Using pulled prebuilt image ${DOCKER_IMAGE}"
+
+      - name: Build Docker Image
+        if: ${{ steps.pull-image.outcome == 'failure' }}
+        env:
+          SELECTED_OS: ${{ needs.pick-os.outputs.os }}
+        run: |
+          echo "::notice title=Docker image::Prebuilt image pull failed; building locally: ${DOCKER_IMAGE}"
           docker build \
             -f "Dockerfile.${SELECTED_OS}" \
             --build-arg REDIS_REF="${REDIS_REF}" \

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -1,9 +1,9 @@
 name: Push Docker Images
 
 # Rollout notes:
-# - Seed the registry before non-labeled PRs rely on prebuilt images. Either run
-#   this workflow manually or merge a PR labeled `docker-image-changes`.
-# - `docker-image-changes` means a merged PR refreshes the registry.
+# - `pack/ramp.yml:docker_image_version` is the single source of truth for CI image tags.
+# - Bump it when Docker image inputs change. Leave it unchanged for module-only
+#   version bumps.
 # - Linux CI pulls prebuilt images first and falls back to building locally when
 #   an image is missing.
 
@@ -15,13 +15,14 @@ on:
   pull_request:
     types:
       - closed
+    branches:
+      - main
+      - master
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+'
+      - 'release/**'
   workflow_dispatch:
     inputs:
-      redis-ref:
-        description: 'Redis ref to bake into the images'
-        type: string
-        required: true
-        default: 'unstable'
       architecture:
         description: 'Architecture images to build'
         type: choice
@@ -34,7 +35,7 @@ on:
 
 jobs:
   setup-matrix:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'docker-image-changes')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -71,7 +72,7 @@ jobs:
 
   push-images:
     name: ${{ matrix.image.os }}-${{ matrix.image.image_arch }}${{ matrix.image.variant && format('-{0}', matrix.image.variant) || '' }}
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'docker-image-changes')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     needs: setup-matrix
     runs-on: ${{ matrix.image.runner }}
     strategy:
@@ -79,7 +80,6 @@ jobs:
       matrix:
         image: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     env:
-      REDIS_REF: ${{ inputs.redis-ref }}
       OS: ${{ matrix.image.os }}
       IMAGE_ARCH: ${{ matrix.image.image_arch }}
       DOCKER_PLATFORM: ${{ matrix.image.platform }}
@@ -95,11 +95,7 @@ jobs:
 
       - name: Set Redis ref
         run: |
-          redis_ref="${REDIS_REF}"
-          if [ -z "$redis_ref" ]; then
-            redis_ref="$(.install/get-redis-ref.sh)"
-          fi
-          echo "REDIS_REF=${redis_ref}" >> "$GITHUB_ENV"
+          echo "REDIS_REF=$(.install/get-redis-ref.sh)" >> "$GITHUB_ENV"
 
       - name: Set Docker Image
         run: |
@@ -111,7 +107,19 @@ jobs:
           fi
           echo "DOCKER_IMAGE=ghcr.io/${repo}/redistimeseries-${IMAGE_ARCH}-${image_os}:${image_tag}" >> "$GITHUB_ENV"
 
+      - name: Check Docker Image
+        id: check-image
+        run: |
+          if docker buildx imagetools inspect "${DOCKER_IMAGE}" >/dev/null 2>&1; then
+            echo "::notice title=Docker image::Image already exists, skipping build: ${DOCKER_IMAGE}"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice title=Docker image::Image is missing, building: ${DOCKER_IMAGE}"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build Docker Image
+        if: ${{ steps.check-image.outputs.exists != 'true' }}
         run: |
           echo "Building ${DOCKER_IMAGE}"
           docker buildx build \
@@ -125,6 +133,7 @@ jobs:
             .
 
       - name: Push Docker Image
+        if: ${{ steps.check-image.outputs.exists != 'true' }}
         run: |
           echo "Pushing ${DOCKER_IMAGE}"
           docker push "${DOCKER_IMAGE}"

--- a/.install/get-image-tag.sh
+++ b/.install/get-image-tag.sh
@@ -1,38 +1,28 @@
 #!/usr/bin/env bash
-# Print the CI Docker image tag derived from the RedisTimeSeries module version.
+# Print the CI Docker image tag that redistimeseries is built/tested with.
 #
-# Development builds use 99.99.99 in src/version.h and map to the moving
-# "unstable" image tag. Release builds use the literal module version.
+# The tag is read from the `docker_image_version` field of the RAMP manifest
+# (pack/ramp.yml), so image producers and consumers share one manually bumped
+# value. Bump it when Docker image inputs change.
 
 set -euo pipefail
 
 PROGNAME="${BASH_SOURCE[0]}"
 HERE="$(cd "$(dirname "$PROGNAME")" &>/dev/null && pwd)"
 ROOT="$(cd "$HERE/.." &>/dev/null && pwd)"
-VERSION_FILE="${1:-$ROOT/src/version.h}"
+RAMP_FILE="$ROOT/pack/ramp.yml"
 
-if [[ ! -f "$VERSION_FILE" ]]; then
-	echo "Error: version file not found at $VERSION_FILE" >&2
+if [[ ! -f "$RAMP_FILE" ]]; then
+	echo "Error: RAMP manifest not found at $RAMP_FILE" >&2
 	exit 1
 fi
 
-read_define() {
-	local name="$1"
-	awk -v name="$name" '$1 == "#define" && $2 == name { print $3; exit }' "$VERSION_FILE"
-}
+IMAGE_TAG="$(sed -nE 's/^docker_image_version:[[:space:]]*(.*)$/\1/p' "$RAMP_FILE" | head -n1 \
+	| sed -E 's/[[:space:]]*#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//; s/^"(.*)"$/\1/; s/^'\''(.*)'\''$/\1/')"
 
-MAJOR="$(read_define REDISTIMESERIES_VERSION_MAJOR)"
-MINOR="$(read_define REDISTIMESERIES_VERSION_MINOR)"
-PATCH="$(read_define REDISTIMESERIES_VERSION_PATCH)"
-
-if [[ -z "$MAJOR" || -z "$MINOR" || -z "$PATCH" ]]; then
-	echo "Error: could not parse RedisTimeSeries version from $VERSION_FILE" >&2
+if [[ -z "$IMAGE_TAG" ]]; then
+	echo "Error: 'docker_image_version' is not defined in $RAMP_FILE" >&2
 	exit 1
 fi
 
-VERSION="${MAJOR}.${MINOR}.${PATCH}"
-if [[ "$VERSION" == "99.99.99" ]]; then
-	echo "unstable"
-else
-	echo "$VERSION"
-fi
+echo "$IMAGE_TAG"

--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -9,6 +9,7 @@ command_line_args: ""
 compatible_redis_version: "99.99"
 min_redis_version: "99.99"
 redis_ref: "unstable"
+docker_image_version: "0.0.1"
 min_redis_pack_version: "7.2.0"
 capabilities:
     - types


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how every Linux CI job obtains its Docker environment; mis-tagged or missing GHCR images cause slower fallback builds or pull/auth failures until images are published.
> 
> **Overview**
> Introduces a **prebuilt Docker image pipeline** so Linux CI can pull from GHCR instead of rebuilding images on every job, with local `docker build` as fallback when a pull fails or prebuilts are disabled.
> 
> **`pack/ramp.yml`** gains **`docker_image_version`** (initially `0.0.1`); **`.install/get-image-tag.sh`** reads that field so publishers and consumers share one tag. Images are named `ghcr.io/{repo}/redistimeseries-{x86|arm}-{os}[:-{sanitizer|valgrind}]:{tag}`.
> 
> A new **`push-docker-images`** workflow runs on **merged PRs** (to main/master/release branches) and **`workflow_dispatch`**, builds the full OS/arch matrix (plus jammy sanitizer/valgrind variants on x86), skips pushes when the tag already exists in GHCR, and publishes to the registry.
> 
> **`flow-linux`** adds **`use_prebuilt_images`** / **`build_images`**, login + pull steps, and conditional local build; sanitizer/valgrind jobs select suffixed image OS names. **Event CI/nightly/tag** workflows enable **`use_prebuilt_images: true`** on Linux jobs and grant **`packages: read`**. **`flow-random-traffic`** follows the same pull-then-fallback pattern for x86 images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a536c6e1ca4b7149f76a66dddb043e6b829e2cca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->