### PR TITLE
MOD-17016 Disable topology events handling in ts under RE (for now)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -48,7 +48,7 @@ void InitConfig(void) {
     TSGlobalConfig.options = SERIES_OPT_DEFAULT_COMPRESSION;
     TSGlobalConfig.libmrProtocol = LIBMR_PROTOCOL_DEFAULT;
     TSGlobalConfig.password = NULL;
-    TSGlobalConfig.topologyEvents = true;
+    TSGlobalConfig.topologyEvents = !RTS_IsEnterprise();
 
     if (getConfigStringCache) {
         RedisModule_FreeString(rts_staticCtx, getConfigStringCache);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line default change at module init; behavior on OSS is unchanged and Enterprise users can still enable topology events via config.
> 
> **Overview**
> **Topology events** now default **off** when RedisTimeSeries runs on **Redis Enterprise**, and stay **on** on OSS.
> 
> `InitConfig()` sets `TSGlobalConfig.topologyEvents` to `!RTS_IsEnterprise()` instead of always `true`, so cluster topology handling is skipped under RE until that path is supported. The `ts-topology-events` option can still override this after startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6365f2c8ff1db78d346c54edd77ed3b0a9cf52b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->