### PR TITLE
MOD-17289 Suppress x86-only Valgrind false positive in MR_BuildCluster

### DIFF
--- a/tests/memcheck/redis_valgrind.sup
+++ b/tests/memcheck/redis_valgrind.sup
@@ -183,3 +183,21 @@
     fun:connSocketEventHandler
     fun:aeProcessEvents
 }
+
+# MOD-17289: x86-only Valgrind false positive. On the topology-change rebuild path
+# (ClusterTopologyChangeCallback -> MR_UpdateClusterTopology -> MR_BuildCluster,
+# LibMR src/cluster.c), memcheck reports "Conditional jump depends on uninitialised
+# value(s)" at the `if (cluster->slots[k] != NULL)` slot-range scan. This does NOT
+# reproduce on aarch64 under the identical -O0 build with --track-origins and no
+# suppressions (the topology path runs, valgrind is active, 0 errors), and the C has
+# no uninitialised read: `cluster` is MR_CALLOC'd (slots zeroed), the slot ranges come
+# from zcalloc'd RedisModule_GetClusterNodeSlotRanges, and every Node field is set via
+# a designated initializer. It is an x86-64 codegen/memcheck-tracking artifact, not a
+# defect. Scoped tightly to this exact call stack so it cannot mask an unrelated issue.
+{
+   <MOD-17289 MR_BuildCluster x86-only Cond false positive (topology-change rebuild)>
+   Memcheck:Cond
+   fun:MR_BuildCluster
+   fun:MR_UpdateClusterTopology
+   fun:ClusterTopologyChangeCallback
+}


### PR DESCRIPTION
## Summary

Test-only fix for the red `linux-valgrind` cluster legs on `master` (MOD-17289). Memcheck reports *"Conditional jump depends on uninitialised value(s)"* at `MR_BuildCluster` (LibMR `cluster.c:1156`, the `if (cluster->slots[k] != NULL)` slot-range scan) on the topology-change rebuild path (`ClusterTopologyChangeCallback` → `MR_UpdateClusterTopology` → `MR_BuildCluster`). The flow tests pass — only the memcheck warning fails the job.

Adds one tightly-scoped entry to `tests/memcheck/redis_valgrind.sup`. **No product/runtime code changes** — the compiled module is byte-identical; the suppression applies only at valgrind test time.

## Why it's a false positive — proven by a positive control

I injected a *deliberate* uninitialised read into `MR_BuildCluster` (`volatile int p; if (p == 0x0BADF00D)`), rebuilt ARM `-O0`, and ran redis under `valgrind --track-origins=yes` with **no suppressions**:

- ARM valgrind **flagged the injected read** — same `Memcheck:Cond`, same stack `MR_BuildCluster ← MR_UpdateClusterTopology ← ClusterTopologyChangeCallback` as the CI failure.
- The **real** `if (cluster->slots[k] != NULL)` line was **not** flagged (0 hits).

⇒ ARM valgrind demonstrably detects uninitialised reads in this exact function, and stays silent on the real code. An uninitialised-variable use in C is architecture-independent, so a real one would fire on ARM too. It doesn't → there is **no uninitialised-read defect in the source**.

Corroborating evidence:
- **Code:** `cluster` is `MR_CALLOC`'d (slots zeroed); ranges come from `zcalloc`'d `RedisModule_GetClusterNodeSlotRanges`; every `Node` field is set via a designated initializer; `flags` is set before its first use.
- **Faithful ARM repro:** multi-shard `TS.MRANGE` (`parseMRangeCommand`, the reported origin) interleaved with reshards, valgrind active (19 procs), `ERROR SUMMARY: 0 errors`.
- **Cross-compiled x86 vs ARM disassembly** of line 1156: identical, clean single load of the zeroed `slots[k]` + compare — no x86 speculative/wide/vectorised load.

## What is NOT pinned (in the interest of honesty)

The exact x86 memcheck trigger is **not** identified. The codegen is clean on both arches, so it's most likely a memcheck x86 shadow-memory tracking quirk rather than a codegen artifact. The one artifact that would show the exact instruction — CI's prebuilt x86 module — is behind ghcr auth. This does not change the conclusion: the positive control proves there is no real uninitialised read to fix.

## Confirmation

Flow Linux run [30358767689](https://github.com/RedisTimeSeries/RedisTimeSeries/actions/runs/30358767689) (x64-jammy, `run_valgrind=true`): both previously-red legs — `x64-jammy-oss_cluster` and `x64-jammy-tls_cluster` — now **pass**. This branch differs from `master` only by the `.sup` entry, so the green is attributable to the suppression.

## Scope / safety

Scoped to the exact 3-frame call stack, so it cannot mask an unrelated uninitialised read. Full evidence + the reusable ARM-valgrind repro recipe are on MOD-17289. Relates to MOD-16382, MOD-16399.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/test-only Valgrind suppression with a narrow call-stack match; no compiled module or production behavior changes.
> 
> **Overview**
> **Test-only** change to unblock failing `linux-valgrind` cluster CI legs (MOD-17289). Adds a **tightly scoped** Valgrind suppression in `tests/memcheck/redis_valgrind.sup` for a `Memcheck:Cond` at `MR_BuildCluster` on the topology rebuild stack (`ClusterTopologyChangeCallback` → `MR_UpdateClusterTopology` → `MR_BuildCluster`).
> 
> **No runtime/product code changes** — only memcheck test configuration. The new block is documented in-file as an x86-64 false positive that does not reproduce on aarch64 with `--track-origins` and no suppressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d175f87474867a88cd7695e4d7360707a0d4607. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->