### PR TITLE
Tal.ba/fix/fix ubuntu hangups

### DIFF
--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -19,6 +19,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+'
       - 'release/**'
+      - tal.ba/test/baseline
   push:
     branches:
       - main
@@ -26,6 +27,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+'
       - 'release/**'
+      - tal.ba/test/baseline
     paths:
       - 'pack/ramp.yml'
   workflow_dispatch:

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -138,6 +138,11 @@ jobs:
       packages: write
     strategy:
       fail-fast: false
+      # Throttle the fan-out: ~37 images build at once otherwise, and the arm64
+      # subset all pull from ports.ubuntu.com (no CDN) in one synchronized burst,
+      # causing "connection timed out" during apt-get update. Cap concurrency so
+      # we trickle rather than slam the mirror. See MOD-16306.
+      max-parallel: 4
       matrix:
         image: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     env:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow tuning and a temporary-looking branch trigger; no application or security surface changes.
> 
> **Overview**
> Limits **Push Docker Images** matrix concurrency with **`max-parallel: 4`** so arm64 jobs no longer hit `ports.ubuntu.com` in a single large burst (previously ~37 parallel builds), which was causing **`apt-get update` connection timeouts** (MOD-16306).
> 
> Also adds branch **`tal.ba/test/baseline`** to the workflow’s **closed PR** and **push** triggers so image publishing can be exercised on that branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10196a62b27165a7b71d490bcf69472d86c8795d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->