### PR TITLE
Tal.ba/feat/upload image

### DIFF
--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -21,6 +21,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+'
       - 'release/**'
+      - 'tal.ba/test/baseline'
   workflow_dispatch:
     inputs:
       architecture:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single workflow branch filter addition; no changes to build, auth, or image push logic.
> 
> **Overview**
> Extends the **Push Docker Images** workflow so it also runs when a pull request targeting **`tal.ba/test/baseline`** is closed (same `closed` event and merged-only job guards as for `main`, `master`, version branches, and `release/**`).
> 
> This lets CI publish GHCR images after merges into that test baseline branch without relying on manual `workflow_dispatch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4660d329a9f580d3da7d716d89715507d86a58d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->