### PR TITLE
MOD-16600 Read INFOCLUSTER status from the end, not index 17 (8.8)

### DIFF
--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -78,7 +78,7 @@ def verifyClusterInitialized(env):
             nodes = res[4]
             allConnected = True
             for n in nodes:
-                status = n[17]
+                status = n[-1]
                 if status != b'connected':
                     allConnected = False
             if not allConnected:

--- a/tests/flow/test_ts_libmr_failiure.py
+++ b/tests/flow/test_ts_libmr_failiure.py
@@ -26,7 +26,7 @@ def verifyClusterInitialized(env):
             nodes = res[4]
             allConnected = True
             for n in nodes:
-                status = n[17]
+                status = n[-1]
                 if status != b'connected' and status != b'uninitialized':
                     allConnected = False
             if not allConnected:


### PR DESCRIPTION
## What

`status = n[17]` → `status = n[-1]` in `tests/flow/includes.py` and `tests/flow/test_ts_libmr_fail*.py`.

## Why

LibMR #117 changed `timeseries.INFOCLUSTER`'s per-node reply from a fixed 18 elements to `14 + 4*ranges`:

```
id, ip, port, unixSocket, runid, [minHslot, maxHslot] x N, pendingMessages, status
```

`status` is the **last** element in both layouts, so `n[-1]` is correct before and after that change, while `n[17]` is only correct for a single-range node. With two ranges `n[17]` reads a slot-range value instead, and `verifyClusterInitialized` then spins forever waiting for `b'connected'` rather than failing cleanly.

**This branch already pins a LibMR containing #117**, so the mismatch is live: any node with more than one slot range — or a slotless master, both reachable via the Redis Enterprise extended ASM long-form CLUSTERSET — hangs the harness. #117 fixed its own consumer inside the LibMR test module, but the RedisTimeSeries half was never ported.

Found while auditing what 8.4/8.6 would inherit by bumping to LibMR master (#2141, #2142); the same fix is included there.

Test-only change, no production code touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to flow harness parsing; no production or runtime module behavior is modified.
> 
> **Overview**
> Updates cluster test helpers so **`verifyClusterInitialized`** reads each node’s connection **`status`** from **`n[-1]`** instead of the fixed index **`n[17]`** when parsing **`timeseries.INFOCLUSTER`** replies.
> 
> That matches LibMR’s variable-length per-node layout (**`14 + 4×ranges`**), where **`status`** is always the final field. The old index only worked for single-range nodes and could make the wait loop spin forever on multi-range or slotless masters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f997b45e305b4b0129ba0a46f730e1a10b3ac29a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->