### PR TITLE
[8.4] MOD-17387 Silence valgrind fork-child false-positive leaks (port of #1905)

### DIFF
--- a/build/LibMR/Makefile
+++ b/build/LibMR/Makefile
@@ -59,6 +59,10 @@ define CC_DEFS +=
 	MODULE_NAME=$(MODULE_NAME)
 endef
 
+ifeq ($(VG),1)
+CC_DEFS += _VALGRIND EXECUTION_DEFAULT_MAX_IDLE_MS=10000
+endif
+
 define CC_INCLUDES +=
 	$(SRCDIR)
 	$(BINDIR)

--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -25,11 +25,15 @@ OSNICK = paella.Platform().osnick
 RLEC_CLUSTER = os.getenv('RLEC_CLUSTER') == '1'
 
 SANITIZER = os.getenv('SANITIZER', '')
-VALGRIND = os.getenv('VALGRIND', '0') == '1'
+VALGRIND = (os.getenv('VALGRIND', '0') == '1') or (os.getenv('VG', '0') == '1')
 CODE_COVERAGE = os.getenv('CODE_COVERAGE', '0') == '1'
 
 
-Defaults.terminate_retries = 3
+# Use generous terminate patience for all configurations. RLTest polls and
+# returns as soon as the process exits, so a high retry count costs nothing
+# when shutdown is fast, but prevents force-kills under Valgrind/sanitizer
+# where shutdown is much slower.
+Defaults.terminate_retries = 20
 Defaults.terminate_retries_secs = 1
 
 
@@ -95,7 +99,10 @@ def Env(*args, **kwargs):
 
     skipRefreshCluster = kwargs.pop('skipRefreshCluster', False)
 
-    env = rltestEnv(*args, terminateRetries=3, terminateRetrySecs=1, **kwargs)
+    env = rltestEnv(*args,
+                    terminateRetries=Defaults.terminate_retries,
+                    terminateRetrySecs=Defaults.terminate_retries_secs,
+                    **kwargs)
     Defaults.no_log = temp_no_log
     Defaults.no_capture_output = no_capture_output
 

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -202,6 +202,8 @@ setup_valgrind() {
 		--leak-check=$VG_LEAK_CHECK \
 		--show-reachable=no \
 		--track-origins=yes \
+		--trace-children=no \
+		--child-silent-after-fork=yes \
 		--show-possibly-lost=no"
 
 	VALGRIND_SUPRESSIONS=$ROOT/tests/memcheck/redis_valgrind.sup

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -406,6 +406,10 @@ PARALLEL=${PARALLEL:-1}
 # due to Python "Can't pickle local object" problem in RLTest
 [[ $OS == macos ]] && PARALLEL=0
 
+# run Valgrind serially: at --parallelism nproc the runner oversubscribes CPU
+# (redis-server is ~30x slower under Valgrind), starving shards past LibMR's max-idle
+[[ $VG == 1 ]] && PARALLEL=0
+
 [[ $EXT == 1 || $EXT == run || $BB == 1 || $GDB == 1 ]] && PARALLEL=0
 
 if [[ -n $PARALLEL && $PARALLEL != 0 ]]; then


### PR DESCRIPTION
Ports **#1905** (`041d7be8`, Feb 2026) to this branch. **Test-harness only — no product code.**

## What was reported

Valgrind "definitely lost" records in `test_asm.test_asm_with_data_and_queries_during_migrations`, in `MultiSeriesSampleIterator_New` (`multiseries_sample_iterator.c:69`/`:78`) via `MultiSerieReduce` → `GroupList_ApplyReducer` → `mrange_done`, plus hiredis buffers via `MR_ClusterSendMsgToNodeInternal`.

## Why these are not leaks

They are **fork children**. Redis forks for background persistence / ASM slot snapshots while `TS.MRANGE` queries are in flight. Only the forking thread survives `fork()`, so the thread holding these pointers in a stack local does not exist in the child, and the child `_exit()`s without unwinding — valgrind reports the parent's *live* allocations as lost in the child. The parent frees everything.

Three independent confirmations:

- **Block counts.** Every record is `in 1 blocks`. `multiseries_sample_iterator.c:78` is inside the `for (i < n_series)` loop and the test's 100 keys share one group, so one query allocates ~100 `MSSample`s — a real missing free would print ~100 blocks from a single query and thousands across the ~40 migrations. Observed: one.
- **Arithmetic.** `58 (48 direct, 10 indirect)` is a 6-slot `curargv` with a single sds attached — a half-built argv, impossible for any completed `redisvFormatCommand`; hiredis frees it on every return path (`hiredis.c:535` and the `cleanup:` label). Two processes report `283,086` and `283,087` bytes — differing by one byte, i.e. one in-flight message each, not accumulation.
- **Provenance.** #1905's own commit message describes this exact test and this exact allocator, and it was fixed there by the same flag.

`--log-file` carries no `%p`, so children append to the parent's log — which is why one file shows several pids with no shard restart in the test.

## Why 8.6/8.4 and not 8.8/master

`--child-silent-after-fork=yes` has been on 8.8 and master since March; **8.6 and 8.4 never got the cherry-pick.** The code is otherwise the same: `src/multiseries_sample_iterator.c` is the identical git blob on every branch, and `MultiSerieReduce` was merely *renamed* `MultiSeriesReduce` on 8.8+ — anyone verifying by grepping the old name will reach the wrong conclusion.

## Two commits, deliberately

1. **fork flags** in `tests/flow/tests.sh` — this alone fixes the reported failure. `--trace-children=no` is valgrind's default and a no-op; it is included only so the block matches 8.8/master byte for byte.
2. **`terminate_retries` 3 → 20** in `tests/flow/includes.py`, threaded through the `Env()` wrapper, plus `VALGRIND` honouring `VG=1`.

⚠️ **Expect commit 2 to change what CI reports.** With 3 retries RLTest SIGKILLs the valgrind'd server after ~3s, and a memcheck leak scan of a redis heap routinely takes longer; a SIGKILLed valgrind under `-q` writes nothing. So parent-side leak checks on this branch may never have completed. The first run after this lands is the first honest parent signal — **if a leg goes red, that is new information, not a regression from this PR**, and it is attributable to commit 2 rather than to the fork flags.

## Not done on purpose

No change to `MultiSeriesSampleIterator_Close` or the LibMR send path — both are correct, and patching them would be a fix on green code. In particular `deps/LibMR/src/cluster.c:519`/`:660` set `n->c = NULL` without `redisAsyncFree`, which looks like a leak but is not: hiredis runs the disconnect callback from *inside* `__redisAsyncFree` and frees the context itself, so adding a free there is a double free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test runners, Valgrind options, and conditional LibMR build flags; no production Redis/module behavior is modified.
> 
> **Overview**
> **Valgrind CI noise and stability** are addressed without changing RedisTimeSeries product logic.
> 
> `tests/flow/tests.sh` adds `--trace-children=no` and **`--child-silent-after-fork=yes`** to `VG_OPTIONS` so fork children from Redis persistence/ASM snapshots are not memchecked (eliminating false “definitely lost” reports from parent allocations). When **`VG=1`**, flow tests run **serially** (`PARALLEL=0`) because parallel Valgrind runs oversubscribe CPU and can trip LibMR max-idle timeouts.
> 
> `tests/flow/includes.py` raises default **`terminate_retries` from 3 to 20** (wired through `Env()`), treats **`VG=1`** like `VALGRIND` for harness flags, so RLTest is less likely to SIGKILL slow Valgrind/sanitizer shutdowns before leak checks finish.
> 
> `build/LibMR/Makefile` defines **`_VALGRIND`** and **`EXECUTION_DEFAULT_MAX_IDLE_MS=10000`** when **`VG=1`**, aligning LibMR test builds with Valgrind timing expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d0519f827fe8085fa121e6926539cdedebc66cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->