### PR TITLE
MOD-17239 gorilla decoder guard over-read

### DIFF
--- a/src/compressed_chunk.c
+++ b/src/compressed_chunk.c
@@ -31,7 +31,7 @@ Chunk_t *Compressed_NewChunk(size_t size) {
     _log_if(size % 8 != 0, "chunk size isn't multiplication of 8");
     CompressedChunk *chunk = (CompressedChunk *)calloc(1, sizeof(CompressedChunk));
     chunk->size = size;
-    chunk->data = (uint64_t *)calloc(chunk->size, sizeof(char));
+    chunk->data = (uint64_t *)calloc(chunk->size + GORILLA_DATA_READAHEAD_BYTES, sizeof(char));
 #ifdef DEBUG
     memset(chunk->data, 0, chunk->size);
 #endif
@@ -54,8 +54,9 @@ Chunk_t *Compressed_CloneChunk(const Chunk_t *chunk) {
     const CompressedChunk *oldChunk = chunk;
     CompressedChunk *newChunk = malloc(sizeof(CompressedChunk));
     memcpy(newChunk, oldChunk, sizeof(CompressedChunk));
-    newChunk->data = malloc(newChunk->size);
+    newChunk->data = malloc(newChunk->size + GORILLA_DATA_READAHEAD_BYTES);
     memcpy(newChunk->data, oldChunk->data, oldChunk->size);
+    memset((char *)newChunk->data + newChunk->size, 0, GORILLA_DATA_READAHEAD_BYTES);
     return newChunk;
 }
 
@@ -82,8 +83,9 @@ static void ensureAddSample(CompressedChunk *chunk, Sample *sample) {
     if (res != CR_OK) {
         int oldsize = chunk->size;
         chunk->size += CHUNK_RESIZE_STEP;
-        chunk->data = (uint64_t *)realloc(chunk->data, chunk->size * sizeof(char));
-        memset((char *)chunk->data + oldsize, 0, CHUNK_RESIZE_STEP);
+        chunk->data =
+            (uint64_t *)realloc(chunk->data, chunk->size + GORILLA_DATA_READAHEAD_BYTES);
+        memset((char *)chunk->data + oldsize, 0, (chunk->size + GORILLA_DATA_READAHEAD_BYTES) - oldsize);
         // printf("Chunk extended to %lu \n", chunk->size);
         res = Compressed_AddSample(chunk, sample);
         assert(res == CR_OK);
@@ -107,7 +109,8 @@ static void trimChunk(CompressedChunk *chunk) {
         // align to 8 bytes (uint64_t) otherwise we will have an heap overflow in gorilla.c because
         // each write happens in 8 bytes blocks.
         newSize += sizeof(binary_t) - (newSize % sizeof(binary_t));
-        chunk->data = realloc(chunk->data, newSize);
+        chunk->data = realloc(chunk->data, newSize + GORILLA_DATA_READAHEAD_BYTES);
+        memset((char *)chunk->data + newSize, 0, GORILLA_DATA_READAHEAD_BYTES);
         chunk->size = newSize;
     }
 }
@@ -511,6 +514,43 @@ void Compressed_SaveToRDB(Chunk_t *chunk, struct RedisModuleIO *io) {
                          (SaveStringBufferFunc)RedisModule_SaveStringBuffer);
 }
 
+// Validates a compressed chunk that was loaded/deserialized from an untrusted source and,
+// when valid, installs read-ahead padding on its data buffer. `len` is the actual length of
+// the loaded `data` buffer. Returns true if the chunk is self-consistent and safe to decode.
+static bool Compressed_ValidateLoadedChunk(CompressedChunk *compchunk, size_t len) {
+    if (compchunk->data == NULL) {
+        return false;
+    }
+    if (len == 0) {
+        return false; /* Buffer size must be non-zero */
+    }
+    if (compchunk->idx > len * 8) {
+        return false; /* Bit index can't exceed buffer size in bits */
+    }
+    if (compchunk->size != len) {
+        return false; /* size metadata must match actual buffer length */
+    }
+    if (compchunk->size % sizeof(binary_t) != 0) {
+        return false; /* gorilla.c reads/writes data in binary_t (8-byte) words */
+    }
+    /* Every sample after the first costs >=2 bits to encode (appendInteger/appendFloat
+     * in gorilla.c), so idx must be able to cover count-1 appended samples.
+     * Written as idx/2 < count-1 (equivalent to idx < 2*(count-1) for non-negative
+     * integers) to avoid overflow when count is attacker-inflated near UINT64_MAX. */
+    if (compchunk->count > 0 && compchunk->idx / 2 < compchunk->count - 1) {
+        return false;
+    }
+    // Over-allocate so the decoder's bounded look-ahead can never touch unallocated memory.
+    uint64_t *padded =
+        (uint64_t *)realloc(compchunk->data, compchunk->size + GORILLA_DATA_READAHEAD_BYTES);
+    if (padded == NULL) {
+        return false;
+    }
+    compchunk->data = padded;
+    memset((char *)compchunk->data + compchunk->size, 0, GORILLA_DATA_READAHEAD_BYTES);
+    return true;
+}
+
 int Compressed_LoadFromRDB(Chunk_t **chunk, struct RedisModuleIO *io) {
     bool err = false;
     errdefer(err, *chunk = NULL);
@@ -537,27 +577,7 @@ int Compressed_LoadFromRDB(Chunk_t **chunk, struct RedisModuleIO *io) {
 
     size_t len;
     compchunk->data = (uint64_t *)LoadStringBuffer_IOError(io, &len, err, TSDB_ERROR);
-    if (len == 0) {
-        err = true;
-        return TSDB_ERROR; /* Buffer size must be non-zero */
-    }
-    if (compchunk->idx > len * 8) {
-        err = true;
-        return TSDB_ERROR; /* Bit index can't exceed buffer size in bits */
-    }
-    if (compchunk->size != len) {
-        err = true;
-        return TSDB_ERROR; /* size metadata must match actual buffer length */
-    }
-    if (compchunk->size % sizeof(binary_t) != 0) {
-        err = true;
-        return TSDB_ERROR; /* gorilla.c reads/writes data in binary_t (8-byte) words */
-    }
-    /* Every sample after the first costs >=2 bits to encode (appendInteger/appendFloat
-     * in gorilla.c), so idx must be able to cover count-1 appended samples.
-     * Written as idx/2 < count-1 (equivalent to idx < 2*(count-1) for non-negative
-     * integers) to avoid overflow when count is attacker-inflated near UINT64_MAX. */
-    if (compchunk->count > 0 && compchunk->idx / 2 < compchunk->count - 1) {
+    if (!Compressed_ValidateLoadedChunk(compchunk, len)) {
         err = true;
         return TSDB_ERROR;
     }
@@ -575,6 +595,10 @@ void Compressed_MRSerialize(Chunk_t *chunk, WriteSerializationCtx *sctx) {
 
 int Compressed_MRDeserialize(Chunk_t **chunk, ReaderSerializationCtx *sctx) {
     CompressedChunk *compchunk = (CompressedChunk *)malloc(sizeof(*compchunk));
+    if (compchunk == NULL) {
+        *chunk = NULL;
+        return TSDB_ERROR;
+    }
 
     compchunk->data = NULL;
     compchunk->size = MR_SerializationCtxReadLongLongWrapper(sctx);
@@ -590,6 +614,11 @@ int Compressed_MRDeserialize(Chunk_t **chunk, ReaderSerializationCtx *sctx) {
 
     size_t len;
     compchunk->data = (uint64_t *)MR_ownedBufferFrom(sctx, &len);
+    if (!Compressed_ValidateLoadedChunk(compchunk, len)) {
+        Compressed_FreeChunk(compchunk);
+        *chunk = NULL;
+        return TSDB_ERROR;
+    }
     *chunk = (Chunk_t *)compchunk;
     return TSDB_OK;
 }

--- a/src/compressed_chunk.c
+++ b/src/compressed_chunk.c
@@ -83,9 +83,10 @@ static void ensureAddSample(CompressedChunk *chunk, Sample *sample) {
     if (res != CR_OK) {
         int oldsize = chunk->size;
         chunk->size += CHUNK_RESIZE_STEP;
-        chunk->data =
-            (uint64_t *)realloc(chunk->data, chunk->size + GORILLA_DATA_READAHEAD_BYTES);
-        memset((char *)chunk->data + oldsize, 0, (chunk->size + GORILLA_DATA_READAHEAD_BYTES) - oldsize);
+        chunk->data = (uint64_t *)realloc(chunk->data, chunk->size + GORILLA_DATA_READAHEAD_BYTES);
+        memset((char *)chunk->data + oldsize,
+               0,
+               (chunk->size + GORILLA_DATA_READAHEAD_BYTES) - oldsize);
         // printf("Chunk extended to %lu \n", chunk->size);
         res = Compressed_AddSample(chunk, sample);
         assert(res == CR_OK);

--- a/src/gorilla.c
+++ b/src/gorilla.c
@@ -534,6 +534,11 @@ ChunkResult Compressed_ChunkIteratorGetNext(ChunkIter_t *abstractIter, Sample *s
         iter->count++;
         return CR_OK;
     }
+    // Defense against a corrupt chunk whose `count` claims more samples than the data buffer actually encodes.
+    if (unlikely(iter->idx >= iter->chunk->size * 8)) {
+        iter->count++;
+        return CR_END;
+    }
     const uint64_t *bins = iter->chunk->data;
     // We're fast checking the control bits for the cases in which the delta is 0
     // This avoids the call to expensive readInteger and readFloat functions

--- a/src/gorilla.c
+++ b/src/gorilla.c
@@ -534,7 +534,8 @@ ChunkResult Compressed_ChunkIteratorGetNext(ChunkIter_t *abstractIter, Sample *s
         iter->count++;
         return CR_OK;
     }
-    // Defense against a corrupt chunk whose `count` claims more samples than the data buffer actually encodes.
+    // Defense against a corrupt chunk whose `count` claims more samples than the data buffer
+    // actually encodes.
     if (unlikely(iter->idx >= iter->chunk->size * 8)) {
         iter->count++;
         return CR_END;

--- a/src/gorilla.h
+++ b/src/gorilla.h
@@ -21,6 +21,13 @@ typedef uint64_t binary_t;
 typedef uint64_t globalbit_t;
 typedef uint8_t localbit_t;
 
+// The gorilla bit reader (readBits) may look one 64-bit word past the word holding the
+// current bit position, and a single sample decode advances the cursor by up to ~211 bits.
+// Compressed chunk data buffers are over-allocated by this many bytes so that decoding which
+// is bounded at `size * 8` bits (see Compressed_ChunkIteratorGetNext) can never read or write
+// outside the allocation, even for a corrupt chunk whose `count` exceeds its encoded data.
+#define GORILLA_DATA_READAHEAD_BYTES (8 * sizeof(binary_t))
+
 typedef union
 {
     double d;

--- a/tests/flow/test_borken_rdb.py
+++ b/tests/flow/test_borken_rdb.py
@@ -573,3 +573,177 @@ def test_broken_rdb_rejects_compressed_chunk_count_overflow_bypass(env):
     env.cmd('DEL', 'test_key')
 
     env.expect('RESTORE', 'test_key', 0, malicious_dump).error()
+
+def _gorilla_wide_sample_bitstream(nbits: int) -> bytes:
+    """
+    Build a gorilla data buffer of `nbits` bits (rounded up to whole bytes) whose
+    every decoded sample consumes 71 bits, so decoding drives `iter->idx` forward
+    fast. Crucially it never takes the readFloat path, so it does NOT trip the
+    DEBUG-only asserts in gorilla.c (which would abort the server on any build
+    regardless of this fix) -- the test must stay portable across debug/release/asan.
+
+    Per-sample bit layout consumed by Compressed_ChunkIteratorGetNext (LSB-first):
+      1 : timestamp control bit = 1  -> not "off", so readInteger() is called
+      5 : readInteger control bits = 1 x5 -> falls through to the 64-bit branch
+      64: the delta value (zeros)
+      1 : value control bit = 0 -> "off", uses prevValue, readFloat() NOT called
+    => 71 bits/sample, all control paths assert-free.
+    """
+    unit = [1, 1, 1, 1, 1, 1] + [0] * 65  # 6 ones + 64 delta zeros + 1 value-control zero
+    total_bits = ((nbits + 7) // 8) * 8
+    bits = (unit * (total_bits // len(unit) + 1))[:total_bits]
+    out = bytearray(total_bits // 8)
+    for i, bit in enumerate(bits):
+        if bit:
+            out[i // 8] |= (1 << (i % 8))  # bit position p -> byte p//8, LSB-first
+    return bytes(out)
+
+
+def _patch_first_compressed_chunk_overread(dump: bytes):
+    """
+    Craft a poisoned compressed chunk that PASSES the load-time count/idx/size
+    consistency checks but whose `count`-driven decoder would still walk off the
+    data buffer.
+
+    We set idx = size*8 (the max the load check allows) and count = size*4 (so
+    count-1 <= idx/2 holds), and fill the data buffer with a pattern in which each
+    decoded sample consumes 71 bits. Decoding `count` such samples requires far
+    more than the size*8 bits the buffer holds, so without the decoder-time
+    `idx >= size*8` bound the reader reads adjacent heap.
+
+    Returns (poisoned_dump, inflated_count).
+    """
+    b = bytearray(dump)
+    assert _verify_dump_payload(dump), "baseline DUMP payload should have valid checksum"
+
+    idx = 0
+    idx += 1  # object type byte
+    _, _, idx = _rdb_load_len(dump, idx)  # moduleid
+
+    def read_opcode():
+        nonlocal idx
+        op, _, idx2 = _rdb_load_len(dump, idx)
+        idx = idx2
+        return op
+
+    def read_uint_capture():
+        nonlocal idx
+        op = read_opcode()
+        assert op == 2  # RDB_MODULE_OPCODE_UINT
+        val_start = idx
+        val, _, idx2 = _rdb_load_len(dump, idx)
+        idx = idx2
+        return val, val_start, idx
+
+    def read_string_skip():
+        nonlocal idx
+        op = read_opcode()
+        assert op == 5  # RDB_MODULE_OPCODE_STRING
+        idx = _rdb_skip_string(dump, idx)
+
+    def read_double_skip():
+        nonlocal idx
+        op = read_opcode()
+        assert op == 4  # RDB_MODULE_OPCODE_DOUBLE
+        idx += 8
+
+    read_string_skip()                 # keyName
+    read_uint_capture()                # retentionTime
+    read_uint_capture()                # chunkSizeBytes
+    options, _, _ = read_uint_capture()
+    assert options == 2, "test assumes default COMPRESSED encoding (SERIES_OPT_COMPRESSED_GORILLA)"
+    read_uint_capture()                # lastTimestamp
+    read_double_skip()                 # lastValue
+    read_uint_capture()                # totalSamples
+    read_uint_capture()                # duplicatePolicy
+    has_src, _, _ = read_uint_capture()
+    assert has_src == 0
+    read_uint_capture()                # ignoreMaxTimeDiff
+    read_double_skip()                 # ignoreMaxValDiff
+    labels_count, _, _ = read_uint_capture()
+    assert labels_count == 0
+    rules_count, _, _ = read_uint_capture()
+    assert rules_count == 0
+    num_chunks, _, _ = read_uint_capture()
+    assert num_chunks == 1
+
+    size_val, size_start, size_end = read_uint_capture()   # chunk->size
+    _, count_start, count_end = read_uint_capture()        # chunk->count
+    _, idx_start, idx_end = read_uint_capture()            # chunk->idx
+
+    assert size_val % 8 == 0 and size_val > 0
+
+    # Skip the remaining scalar fields to reach the data-string field.
+    read_uint_capture()  # baseValue
+    read_uint_capture()  # baseTimestamp
+    read_uint_capture()  # prevTimestamp
+    read_uint_capture()  # prevTimestampDelta
+    read_uint_capture()  # prevValue
+    read_uint_capture()  # prevLeading
+    read_uint_capture()  # prevTrailing
+
+    string_field_start = idx
+    op = read_opcode()
+    assert op == 5  # RDB_MODULE_OPCODE_STRING
+    data_field_end = _rdb_skip_string(dump, idx)
+
+    inflated_count = size_val * 4          # count-1 <= idx/2 == size*4, so this passes the load check
+    poisoned_idx = size_val * 8            # max idx the load check permits
+
+    # Rebuild the data-string field as a plain (non-encoded) buffer of the declared
+    # size whose every decoded sample consumes 71 bits (assert-free, see helper).
+    data = _gorilla_wide_sample_bitstream(size_val * 8)
+    new_field = bytes([5]) + _rdb_encode_len(size_val) + data
+
+    # Edit right-to-left so earlier offsets stay valid.
+    b[string_field_start:data_field_end] = new_field
+    b[idx_start:idx_end] = _rdb_encode_len(poisoned_idx)
+    b[count_start:count_end] = _rdb_encode_len(inflated_count)
+
+    _patch_dump_crc(b)
+    assert _verify_dump_payload(bytes(b)), "patched DUMP payload should have valid checksum"
+    return bytes(b), inflated_count
+
+
+def test_broken_rdb_compressed_chunk_read_side_over_read_is_bounded(env):
+    """
+    Regression for the read-side heap over-read (MOD-17238 / VDP-4940): a chunk
+    whose `count` claims more samples than its data encodes must not let the
+    gorilla decoder read past the buffer.
+
+    The poisoned chunk is internally consistent (passes the load-time checks) but
+    each of its samples decodes to 71 bits, so an unbounded `count`-driven decode
+    walks far past the `size*8`-bit buffer -- crashing under ASan / on a real
+    over-read. With the fix the decoder stops at `size*8` bits (the data buffer is
+    over-allocated so the last look-ahead stays in-bounds); the loop, still bounded
+    by `count`, then re-emits the last in-bounds sample instead of leaking heap.
+
+    So the server must survive and every returned sample must be the safe decoded
+    value (baseTimestamp=1000, delta 0) -- never adjacent heap content.
+    """
+    env.skipOnCluster()
+
+    env.cmd('TS.CREATE', 'test_key', 'CHUNK_SIZE', '64')
+    env.cmd('TS.ADD', 'test_key', 1000, 1.0)
+
+    valid_dump = env.cmd('DUMP', 'test_key')
+    poisoned_dump, _inflated_count = _patch_first_compressed_chunk_overread(valid_dump)
+
+    env.cmd('DEL', 'test_key')
+
+    # The payload is internally consistent, so RESTORE may accept it; if it does,
+    # decoding it must be bounded (no out-of-bounds read, no crash).
+    try:
+        env.cmd('RESTORE', 'test_key', 0, poisoned_dump)
+    except Exception:
+        # Rejected at load time is also a safe outcome.
+        assert env.cmd('PING')
+        return
+
+    res = env.cmd('TS.RANGE', 'test_key', '-', '+')
+
+    # Server must survive decoding the poisoned chunk (an over-read would crash it).
+    assert env.cmd('PING')
+    # No heap must leak: every sample stays at the in-bounds decoded timestamp.
+    for ts, _val in res:
+        env.assertEqual(int(ts), 1000)

--- a/tests/unit/unittests_compressed_chunk.c
+++ b/tests/unit/unittests_compressed_chunk.c
@@ -261,6 +261,56 @@ MU_TEST(test_nan_mixed_compression) {
     Compressed_FreeChunk(chunk_varying);
 }
 
+MU_TEST(test_compressed_decode_is_bounded_by_size) {
+    const size_t size = 64;                 // 64 bytes -> 512 bits of real buffer
+    CompressedChunk *chunk = Compressed_NewChunk(size);
+    mu_assert(chunk != NULL, "create compressed chunk");
+
+    // Give the decoder a huge safety margin so a pre-fix, count-driven runaway stays
+    // inside the allocation (we are testing the cursor invariant, not a crash).
+    const size_t test_alloc = size + 4096;
+    chunk->data = (uint64_t *)realloc(chunk->data, test_alloc);
+    mu_assert(chunk->data != NULL, "grow test buffer");
+    memset(chunk->data, 0, test_alloc);
+
+    // Fill the real buffer so every decoded sample consumes 71 bits (timestamp
+    // control=1 -> readInteger 64-bit branch; value control=0 -> no readFloat).
+    // bit p -> byte p/8, LSB-first; per-sample unit = 6 ones, 64 zeros, 1 zero.
+    for (size_t bit = 0; bit < size * 8; ++bit) {
+        if ((bit % 71) < 6) {
+            ((unsigned char *)chunk->data)[bit / 8] |= (unsigned char)(1u << (bit % 8));
+        }
+    }
+
+    // Internally consistent metadata (would pass Compressed_ValidateLoadedChunk):
+    // idx = size*8 (max allowed), count = size*4 (so count-1 <= idx/2).
+    chunk->idx = size * 8;
+    chunk->count = size * 4;
+    chunk->baseTimestamp = 1000;
+    chunk->baseValue.d = 1.0;
+
+    ChunkIter_t *iter = Compressed_NewChunkIterator(chunk);
+    Sample sample;
+    uint64_t decoded = 0;
+    bool terminated = false;
+    for (uint64_t i = 0; i < chunk->count; ++i) {
+        ChunkResult rv = Compressed_ChunkIteratorGetNext(iter, &sample);
+        if (rv != CR_OK) {
+            terminated = true;
+            break;
+        }
+        decoded++;
+    }
+
+    // The decoder must stop once it reaches the end of the physical buffer instead
+    // of decoding all `count` samples out of thin air. Pre-fix this never triggers.
+    mu_assert(terminated, "decoder must return CR_END once the data buffer is exhausted");
+    mu_assert(decoded < chunk->count, "decoder must not honor the inflated count");
+
+    Compressed_FreeChunkIterator(iter);
+    Compressed_FreeChunk(chunk);
+}
+
 MU_TEST_SUITE(compressed_chunk_test_suite) {
     MU_RUN_TEST(test_compressed_upsert);
     MU_RUN_TEST(test_compressed_fail_appendInteger);
@@ -268,4 +318,5 @@ MU_TEST_SUITE(compressed_chunk_test_suite) {
     MU_RUN_TEST(test_Compressed_SplitChunk_odd);
     MU_RUN_TEST(test_Compressed_SplitChunk_force_realloc);
     MU_RUN_TEST(test_nan_mixed_compression);
+    MU_RUN_TEST(test_compressed_decode_is_bounded_by_size);
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Security-sensitive decode path for untrusted RDB/module payloads; incorrect bounds or padding could still allow OOB reads or change observable series data on corrupt chunks.
> 
> **Overview**
> Fixes a **heap over-read** when Gorilla-compressed chunks have metadata that passes load-time checks but **`count` still drives decoding past the encoded bitstream** (e.g. poisoned `DUMP`/`RESTORE` payloads).
> 
> **Decoder:** `Compressed_ChunkIteratorGetNext` now stops with `CR_END` when `iter->idx >= chunk->size * 8` before further bit reads, so iteration cannot walk past the logical buffer even if `count` is inflated.
> 
> **Buffers:** Introduces `GORILLA_DATA_READAHEAD_BYTES` (64 bytes) so `readBits`’s 64-bit word look-ahead stays inside the allocation when decoding is bounded at `size * 8` bits. Chunk **new/clone/resize/trim** paths over-allocate and zero that tail; loaded chunks get the same via a shared **`Compressed_ValidateLoadedChunk`** used from **RDB** and **MR** deserialize (replacing inline validation). **MR** deserialize also handles `malloc` failure.
> 
> **Tests:** Unit test for bounded decode on synthetic corrupt metadata; flow test that crafts an internally consistent malicious compressed chunk and asserts the server survives `RESTORE`/`TS.RANGE` without leaking heap into results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44cc741c63f94f4dda4f6f576ae6777b1dadc506. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->