### PR TITLE
MOD-16383 ci: coverage nightly-only + full topology suite

### DIFF
--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -165,14 +165,16 @@ jobs:
     needs: [prepare-values]
     with:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-      test-config: QUICK=1
+      # Full topology suite (not QUICK=1) so replication/AOF/cluster/LibMR code
+      # paths are exercised and coverage is not understated.
+      test-config: GEN=1 SLAVES=1 AOF=1 AOF_SLAVES=1 OSS_CLUSTER=1
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   notify-results:
     name: Aggregate Results & Notify
     runs-on: ubuntu-latest
-    needs: [random-traffic, prepare-values, linter, build-linux-x64, build-linux-arm64, macos, linux-valgrind, linux-sanitizer]
+    needs: [random-traffic, prepare-values, linter, build-linux-x64, build-linux-arm64, macos, linux-valgrind, linux-sanitizer, coverage]
     if: always() && (github.event_name == 'schedule' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.send-slack-message == true))
     permissions:
       actions: read
@@ -192,7 +194,8 @@ jobs:
             "macos": "${{ needs.macos.result }}",
             "linux-valgrind": "${{ needs.linux-valgrind.result }}",
             "linux-sanitizer": "${{ needs.linux-sanitizer.result }}",
-            "random-traffic": "${{ needs.random-traffic.result }}"
+            "random-traffic": "${{ needs.random-traffic.result }}",
+            "coverage": "${{ needs.coverage.result }}"
           }
           EOF
           )

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -184,6 +184,9 @@ jobs:
 
       - name: Build job results JSON
         id: build-results
+        env:
+          COVERAGE_ENABLED: ${{ vars.ENABLE_CODE_COVERAGE != 'false' }}
+          COVERAGE_RESULT: ${{ needs.coverage.result }}
         run: |
           # Build JSON object with job results
           JOB_RESULTS=$(cat <<'EOF'
@@ -194,11 +197,15 @@ jobs:
             "macos": "${{ needs.macos.result }}",
             "linux-valgrind": "${{ needs.linux-valgrind.result }}",
             "linux-sanitizer": "${{ needs.linux-sanitizer.result }}",
-            "random-traffic": "${{ needs.random-traffic.result }}",
-            "coverage": "${{ needs.coverage.result }}"
+            "random-traffic": "${{ needs.random-traffic.result }}"
           }
           EOF
           )
+          # A deliberately disabled coverage job is skipped, not failed. Omit it
+          # from the summary so it does not turn a successful nightly "skipped".
+          if [[ "$COVERAGE_ENABLED" == "true" ]]; then
+            JOB_RESULTS=$(echo "$JOB_RESULTS" | jq --arg result "$COVERAGE_RESULT" '. + {coverage: $result}')
+          fi
           # Output as single line for GitHub Actions
           echo "job_results=$(echo "$JOB_RESULTS" | jq -c .)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Follow-up to the coverage work merged in #2070.

## What & why

**Nightly coverage now runs the full topology suite.**
`QUICK=1` runs only the `GEN` topology, so replication (`SLAVES`), AOF, `AOF_SLAVES`, and OSS-cluster — and therefore **all LibMR / multi-shard code paths** — never execute, and the coverage Codecov reports is understated/misleading. The **nightly** coverage job now runs `GEN=1 SLAVES=1 AOF=1 AOF_SLAVES=1 OSS_CLUSTER=1`, and is wired into `notify-results` (`needs` + the job-results JSON) so a failed/cancelled coverage run is reflected in the nightly Slack summary (this also resolves the earlier Bugbot comment on #2070).

**PR-gate coverage is unchanged (`QUICK=1`).**
The full-suite instrumented build is slow (~40-50 min) — too slow to sit on the PR gate. The `event-ci` coverage job stays on `QUICK=1`: it's fast and keeps posting the per-PR Codecov diff comment. The authoritative, accurate full-suite number comes from the nightly.

Net change: `event-nightly.yml` only.

Jira: [MOD-16383](https://redislabs.atlassian.net/browse/MOD-16383)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MOD-16383]: https://redislabs.atlassian.net/browse/MOD-16383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only changes; PR-gate coverage in `event-ci.yml` remains `QUICK=1`.
> 
> **Overview**
> **Nightly coverage** no longer uses `QUICK=1` (GEN-only). It now passes `GEN=1 SLAVES=1 AOF=1 AOF_SLAVES=1 OSS_CLUSTER=1` into `flow-coverage.yml` so replication, AOF, OSS cluster, and LibMR/multi-shard paths are included in Codecov uploads.
> 
> **Nightly notifications** now wait on the `coverage` job and, when `ENABLE_CODE_COVERAGE` is not `false`, add a `coverage` entry to the job-results JSON passed to `test-summary`—so failures/skips surface in Slack without treating a disabled (skipped) coverage job as a failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e76a578c97f1fc87e1ec8ea73b876668639552ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->