### PR TITLE
MOD-17566 - Fix S3 artifact names for nightly and manual builds

### DIFF
--- a/.github/actions/upload-artifacts-to-s3-without-make/action.yml
+++ b/.github/actions/upload-artifacts-to-s3-without-make/action.yml
@@ -61,7 +61,7 @@ runs:
           echo ::group::upload production release
             REF="${{ inputs.github-ref }}"
             PATTERN="refs/tags/v[0-9]+.*"
-            if [[ $REF =~ $PATTERN ]]; then
+            if [[ -z "${{ inputs.beta-version }}" && $REF =~ $PATTERN ]]; then
               echo "This is a tagged build"
               RELEASE=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
             fi

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -53,15 +53,19 @@ jobs:
           # Generate timestamp at workflow start for consistent beta versioning
           TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")
           WORKFLOW_NUM=${{ github.run_number }}
-          BETA_VERSION="99.99.99.${TIMESTAMP}.${WORKFLOW_NUM}"
+          REF_NAME="${{ github.ref_name }}"
+          REF_NAME="${REF_NAME//[^A-Za-z0-9._-]/_}"
+          if [[ "$REF_NAME" == "master" ]]; then
+            BETA_VERSION="99.99.99.${TIMESTAMP}.${WORKFLOW_NUM}"
+          else
+            BETA_VERSION="${REF_NAME}.${TIMESTAMP}.${WORKFLOW_NUM}"
+          fi
           
           echo "beta-timestamp=${TIMESTAMP}" >> $GITHUB_OUTPUT
           echo "beta-version=${BETA_VERSION}" >> $GITHUB_OUTPUT
           echo "Generated beta version: ${BETA_VERSION}"
 
-          BRANCH_NAME="${{ github.ref_name }}"
-          BRANCH_NAME="${BRANCH_NAME//[^A-Za-z0-9._-]/_}"
-          SNAPSHOT_TEMPLATE="redistimeseries/snapshots/redistimeseries.@OS.${BRANCH_NAME}.${TIMESTAMP}.${WORKFLOW_NUM}.zip"
+          SNAPSHOT_TEMPLATE="redistimeseries/snapshots/redistimeseries.@OS.${BETA_VERSION}.zip"
           echo "snapshot-template=${SNAPSHOT_TEMPLATE}" >> $GITHUB_OUTPUT
           echo "Snapshot template: ${SNAPSHOT_TEMPLATE}"
 

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -278,12 +278,6 @@ pack_deps() {
 NUMVER="$(NUMERIC=1 $SBIN/getver)"
 SEMVER="$($SBIN/getver)"
 
-# Override SEMVER with BETA_VERSION if provided (for nightly builds)
-if [[ -n $BETA_VERSION ]]; then
-	SEMVER="$BETA_VERSION"
-	echo "# Using beta version: $BETA_VERSION"
-fi
-
 if [[ -n $VARIANT ]]; then
 	_VARIANT="-${VARIANT}"
 fi
@@ -317,8 +311,9 @@ if [[ $WITH_GITSHA == 1 ]]; then
 fi
 
 if [[ -n $BETA_VERSION ]]; then
-	BETA_SUFFIX=$(echo "$BETA_VERSION" | cut -d'.' -f4,5,6)
-	BRANCH="${BRANCH}.${BETA_SUFFIX}"
+	SEMVER=${BETA_VERSION//[^A-Za-z0-9._-]/_}
+	BRANCH="$SEMVER"
+	echo "# Using beta version: $SEMVER"
 fi
 
 #----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Use branch/tag plus timestamp/run for non-release artifact names instead of the placeholder 99.99.99 version. Generate a beta suffix for manual branch runs, keep tag releases unchanged, and apply the resolved name to both snapshot and release-style package filenames to avoid S3 overwrites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes S3 artifact naming and when production release uploads run. A mistake could overwrite packages or skip/publish the wrong release path.
> 
> **Overview**
> Stops nightly and manual branch builds from colliding on S3 by using a unique beta name instead of the `99.99.99` placeholder (kept only for `master`).
> 
> Non-master refs get `{sanitized-ref}.{timestamp}.{run}`; snapshot templates use that full version. `pack.sh` now sets both `SEMVER` and `BRANCH` from `BETA_VERSION`, so release-style and snapshot zips share the same unique name.
> 
> Production release uploads are skipped whenever `beta-version` is set, even on version tags, so tagged nightly/manual runs do not overwrite real releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 399beea894eedc3a6fd0b7d60ca97aedfb01f98a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->