### PR TITLE
trying on version

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: set env
         id: set-env
         run: |
-          echo "redis-ref=$(.install/get-redis-ref.sh)" >> "$GITHUB_OUTPUT"
+          echo "redis-ref=unstable" >> "$GITHUB_OUTPUT"
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Set Redis ref
         run: |
-          echo "REDIS_REF=$(.install/get-redis-ref.sh)" >> "$GITHUB_ENV"
+          echo "REDIS_REF=unstable" >> "$GITHUB_ENV"
 
       - name: Set Docker Image
         run: |

--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -8,7 +8,7 @@ license: Redis Source Available License 2.0 (RSALv2) or the Server Side Public L
 command_line_args: ""
 compatible_redis_version: "99.99"
 min_redis_version: "99.99"
-redis_ref: "unstable"
+redis_ref: "998.998.998"
 min_redis_pack_version: "7.2.0"
 capabilities:
     - types


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Workflow changes can desync CI Redis builds (`unstable`) from image tags and ramp metadata (`998.998.998`), affecting reproducibility and which GHCR tags get built or skipped.
> 
> **Overview**
> This PR looks like a **version/CI experiment** rather than a production alignment change.
> 
> **`pack/ramp.yml`** changes `redis_ref` from `unstable` to `998.998.998`, which would normally drive Docker image tags and other readers of the RAMP manifest via `.install/get-redis-ref.sh`.
> 
> **Event CI** and **push-docker-images** no longer set the Redis build ref from `get-redis-ref.sh`; they hardcode `unstable` for the `redis-ref` / `REDIS_REF` env used when building and testing. Docker image naming in push-docker-images still uses `get-redis-ref.sh` for `image_tag`, so published tags would follow `998.998.998` while the Redis source built into those images would still be `unstable` unless something else overrides it.
> 
> Together, this decouples PR CI’s Redis checkout from `pack/ramp.yml` while bumping the manifest ref to a synthetic version string—useful for trying version-driven behavior without changing what Redis branch CI actually compiles against.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da0f9e00338837735e754f848672fbb063da7d15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->