### PR TITLE
Tal.ba/fix/fix ubuntu hangups

### DIFF
--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -138,6 +138,11 @@ jobs:
       packages: write
     strategy:
       fail-fast: false
+      # Throttle the fan-out: ~37 images build at once otherwise, and the arm64
+      # subset all pull from ports.ubuntu.com (no CDN) in one synchronized burst,
+      # causing "connection timed out" during apt-get update. Cap concurrency so
+      # we trickle rather than slam the mirror. See MOD-16306.
+      max-parallel: 4
       matrix:
         image: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     env:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> New multi-shard TS.QUERYLABELS and changed TS.INCRBY/DECRBY replication affect production data paths; large CI/image pipeline changes can break builds if GHCR tags or permissions are wrong.
> 
> **Overview**
> **CI and Docker** now publish and consume **GHCR prebuilt images** tagged from `pack/ramp.yml`’s `redis_ref` (`push-docker-images.yml`), with Linux/random-traffic jobs **pulling first** and building locally on miss or when the PR label `docker-image-changes` disables prebuilts. Image publishing is **throttled** (`max-parallel: 4`) and **apt retries** were added to reduce arm64 mirror timeouts; Alpine CI forces **distro Python** instead of uv’s musl interpreter.
> 
> **Coverage** runs via new **`flow-coverage.yml`** on **nightly** and **non-draft PRs** (toggle `ENABLE_CODE_COVERAGE`, upload to Codecov).
> 
> **Module behavior:** adds **`TS.QUERYLABELS`** (`LABELS` / `VALUES label` with optional `FILTER`) including **cluster LibMR** fan-out, indexer helpers for label aggregation, **reshard slot trimming** refactored, and **atomic** `QueryPredicateList` refcounting. **`TS.INCRBY` / `TS.DECRBY`** with implicit `*` timestamp now **replicate with a concrete `TIMESTAMP`** instead of verbatim argv so replicas match the primary.
> 
> Also: shared **`parseFilter`**, **`get-ramp-field.sh`**, command info for `TS.QUERYLABELS`, flow tests, and bumped **gevent** / **Flask-Cors** in `tools/requirements.txt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b17d50cd372634075bcddb357ca9157a27f292be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->