### PR TITLE
MOD-16600 Read INFOCLUSTER status from the end, not index 17

### DIFF
--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -86,7 +86,7 @@ def verifyClusterInitialized(env):
             nodes = res[4]
             allConnected = True
             for n in nodes:
-                status = n[17]
+                status = n[-1]
                 if status != b'connected':
                     allConnected = False
             if not allConnected:

--- a/tests/flow/test_ts_libmr_failure.py
+++ b/tests/flow/test_ts_libmr_failure.py
@@ -26,7 +26,7 @@ def verifyClusterInitialized(env):
             nodes = res[4]
             allConnected = True
             for n in nodes:
-                status = n[17]
+                status = n[-1]
                 if status != b'connected' and status != b'uninitialized':
                     allConnected = False
             if not allConnected:


### PR DESCRIPTION
## What

`status = n[17]` → `status = n[-1]` in `tests/flow/includes.py` and `tests/flow/test_ts_libmr_fail*.py`.

## Why

LibMR #117 changed `timeseries.INFOCLUSTER`'s per-node reply from a fixed 18 elements to `14 + 4*ranges`:

```
id, ip, port, unixSocket, runid, [minHslot, maxHslot] x N, pendingMessages, status
```

`status` is the **last** element in both layouts, so `n[-1]` is correct before and after that change, while `n[17]` is only correct for a single-range node. With two ranges `n[17]` reads a slot-range value instead, and `verifyClusterInitialized` then spins forever waiting for `b'connected'` rather than failing cleanly.

**This branch already pins a LibMR containing #117**, so the mismatch is live: any node with more than one slot range — or a slotless master, both reachable via the Redis Enterprise extended ASM long-form CLUSTERSET — hangs the harness. #117 fixed its own consumer inside the LibMR test module, but the RedisTimeSeries half was never ported.

Found while auditing what 8.4/8.6 would inherit by bumping to LibMR master (#2141, #2142); the same fix is included there.

Test-only change, no production code touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only polling fix with no production or security impact.
> 
> **Overview**
> **Fixes cluster harness polling** after LibMR changed `timeseries.INFOCLUSTER` per-node replies from a fixed 18 fields to `14 + 4×ranges`, so `status` is always the **last** element.
> 
> `verifyClusterInitialized` in `tests/flow/includes.py` and `tests/flow/test_ts_libmr_failure.py` now uses `n[-1]` instead of `n[17]` when checking each node’s connection state. The old index only matched single-range nodes; with multiple slot ranges (or slotless masters) it read a slot field and the wait loop never saw `b'connected'`, hanging tests instead of progressing.
> 
> Test-only change; no production code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c95c8005e98e59d1f9ce7e93beaa4be085b0b5a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->