### PR TITLE
MOD-16873 `TS.INCRBY` replicate master timestamp when timestamp is lo…

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1489,7 +1489,9 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     long long currentUpdatedTime = -1;
     int timestampLoc = RMUtil_ArgIndex("TIMESTAMP", argv, argc);
-    if (timestampLoc == -1 || RMUtil_StringEqualsC(argv[timestampLoc + 1], "*")) {
+    const bool useLocalTimestamp =
+        timestampLoc == -1 || RMUtil_StringEqualsC(argv[timestampLoc + 1], "*");
+    if (useLocalTimestamp) {
         currentUpdatedTime = RedisModule_Milliseconds();
     } else if (RedisModule_StringToLongLong(argv[timestampLoc + 1],
                                             (long long *)&currentUpdatedTime) != REDISMODULE_OK) {
@@ -1527,7 +1529,27 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     }
 
     int rv = internalAdd(ctx, series, currentUpdatedTime, result, DP_LAST, true);
-    RedisModule_ReplicateVerbatim(ctx);
+
+    if (useLocalTimestamp) {
+        const char *replCmd = isIncr ? "TS.INCRBY" : "TS.DECRBY";
+        if (timestampLoc == -1) {
+            RedisModule_Replicate(
+                ctx, replCmd, "vcl", argv + 1, argc - 1, "TIMESTAMP", currentUpdatedTime);
+        } else {
+            RedisModule_Replicate(
+                ctx,
+                replCmd,
+                "vlv",
+                argv + 1,           // start after the command name
+                timestampLoc,       // number of args, until the TIMESTAMP argument(included)
+                currentUpdatedTime, // the timestamp value
+                argv + timestampLoc +
+                    2, // start after the TIMESTAMP argument, rest of the arguments
+                argc - timestampLoc - 2); // number of args, after the TIMESTAMP argument
+        }
+    } else {
+        RedisModule_ReplicateVerbatim(ctx);
+    }
     RedisModule_CloseKey(key);
 
     RedisModule_NotifyKeyspaceEvent(

--- a/src/module.c
+++ b/src/module.c
@@ -1533,19 +1533,24 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (useLocalTimestamp) {
         const char *replCmd = isIncr ? "TS.INCRBY" : "TS.DECRBY";
         if (timestampLoc == -1) {
+            const size_t replArgc = argc - 1;
             RedisModule_Replicate(
-                ctx, replCmd, "vcl", argv + 1, argc - 1, "TIMESTAMP", currentUpdatedTime);
+                ctx, replCmd, "vcl", argv + 1, replArgc, "TIMESTAMP", currentUpdatedTime);
         } else {
+            // number of args, until the TIMESTAMP argument (included)
+            const size_t preArgc = timestampLoc;
+            // number of args, after the TIMESTAMP argument
+            const size_t postArgc = argc - timestampLoc - 2;
             RedisModule_Replicate(
                 ctx,
                 replCmd,
                 "vlv",
-                argv + 1,           // start after the command name
-                timestampLoc,       // number of args, until the TIMESTAMP argument(included)
+                argv + 1, // start after the command name
+                preArgc,
                 currentUpdatedTime, // the timestamp value
                 argv + timestampLoc +
                     2, // start after the TIMESTAMP argument, rest of the arguments
-                argc - timestampLoc - 2); // number of args, after the TIMESTAMP argument
+                postArgc);
         }
     } else {
         RedisModule_ReplicateVerbatim(ctx);

--- a/tests/flow/test_ts_incrby.py
+++ b/tests/flow/test_ts_incrby.py
@@ -1,4 +1,5 @@
 import math
+import threading
 import time
 
 # import pytest
@@ -121,3 +122,49 @@ def test_ts_incrby_arg_validation_before_creation():
         # Key should exist
         result = r.execute_command('TS.GET', 'test_valid')
         assert result is not None
+
+
+def test_incrby_no_timestamp_replicates_diverging_timestamp():
+    # TS.INCRBY/TS.DECRBY without an explicit TIMESTAMP resolve the timestamp
+    # via RedisModule_Milliseconds() on the primary, but TSDB_incrby then
+    # calls RedisModule_ReplicateVerbatim(), propagating the original argv
+    # (still lacking a concrete timestamp) instead of a rewritten one like
+    # TS.ADD/TS.MADD do. A replica that applies the propagated command later
+    # re-evaluates RedisModule_Milliseconds() at its own, later, wall-clock
+    # instant, so it stores the sample under a different timestamp than the
+    # primary did for the same logical write.
+    if not Env().useSlaves:
+        Env().skip()
+    Env().skipOnCluster()
+    env = Env()
+    key = 'incrby_repl_divergence'
+    with env.getConnection() as master:
+        master.execute_command('ts.create', key)
+    # Make sure the initial replica sync has caught up with the key creation
+    # before we start controlling timing below, so the only delay measured
+    # is the one we inject, not leftover initial-sync latency.
+    for _ in range(100):
+        with env.getSlaveConnection() as slave:
+            if slave.execute_command('exists', key):
+                break
+        time.sleep(0.1)
+    else:
+        raise Exception('replica never caught up with initial ts.create')
+    slave_sleep_secs = 2
+    def block_slave_main_thread():
+        # DEBUG SLEEP blocks the replica's single event loop entirely, so it
+        # cannot apply the replicated TS.INCRBY until the sleep elapses -
+        # forcing a deterministic, multi-second gap between when the primary
+        # resolves "now" and when the replica would resolve it.
+        with env.getSlaveConnection() as slave:
+            slave.execute_command('DEBUG', 'SLEEP', slave_sleep_secs)
+    blocker = threading.Thread(target=block_slave_main_thread)
+    blocker.start()
+    time.sleep(0.3)  # let DEBUG SLEEP actually start running on the slave
+    with env.getConnection() as master:
+        master_ts = master.execute_command('ts.incrby', key, 1)
+    blocker.join()
+    time.sleep(1)  # give the replica time to apply the now-unblocked command
+    with env.getSlaveConnection() as slave:
+        slave_sample = slave.execute_command('ts.get', key)
+    env.assertEqual(master_ts, slave_sample[0])


### PR DESCRIPTION
…cal server clock

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes replication behavior for a write path on primary/replica setups; explicit TIMESTAMP commands are unchanged, but implicit-timestamp traffic now gets rewritten AOF/replication commands.
> 
> **Overview**
> **Fixes primary/replica timestamp drift** for `TS.INCRBY` and `TS.DECRBY` when no explicit timestamp is given (or `TIMESTAMP *`).
> 
> Previously replication used `RedisModule_ReplicateVerbatim()`, so replicas re-ran `RedisModule_Milliseconds()` at apply time and could store the same logical write under a different timestamp than the primary. The handler now mirrors `TS.ADD`/`TS.MADD`: when the timestamp is resolved locally on the master, it replicates `TS.INCRBY`/`TS.DECRBY` with a concrete `TIMESTAMP` value (appending it when omitted, or replacing `*` when present). Explicit numeric timestamps still replicate verbatim.
> 
> A master/slave flow test uses `DEBUG SLEEP` on the replica to delay apply and asserts `TS.GET` on the slave uses the same timestamp the master returned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80b97f4b4228a333515237d56c7e179f2f825f5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->