### PR TITLE
fix(ci): build Redis 6.2 with ASan instrumentation for sanitizer job

### DIFF
--- a/.install/install_redis.sh
+++ b/.install/install_redis.sh
@@ -8,17 +8,28 @@ fi
 
 echo "Installing Redis from ref: ${REDIS_REF}"
 
-# SANITIZER can be passed to build Redis with sanitizer support (e.g., SANITIZER=address)
-if [ -n "${SANITIZER}" ]; then
-    echo "Building Redis with SANITIZER=${SANITIZER}"
-fi
-
-git clone https://github.com/redis/redis.git 
+# SANITIZER can be passed to build Redis with sanitizer support (e.g., SANITIZER=address).
+#
+# Redis's Makefile only learned about the SANITIZER flag in 7.0. This branch builds
+# Redis 6.2, whose Makefile ignores SANITIZER entirely: `make SANITIZER=address` yields
+# a NON-instrumented server, which then aborts on load of the ASan-built module
+# ("ASan runtime does not come first in initial library list") and every flow test gets
+# connection-refused. So inject the flags 7.0+ sets under SANITIZER via the CFLAGS/LDFLAGS
+# vars 6.2 honors, and force MALLOC=libc (ASan and jemalloc can't coexist).
+git clone https://github.com/redis/redis.git
 cd redis
 git fetch origin ${REDIS_REF}
 git checkout ${REDIS_REF}
 git submodule update --init --recursive
-make SANITIZER=${SANITIZER:-} -j$(nproc)
+if [ -n "${SANITIZER}" ]; then
+    echo "Building Redis with SANITIZER=${SANITIZER} (manual flags for Redis < 7.0)"
+    make MALLOC=libc \
+         CFLAGS="-fsanitize=${SANITIZER} -fno-omit-frame-pointer -fno-sanitize-recover=all" \
+         LDFLAGS="-fsanitize=${SANITIZER}" \
+         -j"$(nproc)"
+else
+    make -j"$(nproc)"
+fi
 make install
 cd ..
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI install-script change only; no runtime application logic, with behavior unchanged when SANITIZER is unset.
> 
> **Overview**
> Fixes the CI sanitizer job when **Redis 6.2** is installed with `SANITIZER=address`. Redis’s Makefile only applies `SANITIZER` from **7.0** onward, so the previous single `make SANITIZER=…` produced a **non-ASan** `redis-server` while the module stayed ASan-instrumented—leading to ASan runtime load failures and connection-refused in flow tests.
> 
> When `SANITIZER` is set, the install script now builds with **`MALLOC=libc`** and passes sanitizer flags via **`CFLAGS`/`LDFLAGS`** (what 6.2’s Makefile respects), matching what 7.0+ does under `SANITIZER`. Non-sanitizer installs still use a plain `make -j$(nproc)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46812d7fb2f9dd84f64a8be209e926f685d5172e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->