### PR TITLE
MOD-17095 Add tls cluster tests leg

### DIFF
--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -152,7 +152,7 @@ jobs:
           read -r -a OS_LIST <<< "$OS"
           if [ "$QUICK" != "true" ] && { [ "$RUN_VALGRIND" == "true" ] || [ "$RUN_SANITIZER" == "true" ] || [ "$SHARD_TOPOLOGIES" == "true" ]; }; then
             for os in "${OS_LIST[@]}"; do
-              for topo in gen slaves aof aof_slaves oss_cluster; do
+              for topo in gen slaves aof aof_slaves oss_cluster tls_cluster; do
                 MATRIX="${MATRIX}{\"os\": \"${os}\", \"topo\": \"${topo}\"},"
               done
             done
@@ -255,6 +255,7 @@ jobs:
             aof)         TOPO_ARGS="GEN=0 SLAVES=0 AOF=1 AOF_SLAVES=0 OSS_CLUSTER=0" ;;
             aof_slaves)  TOPO_ARGS="GEN=0 SLAVES=0 AOF=0 AOF_SLAVES=1 OSS_CLUSTER=0" ;;
             oss_cluster) TOPO_ARGS="GEN=0 SLAVES=0 AOF=0 AOF_SLAVES=0 OSS_CLUSTER=1" ;;
+            tls_cluster) TOPO_ARGS="GEN=0 SLAVES=0 AOF=0 AOF_SLAVES=0 OSS_CLUSTER=0 TLS_CLUSTER=1" ;;
           esac
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -250,11 +250,11 @@ jobs:
           # TOPO keeps the default behaviour (QUICK selects the variants to run).
           TOPO_ARGS=""
           case "${TOPO}" in
-            gen)         TOPO_ARGS="GEN=1 SLAVES=0 AOF=0 AOF_SLAVES=0 OSS_CLUSTER=0" ;;
-            slaves)      TOPO_ARGS="GEN=0 SLAVES=1 AOF=0 AOF_SLAVES=0 OSS_CLUSTER=0" ;;
-            aof)         TOPO_ARGS="GEN=0 SLAVES=0 AOF=1 AOF_SLAVES=0 OSS_CLUSTER=0" ;;
-            aof_slaves)  TOPO_ARGS="GEN=0 SLAVES=0 AOF=0 AOF_SLAVES=1 OSS_CLUSTER=0" ;;
-            oss_cluster) TOPO_ARGS="GEN=0 SLAVES=0 AOF=0 AOF_SLAVES=0 OSS_CLUSTER=1" ;;
+            gen)         TOPO_ARGS="GEN=1 SLAVES=0 AOF=0 AOF_SLAVES=0 OSS_CLUSTER=0 TLS_CLUSTER=0" ;;
+            slaves)      TOPO_ARGS="GEN=0 SLAVES=1 AOF=0 AOF_SLAVES=0 OSS_CLUSTER=0 TLS_CLUSTER=0" ;;
+            aof)         TOPO_ARGS="GEN=0 SLAVES=0 AOF=1 AOF_SLAVES=0 OSS_CLUSTER=0 TLS_CLUSTER=0" ;;
+            aof_slaves)  TOPO_ARGS="GEN=0 SLAVES=0 AOF=0 AOF_SLAVES=1 OSS_CLUSTER=0 TLS_CLUSTER=0" ;;
+            oss_cluster) TOPO_ARGS="GEN=0 SLAVES=0 AOF=0 AOF_SLAVES=0 OSS_CLUSTER=1 TLS_CLUSTER=0" ;;
             tls_cluster) TOPO_ARGS="GEN=0 SLAVES=0 AOF=0 AOF_SLAVES=0 OSS_CLUSTER=0 TLS_CLUSTER=1" ;;
           esac
           docker run --rm \

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ compile_commands.json
 redis/
 temp-redis-config*
 .prepared
+/tests/flow/tls/

--- a/.install/install_redis.sh
+++ b/.install/install_redis.sh
@@ -40,7 +40,10 @@ if [ -n "${VALGRIND}" ]; then
 fi
 # `install` builds `all` first, so a single invocation keeps the compiler flags
 # consistent and avoids a redundant rebuild.
-make SANITIZER=${SANITIZER:-} REDIS_CFLAGS="${REDIS_EXTRA_CFLAGS}" install -j$(nproc)
+# BUILD_TLS=yes so flow tests can exercise TLS (incl. tls-cluster) topologies;
+# TLS ports/certs are opt-in at runtime via redis.conf, so this is a no-op for
+# every other topology.
+make SANITIZER=${SANITIZER:-} REDIS_CFLAGS="${REDIS_EXTRA_CFLAGS}" BUILD_TLS=yes install -j$(nproc)
 cd ..
 
 echo "Redis installed successfully"

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -59,7 +59,7 @@ RHEL_BASE="
 TDNF_BASE="
     ca-certificates wget curl git
     build-essential gcc g++ make cmake autoconf automake libtool clang
-    openssl-devel bzip2-devel libffi-devel zlib-devel readline-devel
+    openssl openssl-devel bzip2-devel libffi-devel zlib-devel readline-devel
     python3 python3-pip python3-devel
     unzip jq tar which
 "

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ make flow_tests    # run tests
   SLAVES=1         # run replication tests on standalone Redis topology
   AOF_SLAVES=1     # run AND and replication tests on standalone Redis topology
   OSS_CLUSTER=1    # run general tests on an OSS Cluster topology
+  TLS_CLUSTER=1    # run general tests on an OSS Cluster topology with TLS (tls-cluster yes)
   SHARDS=num       # run OSS cluster with `num` shards (default: 3)
   RLEC=1           # flow tests on RLEC
   COV=1            # perform coverage analysis
@@ -431,12 +432,17 @@ export AOF_SLAVES ?= 1
 export OSS_CLUSTER ?= 1
 endif
 
+# TLS_CLUSTER is opt-in only (needs a TLS-capable redis-server build + certs),
+# so it stays out of the QUICK/default variant set above.
+export TLS_CLUSTER ?= 0
+
 ifneq ($(RLEC),1)
 
 flow_tests: #$(TARGET)
 	$(SHOW)\
 	MODULE=$(realpath $(TARGET)) \
 	GEN=$(GEN) AOF=$(AOF) SLAVES=$(SLAVES) AOF_SLAVES=$(AOF_SLAVES) OSS_CLUSTER=$(OSS_CLUSTER) \
+	TLS_CLUSTER=$(TLS_CLUSTER) \
 	VALGRIND=$(VALGRIND) \
 	TEST=$(TEST) \
 	$(ROOT)/tests/flow/tests.sh

--- a/tests/flow/generate_tls_certs.sh
+++ b/tests/flow/generate_tls_certs.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -x
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+mkdir -p $HERE/tls
+cd $HERE/tls
+
+openssl genrsa -out ca.key 4096
+openssl req \
+    -x509 -new -nodes -sha256 \
+    -key ca.key \
+    -days 3650 \
+    -subj '/O=Redis Test/CN=Certificate Authority' \
+    -out ca.crt
+openssl genrsa -out redis.key -aes256 -passout pass:foobar 2048
+openssl req \
+    -new -sha256 \
+    -key redis.key \
+    -passin pass:foobar \
+    -subj '/O=Redis Test/CN=Server' | \
+    openssl x509 \
+        -req -sha256 \
+        -CA ca.crt \
+        -CAkey ca.key \
+        -CAserial ca.txt \
+        -CAcreateserial \
+        -days 365 \
+        -out redis.crt
+openssl dhparam -out redis.dh 2048

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -62,6 +62,7 @@ help() {
 		SLAVES=0|1            Replication tests on standalone Redis
 		AOF_SLAVES=0|1        AOF together SLAVES persistency tests on standalone Redis
 		OSS_CLUSTER=0|1       General tests on Redis OSS Cluster
+		TLS_CLUSTER=0|1       General tests on Redis OSS Cluster with TLS (tls-cluster yes)
 		SHARDS=n              Number of shards (default: 3)
 
 		QUICK=1               Perform only one test variant
@@ -540,12 +541,14 @@ if [[ $QUICK != 1 ]]; then
 	AOF=${AOF:-1}
 	AOF_SLAVES=${AOF_SLAVES:-1}
 	OSS_CLUSTER=${OSS_CLUSTER:-1}
+	TLS_CLUSTER=${TLS_CLUSTER:-1}
 else
 	GEN=1
 	SLAVES=0
 	AOF=0
 	AOF_SLAVES=0
 	OSS_CLUSTER=0
+	TLS_CLUSTER=0
 fi
 
 if [[ $RLEC == 1 ]]; then
@@ -554,6 +557,7 @@ if [[ $RLEC == 1 ]]; then
 	AOF=0
 	AOF_SLAVES=0
 	OSS_CLUSTER=0
+	TLS_CLUSTER=0
 fi
 
 #-------------------------------------------------------------------------------- Running tests
@@ -580,6 +584,17 @@ if [[ $OSS_CLUSTER == 1 ]]; then
 		   RLTEST_TEST_ARGS="$RLTEST_TEST_ARGS_1" \
 		   run_tests "tests on OSS cluster with password"); (( E |= $? )); } || true
 	fi
+fi
+
+if [[ $TLS_CLUSTER == 1 ]]; then
+	TLS_DIR=$HERE/tls
+	if [[ ! -f $TLS_DIR/redis.crt ]]; then
+		bash $HERE/generate_tls_certs.sh
+	fi
+	{ (RLTEST_ARGS="${RLTEST_ARGS} --cluster_node_timeout 60000 --env oss-cluster --shards-count $SHARDS \
+			--tls --tls-cert-file $TLS_DIR/redis.crt --tls-key-file $TLS_DIR/redis.key \
+			--tls-ca-cert-file $TLS_DIR/ca.crt --tls-passphrase foobar" \
+		run_tests "tests on OSS cluster with TLS"); (( E |= $? )); } || true
 fi
 
 if [[ $RLEC == 1 ]]; then


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test and CI infrastructure only; TLS Redis build is documented as inert for non-TLS topologies, with no production runtime behavior changes.
> 
> **Overview**
> Introduces a **`TLS_CLUSTER`** flow-test variant that runs the general suite against an OSS cluster over TLS, alongside existing topologies (gen, slaves, AOF, OSS cluster, etc.). **`TLS_CLUSTER` stays off for `QUICK=1` and defaults to `0` in the Makefile** so normal/quick runs are unchanged; full non-quick runs enable it via `tests.sh`.
> 
> When enabled, **`tests/flow/tests.sh`** generates certs under `tests/flow/tls/` (via new **`generate_tls_certs.sh`**, gitignored) if missing, then invokes RLTest with `--tls` and cert/key/CA/passphrase flags on the OSS cluster env. **`make flow_tests`** documents and forwards `TLS_CLUSTER=1`.
> 
> **CI (`flow-linux.yml`)** adds a **`tls_cluster`** shard when topologies are split (valgrind/sanitizer/shard mode), with explicit `TLS_CLUSTER=1` / other flags cleared per shard. **Redis is built with `BUILD_TLS=yes`** in **`install_redis.sh`** so the server can speak TLS at runtime when tests opt in.
> 
> **Azure Linux / tdnf** package list gains **`openssl`** alongside **`openssl-devel`** for TLS tooling during image setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21dab75f21b92f0b440afa2bf00e7c1093769a82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->