### PR TITLE
MOD-16364 - update requirements deps

### DIFF
--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -43,16 +43,20 @@ fi
 _pm_apt_updated=0
 apt_install() {
     [ "$#" -gt 0 ] || return 0
+    # Acquire::Retries: ports.ubuntu.com (arm64 mirror) intermittently drops
+    # connections mid-build; without retries a single dropped fetch fails the
+    # whole docker build (exit 100). Retry each download before giving up.
+    local apt_retry="-o Acquire::Retries=5"
     if [ "$_pm_apt_updated" = 0 ]; then
         export DEBIAN_FRONTEND=noninteractive
-        $SUDO apt-get update -qq
+        $SUDO apt-get update -qq $apt_retry
         _pm_apt_updated=1
     fi
     # env goes THROUGH $SUDO: sudo's env_reset strips exported variables, so a
     # plain export upstream never reaches dpkg — debconf (e.g. tzdata on focal,
     # which the base image doesn't preinstall) then blocks on an interactive
     # prompt and the bootstrap hangs.
-    $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends "$@"
+    $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends $apt_retry "$@"
 }
 
 # `--allowerasing` lets dnf pick our `curl` over the slimmer `curl-minimal`

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,5 +1,5 @@
 redis==2.10.5
-gevent==1.2.1
+gevent==23.9.1
 Flask>=0.12
-Flask-Cors==3.0.9
+Flask-Cors==4.0.2
 python-dateutil==2.6.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Large gevent major upgrade can change runtime behavior for GraphiteServer; apt retry change is low risk but affects all Debian-based installs.
> 
> **Overview**
> **Python tooling deps** in `tools/requirements.txt` are bumped: `gevent` from 1.2.1 to **23.9.1** (used by `GraphiteServer.py`’s `StreamServer`) and **Flask-Cors** from 3.0.9 to **4.0.2**.
> 
> **Bootstrap reliability:** `apt_install` in `.install/lib/pm.sh` now passes **`-o Acquire::Retries=5`** on both `apt-get update` and `apt-get install`, so transient mirror drops (notably on arm64 `ports.ubuntu.com`) are less likely to fail Docker builds with exit 100.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89284d8d083f1cdf9b0509a02b079851db46ae95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->