### PR TITLE
MOD-17281 Fix test_failover timeouts and hang

### DIFF
--- a/tests/flow/test_asm.py
+++ b/tests/flow/test_asm.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import redis
 
 from includes import Env, VALGRIND, SANITIZER, RUNNER_LABEL
-from utils import migrate_slots_back_and_forth, fill_ts_data, wait_for_valid_cluster
+from utils import migrate_slots_back_and_forth, fill_ts_data, wait_for_valid_cluster, get_timeout
 
 
 MIGRATION_CYCLES = 10
@@ -165,7 +165,7 @@ def test_short_form_clusterset():
     # Poll TS.QUERYINDEX until propagation lands -- fan-out goes from local-only
     # (~number_of_keys / shardsCount) to the full set once every shard has been
     # informed via CLUSTERSETFROMSHARD.
-    deadline = time.time() + (60 if (VALGRIND or SANITIZER) else 10)
+    deadline = time.time() + get_timeout()
     while time.time() < deadline:
         queryindex = conn.execute_command('TS.QUERYINDEX', 'label=test')
         if len(queryindex) == number_of_keys:

--- a/tests/flow/test_topology_events.py
+++ b/tests/flow/test_topology_events.py
@@ -12,6 +12,7 @@ from utils import (
     NUMBER_OF_SLOTS,
     failover_node,
     added_slaves_to_cluster,
+    get_timeout,
 )
 from test_asm import validate_queries_during_migrations
 
@@ -208,7 +209,7 @@ def ts_cluster_from_conn(conn):
 
 def wait_for_valid_ts_infocluster(env):
     """Wait until every node's timeseries.INFOCLUSTER reports full coverage and all nodes agree."""
-    timeout = 60 if (VALGRIND or SANITIZER) else 5
+    timeout = get_timeout()
     deadline = time.time() + timeout
     while True:
         clusters = [ts_cluster_from_conn(env.getConnection(i)) for i in range(env.shardsCount)]

--- a/tests/flow/utils.py
+++ b/tests/flow/utils.py
@@ -264,7 +264,7 @@ def validate_cluster(conn):
 
 
 def compare_clusters(cluster1, cluster2):
-    """Compare two validate_cluster() dicts, per node only by id, ip, port, flags and slots."""
+    """Compare two validate_cluster() {node_id: ClusterNode} dicts"""
     # 'myself' and other flags like 'handshake'/'fail?' are transient, so they depend on which node we asked
     # only these flags are invariant across views:
     invariant_flags = {"master", "slave"}
@@ -272,8 +272,8 @@ def compare_clusters(cluster1, cluster2):
         return False
     for node_id in cluster1:
         n1, n2 = cluster1[node_id], cluster2[node_id]
-        if (n1.id, n1.ip, n1.port, n1.flags & invariant_flags, n1.slots) != \
-           (n2.id, n2.ip, n2.port, n2.flags & invariant_flags, n2.slots):
+        if (n1.id, n1.ip, n1.port, n1.flags & invariant_flags, n1.slots, n1.master) != \
+           (n2.id, n2.ip, n2.port, n2.flags & invariant_flags, n2.slots, n2.master):
             return False
     return True
 
@@ -415,6 +415,8 @@ def added_slaves_to_cluster(env):
             if time.time() - start_time > timeout:
                 raise AssertionError(f"cluster topology not as expected after {timeout}s, CLUSTER NODES: {nodes}")
             time.sleep(0.1)
+
+        wait_for_valid_cluster(env)
 
         yield master_id_of_replica_port
     finally:

--- a/tests/flow/utils.py
+++ b/tests/flow/utils.py
@@ -355,6 +355,10 @@ def added_slaves_to_cluster(env):
             cluster_config_file = f"/tmp/replica-{replica_port}-{time.time_ns()}.conf"
 
             cluster_node_timeout = shard.getConnection().config_get("cluster-node-timeout")["cluster-node-timeout"]
+            master_log = shard.getConnection().config_get("logfile")["logfile"]
+            master_rdb = shard.getConnection().config_get("dbfilename")["dbfilename"]
+            replica_log = master_log.replace("master-", "slave-", 1) if "master-" in master_log else f"replica-{replica_port}.log"
+            replica_rdb = master_rdb.replace("master-", "slave-", 1) if "master-" in master_rdb else f"replica-{replica_port}.rdb"
             enable_debug_command = "no" if shard.enableDebugCommand is False else "yes"
             cmd = [shard.redisBinaryPath, "--port", str(replica_port),
                    "--cluster-enabled", "yes",
@@ -362,8 +366,8 @@ def added_slaves_to_cluster(env):
                    "--cluster-node-timeout", cluster_node_timeout,
                    "--enable-debug-command", enable_debug_command,
                    "--dir", shard.dbDirPath,
-                   "--dbfilename", f"replica-{replica_port}.rdb",
-                   "--logfile", f"replica-{replica_port}.log"]
+                   "--dbfilename", replica_rdb,
+                   "--logfile", replica_log]
             for pos, module in enumerate(shard.modulePath or []):
                 cmd += ["--loadmodule", module]
                 module_args = shard.moduleArgs[pos] if shard.moduleArgs else None

--- a/tests/flow/utils.py
+++ b/tests/flow/utils.py
@@ -282,6 +282,15 @@ def wait_for_valid_cluster(env):
     """Wait until every node reports a valid cluster and all nodes agree on the topology."""
     timeout = get_timeout()
     deadline = time.time() + timeout
+    # Note that only the nodes in env are polled but any slaves added by added_slaves_to_cluster are not in env.
+    # This will be fixed in MOD-17386 when a fully cluster-aware env will enable waiting on all nodes.
+    # But the logic of waiting until all originally-master nodes have the same cluster topology view still holds,
+    # even when some of them were demoted due to a failover. Here's why:
+    # - A master is the authoritative origin of its own slot/role claims, so a polled slave node agreeing implies
+    #   its master already agrees on those.
+    # - The slaveof relation (ClusterNode.master) is weaker, since it is originated by the replica, but a replica
+    #   gossips with its own master most frequently and failover_node separately waits for master_link_status == up
+    #   before a failover, so it also holds.
     while True:
         clusters = [validate_cluster(env.getConnection(i)) for i in range(env.shardsCount)]
         if all(c is not None for c in clusters) and all(compare_clusters(clusters[0], c) for c in clusters[1:]):

--- a/tests/flow/utils.py
+++ b/tests/flow/utils.py
@@ -11,6 +11,11 @@ import contextlib
 
 NUMBER_OF_SLOTS = 2**14
 
+
+def get_timeout():
+    return 60 if (VALGRIND or SANITIZER) else 10
+
+
 def Refresh_Cluster(env):
     for shard in range(0, env.shardsCount):
         con = env.getConnection(shard)
@@ -275,7 +280,7 @@ def compare_clusters(cluster1, cluster2):
 
 def wait_for_valid_cluster(env):
     """Wait until every node reports a valid cluster and all nodes agree on the topology."""
-    timeout = 60 if (VALGRIND or SANITIZER) else 5
+    timeout = get_timeout()
     deadline = time.time() + timeout
     while True:
         clusters = [validate_cluster(env.getConnection(i)) for i in range(env.shardsCount)]
@@ -293,7 +298,7 @@ def import_slots(source_conn, target_conn, slot_range: SlotRange):
         # Migration clients wait for `repl-diskless-sync-delay` seconds to start a new fork after the last child exits
         # so for rapid ASM operations (as we do here) we need to add this value to our expected timeouts.
         repl_diskless_sync_delay = float(conn.config_get()["repl-diskless-sync-delay"])
-        timeout = repl_diskless_sync_delay + (5 if not (VALGRIND or SANITIZER) else 60)
+        timeout = repl_diskless_sync_delay + get_timeout()
         while time.time() - start_time < timeout:
             (migration_status,) = conn.execute_command("CLUSTER", "MIGRATION", "STATUS", "ID", task_id)
             migration_status = {key: value for key, value in zip(migration_status[0::2], migration_status[1::2])}
@@ -383,7 +388,7 @@ def added_slaves_to_cluster(env):
             # Wait for the initial sync to finish; CLUSTER FAILOVER times out on a not-yet-caught-up replica.
             # The master waits repl-diskless-sync-delay seconds before forking the sync child, so add it.
             repl_diskless_sync_delay = float(shard.getConnection().config_get("repl-diskless-sync-delay")["repl-diskless-sync-delay"])
-            timeout = repl_diskless_sync_delay + (5 if not (VALGRIND or SANITIZER) else 60)
+            timeout = repl_diskless_sync_delay + get_timeout()
             start_time = time.time()
             while replica_conn.info("replication")["master_link_status"] != "up":
                 if time.time() - start_time > timeout:
@@ -404,7 +409,7 @@ def added_slaves_to_cluster(env):
                 for replica_port, master_id in master_id_of_replica_port.items()
             )
 
-        timeout = 5 if not (VALGRIND or SANITIZER) else 60
+        timeout = get_timeout()
         start_time = time.time()
         while not expected(nodes := cluster_nodes(env.getConnection(0))):
             if time.time() - start_time > timeout:
@@ -433,7 +438,7 @@ def failover_node(replica_conn):
     master_conn = redis.Redis(host=master_ip, port=master_port, decode_responses=True)
 
     repl_diskless_sync_delay = float(master_conn.config_get("repl-diskless-sync-delay")["repl-diskless-sync-delay"])
-    sync_timeout = repl_diskless_sync_delay + (5 if not (VALGRIND or SANITIZER) else 60)
+    sync_timeout = repl_diskless_sync_delay + get_timeout()
     start_time = time.time()
     while replica_conn.info("replication")["master_link_status"] != "up":
         if time.time() - start_time > sync_timeout:
@@ -444,7 +449,7 @@ def failover_node(replica_conn):
 
     replica_conn.execute_command("CLUSTER", "FAILOVER")
 
-    timeout = 5 if not (VALGRIND or SANITIZER) else 60
+    timeout = get_timeout()
     start_time = time.time()
     while time.time() - start_time < timeout:
         if replica_conn.execute_command("ROLE")[0] == "master" and master_conn.execute_command("ROLE")[0] == "slave":

--- a/tests/flow/utils.py
+++ b/tests/flow/utils.py
@@ -295,7 +295,9 @@ def wait_for_valid_cluster(env):
         clusters = [validate_cluster(env.getConnection(i)) for i in range(env.shardsCount)]
         if all(c is not None for c in clusters) and all(compare_clusters(clusters[0], c) for c in clusters[1:]):
             return
-        assert time.time() < deadline, "cluster did not reach a valid, agreed state in time"
+        if time.time() >= deadline:
+            nodes = {i: env.getConnection(i).execute_command("CLUSTER", "NODES") for i in range(env.shardsCount)}
+            raise AssertionError(f"cluster did not reach a valid, agreed state in time, CLUSTER NODES: {nodes}")
         time.sleep(0.2)
 
 


### PR DESCRIPTION
Fixes flakiness/hang in `test_failover`:

- Centralize cluster timeouts in `get_timeout()` (10s normally, up from 5s; 60s under valgrind/sanitizer). The old 5s wait raced redis's own 5s `CLUSTER_MF_TIMEOUT`.
- Stricter validation of added slaves: `compare_clusters` now also compares each node's `master` (slaveof), and `added_slaves_to_cluster` waits for a valid, agreed cluster before yielding. This guarantees the target master already sees the replica as its own before a manual `CLUSTER FAILOVER`, which is otherwise silently dropped (`sender->slaveof == myself`) and hangs until timeout.
- Match added replicas' `.log`/`.rdb` file names to their masters' (read from the master via `CONFIG GET`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Python flow tests and shared test utilities; no runtime module or cluster behavior is modified.
> 
> **Overview**
> **Test harness hardening** for flaky `test_failover` and related OSS-cluster flow tests—no production code changes.
> 
> Adds **`get_timeout()`** in `utils.py` (10s default, 60s under Valgrind/sanitizer) and routes migration, cluster-wait, failover, and `TS.QUERYINDEX` polling through it instead of scattered 5s/10s/60s literals.
> 
> **`compare_clusters`** now also compares each node’s **`master`** (replica-of) field. **`added_slaves_to_cluster`** calls **`wait_for_valid_cluster`** after replicas join so masters see consistent topology before **`CLUSTER FAILOVER`**, and on cluster-wait failure dumps **`CLUSTER NODES`** from all shards.
> 
> Spawned test replicas inherit **logfile** and **dbfilename** from their master via **`CONFIG GET`** (with master→slave name substitution) instead of fixed `replica-{port}` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d11560373dcf130fb73678e998e39636c90c3fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->