### PR TITLE
Tal.ba/feat/upload image

### DIFF
--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -21,6 +21,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+'
       - 'release/**'
+      - 'tal.ba/test/baseline'
   workflow_dispatch:
     inputs:
       architecture:

--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -10,6 +10,7 @@ compatible_redis_version: "99.99"
 min_redis_version: "99.99"
 redis_ref: "unstable"
 docker_image_version: "0.0.1"
+
 min_redis_pack_version: "7.2.0"
 capabilities:
     - types


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI trigger branch list change only; no application, auth, or image build logic changes.
> 
> **Overview**
> Extends the **Push Docker Images** workflow so it also runs when a pull request is **closed after merge** into **`tal.ba/test/baseline`**, alongside existing targets (`main`, `master`, version branches, and `release/**`). Behavior is unchanged: the job still only runs for merges or `workflow_dispatch`, builds missing GHCR images, and skips when an image already exists.
> 
> `pack/ramp.yml` only gains a blank line after `docker_image_version`; no version or metadata change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99ba769505ae1a10351d7e73b7e49d35fc4d6fd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->