### PR TITLE
MOD-16600 Bump LibMR to master: fix the mr.c:939 assertion on 8.8

### DIFF
--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -1022,7 +1022,7 @@ int LibMR_ResizeExecutionThreadPoolIfUnstarted(long long numThreads) {
 }
 
 int register_mr(RedisModuleCtx *ctx, long long numThreads) {
-    if (MR_Init(ctx, numThreads, TSGlobalConfig.password) != REDISMODULE_OK) {
+    if (MR_Init(ctx, numThreads, TSGlobalConfig.password, false) != REDISMODULE_OK) {
         RedisModule_Log(ctx, "warning", "Failed to init LibMR. aborting...");
         return REDISMODULE_ERR;
     }


### PR DESCRIPTION
## What

`deps/LibMR` `a37b672` → `c6a5ed62` (master), plus `topologyEvents=false` at the `MR_Init` call site — two lines total.

## Why

The assertion LibMR #116 fixes is **still reproducing on the RE8.8 nightly**, because this branch has never carried #116. Build `100.0.20-7660` (2026-08-05), released TS `80802`, shard `redis-119`:

```
21:22:23.033  <timeseries> cluster topology changed        (x5 within 4ms)
21:22:23.037  <timeseries> Got cluster set command (long form)
21:22:23.037  === REDIS BUG REPORT START
21:22:23.037  # ==> /workspace/deps/LibMR/src/mr.c:939 'false' is not true
```

Long-form `CLUSTERSET` → `MR_SetClusterData` → `MR_ClusterFree()` transiently reports a one-shard topology → a concurrent execution takes `ExecutionFlag_Local` → its `StepType_InternalCommand` reaches the worker path → assert. #116 holds the Redis lock across the free/rebuild so that state is never observable. It landed on LibMR master on 2026-07-26; `a37b672` predates it.

Consequence today: **MOD-16600 sits in verification against a lane that structurally cannot verify it.** Liran has re-reported it on essentially every nightly.

## Why bump to master instead of backporting

`MR_Init` is the *only* LibMR API that changed between the two pins. Of the 39 `MR_*` symbols this branch references, 32 are declared in LibMR headers, and `MR_Init` is the single one whose declaration differs — nothing was removed:

```
CHANGED MR_Init      changed: 1   removed: 0
```

So one extra argument is the entire compatibility cost — cheaper than a LibMR maintenance branch plus a cherry-pick for every future fix. (I opened both alternatives as RedisGears/LibMR#120 and #121 and closed them in favour of this.)

## Why `topologyEvents=false` is correct, not just conservative

Redis on this line never emits the topology-change notification — the Enterprise cluster plugin says so at startup:

```
ClusterPlugin: Failed to load symbol: "clusterNotifyTopologyChanged",
               assuming this an old redis version w/out ASM
```

So the topology-event paths are unreachable here, not merely disabled. And `MR_ClusterInit`'s entire diff between the two pins is `clusterCtx.topologyEvents = topologyEvents;` — no conditional registration, no behaviour branch — so `false` reproduces `a37b672`'s behaviour exactly.

## What else arrives with the bump

| commit | effect on 8.8 |
|---|---|
| #104 skip rebuild on unchanged CLUSTERSET (MOD-16399) | wanted |
| #108 fix execution leak on aborted initiator execution | wanted |
| #111 / #115 gate inter-shard TLS on `tls-cluster` for native-cluster-view paths (MOD-16951) | **wanted** — long-form CLUSTERSET keeps the historical tls-port fallback, and this branch shows the symptom they fix: 97 × `execution max idle reached` on `redis-119` in the 7660 package |
| #117 / #119 topology-event adjustments | inert with the flag off |

## Verification

- Builds clean for `linux-arm64` in `rockylinux:9` + `gcc-toolset-13` — the toolchain behind the shipped rhel9-arm64 artifact. Module links.
- API check against pristine LibMR master: the 4-arg call compiles with 0 errors; the current 3-arg call fails with `too few arguments to function call, expected 4, have 3`, confirming the one-liner is both necessary and sufficient.
- **Flow suite not run locally** — leaving that to CI, which is the real gate here.

## Not fixed by this

MOD-16600's scenario has a second defect that this does not touch: the MOD-15896 Enterprise/OSS misdetection. The same 7660 packages show `Detected redis oss (cluster-enabled=yes)` on the ASM shards (×14 / ×24, versus ×180 correct `enterprise (cluster-enabled=no)` on non-cluster DBs), producing 1309 rejected `timeseries.HELLO`, 722 `message was not sent because status is not connected`, and 97 `execution max idle reached` on one shard. So expect the crash to stop and the scale-under-traffic scenario to possibly still fail until that is fixed separately.

8.6 / 8.4 pin the same `a37b672` and can take the identical two-line change if wanted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster coordination and inter-shard execution (LibMR) at module init and during CLUSTERSET; wrong topologyEvents or regressions in the bump could affect MRANGE/MGET across shards, though `false` is chosen to preserve legacy behavior on 8.8.
> 
> **Overview**
> **Fixes MOD-16600** by moving `deps/LibMR` to current master so LibMR #116 is included: cluster topology rebuild during long-form `CLUSTERSET` no longer exposes a transient one-shard view that could trip the `mr.c:939` assert on concurrent internal-command execution.
> 
> The only Timeseries call-site change is in `register_mr`: `MR_Init` now takes a fourth argument, **`false`**, because this Redis line does not emit topology-change notifications (ASM/`clusterNotifyTopologyChanged` is absent). That matches prior behavior on the old pin and keeps topology-event paths inactive.
> 
> The bump also pulls in unrelated LibMR fixes on this branch (e.g. skip redundant CLUSTERSET rebuild, execution leak fix, inter-shard TLS gating). A separate Enterprise/OSS cluster misdetection issue noted in MOD-16600 is **not** addressed here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0b93193a313559fc0b1b55e9c82675069dcc6f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->