### PR TITLE
MOD-16600 Bump LibMR to master on 8.6

### DIFF
--- a/src/libmr_integration.c
+++ b/src/libmr_integration.c
@@ -792,7 +792,7 @@ static Record *MR_RecordCreate(MRRecordType *type, size_t size) {
 }
 
 int register_rg(RedisModuleCtx *ctx, long long numThreads) {
-    if (MR_Init(ctx, numThreads, TSGlobalConfig.password) != REDISMODULE_OK) {
+    if (MR_Init(ctx, numThreads, TSGlobalConfig.password, false) != REDISMODULE_OK) {
         RedisModule_Log(ctx, "warning", "Failed to init LibMR. aborting...");
         return REDISMODULE_ERR;
     }

--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -72,7 +72,7 @@ def verifyClusterInitialized(env):
             nodes = res[4]
             allConnected = True
             for n in nodes:
-                status = n[17]
+                status = n[-1]
                 if status != b'connected':
                     allConnected = False
             if not allConnected:

--- a/tests/flow/test_ts_libmr_failiure.py
+++ b/tests/flow/test_ts_libmr_failiure.py
@@ -26,7 +26,7 @@ def verifyClusterInitialized(env):
             nodes = res[4]
             allConnected = True
             for n in nodes:
-                status = n[17]
+                status = n[-1]
                 if status != b'connected' and status != b'uninitialized':
                     allConnected = False
             if not allConnected:


### PR DESCRIPTION
## What

- `deps/LibMR` `a37b672` → `c6a5ed62` (master)
- `topologyEvents=false` at the `MR_Init` call site
- INFOCLUSTER's `status` read from the end (`n[-1]`) instead of index 17, in `tests/flow/includes.py` and `tests/flow/test_ts_libmr_failiure.py`

Same shape as #2139 (which landed on 8.8), with the test fix that 8.8 still needs as a follow-up.

## Why, and why it is not the same reason as 8.8

The `mr.c:939` assertion that motivated #2139 **cannot fire on this line** — `git grep -c MR_ExecutionBuilderInternalCommand` returns 0 here versus 6 on 8.8, so no execution contains a `StepType_InternalCommand` step.

What this line *does* have is the silent half of the same race: `MR_ClusterFree` sets `clusterCtx.clusterSize = 1` while `MR_CreateExecution` reads it on the main thread, and an execution wrongly flagged `ExecutionFlag_Local` skips the cross-shard collect — so `TS.MRANGE` / `TS.MGET` / `TS.QUERYINDEX` answer from the local shard **with no error**. #116 closes that by holding the Redis lock across the free/rebuild.

Also arriving, and wanted here:

| commit | why it matters on this line |
|---|---|
| #104 (MOD-16399) | stops an argument-identical CLUSTERSET tearing down connections and aborting in-flight executions |
| #108 | execution leak when an initiator execution is aborted after completing |
| #117 | removes a **live assert** at the current pin — `a37b672 src/cluster.c:1530` `RedisModule_Assert(n->slotRanges->len == 1)`, trippable by a multi-range or slotless master from the RE extended ASM long form |
| #111 + #115 (MOD-16951) | inter-shard TLS gating; see the caveat below |

## Why `topologyEvents=false` is correct, not just conservative

Redis on this line never emits the topology-change notification (the Enterprise cluster plugin logs `Failed to load symbol: "clusterNotifyTopologyChanged"`). Independently of that, `MR_ClusterInit`'s entire diff between the two pins is `clusterCtx.topologyEvents = topologyEvents;`, and `MR_TopologyEventSeen` has exactly **one** setter — `MR_UpdateClusterTopology()` — which no release branch calls. So the gated branches are provably inert and `false` reproduces `a37b672`'s behaviour.

## Why the test change is required

#117 turns INFOCLUSTER's per-node reply from a fixed 18 elements into `14 + 4*ranges`. The order is `id, ip, port, unixSocket, runid, [minHslot, maxHslot]×N, pendingMessages, status` — so `status` is last in **both** layouts. `n[-1]` is therefore correct before and after the bump, while `n[17]` silently reads a slot-range value once a node has more than one range, hanging `verifyClusterInitialized` rather than failing cleanly.

## Two behaviour changes for the release notes

1. **Inter-shard TLS now requires `tls-cluster=yes`.** #115 deletes #111's long-form carve-out, so the `tls-port != 0` fallback is gone for every topology form. The changed cell (`tls-port` set, `tls-cluster` not yes) goes from TLS to plaintext, and it fails open — `checkTLS` returns 0 and `AUTH <internal password>` is then sent in cleartext. Not reachable in RE steady state (CNM writes both settings together), but reachable during a live internode-encryption enable and permanently for a non-RE consumer with TLS endpoints. No release branch has a TLS test leg.
2. **Short-form CLUSTERSET is now fail-closed.** `MR_BuildCluster` rejects a topology with a duplicate slot claim or coverage `!= 16384` instead of installing a degraded one. A rejection leaves the shard answering locally until the next successful CLUSTERSET, so `rejecting topology` / `Cluster topology covers %zu of` / `is claimed by two master nodes` in shard logs are worth alerting on. `short_form_clusterset` is in `pack/ramp.yml` on this line and `tests/flow/test_asm.py` is `env.skip()`, so only real Enterprise exercises it.

## Verification

- Builds clean for `linux-arm64` in `rockylinux:9` + `gcc-toolset-13` — the toolchain behind the shipped rhel9-arm64 artifact.
- Flow suite left to CI.
- Not covered by any existing lane on this branch, and worth a deliberate soak before release: the TLS matrix above, and a cardinality assertion on multi-shard reads while hammering CLUSTERSET (a local-only reply is a correct-looking success, so an existence check will not catch it).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> LibMR cluster/TLS/topology validation changes can affect multi-shard reads and internode encryption; integration surface is critical even though the diff is small.
> 
> **Overview**
> Updates **LibMR** on the 8.6 line and wires it in with **`MR_Init(..., false)`** so topology-event handling stays off on Redis builds that never notify topology changes.
> 
> Flow tests that wait on **`timeseries.INFOCLUSTER`** now read each node’s connection **`status` from `n[-1]`** instead of a fixed index, matching LibMR’s variable-length per-node reply after multi-range slot metadata.
> 
> The dependency bump also brings cluster-topology, execution-lifecycle, and inter-shard TLS behavior changes described in the PR (not all visible in this small diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9906258a1af3f6ecea634262b0ecf1b10e5ea1ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->