### PR TITLE
Cherry-pick: MOD-16873 `TS.INCRBY` replicate master timestamp when timestamp is local server clock (#2109)

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -947,7 +947,9 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     long long currentUpdatedTime = -1;
     int timestampLoc = RMUtil_ArgIndex("TIMESTAMP", argv, argc);
-    if (timestampLoc == -1 || RMUtil_StringEqualsC(argv[timestampLoc + 1], "*")) {
+    const bool useLocalTimestamp =
+        timestampLoc == -1 || RMUtil_StringEqualsC(argv[timestampLoc + 1], "*");
+    if (useLocalTimestamp) {
         currentUpdatedTime = RedisModule_Milliseconds();
     } else if (RedisModule_StringToLongLong(argv[timestampLoc + 1],
                                             (long long *)&currentUpdatedTime) != REDISMODULE_OK) {
@@ -969,7 +971,32 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     }
 
     int rv = internalAdd(ctx, series, currentUpdatedTime, result, DP_LAST, true);
-    RedisModule_ReplicateVerbatim(ctx);
+
+    if (useLocalTimestamp) {
+        const char *replCmd = isIncr ? "TS.INCRBY" : "TS.DECRBY";
+        if (timestampLoc == -1) {
+            const size_t replArgc = argc - 1;
+            RedisModule_Replicate(
+                ctx, replCmd, "vcl", argv + 1, replArgc, "TIMESTAMP", currentUpdatedTime);
+        } else {
+            // number of args, until the TIMESTAMP argument (included)
+            const size_t preArgc = timestampLoc;
+            // number of args, after the TIMESTAMP argument
+            const size_t postArgc = argc - timestampLoc - 2;
+            RedisModule_Replicate(
+                ctx,
+                replCmd,
+                "vlv",
+                argv + 1, // start after the command name
+                preArgc,
+                currentUpdatedTime, // the timestamp value
+                argv + timestampLoc +
+                    2, // start after the TIMESTAMP argument, rest of the arguments
+                postArgc);
+        }
+    } else {
+        RedisModule_ReplicateVerbatim(ctx);
+    }
     RedisModule_CloseKey(key);
 
     RedisModule_NotifyKeyspaceEvent(

--- a/src/module.c
+++ b/src/module.c
@@ -946,7 +946,26 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     }
 
     long long currentUpdatedTime = -1;
-    int timestampLoc = RMUtil_ArgIndex("TIMESTAMP", argv, argc);
+    // Both keywords can only appear at index 3 or later (past <key> <value>), so scan only
+    // from there. Zeroing a late match instead would also discard the real directive when the
+    // key name is itself "TIMESTAMP" or "LABELS" - RMUtil_ArgIndex returns the FIRST match,
+    // which for those key names is argv[1], not the directive.
+    int timestampLoc = RMUtil_ArgIndex("TIMESTAMP", argv + 3, argc - 3);
+    if (timestampLoc != -1) {
+        timestampLoc += 3;
+    }
+    int labelsLoc = RMUtil_ArgIndex("LABELS", argv + 3, argc - 3);
+    if (labelsLoc != -1) {
+        labelsLoc += 3;
+    }
+    if (labelsLoc > 2 && timestampLoc > labelsLoc) {
+        // "TIMESTAMP" matched here is actually a label key/value inside the LABELS tail, not
+        // a real TIMESTAMP directive, since LABELS greedily consumes every token after it.
+        timestampLoc = -1;
+    }
+    if (timestampLoc != -1 && timestampLoc + 1 >= argc) {
+        return RedisModule_WrongArity(ctx);
+    }
     const bool useLocalTimestamp =
         timestampLoc == -1 || RMUtil_StringEqualsC(argv[timestampLoc + 1], "*");
     if (useLocalTimestamp) {
@@ -972,48 +991,52 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     int rv = internalAdd(ctx, series, currentUpdatedTime, result, DP_LAST, true);
 
-    if (useLocalTimestamp) {
-        const char *replCmd = isIncr ? "TS.INCRBY" : "TS.DECRBY";
-        if (timestampLoc == -1) {
-            // LABELS greedily consumes every token after it as a label/value pair, so it must
-            // stay the last clause; insert TIMESTAMP before it instead of after, or a create-on-
-            // write TS.INCRBY/TS.DECRBY with LABELS would replicate a bogus "TIMESTAMP" label.
-            int labelsLoc = RMUtil_ArgIndex("LABELS", argv, argc);
-            if (labelsLoc == -1) {
-                const size_t replArgc = argc - 1;
-                RedisModule_Replicate(
-                    ctx, replCmd, "vcl", argv + 1, replArgc, "TIMESTAMP", currentUpdatedTime);
+    if (rv == REDISMODULE_OK) {
+        if (useLocalTimestamp) {
+            const char *replCmd = isIncr ? "TS.INCRBY" : "TS.DECRBY";
+            if (timestampLoc == -1) {
+                // A real LABELS clause can only start at index 3 (past <key> <value>), and it
+                // greedily consumes every token after it, so the resolved TIMESTAMP has to be
+                // inserted before it. With no LABELS clause, keep appending at the end:
+                // inserting at index 3 would shift the operands of any other clause whose
+                // keyword collides with the key name (e.g. a key named IGNORE, whose second
+                // operand sits at index 3), and the replica would then fail to parse it.
+                if (labelsLoc > 2) {
+                    const size_t preArgc = labelsLoc - 1;
+                    const size_t postArgc = argc - labelsLoc;
+                    RedisModule_Replicate(ctx,
+                                          replCmd,
+                                          "vclv",
+                                          argv + 1, // args before the LABELS clause
+                                          preArgc,
+                                          "TIMESTAMP",
+                                          currentUpdatedTime,
+                                          argv + labelsLoc, // the LABELS clause, unchanged
+                                          postArgc);
+                } else {
+                    const size_t replArgc = argc - 1;
+                    RedisModule_Replicate(
+                        ctx, replCmd, "vcl", argv + 1, replArgc, "TIMESTAMP", currentUpdatedTime);
+                }
             } else {
-                const size_t preArgc = labelsLoc - 1;
-                const size_t postArgc = argc - labelsLoc;
-                RedisModule_Replicate(ctx,
-                                      replCmd,
-                                      "vclv",
-                                      argv + 1, // start after the command name
-                                      preArgc,
-                                      "TIMESTAMP",
-                                      currentUpdatedTime,
-                                      argv + labelsLoc, // the LABELS clause, unchanged
-                                      postArgc);
+                // number of args, until the TIMESTAMP argument (included)
+                const size_t preArgc = timestampLoc;
+                // number of args, after the TIMESTAMP argument
+                const size_t postArgc = argc - timestampLoc - 2;
+                RedisModule_Replicate(
+                    ctx,
+                    replCmd,
+                    "vlv",
+                    argv + 1, // start after the command name
+                    preArgc,
+                    currentUpdatedTime, // the timestamp value
+                    argv + timestampLoc +
+                        2, // start after the TIMESTAMP argument, rest of the arguments
+                    postArgc);
             }
         } else {
-            // number of args, until the TIMESTAMP argument (included)
-            const size_t preArgc = timestampLoc;
-            // number of args, after the TIMESTAMP argument
-            const size_t postArgc = argc - timestampLoc - 2;
-            RedisModule_Replicate(
-                ctx,
-                replCmd,
-                "vlv",
-                argv + 1, // start after the command name
-                preArgc,
-                currentUpdatedTime, // the timestamp value
-                argv + timestampLoc +
-                    2, // start after the TIMESTAMP argument, rest of the arguments
-                postArgc);
+            RedisModule_ReplicateVerbatim(ctx);
         }
-    } else {
-        RedisModule_ReplicateVerbatim(ctx);
     }
     RedisModule_CloseKey(key);
 

--- a/src/module.c
+++ b/src/module.c
@@ -975,9 +975,27 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (useLocalTimestamp) {
         const char *replCmd = isIncr ? "TS.INCRBY" : "TS.DECRBY";
         if (timestampLoc == -1) {
-            const size_t replArgc = argc - 1;
-            RedisModule_Replicate(
-                ctx, replCmd, "vcl", argv + 1, replArgc, "TIMESTAMP", currentUpdatedTime);
+            // LABELS greedily consumes every token after it as a label/value pair, so it must
+            // stay the last clause; insert TIMESTAMP before it instead of after, or a create-on-
+            // write TS.INCRBY/TS.DECRBY with LABELS would replicate a bogus "TIMESTAMP" label.
+            int labelsLoc = RMUtil_ArgIndex("LABELS", argv, argc);
+            if (labelsLoc == -1) {
+                const size_t replArgc = argc - 1;
+                RedisModule_Replicate(
+                    ctx, replCmd, "vcl", argv + 1, replArgc, "TIMESTAMP", currentUpdatedTime);
+            } else {
+                const size_t preArgc = labelsLoc - 1;
+                const size_t postArgc = argc - labelsLoc;
+                RedisModule_Replicate(ctx,
+                                       replCmd,
+                                       "vclv",
+                                       argv + 1, // start after the command name
+                                       preArgc,
+                                       "TIMESTAMP",
+                                       currentUpdatedTime,
+                                       argv + labelsLoc, // the LABELS clause, unchanged
+                                       postArgc);
+            }
         } else {
             // number of args, until the TIMESTAMP argument (included)
             const size_t preArgc = timestampLoc;

--- a/src/module.c
+++ b/src/module.c
@@ -987,14 +987,14 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                 const size_t preArgc = labelsLoc - 1;
                 const size_t postArgc = argc - labelsLoc;
                 RedisModule_Replicate(ctx,
-                                       replCmd,
-                                       "vclv",
-                                       argv + 1, // start after the command name
-                                       preArgc,
-                                       "TIMESTAMP",
-                                       currentUpdatedTime,
-                                       argv + labelsLoc, // the LABELS clause, unchanged
-                                       postArgc);
+                                      replCmd,
+                                      "vclv",
+                                      argv + 1, // start after the command name
+                                      preArgc,
+                                      "TIMESTAMP",
+                                      currentUpdatedTime,
+                                      argv + labelsLoc, // the LABELS clause, unchanged
+                                      postArgc);
             }
         } else {
             // number of args, until the TIMESTAMP argument (included)

--- a/tests/flow/test_ts_incrby.py
+++ b/tests/flow/test_ts_incrby.py
@@ -1,4 +1,5 @@
 import math
+import threading
 import time
 
 import pytest
@@ -66,3 +67,104 @@ def test_incrby_with_update_latest():
         result = r.execute_command('TS.RANGE', 'tester', 0, 20)
         assert len(result) == 20
         assert result[19] == [20, b'95']
+
+
+def test_incrby_error_cases():
+    """Minimal test for TS.INCRBY error handling (cluster-compatible)"""
+    with Env().getClusterConnectionIfNeeded() as r:
+        # Test with wrong number of arguments - cluster-compatible approach
+        if hasattr(r, 'nodes_manager'):  # Redis cluster
+            with pytest.raises(redis.ResponseError):
+                r.execute_command('TS.INCRBY', target_nodes=r.get_default_node())
+        else:  # Single node Redis
+            with pytest.raises(redis.ResponseError):
+                r.execute_command('TS.INCRBY')
+        
+        # Test with invalid addend value
+        with pytest.raises(redis.ResponseError):
+            r.execute_command('TS.INCRBY', 'test_key', 'not_a_number')
+
+def test_ts_incrby_NaN():
+    with Env().getClusterConnectionIfNeeded() as r:
+        r.execute_command('ts.create', 'tester')
+        r.execute_command('ts.add', 'tester', 1, 'nan')
+
+        # Add a number to a NaN value, error expected
+        with pytest.raises(redis.ResponseError):
+            r.execute_command('TS.incrby', 'tester', '1')
+            r.execute_command('TS.decrby', 'tester', '1')
+        
+        r.execute_command('ts.add', 'tester', 2,  1)
+        # Add a NaN value to a number, error expected
+        with pytest.raises(redis.ResponseError):
+            r.execute_command('TS.incrby', 'tester', 'nan')
+            r.execute_command('TS.decrby', 'tester', 'nan')
+
+def test_ts_incrby_arg_validation_before_creation():
+    # This test ensures that the key is not created if validation fails (MOD-8167)
+    with Env().getClusterConnectionIfNeeded() as r:
+        # Test 1: Invalid value should not create the key
+        with pytest.raises(redis.ResponseError):
+            r.execute_command('TS.INCRBY', 'test_invalid_value', 'foo')
+        # Key should not exist
+        with pytest.raises(redis.ResponseError):
+            r.execute_command('TS.GET', 'test_invalid_value')
+        
+        # Test 2: Invalid timestamp should not create the key
+        with pytest.raises(redis.ResponseError):
+            r.execute_command('TS.INCRBY', 'test_invalid_ts', '5', 'TIMESTAMP', 'invalid')
+        # Key should not exist
+        with pytest.raises(redis.ResponseError):
+            r.execute_command('TS.GET', 'test_invalid_ts')
+        
+        # Test 3: Valid command should create the key
+        r.execute_command('TS.INCRBY', 'test_valid', '5')
+        # Key should exist
+        result = r.execute_command('TS.GET', 'test_valid')
+        assert result is not None
+
+
+def test_incrby_no_timestamp_replicates_diverging_timestamp():
+    # TS.INCRBY/TS.DECRBY without an explicit TIMESTAMP resolve the timestamp
+    # via RedisModule_Milliseconds() on the primary, but TSDB_incrby then
+    # calls RedisModule_ReplicateVerbatim(), propagating the original argv
+    # (still lacking a concrete timestamp) instead of a rewritten one like
+    # TS.ADD/TS.MADD do. A replica that applies the propagated command later
+    # re-evaluates RedisModule_Milliseconds() at its own, later, wall-clock
+    # instant, so it stores the sample under a different timestamp than the
+    # primary did for the same logical write.
+    if not Env().useSlaves:
+        Env().skip()
+    Env().skipOnCluster()
+    env = Env()
+    key = 'incrby_repl_divergence'
+    with env.getConnection() as master:
+        master.execute_command('ts.create', key)
+    # Make sure the initial replica sync has caught up with the key creation
+    # before we start controlling timing below, so the only delay measured
+    # is the one we inject, not leftover initial-sync latency.
+    for _ in range(100):
+        with env.getSlaveConnection() as slave:
+            if slave.execute_command('exists', key):
+                break
+        time.sleep(0.1)
+    else:
+        raise Exception('replica never caught up with initial ts.create')
+    slave_sleep_secs = 2
+    def block_slave_main_thread():
+        # DEBUG SLEEP blocks the replica's single event loop entirely, so it
+        # cannot apply the replicated TS.INCRBY until the sleep elapses -
+        # forcing a deterministic, multi-second gap between when the primary
+        # resolves "now" and when the replica would resolve it.
+        with env.getSlaveConnection() as slave:
+            slave.execute_command('DEBUG', 'SLEEP', slave_sleep_secs)
+    blocker = threading.Thread(target=block_slave_main_thread)
+    blocker.start()
+    time.sleep(0.3)  # let DEBUG SLEEP actually start running on the slave
+    with env.getConnection() as master:
+        master_ts = master.execute_command('ts.incrby', key, 1)
+    blocker.join()
+    time.sleep(1)  # give the replica time to apply the now-unblocked command
+    with env.getSlaveConnection() as slave:
+        slave_sample = slave.execute_command('ts.get', key)
+    env.assertEqual(master_ts, slave_sample[0])

--- a/tests/flow/test_ts_incrby.py
+++ b/tests/flow/test_ts_incrby.py
@@ -6,6 +6,7 @@ import time
 # import redis
 # from utils import Env
 import pytest
+import redis
 from RLTest import Env
 from includes import *
 from test_helper_classes import _get_ts_info

--- a/tests/flow/test_ts_incrby.py
+++ b/tests/flow/test_ts_incrby.py
@@ -143,7 +143,8 @@ def test_incrby_create_with_labels_replicates_correctly():
     else:
         raise Exception('replica never caught up with warmup key')
     with env.getConnection() as master:
-        master.execute_command('ts.incrby', key, 1, 'LABELS', 'region', 'us')
+        master_ts = master.execute_command('ts.incrby', key, 1, 'LABELS', 'region', 'us')
+        master_sample = master.execute_command('ts.get', key)
     for _ in range(100):
         with env.getSlaveConnection() as slave:
             if slave.execute_command('exists', key):
@@ -153,4 +154,7 @@ def test_incrby_create_with_labels_replicates_correctly():
         raise Exception('replica never caught up with initial ts.incrby')
     with env.getSlaveConnection() as slave:
         info = _get_ts_info(slave, key)
+        slave_sample = slave.execute_command('ts.get', key)
     env.assertEqual(info.labels, {b'region': b'us'})
+    env.assertEqual(master_ts, slave_sample[0])
+    env.assertEqual(master_sample, slave_sample)

--- a/tests/flow/test_ts_incrby.py
+++ b/tests/flow/test_ts_incrby.py
@@ -2,11 +2,31 @@ import math
 import threading
 import time
 
-import pytest
-import redis
-from utils import Env
+# import pytest
+# import redis
+# from utils import Env
 from includes import *
 from test_helper_classes import _get_ts_info
+
+
+def _wait_for_replica_key(env, key, what):
+    for _ in range(100):
+        with env.getSlaveConnection() as slave:
+            if slave.execute_command('exists', key):
+                return
+        time.sleep(0.1)
+    raise Exception('replica never caught up with %s' % what)
+
+
+def _wait_for_replica_online(env, warmup_key):
+    # The replica only joins the live propagation stream once its initial full
+    # sync completes (repl-diskless-sync-delay defaults to 5s). Until then a
+    # create-on-write key arrives inside the full-sync RDB and the rewritten
+    # command is never parsed by the replica at all - which would make these
+    # tests pass vacuously.
+    with env.getConnection() as master:
+        master.execute_command('ts.create', warmup_key)
+    _wait_for_replica_key(env, warmup_key, 'warmup key')
 
 
 def test_incrby():
@@ -70,6 +90,61 @@ def test_incrby_with_update_latest():
         assert result[19] == [20, b'95']
 
 
+def test_incrby_error_cases():
+    """Minimal test for TS.INCRBY error handling (cluster-compatible)"""
+    with Env().getClusterConnectionIfNeeded() as r:
+        # Test with wrong number of arguments - cluster-compatible approach
+        if hasattr(r, 'nodes_manager'):  # Redis cluster
+            with pytest.raises(redis.ResponseError):
+                r.execute_command('TS.INCRBY', target_nodes=r.get_default_node())
+        else:  # Single node Redis
+            with pytest.raises(redis.ResponseError):
+                r.execute_command('TS.INCRBY')
+        
+        # Test with invalid addend value
+        with pytest.raises(redis.ResponseError):
+            r.execute_command('TS.INCRBY', 'test_key', 'not_a_number')
+
+def test_ts_incrby_NaN():
+    with Env().getClusterConnectionIfNeeded() as r:
+        r.execute_command('ts.create', 'tester')
+        r.execute_command('ts.add', 'tester', 1, 'nan')
+
+        # Add a number to a NaN value, error expected
+        with pytest.raises(redis.ResponseError):
+            r.execute_command('TS.incrby', 'tester', '1')
+            r.execute_command('TS.decrby', 'tester', '1')
+        
+        r.execute_command('ts.add', 'tester', 2,  1)
+        # Add a NaN value to a number, error expected
+        with pytest.raises(redis.ResponseError):
+            r.execute_command('TS.incrby', 'tester', 'nan')
+            r.execute_command('TS.decrby', 'tester', 'nan')
+
+def test_ts_incrby_arg_validation_before_creation():
+    # This test ensures that the key is not created if validation fails (MOD-8167)
+    with Env().getClusterConnectionIfNeeded() as r:
+        # Test 1: Invalid value should not create the key
+        with pytest.raises(redis.ResponseError):
+            r.execute_command('TS.INCRBY', 'test_invalid_value', 'foo')
+        # Key should not exist
+        with pytest.raises(redis.ResponseError):
+            r.execute_command('TS.GET', 'test_invalid_value')
+        
+        # Test 2: Invalid timestamp should not create the key
+        with pytest.raises(redis.ResponseError):
+            r.execute_command('TS.INCRBY', 'test_invalid_ts', '5', 'TIMESTAMP', 'invalid')
+        # Key should not exist
+        with pytest.raises(redis.ResponseError):
+            r.execute_command('TS.GET', 'test_invalid_ts')
+        
+        # Test 3: Valid command should create the key
+        r.execute_command('TS.INCRBY', 'test_valid', '5')
+        # Key should exist
+        result = r.execute_command('TS.GET', 'test_valid')
+        assert result is not None
+
+
 def test_incrby_no_timestamp_replicates_diverging_timestamp():
     # TS.INCRBY/TS.DECRBY without an explicit TIMESTAMP resolve the timestamp
     # via RedisModule_Milliseconds() on the primary, but TSDB_incrby then
@@ -89,13 +164,7 @@ def test_incrby_no_timestamp_replicates_diverging_timestamp():
     # Make sure the initial replica sync has caught up with the key creation
     # before we start controlling timing below, so the only delay measured
     # is the one we inject, not leftover initial-sync latency.
-    for _ in range(100):
-        with env.getSlaveConnection() as slave:
-            if slave.execute_command('exists', key):
-                break
-        time.sleep(0.1)
-    else:
-        raise Exception('replica never caught up with initial ts.create')
+    _wait_for_replica_key(env, key, 'initial ts.create')
     slave_sleep_secs = 2
     def block_slave_main_thread():
         # DEBUG SLEEP blocks the replica's single event loop entirely, so it
@@ -116,45 +185,174 @@ def test_incrby_no_timestamp_replicates_diverging_timestamp():
     env.assertEqual(master_ts, slave_sample[0])
 
 
-def test_incrby_create_with_labels_replicates_correctly():
-    # When TIMESTAMP is omitted, replication rewrites the command by
-    # appending "TIMESTAMP <ts>" (see
-    # test_incrby_no_timestamp_replicates_diverging_timestamp). If the
-    # create-on-write command also carries a trailing LABELS clause,
-    # appending TIMESTAMP after it gets swallowed as a bogus label/value
-    # pair on replicas and AOF-replay, since LABELS greedily consumes every
-    # token that follows it.
+def test_incrby_key_named_timestamp_replicates_correctly():
+    # RMUtil_ArgIndex returns the FIRST match scanning from argv[0], so a
+    # key literally named "TIMESTAMP" (case-insensitively) matches at the
+    # key's own position. The resolved timestamp computed on the primary
+    # must still reach the replica intact - not re-resolved to the
+    # replica's own, later wall-clock instant - even under replication
+    # delay. Without the injected stall below this passes by luck: on an
+    # idle loopback the gap can be as little as 1ms.
     if not Env().useSlaves:
         Env().skip()
     Env().skipOnCluster()
     env = Env()
-    key = 'incrby_create_with_labels'
-    warmup_key = 'incrby_create_with_labels_warmup'
+    key = 'TIMESTAMP'
     with env.getConnection() as master:
-        master.execute_command('ts.create', warmup_key)
-    # Make sure the replica is already online and streaming live-propagated
-    # commands (rather than picking up our key via a fresh full RDB sync)
-    # before we issue the create-on-write TS.INCRBY below.
-    for _ in range(100):
-        with env.getSlaveConnection() as slave:
-            if slave.execute_command('exists', warmup_key):
-                break
-        time.sleep(0.1)
-    else:
-        raise Exception('replica never caught up with warmup key')
+        master.execute_command('ts.create', key)
+    _wait_for_replica_key(env, key, 'initial ts.create')
+    before_ms = int(time.time() * 1000)
+    slave_sleep_secs = 2
+    stall_error = []
+    def block_slave_main_thread():
+        # A failure in here cannot fail the test on its own - the stall would
+        # silently vanish and the assertions below would pass trivially - so
+        # record it and re-raise on the main thread.
+        try:
+            with env.getSlaveConnection() as slave:
+                slave.execute_command('DEBUG', 'SLEEP', slave_sleep_secs)
+        except Exception as e:
+            stall_error.append(e)
+    blocker = threading.Thread(target=block_slave_main_thread)
+    blocker.start()
+    time.sleep(0.3)  # let DEBUG SLEEP actually start running on the slave
     with env.getConnection() as master:
-        master_ts = master.execute_command('ts.incrby', key, 1, 'LABELS', 'region', 'us')
-        master_sample = master.execute_command('ts.get', key)
-    for _ in range(100):
-        with env.getSlaveConnection() as slave:
-            if slave.execute_command('exists', key):
-                break
-        time.sleep(0.1)
-    else:
-        raise Exception('replica never caught up with initial ts.incrby')
+        master_ts = master.execute_command('ts.incrby', key, 5)
+    blocker.join()
+    if stall_error:
+        raise stall_error[0]
+    time.sleep(1)  # give the replica time to apply the now-unblocked command
     with env.getSlaveConnection() as slave:
-        info = _get_ts_info(slave, key)
         slave_sample = slave.execute_command('ts.get', key)
-    env.assertEqual(info.labels, {b'region': b'us'})
     env.assertEqual(master_ts, slave_sample[0])
+    # The resolved timestamp must be wall-clock "now". Before the fix a key
+    # named TIMESTAMP made argv[2] the timestamp, storing the sample at ts=5.
+    env.assertGreaterEqual(master_ts, before_ms)
+
+
+def test_incrby_create_with_labels_replicates_correctly():
+    # When TIMESTAMP is omitted, replication rewrites the command with a
+    # resolved "TIMESTAMP <ts>" (see
+    # test_incrby_no_timestamp_replicates_diverging_timestamp). Because
+    # LABELS greedily consumes every token that follows it, TIMESTAMP has to
+    # be inserted *before* a trailing LABELS clause - appending it would be
+    # swallowed as a bogus label/value pair on replicas and in AOF replay.
+    if not Env().useSlaves:
+        Env().skip()
+    Env().skipOnCluster()
+    env = Env()
+    warmup_key = 'incrby_create_with_labels_warmup'
+    _wait_for_replica_online(env, warmup_key)
+
+    pre_restart_sample = {}
+    for cmd in ('ts.incrby', 'ts.decrby'):
+        key = 'incrby_create_with_labels_%s' % cmd
+        with env.getConnection() as master:
+            master.execute_command(cmd, key, 1, 'LABELS', 'region', 'us')
+            master_sample = master.execute_command('ts.get', key)
+        _wait_for_replica_key(env, key, 'initial %s' % cmd)
+        with env.getSlaveConnection() as slave:
+            info = _get_ts_info(slave, key)
+            slave_sample = slave.execute_command('ts.get', key)
+        env.assertEqual(info.labels, {b'region': b'us'})
+        env.assertEqual(master_sample, slave_sample)
+        pre_restart_sample[cmd] = master_sample
+
+    # Also exercise the AOF-replay path (not just the live replication
+    # stream): restart master and replica and reload from AOF/RDB, then
+    # verify the data survived intact against what was captured before
+    # the restart.
+    env.restartAndReload()
+    for cmd in ('ts.incrby', 'ts.decrby'):
+        key = 'incrby_create_with_labels_%s' % cmd
+        with env.getConnection() as master:
+            master_info = _get_ts_info(master, key)
+            master_sample = master.execute_command('ts.get', key)
+        with env.getSlaveConnection() as slave:
+            slave_info = _get_ts_info(slave, key)
+            slave_sample = slave.execute_command('ts.get', key)
+        env.assertEqual(master_info.labels, {b'region': b'us'})
+        env.assertEqual(slave_info.labels, {b'region': b'us'})
+        env.assertEqual(master_sample, pre_restart_sample[cmd])
+        env.assertEqual(slave_sample, pre_restart_sample[cmd])
+
+
+def test_incrby_create_with_key_named_labels_replicates_correctly():
+    # RMUtil_ArgIndex scans the whole argv, so a key literally named
+    # "LABELS" (case-insensitively) must not be mistaken for a LABELS
+    # clause when deciding where to insert the resolved TIMESTAMP.
+    #
+    # Note: this only checks the sample, not labels - a key named LABELS
+    # also confuses parseLabelsFromArgs itself (which scans from argv[0],
+    # same as here), a separate, pre-existing bug outside this fix's scope.
+    if not Env().useSlaves:
+        Env().skip()
+    Env().skipOnCluster()
+    env = Env()
+    key = 'LABELS'
+    warmup_key = 'incrby_key_named_labels_warmup'
+    _wait_for_replica_online(env, warmup_key)
+    with env.getConnection() as master:
+        master.execute_command('ts.incrby', key, 1)
+        master_sample = master.execute_command('ts.get', key)
+    _wait_for_replica_key(env, key, 'initial ts.incrby')
+    with env.getSlaveConnection() as slave:
+        slave_sample = slave.execute_command('ts.get', key)
     env.assertEqual(master_sample, slave_sample)
+
+
+def test_incrby_create_with_key_named_ignore_replicates_correctly():
+    # A key literally named "IGNORE" (case-insensitively) makes
+    # parseIgnoreArgs match the key instead of a real IGNORE clause, so its
+    # two operands land right after the key. Inserting the resolved
+    # TIMESTAMP at a fixed index would shift those operands and break
+    # replica/AOF parsing entirely - this is why the insert must stay
+    # gated on an actual LABELS clause (labelsLoc > 2) instead.
+    if not Env().useSlaves:
+        Env().skip()
+    Env().skipOnCluster()
+    env = Env()
+    key = 'IGNORE'
+    warmup_key = 'incrby_key_named_ignore_warmup'
+    _wait_for_replica_online(env, warmup_key)
+    with env.getConnection() as master:
+        master.execute_command('ts.incrby', key, 1, 5)
+        master_sample = master.execute_command('ts.get', key)
+    _wait_for_replica_key(env, key, 'initial ts.incrby')
+    with env.getSlaveConnection() as slave:
+        slave_sample = slave.execute_command('ts.get', key)
+    env.assertEqual(master_sample, slave_sample)
+
+
+def test_incrby_labels_key_named_timestamp_replicates_correctly():
+    # A label whose key is literally "TIMESTAMP" collides with the reserved
+    # keyword: RMUtil_ArgIndex's naive scan for "TIMESTAMP" would otherwise
+    # match this label key instead of a real TIMESTAMP directive, and the
+    # resulting rewritten command must still parse to the same labels on
+    # replicas as it did on the primary.
+    if not Env().useSlaves:
+        Env().skip()
+    Env().skipOnCluster()
+    env = Env()
+    key = 'incrby_labels_key_named_timestamp'
+    warmup_key = 'incrby_labels_key_named_timestamp_warmup'
+    _wait_for_replica_online(env, warmup_key)
+    with env.getConnection() as master:
+        master.execute_command('ts.incrby', key, 1, 'LABELS', 'a', 'b', 'TIMESTAMP', '*')
+        master_info = _get_ts_info(master, key)
+        master_sample = master.execute_command('ts.get', key)
+    _wait_for_replica_key(env, key, 'initial ts.incrby')
+    with env.getSlaveConnection() as slave:
+        slave_info = _get_ts_info(slave, key)
+        slave_sample = slave.execute_command('ts.get', key)
+    env.assertEqual(master_info.labels, slave_info.labels)
+    env.assertEqual(master_sample, slave_sample)
+
+
+def test_incrby_timestamp_missing_value_returns_error():
+    # TIMESTAMP as the very last token has no value after it; this must be
+    # rejected cleanly instead of reading one RedisModuleString past the end
+    # of argv.
+    with Env().getClusterConnectionIfNeeded() as r:
+        with pytest.raises(redis.ResponseError):
+            r.execute_command('TS.INCRBY', 'incrby_timestamp_missing_value', '5', 'TIMESTAMP')

--- a/tests/flow/test_ts_incrby.py
+++ b/tests/flow/test_ts_incrby.py
@@ -69,61 +69,6 @@ def test_incrby_with_update_latest():
         assert result[19] == [20, b'95']
 
 
-def test_incrby_error_cases():
-    """Minimal test for TS.INCRBY error handling (cluster-compatible)"""
-    with Env().getClusterConnectionIfNeeded() as r:
-        # Test with wrong number of arguments - cluster-compatible approach
-        if hasattr(r, 'nodes_manager'):  # Redis cluster
-            with pytest.raises(redis.ResponseError):
-                r.execute_command('TS.INCRBY', target_nodes=r.get_default_node())
-        else:  # Single node Redis
-            with pytest.raises(redis.ResponseError):
-                r.execute_command('TS.INCRBY')
-        
-        # Test with invalid addend value
-        with pytest.raises(redis.ResponseError):
-            r.execute_command('TS.INCRBY', 'test_key', 'not_a_number')
-
-def test_ts_incrby_NaN():
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('ts.create', 'tester')
-        r.execute_command('ts.add', 'tester', 1, 'nan')
-
-        # Add a number to a NaN value, error expected
-        with pytest.raises(redis.ResponseError):
-            r.execute_command('TS.incrby', 'tester', '1')
-            r.execute_command('TS.decrby', 'tester', '1')
-        
-        r.execute_command('ts.add', 'tester', 2,  1)
-        # Add a NaN value to a number, error expected
-        with pytest.raises(redis.ResponseError):
-            r.execute_command('TS.incrby', 'tester', 'nan')
-            r.execute_command('TS.decrby', 'tester', 'nan')
-
-def test_ts_incrby_arg_validation_before_creation():
-    # This test ensures that the key is not created if validation fails (MOD-8167)
-    with Env().getClusterConnectionIfNeeded() as r:
-        # Test 1: Invalid value should not create the key
-        with pytest.raises(redis.ResponseError):
-            r.execute_command('TS.INCRBY', 'test_invalid_value', 'foo')
-        # Key should not exist
-        with pytest.raises(redis.ResponseError):
-            r.execute_command('TS.GET', 'test_invalid_value')
-        
-        # Test 2: Invalid timestamp should not create the key
-        with pytest.raises(redis.ResponseError):
-            r.execute_command('TS.INCRBY', 'test_invalid_ts', '5', 'TIMESTAMP', 'invalid')
-        # Key should not exist
-        with pytest.raises(redis.ResponseError):
-            r.execute_command('TS.GET', 'test_invalid_ts')
-        
-        # Test 3: Valid command should create the key
-        r.execute_command('TS.INCRBY', 'test_valid', '5')
-        # Key should exist
-        result = r.execute_command('TS.GET', 'test_valid')
-        assert result is not None
-
-
 def test_incrby_no_timestamp_replicates_diverging_timestamp():
     # TS.INCRBY/TS.DECRBY without an explicit TIMESTAMP resolve the timestamp
     # via RedisModule_Milliseconds() on the primary, but TSDB_incrby then

--- a/tests/flow/test_ts_incrby.py
+++ b/tests/flow/test_ts_incrby.py
@@ -5,6 +5,7 @@ import time
 # import pytest
 # import redis
 # from utils import Env
+from RLTest import Env
 from includes import *
 from test_helper_classes import _get_ts_info
 
@@ -88,62 +89,6 @@ def test_incrby_with_update_latest():
         result = r.execute_command('TS.RANGE', 'tester', 0, 20)
         assert len(result) == 20
         assert result[19] == [20, b'95']
-
-
-def test_incrby_error_cases():
-    """Minimal test for TS.INCRBY error handling (cluster-compatible)"""
-    with Env().getClusterConnectionIfNeeded() as r:
-        # Test with wrong number of arguments - cluster-compatible approach
-        if hasattr(r, 'nodes_manager'):  # Redis cluster
-            with pytest.raises(redis.ResponseError):
-                r.execute_command('TS.INCRBY', target_nodes=r.get_default_node())
-        else:  # Single node Redis
-            with pytest.raises(redis.ResponseError):
-                r.execute_command('TS.INCRBY')
-        
-        # Test with invalid addend value
-        with pytest.raises(redis.ResponseError):
-            r.execute_command('TS.INCRBY', 'test_key', 'not_a_number')
-
-def test_ts_incrby_NaN():
-    with Env().getClusterConnectionIfNeeded() as r:
-        r.execute_command('ts.create', 'tester')
-        r.execute_command('ts.add', 'tester', 1, 'nan')
-
-        # Add a number to a NaN value, error expected
-        with pytest.raises(redis.ResponseError):
-            r.execute_command('TS.incrby', 'tester', '1')
-            r.execute_command('TS.decrby', 'tester', '1')
-        
-        r.execute_command('ts.add', 'tester', 2,  1)
-        # Add a NaN value to a number, error expected
-        with pytest.raises(redis.ResponseError):
-            r.execute_command('TS.incrby', 'tester', 'nan')
-            r.execute_command('TS.decrby', 'tester', 'nan')
-
-def test_ts_incrby_arg_validation_before_creation():
-    # This test ensures that the key is not created if validation fails (MOD-8167)
-    with Env().getClusterConnectionIfNeeded() as r:
-        # Test 1: Invalid value should not create the key
-        with pytest.raises(redis.ResponseError):
-            r.execute_command('TS.INCRBY', 'test_invalid_value', 'foo')
-        # Key should not exist
-        with pytest.raises(redis.ResponseError):
-            r.execute_command('TS.GET', 'test_invalid_value')
-        
-        # Test 2: Invalid timestamp should not create the key
-        with pytest.raises(redis.ResponseError):
-            r.execute_command('TS.INCRBY', 'test_invalid_ts', '5', 'TIMESTAMP', 'invalid')
-        # Key should not exist
-        with pytest.raises(redis.ResponseError):
-            r.execute_command('TS.GET', 'test_invalid_ts')
-        
-        # Test 3: Valid command should create the key
-        r.execute_command('TS.INCRBY', 'test_valid', '5')
-        # Key should exist
-        result = r.execute_command('TS.GET', 'test_valid')
-        assert result is not None
-
 
 def test_incrby_no_timestamp_replicates_diverging_timestamp():
     # TS.INCRBY/TS.DECRBY without an explicit TIMESTAMP resolve the timestamp

--- a/tests/flow/test_ts_incrby.py
+++ b/tests/flow/test_ts_incrby.py
@@ -5,6 +5,7 @@ import time
 # import pytest
 # import redis
 # from utils import Env
+import pytest
 from RLTest import Env
 from includes import *
 from test_helper_classes import _get_ts_info

--- a/tests/flow/test_ts_incrby.py
+++ b/tests/flow/test_ts_incrby.py
@@ -6,6 +6,7 @@ import pytest
 import redis
 from utils import Env
 from includes import *
+from test_helper_classes import _get_ts_info
 
 
 def test_incrby():
@@ -113,3 +114,43 @@ def test_incrby_no_timestamp_replicates_diverging_timestamp():
     with env.getSlaveConnection() as slave:
         slave_sample = slave.execute_command('ts.get', key)
     env.assertEqual(master_ts, slave_sample[0])
+
+
+def test_incrby_create_with_labels_replicates_correctly():
+    # When TIMESTAMP is omitted, replication rewrites the command by
+    # appending "TIMESTAMP <ts>" (see
+    # test_incrby_no_timestamp_replicates_diverging_timestamp). If the
+    # create-on-write command also carries a trailing LABELS clause,
+    # appending TIMESTAMP after it gets swallowed as a bogus label/value
+    # pair on replicas and AOF-replay, since LABELS greedily consumes every
+    # token that follows it.
+    if not Env().useSlaves:
+        Env().skip()
+    Env().skipOnCluster()
+    env = Env()
+    key = 'incrby_create_with_labels'
+    warmup_key = 'incrby_create_with_labels_warmup'
+    with env.getConnection() as master:
+        master.execute_command('ts.create', warmup_key)
+    # Make sure the replica is already online and streaming live-propagated
+    # commands (rather than picking up our key via a fresh full RDB sync)
+    # before we issue the create-on-write TS.INCRBY below.
+    for _ in range(100):
+        with env.getSlaveConnection() as slave:
+            if slave.execute_command('exists', warmup_key):
+                break
+        time.sleep(0.1)
+    else:
+        raise Exception('replica never caught up with warmup key')
+    with env.getConnection() as master:
+        master.execute_command('ts.incrby', key, 1, 'LABELS', 'region', 'us')
+    for _ in range(100):
+        with env.getSlaveConnection() as slave:
+            if slave.execute_command('exists', key):
+                break
+        time.sleep(0.1)
+    else:
+        raise Exception('replica never caught up with initial ts.incrby')
+    with env.getSlaveConnection() as slave:
+        info = _get_ts_info(slave, key)
+    env.assertEqual(info.labels, {b'region': b'us'})


### PR DESCRIPTION
MOD-16873 `TS.INCRBY` replicate master timestamp when timestamp is local server clock (#2109)

* MOD-16873 `TS.INCRBY` replicate master timestamp when timestamp is local server clock

* .

Cherry-pick of ca3375a9f00e84733f244640c278688d1005b0ed onto 1.8

Note: had a minor conflict in tests/flow/test_ts_incrby.py (1.8 was missing several test functions this commit adds at the end of the file, including test_incrby_error_cases and test_ts_incrby_NaN) — resolved by taking the incoming tests as-is.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes replication and command parsing for widely used write paths; mistakes could break replicas, AOF replay, or edge-case argv layouts, though behavior for explicit timestamps is unchanged.
> 
> **Overview**
> Fixes **primary/replica timestamp drift** when `TS.INCRBY` / `TS.DECRBY` use implicit “now” (`TIMESTAMP` omitted or `TIMESTAMP *`). The master no longer uses verbatim replication in that case; it **rewrites the propagated command** with the concrete millisecond timestamp it applied (aligned with `TS.ADD` / `TS.MADD`).
> 
> **Argument parsing** for `TIMESTAMP` and `LABELS` now scans only after `<key> <value>`, so keys named `TIMESTAMP` / `LABELS` are not mistaken for directives. Matches inside a trailing `LABELS` tail are ignored, and a bare trailing `TIMESTAMP` returns wrong arity instead of reading past `argv`.
> 
> **Replication layout** inserts `TIMESTAMP <ts>` **before** an actual `LABELS` clause (so replicas/AOF do not treat it as label pairs), appends it at the end when there is no `LABELS`, or substitutes the numeric value when `TIMESTAMP *` was used; explicit numeric timestamps still replicate verbatim.
> 
> Flow tests add master/replica coverage (including delayed replica apply, create-on-write with `LABELS`, restart/AOF reload, and awkward key/label names).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ada5e79c95c93bccd3f1130ae75d2203551e04a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->