### PR TITLE
trying on version

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: set env
         id: set-env
         run: |
-          echo "redis-ref=$(.install/get-redis-ref.sh)" >> "$GITHUB_OUTPUT"
+          echo "redis-ref=unstable" >> "$GITHUB_OUTPUT"
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Set Redis ref
         run: |
-          echo "REDIS_REF=$(.install/get-redis-ref.sh)" >> "$GITHUB_ENV"
+          echo "REDIS_REF=unstable" >> "$GITHUB_ENV"
 
       - name: Set Docker Image
         run: |

--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -8,7 +8,7 @@ license: Redis Source Available License 2.0 (RSALv2) or the Server Side Public L
 command_line_args: ""
 compatible_redis_version: "99.99"
 min_redis_version: "99.99"
-redis_ref: "unstable"
+redis_ref: "998.998.998"
 min_redis_pack_version: "7.2.0"
 capabilities:
     - types


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes CI/docker Redis pinning and the canonical `redis_ref` in `pack/ramp.yml`, which can misalign prebuilt image tags with what PR CI actually builds against if merged unintentionally.
> 
> **Overview**
> **Pins `redis_ref` in `pack/ramp.yml`** from `unstable` to `998.998.998`, which would normally drive Docker image tags and other consumers via `.install/get-redis-ref.sh`.
> 
> **Overrides that manifest in two workflows** by hardcoding `unstable` where `redis-ref` / `REDIS_REF` used to be set from `get-redis-ref.sh` in **Event CI** and **Push Docker Images** (Docker build `REDIS_REF` only; image tag steps still call `get-redis-ref.sh`, so tags would follow the new ramp value while the Redis checkout in the image build stays on `unstable`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da0f9e00338837735e754f848672fbb063da7d15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->