### PR TITLE
Tal.ba/feat/upload image

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: set env
         id: set-env
         run: |
-          echo "redis-ref=$(.install/get-redis-ref.sh)" >> "$GITHUB_OUTPUT"
+          echo "redis-ref=unstable" >> "$GITHUB_OUTPUT"
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Set Redis ref
         run: |
-          echo "REDIS_REF=$(.install/get-redis-ref.sh)" >> "$GITHUB_ENV"
+          echo "REDIS_REF=unstable" >> "$GITHUB_ENV"
 
       - name: Set Docker Image
         run: |

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -27,6 +27,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+'
       - 'release/**'
+      - 'tal.ba/test/baseline'
     paths:
       - 'pack/ramp.yml'
   workflow_dispatch:

--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -8,7 +8,7 @@ license: Redis Source Available License 2.0 (RSALv2) or the Server Side Public L
 command_line_args: ""
 compatible_redis_version: "99.99"
 min_redis_version: "99.99"
-redis_ref: "unstable"
+redis_ref: "998.998.998"
 min_redis_pack_version: "7.2.0"
 capabilities:
     - types


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes CI Redis pinning and RAMP `redis_ref` (source of truth for image tags), which can publish mismatched build vs tag refs if merged beyond a test branch.
> 
> **Overview**
> **CI and Docker workflows** are adjusted for a `tal.ba/test/baseline` image-upload path, with **hardcoded `unstable`** for Redis build refs in Event CI and the docker push job instead of **`.install/get-redis-ref.sh`**.
> 
> **`pack/ramp.yml`** sets **`redis_ref`** from **`unstable`** to **`998.998.998`**, which still drives image tags via **`get-redis-ref.sh`** in the push workflow while **`REDIS_REF`** for builds stays **`unstable`**.
> 
> **`push-docker-images.yml`** also runs on pushes and merged PRs to **`tal.ba/test/baseline`**, in addition to the existing branch filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da0f9e00338837735e754f848672fbb063da7d15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->