### PR TITLE
MOD-17209 Port missing topology-event tests and hunt for UAFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ wordlist.dic
 /1/
 *.clangd
 compile_commands.json
-
+tags
 .venv
 redis/
 temp-redis-config*

--- a/tests/flow/test_topology_events.py
+++ b/tests/flow/test_topology_events.py
@@ -52,17 +52,20 @@ def test_add_and_remove_node():
     before = wait_for_valid_cluster(env)
     validate_before_addition(before, wait_for_valid_ts_infocluster(env))
 
-    # Add a new node
-    env.addShardToClusterIfExists()
-    env.shardsCount = env.envRunner.shardsCount
+    cycles = 10
+    for _ in range(cycles):
+        # Add a new node
+        env.addShardToClusterIfExists()
+        env.shardsCount = env.envRunner.shardsCount
 
-    after_addition = wait_for_valid_cluster(env)
-    validate_after_addition(after_addition, wait_for_valid_ts_infocluster(env), before)
+        after_addition = wait_for_valid_cluster(env)
+        validate_after_addition(after_addition, wait_for_valid_ts_infocluster(env), before)
 
-    (new_node_id,) = set(after_addition) - set(before)
-    remove_slotless_node(env, new_node_id)
+        # Remove it, restoring the initial cluster
+        (new_node_id,) = set(after_addition) - set(before)
+        remove_slotless_node(env, new_node_id)
 
-    validate_after_removal(wait_for_valid_cluster(env), wait_for_valid_ts_infocluster(env), before)
+        validate_after_removal(wait_for_valid_cluster(env), wait_for_valid_ts_infocluster(env), before)
 
 
 def test_asm():

--- a/tests/flow/test_topology_events.py
+++ b/tests/flow/test_topology_events.py
@@ -142,6 +142,15 @@ def validate_result(result):
     assert all(int(sample[1]) == NUMBER_OF_KEYS for sample in samples)
 
 
+def random_master_node(env):
+    masters = [
+        node
+        for node in map(ClusterNode.from_str, env.getConnection(0).execute_command("CLUSTER", "NODES").splitlines())
+        if "master" in node.flags
+    ]
+    return random.choice(masters)
+
+
 def validate_queries_during_failovers(env, post_failover, command, validate_result):
     TOPOLOGY_CHANGED_ERROR = "A multi-shard command failed because the cluster topology has changed"
     # Clients of multi-shard commands are blocked. If a node that serves such a command is demoted
@@ -159,21 +168,14 @@ def validate_queries_during_failovers(env, post_failover, command, validate_resu
     def connection_of(ip, port):
         return redis.Redis(host=ip, port=port, decode_responses=True)
 
-    def random_master_conn():
-        masters = [
-            node
-            for node in map(ClusterNode.from_str, env.getConnection(0).execute_command("CLUSTER", "NODES").splitlines())
-            if "master" in node.flags
-        ]
-        node = random.choice(masters)
-        return connection_of(node.ip, node.port)
-
     def strict_validation(env):
-        validate_result(random_master_conn().execute_command(command))
+        node = random_master_node(env)
+        validate_result(connection_of(node.ip, node.port).execute_command(command))
 
     def tolerable_validation(env):
+        node = random_master_node(env)
         try:
-            result = random_master_conn().execute_command(command)
+            result = connection_of(node.ip, node.port).execute_command(command)
         except redis.exceptions.ResponseError as x:
             assert str(x) in (TOPOLOGY_CHANGED_ERROR, UNBLOCKED_ERROR, CLUSTERDOWN_ERROR, SLOT_RANGES_ERROR), str(x)
             return

--- a/tests/flow/test_topology_events.py
+++ b/tests/flow/test_topology_events.py
@@ -379,9 +379,10 @@ def wait_for_valid_ts_infocluster(env):
     while True:
         try:
             clusters = [ts_cluster_from_conn(env.getConnection(i)) for i in range(env.shardsCount)]
-        except redis.exceptions.ClusterDownError:
+        except redis.exceptions.ResponseError as x:
             # A just-rejoined master's cluster state is transiently 'fail', so INFOCLUSTER is rejected;
             # keep polling until it turns healthy.
+            assert str(x) == CLUSTERDOWN_ERROR, str(x)
             clusters = None
         if clusters is not None and all(clusters) and all(compare_clusters(clusters[0], c) for c in clusters[1:]):
             return clusters[0]

--- a/tests/flow/test_topology_events.py
+++ b/tests/flow/test_topology_events.py
@@ -13,8 +13,25 @@ from utils import (
     failover_node,
     added_slaves_to_cluster,
     get_timeout,
+    dump_cluster_nodes,
 )
 from test_asm import validate_queries_during_migrations
+
+
+def test_add_node():
+    env = Env(shardsCount=2, decodeResponses=True, skipRefreshCluster=True)
+    skip_if_needed(env)
+
+    wait_for_valid_cluster(env)
+    print("\n===== before the addition =====")
+    dump_cluster_nodes(env)
+
+    env.addShardToClusterIfExists()
+    env.shardsCount = env.envRunner.shardsCount
+
+    wait_for_valid_cluster(env)
+    print("\n===== after the addition =====")
+    dump_cluster_nodes(env)
 
 
 def test_asm():
@@ -27,6 +44,7 @@ def test_asm():
 
     fill_some_data(env)
     validate_queries_during_migrations(env, post_migration, COMMAND, validate_result)
+
 
 def test_failover():
     env = Env(shardsCount=3, decodeResponses=True, skipRefreshCluster=True)
@@ -76,6 +94,7 @@ def skip_if_needed(env):
     # query within LibMR's 5s max-idle during migration churn (MOD-14615 residual).
     if RUNNER_LABEL == "macos-15-intel":
         env.skip()
+
 
 def fill_some_data(env):
     fill_ts_data(env, NUMBER_OF_KEYS, SAMPLES_PER_KEY, label1=17, label2=19)

--- a/tests/flow/test_topology_events.py
+++ b/tests/flow/test_topology_events.py
@@ -23,10 +23,6 @@ def test_add_and_remove_node():
     env = Env(shardsCount=2, decodeResponses=True, skipRefreshCluster=True)
     skip_if_needed(env)
 
-    @functools.cache
-    def connection_of(ip, port):
-        return redis.Redis(host=ip, port=port, decode_responses=True)
-
     def node_summary(view):
         # {node_id: (ip, port, slots)} for a {node_id: ClusterNode} view - the node identity we compare.
         return {node_id: (node.ip, node.port, node.slots) for node_id, node in view.items()}
@@ -56,13 +52,15 @@ def test_add_and_remove_node():
     before = wait_for_valid_cluster(env)
     validate_before_addition(before, wait_for_valid_ts_infocluster(env))
 
-    original_masters = list(before.values())
+    # Connections to the original nodes only, snapshotted before any node is added: we don't risk
+    # racing with the added node so choose from OGs. env.getConnection carries the env's TLS config.
+    original_conns = [env.getConnection(i) for i in range(env.shardsCount)]
     fill_some_data(env)
 
     def tolerable_data_validation():
-        random_node = random.choice(original_masters)  # we don't risk racing with the added node so choose from OGs
+        conn = random.choice(original_conns)
         try:
-            result = connection_of(random_node.ip, random_node.port).execute_command(COMMAND)
+            result = conn.execute_command(COMMAND)
         except redis.exceptions.ResponseError as x:
             assert str(x) == TOPOLOGY_CHANGED_ERROR, str(x)
             return
@@ -112,7 +110,7 @@ def test_asm():
 def test_failover():
     env = Env(shardsCount=3, decodeResponses=True, skipRefreshCluster=True)
     skip_if_needed(env)
-    if env.useTLS:
+    if env.useTLS:  # The added slaves do support TLS (for now; will be resolved by MOD-17386)
         env.skip()
 
     def post_failover(env):

--- a/tests/flow/test_topology_events.py
+++ b/tests/flow/test_topology_events.py
@@ -1,6 +1,7 @@
 import time
 import random
 import threading
+import functools
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from includes import *
 from utils import (
@@ -151,7 +152,9 @@ def validate_queries_during_failovers(env, post_failover, command, validate_resu
     # id changes) and momentarily see a slot as unavailable, so we also expect this:
     SLOT_RANGES_ERROR = "Query requires unavailable slots"
 
-    master_conns = {}
+    @functools.cache
+    def connection_of(ip, port):
+        return redis.Redis(host=ip, port=port, decode_responses=True)
 
     def random_master_conn():
         masters = [
@@ -160,9 +163,7 @@ def validate_queries_during_failovers(env, post_failover, command, validate_resu
             if "master" in node.flags
         ]
         node = random.choice(masters)
-        return master_conns.setdefault(
-            (node.ip, node.port), redis.Redis(host=node.ip, port=node.port, decode_responses=True)
-        )
+        return connection_of(node.ip, node.port)
 
     def strict_validation(env):
         validate_result(random_master_conn().execute_command(command))

--- a/tests/flow/test_topology_events.py
+++ b/tests/flow/test_topology_events.py
@@ -74,6 +74,8 @@ def test_add_and_remove_node():
     def add_remove_cycles(done):
         cycles = 10
         for _ in range(cycles):
+            if done.is_set():
+                return
             # Add a new node
             env.addShardToClusterIfExists()
             env.shardsCount = env.envRunner.shardsCount
@@ -117,6 +119,8 @@ def test_take_node_down_and_up():
         cycles = 10
         round_robin_on = [shard for shard in env.envRunner.shards if shard is not untouchable]
         for cycle in range(cycles):
+            if done.is_set():
+                return
             victim = round_robin_on[cycle % len(round_robin_on)]
             time.sleep(1)  # let the node some time to work on subtasks
             victim.stopEnv()

--- a/tests/flow/test_topology_events.py
+++ b/tests/flow/test_topology_events.py
@@ -193,6 +193,7 @@ CLUSTERDOWN_ERROR = "CLUSTERDOWN The cluster is down"
 # id changes) and momentarily see a slot as unavailable, so we also expect this:
 SLOT_RANGES_ERROR = "Query requires unavailable slots"
 # While a peer master is down its slots go unreachable, so the fan-out can time out waiting for that shard:
+# This error is currently swallowed when a node comes down and up again, but should be removed as part of MOD-17548.
 SHARD_TIMEOUT_ERROR = "A multi-keys command failed because at least one shard did not reply within the given timeframe."
 
 

--- a/tests/flow/test_topology_events.py
+++ b/tests/flow/test_topology_events.py
@@ -64,7 +64,7 @@ def test_add_and_remove_node():
         try:
             result = connection_of(random_node.ip, random_node.port).execute_command(COMMAND)
         except redis.exceptions.ResponseError as x:
-            assert str(x) in (TOPOLOGY_CHANGED_ERROR, SLOT_RANGES_ERROR), str(x)
+            assert str(x) == TOPOLOGY_CHANGED_ERROR, str(x)
             return
         validate_result(result)
 

--- a/tests/flow/test_topology_events.py
+++ b/tests/flow/test_topology_events.py
@@ -1,8 +1,6 @@
 import time
 import random
-import threading
 import functools
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from includes import *
 from utils import (
     fill_ts_data,
@@ -15,6 +13,9 @@ from utils import (
     added_slaves_to_cluster,
     get_timeout,
     remove_slotless_node,
+    dump_node_cluster_nodes,
+    dump_node_infocluster,
+    run_until_first_finishes,
 )
 from test_asm import validate_queries_during_migrations
 
@@ -66,13 +67,11 @@ def test_add_and_remove_node():
             return
         validate_result(result)
 
-    done = threading.Event()
-
-    def validate_data_in_a_loop():
+    def validate_data_in_a_loop(done):
         while not done.is_set():
             tolerable_data_validation()
 
-    def add_remove_cycles():
+    def add_remove_cycles(done):
         cycles = 10
         for _ in range(cycles):
             # Add a new node
@@ -88,11 +87,45 @@ def test_add_and_remove_node():
 
             validate_after_removal(wait_for_valid_cluster(env), wait_for_valid_ts_infocluster(env), before)
 
-    with ThreadPoolExecutor() as executor:
-        futures = map(executor.submit, [validate_data_in_a_loop, add_remove_cycles])
-        for future in as_completed(futures):
-            done.set()  # the cycles thread finished (or raised); stop the endless data validator
-            future.result()
+    run_until_first_finishes(validate_data_in_a_loop, add_remove_cycles)
+
+
+def test_take_node_down_and_up():
+    env = Env(shardsCount=3, decodeResponses=True, skipRefreshCluster=True)
+    skip_if_needed(env)
+
+    wait_for_valid_cluster(env)
+    wait_for_valid_ts_infocluster(env)
+
+    # An untouchable node: it is never stopped and we use it for the data validations
+    untouchable = env.envRunner.shards[0]
+    fill_some_data(env)
+
+    def tolerable_data_validation():
+        try:
+            result = untouchable.getConnection().execute_command(COMMAND)
+        except redis.exceptions.ResponseError as x:
+            assert str(x) in (TOPOLOGY_CHANGED_ERROR, SLOT_RANGES_ERROR, CLUSTERDOWN_ERROR, SHARD_TIMEOUT_ERROR), str(x)
+            return
+        validate_result(result)
+
+    def validate_data_in_a_loop(done):
+        while not done.is_set():
+            tolerable_data_validation()
+
+    def node_down_up_cycles(done):
+        cycles = 10
+        round_robin_on = [shard for shard in env.envRunner.shards if shard is not untouchable]
+        for cycle in range(cycles):
+            victim = round_robin_on[cycle % len(round_robin_on)]
+            time.sleep(1)  # let the node some time to work on subtasks
+            victim.stopEnv()
+            wait_for_down_state_view_agreement(env, victim)
+            victim.startEnv()
+            wait_for_valid_cluster(env)
+            wait_for_valid_ts_infocluster(env)
+
+    run_until_first_finishes(validate_data_in_a_loop, node_down_up_cycles)
 
 
 def test_asm():
@@ -159,6 +192,8 @@ CLUSTERDOWN_ERROR = "CLUSTERDOWN The cluster is down"
 # A multi-shard fan-out can race slot-ownership propagation during a failover (the owning node's
 # id changes) and momentarily see a slot as unavailable, so we also expect this:
 SLOT_RANGES_ERROR = "Query requires unavailable slots"
+# While a peer master is down its slots go unreachable, so the fan-out can time out waiting for that shard:
+SHARD_TIMEOUT_ERROR = "A multi-keys command failed because at least one shard did not reply within the given timeframe."
 
 
 def skip_if_needed(env):
@@ -216,25 +251,19 @@ def validate_queries_during_failovers(env, post_failover, command, validate_resu
 
     strict_validation(env)
 
-    done = threading.Event()
-
-    def validate_command_in_a_loop():
+    def validate_command_in_a_loop(done):
         while not done.is_set():
             tolerable_validation(env)
 
-    def failover_back_and_forth():
-        failover_all_slaves(env, validate_after_failover)
-        failover_all_slaves(env, validate_after_failover)
-
-    with ThreadPoolExecutor() as executor:
+    def failover_back_and_forth(done):
         # Just one round-robin and back, unfortunately. We can't loop this since redis rate-limits
         # failover votes to once per 2*cluster-node-timeout per demoted primary, so a second cycle
         # would have to wait out that cooldown period before it could failover the same nodes again.
         # This will make the test too long.
-        futures = map(executor.submit, [validate_command_in_a_loop, failover_back_and_forth])
-        for future in as_completed(futures):
-            done.set()
-            future.result()
+        failover_all_slaves(env, validate_after_failover)
+        failover_all_slaves(env, validate_after_failover)
+
+    run_until_first_finishes(validate_command_in_a_loop, failover_back_and_forth)
 
     strict_validation(env)
 
@@ -250,6 +279,52 @@ def failover_all_slaves(env, validator=None):
         if validator is not None:
             print(f"\n----- master {master.ip}:{master.port} failed over to replica {replica.ip}:{replica.port} -----")
             validator(env)
+
+
+def redis_master_addrs(conn):
+    """{node_id: (ip, port)} for master nodes as seen in CLUSTER NODES (a fail-flagged master still counts)."""
+    return {
+        node.id: (node.ip, node.port)
+        for node in map(ClusterNode.from_str, conn.execute_command("CLUSTER", "NODES").splitlines())
+        if "master" in node.flags
+    }
+
+
+def ts_master_addrs(conn):
+    """{node_id: (ip, port)} for master nodes in timeseries.INFOCLUSTER, ignoring slots (unlike
+    ts_cluster_from_conn there is no full-coverage gate, so this works while a master is down)."""
+    conn.execute_command("debug", "MARK-INTERNAL-CLIENT")
+    reply = conn.execute_command("timeseries.INFOCLUSTER")
+    if reply == "no cluster mode":
+        return None
+    addrs = {}
+    for node in reply[4]:
+        fields = {key: val for key, val in zip(node[::2], node[1::2]) if key not in ("minHslot", "maxHslot")}
+        addrs[fields["id"]] = (fields["ip"], int(fields["port"]))
+    return addrs
+
+
+def wait_for_down_state_view_agreement(env, victim):
+    # While the victim shard is down, wait until the surviving nodes' redis and timeseries views agree
+    # on the same set of nodes (ignoring slots, which are in flux while a node is down).
+    up_shards = [shard for shard in env.envRunner.shards if shard is not victim]
+    deadline = time.time() + get_timeout()
+    while True:
+        conns = [shard.getConnection() for shard in up_shards]
+        redis_views = [redis_master_addrs(c) for c in conns]
+        ts_views = [ts_master_addrs(c) for c in conns]
+        if (
+            all(v == redis_views[0] for v in redis_views[1:])
+            and all(v == ts_views[0] for v in ts_views[1:])
+            and redis_views[0] == ts_views[0]
+        ):
+            return
+        if time.time() >= deadline:
+            for conn in conns:
+                dump_node_cluster_nodes(conn)
+                dump_node_infocluster(conn)
+            assert False, "redis and timeseries master views did not agree while a node was down"
+        time.sleep(0.2)
 
 
 def ts_cluster_from_conn(conn):
@@ -292,15 +367,18 @@ def ts_cluster_from_conn(conn):
 
 
 def wait_for_valid_ts_infocluster(env):
-    """Wait until every node's timeseries.INFOCLUSTER reports full coverage and all nodes agree.
-
-    Returns the agreed topology as a {node_id: ClusterNode} dict (the first polled node's view).
-    """
+    # Wait until every node's timeseries.INFOCLUSTER reports full coverage and all nodes agree.
+    # Returns the agreed topology as a {node_id: ClusterNode} dict (the first polled node's view).
     timeout = get_timeout()
     deadline = time.time() + timeout
     while True:
-        clusters = [ts_cluster_from_conn(env.getConnection(i)) for i in range(env.shardsCount)]
-        if all(c is not None for c in clusters) and all(compare_clusters(clusters[0], c) for c in clusters[1:]):
+        try:
+            clusters = [ts_cluster_from_conn(env.getConnection(i)) for i in range(env.shardsCount)]
+        except redis.exceptions.ClusterDownError:
+            # A just-rejoined master's cluster state is transiently 'fail', so INFOCLUSTER is rejected;
+            # keep polling until it turns healthy.
+            clusters = None
+        if clusters is not None and all(clusters) and all(compare_clusters(clusters[0], c) for c in clusters[1:]):
             return clusters[0]
         assert time.time() < deadline, "timeseries.INFOCLUSTER did not reach a valid, agreed state in time"
         time.sleep(0.2)

--- a/tests/flow/test_topology_events.py
+++ b/tests/flow/test_topology_events.py
@@ -23,6 +23,10 @@ def test_add_and_remove_node():
     env = Env(shardsCount=2, decodeResponses=True, skipRefreshCluster=True)
     skip_if_needed(env)
 
+    @functools.cache
+    def connection_of(ip, port):
+        return redis.Redis(host=ip, port=port, decode_responses=True)
+
     def node_summary(view):
         # {node_id: (ip, port, slots)} for a {node_id: ClusterNode} view - the node identity we compare.
         return {node_id: (node.ip, node.port, node.slots) for node_id, node in view.items()}
@@ -52,20 +56,45 @@ def test_add_and_remove_node():
     before = wait_for_valid_cluster(env)
     validate_before_addition(before, wait_for_valid_ts_infocluster(env))
 
-    cycles = 10
-    for _ in range(cycles):
-        # Add a new node
-        env.addShardToClusterIfExists()
-        env.shardsCount = env.envRunner.shardsCount
+    original_masters = list(before.values())
+    fill_some_data(env)
 
-        after_addition = wait_for_valid_cluster(env)
-        validate_after_addition(after_addition, wait_for_valid_ts_infocluster(env), before)
+    def tolerable_data_validation():
+        random_node = random.choice(original_masters)  # we don't risk racing with the added node so choose from OGs
+        try:
+            result = connection_of(random_node.ip, random_node.port).execute_command(COMMAND)
+        except redis.exceptions.ResponseError as x:
+            assert str(x) in (TOPOLOGY_CHANGED_ERROR, SLOT_RANGES_ERROR), str(x)
+            return
+        validate_result(result)
 
-        # Remove it, restoring the initial cluster
-        (new_node_id,) = set(after_addition) - set(before)
-        remove_slotless_node(env, new_node_id)
+    done = threading.Event()
 
-        validate_after_removal(wait_for_valid_cluster(env), wait_for_valid_ts_infocluster(env), before)
+    def validate_data_in_a_loop():
+        while not done.is_set():
+            tolerable_data_validation()
+
+    def add_remove_cycles():
+        cycles = 10
+        for _ in range(cycles):
+            # Add a new node
+            env.addShardToClusterIfExists()
+            env.shardsCount = env.envRunner.shardsCount
+
+            after_addition = wait_for_valid_cluster(env)
+            validate_after_addition(after_addition, wait_for_valid_ts_infocluster(env), before)
+
+            # Remove it, restoring the initial cluster
+            (new_node_id,) = set(after_addition) - set(before)
+            remove_slotless_node(env, new_node_id)
+
+            validate_after_removal(wait_for_valid_cluster(env), wait_for_valid_ts_infocluster(env), before)
+
+    with ThreadPoolExecutor() as executor:
+        futures = map(executor.submit, [validate_data_in_a_loop, add_remove_cycles])
+        for future in as_completed(futures):
+            done.set()  # the cycles thread finished (or raised); stop the endless data validator
+            future.result()
 
 
 def test_asm():
@@ -119,6 +148,20 @@ NUMBER_OF_KEYS = 1000 if not (VALGRIND or SANITIZER) else 100
 SAMPLES_PER_KEY = 150
 COMMAND = "TS.MRANGE - + FILTER label1=17 GROUPBY label1 REDUCE count"
 
+# Some expected errors:
+
+TOPOLOGY_CHANGED_ERROR = "A multi-shard command failed because the cluster topology has changed"
+# Clients of multi-shard commands are blocked. If a node that serves such a command is demoted
+# while the client is still blocked we expect the following error:
+UNBLOCKED_ERROR = "UNBLOCKED force unblock from blocking operation, instance state changed (master -> replica?)"
+# During a failover there is a brief period when the cluster state is set to fail
+# with cluster-allow-reads-when-down off it then rejects reads until it recovers (sub-second)
+# during which time we expect the following error:
+CLUSTERDOWN_ERROR = "CLUSTERDOWN The cluster is down"
+# A multi-shard fan-out can race slot-ownership propagation during a failover (the owning node's
+# id changes) and momentarily see a slot as unavailable, so we also expect this:
+SLOT_RANGES_ERROR = "Query requires unavailable slots"
+
 
 def skip_if_needed(env):
     if env.env != "oss-cluster":
@@ -152,18 +195,6 @@ def random_master_node(env):
 
 
 def validate_queries_during_failovers(env, post_failover, command, validate_result):
-    TOPOLOGY_CHANGED_ERROR = "A multi-shard command failed because the cluster topology has changed"
-    # Clients of multi-shard commands are blocked. If a node that serves such a command is demoted
-    # while the client is still blocked we expect the following error:
-    UNBLOCKED_ERROR = "UNBLOCKED force unblock from blocking operation, instance state changed (master -> replica?)"
-    # During a failover there is a brief period when the cluster state is set to fail
-    # with cluster-allow-reads-when-down off it then rejects reads until it recovers (sub-second)
-    # during which time we expect the following error:
-    CLUSTERDOWN_ERROR = "CLUSTERDOWN The cluster is down"
-    # A multi-shard fan-out can race slot-ownership propagation during a failover (the owning node's
-    # id changes) and momentarily see a slot as unavailable, so we also expect this:
-    SLOT_RANGES_ERROR = "Query requires unavailable slots"
-
     @functools.cache
     def connection_of(ip, port):
         return redis.Redis(host=ip, port=port, decode_responses=True)

--- a/tests/flow/test_topology_events.py
+++ b/tests/flow/test_topology_events.py
@@ -13,25 +13,55 @@ from utils import (
     failover_node,
     added_slaves_to_cluster,
     get_timeout,
-    dump_cluster_nodes,
+    remove_slotless_node,
 )
 from test_asm import validate_queries_during_migrations
 
 
-def test_add_node():
+def test_add_and_remove_node():
     env = Env(shardsCount=2, decodeResponses=True, skipRefreshCluster=True)
     skip_if_needed(env)
 
-    wait_for_valid_cluster(env)
-    print("\n===== before the addition =====")
-    dump_cluster_nodes(env)
+    def node_summary(view):
+        # {node_id: (ip, port, slots)} for a {node_id: ClusterNode} view - the node identity we compare.
+        return {node_id: (node.ip, node.port, node.slots) for node_id, node in view.items()}
 
+    def validate_views_agree(cluster, infocluster):
+        # The redis (CLUSTER NODES) and timeseries (INFOCLUSTER) views must expose the same
+        # nodes at the same addresses owning the same slots.
+        assert node_summary(cluster) == node_summary(infocluster)
+
+    def validate_before_addition(cluster, infocluster):
+        validate_views_agree(cluster, infocluster)
+        assert len(cluster) == 2  # the two masters the env starts with
+
+    def validate_after_addition(cluster, infocluster, before):
+        validate_views_agree(cluster, infocluster)
+        # Exactly one node joined; its address is irrelevant, we only require that it owns no slots.
+        (new_node_id,) = set(cluster) - set(before)
+        assert cluster[new_node_id].slots == set()
+        # The original masters are untouched (address + slots).
+        assert node_summary({id: node for id, node in cluster.items() if id != new_node_id}) == node_summary(before)
+
+    def validate_after_removal(cluster, infocluster, before):
+        validate_views_agree(cluster, infocluster)
+        # The topology is restored to exactly what it was before the addition (address + slots).
+        assert node_summary(cluster) == node_summary(before)
+
+    before = wait_for_valid_cluster(env)
+    validate_before_addition(before, wait_for_valid_ts_infocluster(env))
+
+    # Add a new node
     env.addShardToClusterIfExists()
     env.shardsCount = env.envRunner.shardsCount
 
-    wait_for_valid_cluster(env)
-    print("\n===== after the addition =====")
-    dump_cluster_nodes(env)
+    after_addition = wait_for_valid_cluster(env)
+    validate_after_addition(after_addition, wait_for_valid_ts_infocluster(env), before)
+
+    (new_node_id,) = set(after_addition) - set(before)
+    remove_slotless_node(env, new_node_id)
+
+    validate_after_removal(wait_for_valid_cluster(env), wait_for_valid_ts_infocluster(env), before)
 
 
 def test_asm():
@@ -227,12 +257,15 @@ def ts_cluster_from_conn(conn):
 
 
 def wait_for_valid_ts_infocluster(env):
-    """Wait until every node's timeseries.INFOCLUSTER reports full coverage and all nodes agree."""
+    """Wait until every node's timeseries.INFOCLUSTER reports full coverage and all nodes agree.
+
+    Returns the agreed topology as a {node_id: ClusterNode} dict (the first polled node's view).
+    """
     timeout = get_timeout()
     deadline = time.time() + timeout
     while True:
         clusters = [ts_cluster_from_conn(env.getConnection(i)) for i in range(env.shardsCount)]
         if all(c is not None for c in clusters) and all(compare_clusters(clusters[0], c) for c in clusters[1:]):
-            return
+            return clusters[0]
         assert time.time() < deadline, "timeseries.INFOCLUSTER did not reach a valid, agreed state in time"
         time.sleep(0.2)

--- a/tests/flow/utils.py
+++ b/tests/flow/utils.py
@@ -533,6 +533,26 @@ def dump_cluster_info(env):
         dump_node_cluster_info(env.getConnection(shard))
 
 
+def dump_node_cluster_nodes(conn):
+    print(f"{get_node_address(conn)}:")
+    nodes = [ClusterNode.from_str(line) for line in conn.execute_command("CLUSTER", "NODES").splitlines()]
+    for n in sorted(nodes, key=lambda n: (n.port)):
+        role = "master" if "master" in n.flags else ("slave" if "slave" in n.flags else "?")
+        slots = ",".join(f"{sr.start}-{sr.end}" for sr in sorted(n.slots, key=lambda sr: sr.start)) or "-"
+        flags = ",".join(sorted(n.flags))
+        link = "connected" if n.link_state else "disconnected"
+        print(
+            f"    node {n.id} {n.ip}:{n.port} {role} master={n.master} "
+            f"slots={slots} flags={flags} link={link} epoch={n.config_epoch}"
+        )
+
+
+def dump_cluster_nodes(env):
+    print("\n===== CLUSTER NODES =====")
+    for shard in range(0, env.shardsCount):
+        dump_node_cluster_nodes(env.getConnection(shard))
+
+
 # A table of the shortest possible alphanumeric string that is mapped by redis' hslot (index in the table)
 # Shamelessly stolen from redis' crc16_slottable.h
 slot_table = [

--- a/tests/flow/utils.py
+++ b/tests/flow/utils.py
@@ -6,7 +6,9 @@ import time
 import inspect
 import re
 import random
+import threading
 import contextlib
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
 NUMBER_OF_SLOTS = 2**14
@@ -610,6 +612,18 @@ def dump_cluster_nodes(env):
     print("\n===== CLUSTER NODES =====")
     for shard in range(0, env.shardsCount):
         dump_node_cluster_nodes(env.getConnection(shard))
+
+
+def run_until_first_finishes(*tasks):
+    """Run tasks concurrently; when the first one finishes (or raises), signal the rest to stop and
+    propagate any exception. Each task is called with a threading.Event that is set once any task
+    returns - an endless task should loop while not event.is_set()."""
+    done = threading.Event()
+    with ThreadPoolExecutor() as executor:
+        futures = [executor.submit(task, done) for task in tasks]
+        for future in as_completed(futures):
+            done.set()
+            future.result()
 
 
 # A table of the shortest possible alphanumeric string that is mapped by redis' hslot (index in the table)
@@ -1642,3 +1656,4 @@ slot_table = [
 ]
 
 assert len(slot_table) == NUMBER_OF_SLOTS
+

--- a/tests/flow/utils.py
+++ b/tests/flow/utils.py
@@ -279,7 +279,10 @@ def compare_clusters(cluster1, cluster2):
 
 
 def wait_for_valid_cluster(env):
-    """Wait until every node reports a valid cluster and all nodes agree on the topology."""
+    """Wait until every node reports a valid cluster and all nodes agree on the topology.
+
+    Returns the agreed topology as a {node_id: ClusterNode} dict (the first polled node's view).
+    """
     timeout = get_timeout()
     deadline = time.time() + timeout
     # Note that only the nodes in env are polled but any slaves added by added_slaves_to_cluster are not in env.
@@ -294,11 +297,67 @@ def wait_for_valid_cluster(env):
     while True:
         clusters = [validate_cluster(env.getConnection(i)) for i in range(env.shardsCount)]
         if all(c is not None for c in clusters) and all(compare_clusters(clusters[0], c) for c in clusters[1:]):
-            return
+            return clusters[0]
         if time.time() >= deadline:
             nodes = {i: env.getConnection(i).execute_command("CLUSTER", "NODES") for i in range(env.shardsCount)}
             raise AssertionError(f"cluster did not reach a valid, agreed state in time, CLUSTER NODES: {nodes}")
         time.sleep(0.2)
+
+
+def remove_slotless_node(env, node_id):
+    """Remove a slot-less master node (given by its id) from the OSS-cluster env, the
+    mirror image of `env.addShardToClusterIfExists()` that's unfortunately missing from RLTest.
+
+    Performs the canonical removal procedure that `redis-cli --cluster del-node` uses:
+    `CLUSTER FORGET <id>` on every *other* node, then `CLUSTER RESET SOFT` on the removed
+    node. Asserts the node owns no slots (a node that still owns slots must have them
+    migrated away first). Finally tears down the removed node's process and drops it from
+    RLTest's env bookkeeping so it is no longer polled or awaited.
+    """
+    def cluster_node_ids(c):
+        return {node.id for node in map(ClusterNode.from_str, c.execute_command("CLUSTER", "NODES").splitlines())}
+
+    # Locate the RLTest shard backing this node (so we can drive and later tear it down).
+    victim_shard = next(
+        (shard for shard in env.envRunner.shards if shard.getConnection().execute_command("CLUSTER", "MYID") == node_id),
+        None,
+    )
+    assert victim_shard is not None, f"no node with id {node_id} in the env"
+    conn = victim_shard.getConnection()
+    remaining_shards = [shard for shard in env.envRunner.shards if shard is not victim_shard]
+
+    # A node that still owns slots can't be removed; the caller must migrate its slots away first.
+    myself = next(
+        node
+        for node in map(ClusterNode.from_str, conn.execute_command("CLUSTER", "NODES").splitlines())
+        if "myself" in node.flags
+    )
+    assert not myself.slots, f"node {node_id} still owns slots {myself.slots}; migrate them away before removal"
+
+    # CLUSTER FORGET is synchronous per node; send it from every *other* node, sowe only wait for the +OK response.
+    for shard in remaining_shards:
+        response = shard.getConnection().execute_command("CLUSTER", "FORGET", node_id)
+        assert response in ("OK", b"OK")
+
+    # CLUSTER RESET SOFT is also synchronous; it makes the removed node forget the rest of the cluster.
+    response = conn.execute_command("CLUSTER", "RESET", "SOFT")
+    assert response in ("OK", b"OK")
+
+    # FORGET takes effect locally at once, but each node keeps gossiping its own view; wait until every
+    # remaining node has dropped the removed id from its topology (the asynchronous part of the removal).
+    deadline = time.time() + get_timeout()
+    while True:
+        views = {shard.getMasterPort(): cluster_node_ids(shard.getConnection()) for shard in remaining_shards}
+        if all(node_id not in ids for ids in views.values()):
+            break
+        assert time.time() < deadline, f"node {node_id} still present after {get_timeout()}s: {views}"
+        time.sleep(0.2)
+
+    # Tear down the removed node's process and drop it from RLTest's bookkeeping.
+    victim_shard.stopEnv()
+    env.envRunner.shards.remove(victim_shard)
+    env.envRunner.shardsCount -= 1
+    env.shardsCount = env.envRunner.shardsCount
 
 
 def import_slots(source_conn, target_conn, slot_range: SlotRange):


### PR DESCRIPTION
Ports the missing topology-event test scaffolding:

- Add a `dump_cluster_nodes` utility that parses `CLUSTER NODES` into `ClusterNode` objects and dumps them.
- Add an initial dump-only `test_add_node` that adds a node to a running oss-cluster (via RLTest's `addShardToClusterIfExists`) and dumps the topology before/after.

Groundwork for hunting UAFs around topology changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to flow tests and test utilities; no production module or cluster runtime code is modified.
> 
> **Overview**
> Expands **topology-event** flow tests to stress multi-shard `TS.MRANGE` while the cluster changes, with shared helpers for removal, concurrency, and debugging.
> 
> **New tests** run **10 cycles** of add/remove or stop/start while a background loop issues `TS.MRANGE` and accepts transient topology errors. `test_add_and_remove_node` checks that **CLUSTER NODES** and **timeseries.INFOCLUSTER** agree on nodes, addresses, and slots before/after each add and after removal restores the original topology. `test_take_node_down_and_up` round-robins shard restarts and uses `wait_for_down_state_view_agreement` so surviving nodes agree on master identities while a peer is down.
> 
> **Test utilities** add `remove_slotless_node` (FORGET + RESET + RLTest teardown, mirror of `addShardToClusterIfExists`), `run_until_first_finishes` for paired background/query workloads, `dump_node_cluster_nodes`, and return values from `wait_for_valid_cluster` / `wait_for_valid_ts_infocluster`. Failover tests are refactored to the same concurrency pattern; `wait_for_valid_ts_infocluster` tolerates transient `ClusterDownError` after rejoin.
> 
> `.gitignore` adds `tags`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e7f0552fa5c6aab96c515d6cc2fbc63914503cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->