### PR TITLE
Tal.ba/fix/fix ubuntu hangups

### DIFF
--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -144,7 +144,7 @@ jobs:
       # subset all pull from ports.ubuntu.com (no CDN) in one synchronized burst,
       # causing "connection timed out" during apt-get update. Cap concurrency so
       # we trickle rather than slam the mirror. See MOD-16306.
-      max-parallel: 4
+      max-parallel: 8
       matrix:
         image: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     env:
@@ -206,10 +206,15 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build Docker Image
+      - name: Build and Push Docker Image
         if: ${{ steps.check-image.outputs.exists != 'true' }}
         run: |
-          echo "Building ${DOCKER_IMAGE}"
+          echo "Building and pushing ${DOCKER_IMAGE}"
+          # Push straight from buildx (--push) instead of --load + `docker push`.
+          # The load→push round-trip through the docker daemon store intermittently
+          # fails with "unknown blob" (the loaded image references a config/layer
+          # blob the classic pusher can't find). buildx uploads a correct manifest
+          # directly to GHCR. --provenance=false keeps it a plain single-arch image.
           docker buildx build \
             --platform "${DOCKER_PLATFORM}" \
             -f "Dockerfile.${OS}" \
@@ -217,11 +222,6 @@ jobs:
             --build-arg SANITIZER=${{ matrix.image.variant == 'sanitizer' && 'address' || '' }} \
             --build-arg VALGRIND=${{ matrix.image.variant == 'valgrind' && '1' || '' }} \
             -t "${DOCKER_IMAGE}" \
-            --load \
+            --provenance=false \
+            --push \
             .
-
-      - name: Push Docker Image
-        if: ${{ steps.check-image.outputs.exists != 'true' }}
-        run: |
-          echo "Pushing ${DOCKER_IMAGE}"
-          docker push "${DOCKER_IMAGE}"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes only affect GitHub Actions Docker publishing behavior and a temporary test branch trigger, not runtime application code.
> 
> **Overview**
> **CI image publishing** is adjusted to reduce Ubuntu mirror timeouts and flaky GHCR pushes.
> 
> The `push-images` matrix job now sets **`max-parallel: 8`** so arm64 builds don’t all hit `ports.ubuntu.com` at once (MOD-16306). Image publish uses a single **buildx `--push`** step with **`--provenance=false`** instead of **`--load`** plus a separate **`docker push`**, avoiding intermittent **“unknown blob”** failures from the daemon round-trip.
> 
> The workflow also triggers on branch **`tal.ba/test/baseline`** for pull requests and pushes (alongside existing release/main patterns).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95f28bb5b592afe6a30677ed72777c7656f43d45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->