### PR TITLE
MOD-17350 Fix TS.CREATERULE advertised arity (-5 -> -6)

### DIFF
--- a/src/cmd_info/ts_info.c
+++ b/src/cmd_info/ts_info.c
@@ -624,7 +624,10 @@ static const RedisModuleCommandInfo TS_CREATERULE_INFO = {
     .summary = "Create a compaction rule",
     .complexity = "O(1)",
     .since = "1.0.0",
-    .arity = -5,
+    // TS.CREATERULE sourceKey destKey AGGREGATION aggregator bucketDuration
+    // [alignTimestamp] -- 6 tokens minimum, matching the argc != 6 && argc != 7
+    // check in TSDB_createRule
+    .arity = -6,
     .key_specs = (RedisModuleCommandKeySpec *)TS_CREATERULE_KEYSPECS,
     .args = (RedisModuleCommandArg *)TS_CREATERULE_ARGS,
 };

--- a/tests/flow/test_cmd_info.py
+++ b/tests/flow/test_cmd_info.py
@@ -43,7 +43,7 @@ class testCommandDocsAndHelp():
         with env.getClusterConnectionIfNeeded() as r:
             res = r.execute_command('COMMAND', 'INFO', 'TS.CREATERULE')
             assert res
-            assert_docs(env, 'TS.CREATERULE', summary='Create a compaction rule', complexity='O(1)', arity='-5', since='1.0.0', group='module')
+            assert_docs(env, 'TS.CREATERULE', summary='Create a compaction rule', complexity='O(1)', arity='-6', since='1.0.0', group='module')
 
     def test_command_info_ts_range(self):
         env = self.env

--- a/tests/unit/unittests_cmd_info.c
+++ b/tests/unit/unittests_cmd_info.c
@@ -57,7 +57,7 @@ MU_TEST(test_ts_create_command_info_structure) {
 MU_TEST(test_ts_createrule_command_info_structure) {
     // Test that TS_CREATERULE_INFO has correct basic properties
     mu_check(TS_CREATERULE_INFO.version == REDISMODULE_COMMAND_INFO_VERSION);
-    mu_check(TS_CREATERULE_INFO.arity == -5); // At least 5 arguments: TS.CREATERULE sourceKey destKey AGGREGATION aggregator bucketDuration
+    mu_check(TS_CREATERULE_INFO.arity == -6); // At least 6 arguments: TS.CREATERULE sourceKey destKey AGGREGATION aggregator bucketDuration
     mu_check(TS_CREATERULE_INFO.since != NULL);
     mu_check(strcmp(TS_CREATERULE_INFO.since, "1.0.0") == 0);
     mu_check(TS_CREATERULE_INFO.summary != NULL);


### PR DESCRIPTION
## What

`TS.CREATERULE` advertises `arity = -5`, but its handler requires **6** tokens. The advertised arity is one too permissive.

`src/cmd_info/ts_info.c`:
```c
.arity = -5,
```

`src/module.c` — `TSDB_createRule`:
```c
if (argc != 6 && argc != 7) {
    return RedisModule_WrongArity(ctx);
}
```

The minimum valid invocation is `TS.CREATERULE sourceKey destKey AGGREGATION aggregator bucketDuration` = 6 tokens (`[alignTimestamp]` is the optional 7th).

`RegisterCommandWithModesAndAcls` → `__rmutil_register_cmd` does not pass an arity to `RedisModule_CreateCommand` (that API has no arity parameter), so `RedisModule_SetCommandInfo` is the only thing that sets the advertised arity.

## Impact

With `-5`, a 5-token call such as `TS.CREATERULE a b AGGREGATION avg` passes the server's own arity gate and reaches the module, which then rejects it. With `-6` the server rejects it up front, and clients that validate against the advertised arity no longer accept a call the server will refuse.

## Changes

- `src/cmd_info/ts_info.c` — `.arity = -5` → `-6`, with a comment tying the value to the handler's check.
- `tests/unit/unittests_cmd_info.c` — `test_ts_createrule_command_info_structure` asserted `-5`, locking in the wrong value; tightened to `-6`.
- `tests/flow/test_cmd_info.py` — `test_command_info_ts_createrule` asserted `arity='-5'`; updated to `'-6'`. (This assertion is dormant in practice: `COMMAND DOCS` does not report arity.)

## Verification

- Unit test compiles clean (`clang -fsyntax-only`); flow test compiles.
- Confirmed only `TS_CREATERULE_INFO` changed — `TS.NRANGE`/`TS.NREVRANGE` also use `-5` and are untouched.
- Audited every `TS.CREATERULE` call site in `tests/flow`: none uses exactly 5 tokens, so no existing expectation changes. The zero-argument call in `test_negative.py` still raises `ResponseError`.

Found during a cross-artifact audit of command metadata while fixing #2127 / MOD-17349; kept separate from that PR because this one changes advertised command metadata.

Jira: [MOD-17350](https://redislabs.atlassian.net/browse/MOD-17350)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MOD-17350]: https://redislabs.atlassian.net/browse/MOD-17350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only fix for command arity; no changes to TSDB_createRule or compaction logic.
> 
> **Overview**
> Aligns **`TS.CREATERULE`** command metadata with the real handler: **`TS_CREATERULE_INFO.arity`** changes from **`-5`** to **`-6`**, with a comment pointing at **`TSDB_createRule`**’s `argc != 6 && argc != 7` check (minimum six tokens through `bucketDuration`, optional seventh `alignTimestamp`).
> 
> Unit and flow tests that assert command info for **`TS.CREATERULE`** are updated to expect **`-6`**. No command implementation or runtime behavior changes beyond what Redis advertises for arity validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c657b8a8b371ce842f4cd4d4e6c71add8708ac31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->