### PR TITLE
MOD-16265 - retry the dumpAndReload() for max 2 sec  so no "Background save already in progress to give enough time to existing rdb save to finish

### DIFF
--- a/tests/flow/test_rdbs.py
+++ b/tests/flow/test_rdbs.py
@@ -99,10 +99,6 @@ def testRDBCompatibilityWithNaN():
     result = None
     ts = int(time.time())
     with env.getConnection() as r:
-        # Disable auto-save so Redis 8.x's default save policy can't fire a BGSAVE that races
-        # dumpAndReload()'s synchronous SAVE -> "Background save already in progress" (MOD-16265).
-        # Scoped to this test's own Env; no test relies on auto-save.
-        r.execute_command("CONFIG", "SET", "save", "")
         key = "rdb_nan_test"
         r.execute_command("ts.create", key)
         for _ in range(1, 1000):
@@ -122,6 +118,12 @@ def testRDBCompatibilityWithNaN():
         result_after = r.execute_command("ts.range", new_key, "-", "+")
         assert result == result_after
 
+        # Wait out any auto-BGSAVE (Redis 8.x default save policy) before dumpAndReload()'s
+        # synchronous SAVE, else they race -> "Background save already in progress" (MOD-16265).
+        # Keeps auto-save enabled; only closes the timing window.
+        deadline = time.time() + 2
+        while r.info("persistence")["rdb_bgsave_in_progress"] and time.time() < deadline:
+            time.sleep(0.1)
         env.dumpAndReload()
         result_after = r.execute_command("ts.range", key, "-", "+")
         assert result == result_after

--- a/tests/flow/test_rdbs.py
+++ b/tests/flow/test_rdbs.py
@@ -99,6 +99,10 @@ def testRDBCompatibilityWithNaN():
     result = None
     ts = int(time.time())
     with env.getConnection() as r:
+        # Disable auto-save so Redis 8.x's default save policy can't fire a BGSAVE that races
+        # dumpAndReload()'s synchronous SAVE -> "Background save already in progress" (MOD-16265).
+        # Scoped to this test's own Env; no test relies on auto-save.
+        r.execute_command("CONFIG", "SET", "save", "")
         key = "rdb_nan_test"
         r.execute_command("ts.create", key)
         for _ in range(1, 1000):

--- a/tests/flow/test_rdbs.py
+++ b/tests/flow/test_rdbs.py
@@ -124,6 +124,8 @@ def testRDBCompatibilityWithNaN():
         deadline = time.time() + 2
         while r.info("persistence")["rdb_bgsave_in_progress"] and time.time() < deadline:
             time.sleep(0.1)
+        assert not r.info("persistence")["rdb_bgsave_in_progress"], \
+            "auto-BGSAVE did not finish within 2s -- possible stuck save, not a race"
         env.dumpAndReload()
         result_after = r.execute_command("ts.range", key, "-", "+")
         assert result == result_after


### PR DESCRIPTION
…s" happens

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only synchronization change with no production or persistence logic changes.
> 
> **Overview**
> Fixes flaky **MOD-16265** failures in `testRDBCompatibilityWithNaN` on Redis 8.x, where the default auto-save policy can start a **BGSAVE** at the same time `dumpAndReload()` triggers a synchronous **SAVE**, producing *"Background save already in progress"*.
> 
> Before `env.dumpAndReload()`, the test now polls `rdb_bgsave_in_progress` for up to **2 seconds** (100ms sleeps), then asserts no background save is active. Auto-save stays enabled; this only closes the timing window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc645e80c555d087ff2b5cd25e5630adf35ae2a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->