### PR TITLE
[8.8] MOD-14615 Run the valgrind suite serially (port of #2083)

### DIFF
--- a/build/LibMR/Makefile
+++ b/build/LibMR/Makefile
@@ -59,6 +59,10 @@ define CC_DEFS +=
 	MODULE_NAME=$(MODULE_NAME)
 endef
 
+ifeq ($(VG),1)
+CC_DEFS += _VALGRIND EXECUTION_DEFAULT_MAX_IDLE_MS=10000
+endif
+
 define CC_INCLUDES +=
 	$(SRCDIR)
 	$(BINDIR)

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -406,6 +406,10 @@ PARALLEL=${PARALLEL:-1}
 # due to Python "Can't pickle local object" problem in RLTest
 [[ $OS == macos ]] && PARALLEL=0
 
+# run Valgrind serially: at --parallelism nproc the runner oversubscribes CPU
+# (redis-server is ~30x slower under Valgrind), starving shards past LibMR's max-idle
+[[ $VG == 1 ]] && PARALLEL=0
+
 [[ $EXT == 1 || $EXT == run || $BB == 1 || $GDB == 1 ]] && PARALLEL=0
 
 if [[ -n $PARALLEL && $PARALLEL != 0 ]]; then


### PR DESCRIPTION
()

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-runner and Valgrind-only compile flags; no production behavior change when Valgrind is not used.
> 
> **Overview**
> **Valgrind flow tests no longer run in parallel.** When `VG=1`, `tests.sh` forces `PARALLEL=0` so RLTest does not launch `--parallelism nproc` workers. The comment notes that Valgrind slows `redis-server` enough that parallel runs oversubscribe CPU and shards can exceed LibMR’s max-idle limit.
> 
> **LibMR Valgrind builds get longer default idle time.** With `VG=1`, the LibMR `Makefile` adds `_VALGRIND` and `EXECUTION_DEFAULT_MAX_IDLE_MS=10000` to compile definitions, aligning module behavior with slower Valgrind execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3762f785c06ee361da678630da6a2f2caa0ccbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->