### PR TITLE
fix ubuntu hangs 

### DIFF
--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -19,6 +19,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+'
       - 'release/**'
+      - tal.ba/test/baseline
   push:
     branches:
       - main
@@ -26,6 +27,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+'
       - 'release/**'
+      - tal.ba/test/baseline
     paths:
       - 'pack/ramp.yml'
   workflow_dispatch:

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -144,7 +144,7 @@ jobs:
       # subset all pull from ports.ubuntu.com (no CDN) in one synchronized burst,
       # causing "connection timed out" during apt-get update. Cap concurrency so
       # we trickle rather than slam the mirror. See MOD-16306.
-      max-parallel: 4
+      max-parallel: 8
       matrix:
         image: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     env:
@@ -206,10 +206,15 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build Docker Image
+      - name: Build and Push Docker Image
         if: ${{ steps.check-image.outputs.exists != 'true' }}
         run: |
-          echo "Building ${DOCKER_IMAGE}"
+          echo "Building and pushing ${DOCKER_IMAGE}"
+          # Push straight from buildx (--push) instead of --load + `docker push`.
+          # The load→push round-trip through the docker daemon store intermittently
+          # fails with "unknown blob" (the loaded image references a config/layer
+          # blob the classic pusher can't find). buildx uploads a correct manifest
+          # directly to GHCR. --provenance=false keeps it a plain single-arch image.
           docker buildx build \
             --platform "${DOCKER_PLATFORM}" \
             -f "Dockerfile.${OS}" \
@@ -217,11 +222,6 @@ jobs:
             --build-arg SANITIZER=${{ matrix.image.variant == 'sanitizer' && 'address' || '' }} \
             --build-arg VALGRIND=${{ matrix.image.variant == 'valgrind' && '1' || '' }} \
             -t "${DOCKER_IMAGE}" \
-            --load \
+            --provenance=false \
+            --push \
             .
-
-      - name: Push Docker Image
-        if: ${{ steps.check-image.outputs.exists != 'true' }}
-        run: |
-          echo "Pushing ${DOCKER_IMAGE}"
-          docker push "${DOCKER_IMAGE}"

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -138,6 +138,11 @@ jobs:
       packages: write
     strategy:
       fail-fast: false
+      # Throttle the fan-out: ~37 images build at once otherwise, and the arm64
+      # subset all pull from ports.ubuntu.com (no CDN) in one synchronized burst,
+      # causing "connection timed out" during apt-get update. Cap concurrency so
+      # we trickle rather than slam the mirror. See MOD-16306.
+      max-parallel: 4
       matrix:
         image: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     env:

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -19,7 +19,6 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+'
       - 'release/**'
-      - tal.ba/test/baseline
   push:
     branches:
       - main
@@ -27,7 +26,6 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+'
       - 'release/**'
-      - tal.ba/test/baseline
     paths:
       - 'pack/ramp.yml'
   workflow_dispatch:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow changes; no runtime or application code affected, though publish behavior shifts to direct buildx push.
> 
> **Overview**
> Addresses flaky **Push Docker Images** runs where many matrix jobs start at once and arm64 builds hit **apt** timeouts against `ports.ubuntu.com`, and where **load then push** sometimes fails with **unknown blob**.
> 
> The `push-images` matrix now uses **`max-parallel: 8`** so builds trickle instead of ~37 concurrent jobs hammering the Ubuntu mirror (MOD-16306).
> 
> Missing images are **built and published in one step**: `docker buildx build` uses **`--push`** and **`--provenance=false`** instead of **`--load`** plus a separate **`docker push`**, avoiding the daemon round-trip that broke GHCR uploads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3815a5336fbb2b5cf6e1c83681a0b42309d0046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->