### PR TITLE
MOD-17566 - add new stage to tag flow to verify tag version miss match 

### DIFF
--- a/.github/workflows/event-tag.yml
+++ b/.github/workflows/event-tag.yml
@@ -24,6 +24,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Validate tag version
+        env:
+          GITHUB_REF: ${{ github.ref }}
+        run: ./sbin/validate-tag-version
       - name: set env
         id: set-env
         env:
@@ -36,6 +40,7 @@ jobs:
           echo "redis-ref=${REDIS_REF}" >> $GITHUB_OUTPUT
   linter:
     uses: ./.github/workflows/flow-linter.yml
+    needs: [prepare-values]
     secrets: inherit
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml

--- a/sbin/validate-tag-version
+++ b/sbin/validate-tag-version
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PROGNAME="${BASH_SOURCE[0]}"
+HERE="$(cd "$(dirname "$PROGNAME")" &>/dev/null && pwd)"
+ROOT=$(cd "$HERE/.." && pwd)
+
+cd "$ROOT"
+
+if [[ ! "${GITHUB_REF:-}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+	echo "::error::Event TAG must run on a version tag like v10.9.9. Current ref: ${GITHUB_REF:-}"
+	exit 1
+fi
+
+TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+HEADER_VERSION="$("$HERE/getver")"
+
+if [[ "$TAG_VERSION" != "$HEADER_VERSION" ]]; then
+	echo "::error::Tag version (${TAG_VERSION}) does not match src/version.h (${HEADER_VERSION})."
+	exit 1
+fi
+
+echo "Tag version matches src/version.h: ${TAG_VERSION}"

--- a/sbin/validate-tag-version
+++ b/sbin/validate-tag-version
@@ -14,7 +14,20 @@ if [[ ! "${GITHUB_REF:-}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 fi
 
 TAG_VERSION="${GITHUB_REF#refs/tags/v}"
-HEADER_VERSION="$("$HERE/getver")"
+HEADER_VERSION="$(awk '
+	$1 == "#define" && $2 == "REDISTIMESERIES_VERSION_MAJOR" { major=$3 }
+	$1 == "#define" && $2 == "REDISTIMESERIES_VERSION_MINOR" { minor=$3 }
+	$1 == "#define" && $2 == "REDISTIMESERIES_VERSION_PATCH" { patch=$3 }
+	END {
+		if (major !~ /^[0-9]+$/ || minor !~ /^[0-9]+$/ || patch !~ /^[0-9]+$/) {
+			exit 1
+		}
+		print major "." minor "." patch
+	}
+' src/version.h)" || {
+	echo "::error::Could not read RedisTimeSeries version from src/version.h."
+	exit 1
+}
 
 if [[ "$TAG_VERSION" != "$HEADER_VERSION" ]]; then
 	echo "::error::Tag version (${TAG_VERSION}) does not match src/version.h (${HEADER_VERSION})."


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only guardrail with no runtime or release artifact logic changes beyond failing fast on tag/version drift.
> 
> **Overview**
> Adds an early **gate on the Event TAG workflow** so a mistagged release fails before lint or multi-platform builds run.
> 
> The `prepare-values` job now runs new script `sbin/validate-tag-version`, which requires `GITHUB_REF` to be a `vMAJOR.MINOR.PATCH` tag and compares that version to `REDISTIMESERIES_VERSION_*` in `src/version.h`. Mismatches or unreadable headers emit GitHub `::error::` messages and exit non-zero.
> 
> The **linter** reusable workflow now `needs: [prepare-values]`, so it runs only after that validation (along with the existing Linux/macOS build jobs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98d0b63a927724246451ffcd29bbac75e43b3557. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->