### PR TITLE
use key_spec in command json

### DIFF
--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -252,7 +252,8 @@ jobs:
             tests/**/*.log
 
       - name: Pack module
-        if: ${{ !inputs.run_valgrind && !inputs.run_sanitizer && !inputs.build_only && (!matrix.platform.topo || matrix.platform.topo == 'gen') }}
+        # ponytail: temp — also pack jammy-aof so we can verify S3 upload for that shard; drop the jammy-aof clause when done
+        if: ${{ !inputs.run_valgrind && !inputs.run_sanitizer && !inputs.build_only && (!matrix.platform.topo || matrix.platform.topo == 'gen' || (matrix.platform.os == 'jammy' && matrix.platform.topo == 'aof')) }}
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
@@ -264,7 +265,8 @@ jobs:
             make pack SHOW=1
 
       - name: Upload artifacts to S3
-        if: ${{ !inputs.run_valgrind && !inputs.run_sanitizer && !inputs.build_only && (!matrix.platform.topo || matrix.platform.topo == 'gen') }}
+        # ponytail: temp — also upload jammy-aof to verify S3 for that shard; drop the jammy-aof clause when done
+        if: ${{ !inputs.run_valgrind && !inputs.run_sanitizer && !inputs.build_only && (!matrix.platform.topo || matrix.platform.topo == 'gen' || (matrix.platform.os == 'jammy' && matrix.platform.topo == 'aof')) }}
         uses: ./.github/actions/upload-artifacts-to-s3-without-make
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/commands.json
+++ b/commands.json
@@ -666,6 +666,13 @@
     "TS.NRANGE": {
         "summary": "Query a range across multiple time series in forward direction, returning the results pivoted by timestamp (one value column per key)",
         "complexity": "O(numkeys*(n/m+k)) where n = Number of samples, m = Chunk size (samples per chunk), k = Number of samples that are in the requested range",
+        "key_specs": [
+            {
+                "flags": ["RO", "ACCESS"],
+                "begin_search": { "index": { "pos": 1 } },
+                "find_keys": { "keynum": { "keynumidx": 0, "firstkey": 1, "step": 1 } }
+            }
+        ],
         "arguments": [
             {
                 "name": "numkeys",
@@ -764,6 +771,13 @@
     "TS.NREVRANGE": {
         "summary": "Query a range across multiple time series in reverse direction, returning the results pivoted by timestamp (one value column per key)",
         "complexity": "O(numkeys*(n/m+k)) where n = Number of samples, m = Chunk size (samples per chunk), k = Number of samples that are in the requested range",
+        "key_specs": [
+            {
+                "flags": ["RO", "ACCESS"],
+                "begin_search": { "index": { "pos": 1 } },
+                "find_keys": { "keynum": { "keynumidx": 0, "firstkey": 1, "step": 1 } }
+            }
+        ],
         "arguments": [
             {
                 "name": "numkeys",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata and temporary CI condition changes only; no command behavior or production packaging logic is altered beyond an extra test shard uploading artifacts.
> 
> **Overview**
> Adds **`key_specs`** to **`TS.NRANGE`** and **`TS.NREVRANGE`** in `commands.json`, declaring read-only access to the variable key list after `numkeys` (search from argument index 1, count from `numkeys` at index 0). This aligns the JSON command metadata with the existing `TS_NRANGE_KEYSPECS` / `TS_NREVRANGE_KEYSPECS` definitions used at runtime.
> 
> The Linux flow workflow is **temporarily** changed so **pack** and **S3 upload** also run on the **`jammy` + `aof`** topology shard (not only `gen` or untopology jobs), with comments noting the extra clause should be removed after verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f70d155ed065f2ac2dc378685138280109722746. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->