### PR TITLE
ci: skip S3 upload on fork pull requests

### DIFF
--- a/.github/actions/upload-artifacts-to-s3-without-make/action.yml
+++ b/.github/actions/upload-artifacts-to-s3-without-make/action.yml
@@ -25,29 +25,25 @@ runs:
   using: composite
   steps:
     - name: Configure AWS credentials and upload artifcats # todo - use aws role instead
+      # Pull requests from forks never get the repository secrets, so there is
+      # nothing to upload with. Skip rather than fail the whole build.
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       shell: bash
       run: |
+          echo ::group::install aws cli
+          python3 -m venv .aws-cli-venv && source .aws-cli-venv/bin/activate &&
+          pip3 install --upgrade pip && pip3 install --no-cache-dir awscli && rm -rf /var/cache/apk/*
+          echo ::endgroup::
+
           # Variables from the workflow
           export AWS_ACCESS_KEY_ID="${{ inputs.aws-access-key-id }}"
           export AWS_SECRET_ACCESS_KEY="${{ inputs.aws-secret-access-key }}"
           export AWS_REGION="us-east-1"
           # Check if the required environment variables are set
           if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ] || [ -z "$AWS_REGION" ]; then
-            # Pull requests from forks never get the repository secrets, so there is
-            # nothing to upload with. Skip instead of failing the whole build.
-            if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
-              echo "::notice::Fork pull request - repository secrets are unavailable, skipping S3 upload."
-              exit 0
-            fi
-            echo "::error::Missing AWS credentials or region configuration."
+            echo "Missing AWS credentials or region configuration."
             exit 1
           fi
-
-          echo ::group::install aws cli
-          python3 -m venv .aws-cli-venv && source .aws-cli-venv/bin/activate &&
-          pip3 install --upgrade pip && pip3 install --no-cache-dir awscli && rm -rf /var/cache/apk/*
-          echo ::endgroup::
-
           # Configure AWS CLI with provided credentials and region
           echo "Configuring AWS CLI with access keys..."
           aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"

--- a/.github/actions/upload-artifacts-to-s3-without-make/action.yml
+++ b/.github/actions/upload-artifacts-to-s3-without-make/action.yml
@@ -27,20 +27,27 @@ runs:
     - name: Configure AWS credentials and upload artifcats # todo - use aws role instead
       shell: bash
       run: |
-          echo ::group::install aws cli
-          python3 -m venv .aws-cli-venv && source .aws-cli-venv/bin/activate &&
-          pip3 install --upgrade pip && pip3 install --no-cache-dir awscli && rm -rf /var/cache/apk/*
-          echo ::endgroup::
-
           # Variables from the workflow
           export AWS_ACCESS_KEY_ID="${{ inputs.aws-access-key-id }}"
           export AWS_SECRET_ACCESS_KEY="${{ inputs.aws-secret-access-key }}"
           export AWS_REGION="us-east-1"
           # Check if the required environment variables are set
           if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ] || [ -z "$AWS_REGION" ]; then
-            echo "Missing AWS credentials or region configuration."
+            # Pull requests from forks never get the repository secrets, so there is
+            # nothing to upload with. Skip instead of failing the whole build.
+            if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+              echo "::notice::Fork pull request - repository secrets are unavailable, skipping S3 upload."
+              exit 0
+            fi
+            echo "::error::Missing AWS credentials or region configuration."
             exit 1
           fi
+
+          echo ::group::install aws cli
+          python3 -m venv .aws-cli-venv && source .aws-cli-venv/bin/activate &&
+          pip3 install --upgrade pip && pip3 install --no-cache-dir awscli && rm -rf /var/cache/apk/*
+          echo ::endgroup::
+
           # Configure AWS CLI with provided credentials and region
           echo "Configuring AWS CLI with access keys..."
           aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"


### PR DESCRIPTION
## Problem

Every Event CI run on a pull request **from a fork** goes red on `Upload artifacts to S3`, even when the build and the whole test suite pass.

GitHub does not expose repository secrets to `pull_request` runs from forks, so `secrets.AWS_ACCESS_KEY_ID` / `secrets.AWS_SECRET_ACCESS_KEY` resolve to empty strings. The composite action's own guard then hard-fails:

```
export AWS_ACCESS_KEY_ID=""
...
Missing AWS credentials or region configuration.
##[error]Process completed with exit code 1.
```

Evidence:

- [run 31308328000, `x64-jammy-gen`](https://github.com/RedisTimeSeries/RedisTimeSeries/actions/runs/31308328000/job/93232139274) (#2144, from `gabsow/RedisTimeSeries`) — build ✅, tests ✅, pack ✅, step 13 ❌.
- [run 31102355051](https://github.com/RedisTimeSeries/RedisTimeSeries/actions/runs/31102355051) — the same step is the *only* failure on ~40 linux + macos legs.
- Same-repo branch PRs are unaffected, because they do get the secrets.

## Fix

One `if:` on the composite action's step, so all three call sites (`flow-linux.yml`, `flow-macos.yml`, `mariner2.yml`) are covered and a future fourth caller can't forget it:

```yaml
if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
```

The condition is *"not a fork pull request"* rather than *"the credential inputs are empty"* on purpose: gating on empty inputs would also silently skip when a secret is rotated or removed on `master`/tags, hiding a broken publish. As written, those runs still execute the step and the existing `Missing AWS credentials` → `exit 1` check keeps failing loudly.

## Notes

- This PR is from an in-repo branch, so its own CI exercises the **credentialed** path and confirms uploads still work. The skip path needs a fork PR to observe; #2144 can be re-run once this lands.
- RedisJSON has the same bug on both of its upload paths (see [RedisJSON#1623](https://github.com/RedisJSON/RedisJSON/pull/1623), fork PR, `Upload artifacts to S3` failing on macos + all arm64 legs) — fixed separately.
- Switching this action to the OIDC `role-to-assume` form (as the internal repo already does) would *not* fix this on its own: fork PRs get a read-only `GITHUB_TOKEN` and cannot be granted `id-token: write`, so the OIDC token fetch would fail instead. The guard is needed either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)