### PR TITLE
Tal.ba/fix/fix ubuntu hangups

### DIFF
--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -19,6 +19,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+'
       - 'release/**'
+      - tal.ba/test/baseline
   push:
     branches:
       - main
@@ -26,6 +27,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+'
       - 'release/**'
+      - tal.ba/test/baseline
     paths:
       - 'pack/ramp.yml'
   workflow_dispatch:

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -138,6 +138,11 @@ jobs:
       packages: write
     strategy:
       fail-fast: false
+      # Throttle the fan-out: ~37 images build at once otherwise, and the arm64
+      # subset all pull from ports.ubuntu.com (no CDN) in one synchronized burst,
+      # causing "connection timed out" during apt-get update. Cap concurrency so
+      # we trickle rather than slam the mirror. See MOD-16306.
+      max-parallel: 4
       matrix:
         image: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     env:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow changes with no application or security impact; slightly longer total image publish time due to lower parallelism.
> 
> **Overview**
> **Limits concurrent Docker image builds** in `push-docker-images` by setting `max-parallel: 4` on the `push-images` matrix job. Without this, ~37 jobs start at once; arm64 builds hit `ports.ubuntu.com` in a synchronized burst and `apt-get update` often fails with connection timeouts (MOD-16306).
> 
> **Extends workflow triggers** so closed PRs and pushes on branch `tal.ba/test/baseline` also run image publish logic, alongside existing main/master/release/version branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8133973efa98f99a40dff5e161ec67616a861c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->