### PR TITLE
Tal.ba/feat/upload image

### DIFF
--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -21,6 +21,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+'
       - 'release/**'
+      - 'tal.ba/test/baseline'
   workflow_dispatch:
     inputs:
       architecture:

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -10,6 +10,7 @@ name: Push Docker Images
 permissions:
   contents: read
   packages: write
+  pull-requests: read
 
 on:
   pull_request:
@@ -35,8 +36,42 @@ on:
           - arm
 
 jobs:
+  should-run:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Check Docker image version change
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.event.pull_request.merged }}" != "true" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          files="$(gh api --paginate \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/pulls/${PR_NUMBER}/files")"
+          ramp_patch="$(echo "$files" | jq -r '.[] | select(.filename == "pack/ramp.yml") | .patch // empty')"
+          if echo "$ramp_patch" | grep -Eq '^[+-]docker_image_version:'; then
+            echo "::notice title=Docker image::docker_image_version changed; checking/pushing images"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice title=Docker image::docker_image_version did not change; skipping image push"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   setup-matrix:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    if: ${{ needs.should-run.outputs.run == 'true' }}
+    needs: should-run
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -73,7 +108,6 @@ jobs:
 
   push-images:
     name: ${{ matrix.image.os }}-${{ matrix.image.image_arch }}${{ matrix.image.variant && format('-{0}', matrix.image.variant) || '' }}
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     needs: setup-matrix
     runs-on: ${{ matrix.image.runner }}
     strategy:

--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -10,6 +10,7 @@ compatible_redis_version: "99.99"
 min_redis_version: "99.99"
 redis_ref: "unstable"
 docker_image_version: "0.0.1"
+
 min_redis_pack_version: "7.2.0"
 capabilities:
     - types


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mis-detection of the `ramp.yml` patch could skip needed image publishes or run the full matrix unnecessarily; impact is CI/release ops, not app runtime security.
> 
> **Overview**
> **Push Docker Images** now runs the build/push matrix only when it should, instead of on every merged PR to the listed branches.
> 
> A new **`should-run`** job uses the GitHub API to load the merged PR’s file list and inspect the `pack/ramp.yml` patch. Image jobs run when `docker_image_version` changes in that diff, on **`workflow_dispatch`**, or when the PR wasn’t merged (skipped). Otherwise the workflow logs a notice and skips **`setup-matrix`** / **`push-images`**. **`pull-requests: read`** was added for that API access, and branch **`tal.ba/test/baseline`** was added to the PR-closed trigger for testing.
> 
> The diff to **`pack/ramp.yml`** is formatting only (blank line); **`docker_image_version`** is unchanged at `0.0.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7219cb6577bacc6c731fab650313700efb36f897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->