### PR TITLE
MOD-16382 Test gated CLUSTERSET preserves topology

### DIFF
--- a/tests/flow/test_topology_events.py
+++ b/tests/flow/test_topology_events.py
@@ -42,6 +42,24 @@ def test_failover():
         validate_queries_during_failovers(env, post_failover, COMMAND, validate_result)
 
 
+def test_clusterset_after_topology_event_keeps_current_topology():
+    env = Env(shardsCount=3, decodeResponses=True, skipRefreshCluster=True)
+    skip_if_needed(env)
+
+    wait_for_valid_cluster(env)
+    wait_for_valid_ts_infocluster(env)
+
+    conn = env.getConnection(0)
+    expected = ts_cluster_from_conn(conn)
+
+    # CLUSTERSET is obsolete after topology events take over, so it should be
+    # ignored without freeing the topology that was installed by the event.
+    assert conn.execute_command("timeseries.CLUSTERSET") == "OK"
+    actual = ts_cluster_from_conn(conn)
+    assert actual is not None, "CLUSTERSET discarded the topology installed by the event"
+    assert compare_clusters(expected, actual)
+
+
 # Helpers:
 
 NUMBER_OF_KEYS = 1000 if not (VALGRIND or SANITIZER) else 100
@@ -154,6 +172,8 @@ def ts_cluster_from_conn(conn):
     or None if its slots don't fully and uniquely cover the keyspace."""
     conn.execute_command("debug", "MARK-INTERNAL-CLIENT")
     reply = conn.execute_command("timeseries.INFOCLUSTER")
+    if reply == "no cluster mode":
+        return None
     nodes = {}
     total = 0
     min_start = NUMBER_OF_SLOTS


### PR DESCRIPTION
Based on #2121, now merged into `master`.

Uses RedisGears/LibMR#119, now merged into `LibMR/master` as `6ac15616`.

## Problem

After a topology event installed `CurrCluster`, an obsolete `timeseries.CLUSTERSET` was gated off by LibMR—but only after `MR_SetClusterData()` had already freed the current topology.

## Changes

- Pin LibMR to current `master` commit `6ac15616`, containing RedisGears/LibMR#119.
- Add a focused OSS-cluster flow test that waits for event-installed topology, sends short-form `CLUSTERSET`, and verifies the topology is unchanged.
- Let the `INFOCLUSTER` parser return its documented `None` result for `no cluster mode`, producing a direct regression assertion.

## Red/green validation

Using the topology-event Redis build with three OSS shards:

- LibMR `55b5f5e`: fails with `CLUSTERSET discarded the topology installed by the event`.
- LibMR `6ac15616` (`master`): passes, 1/1 tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in the OSS-cluster flow suite; no production code paths modified in this diff.
> 
> **Overview**
> Adds **`test_clusterset_after_topology_event_keeps_current_topology`** in the topology-events flow suite. After the cluster and **`timeseries.INFOCLUSTER`** agree on event-driven topology, the test issues short-form **`timeseries.CLUSTERSET`** and asserts the parsed topology is unchanged—covering the case where LibMR should ignore obsolete CLUSTERSET instead of freeing **`CurrCluster`**.
> 
> Updates **`ts_cluster_from_conn`** so a **`no cluster mode`** **`INFOCLUSTER`** reply returns **`None`**, matching the helper’s documented contract and enabling a direct assertion when CLUSTERSET incorrectly clears topology.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b1d80422bdc04b1ee8b3b904cc200ea542e2e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->