### PR TITLE
MOD-16873 Fix TS.INCRBY/TS.DECRBY replicating a bogus TIMESTAMP label with LABELS

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1490,6 +1490,11 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     long long currentUpdatedTime = -1;
     int timestampLoc = RMUtil_ArgIndex("TIMESTAMP", argv, argc);
     int labelsLoc = RMUtil_ArgIndex("LABELS", argv, argc);
+    // Both keywords can only appear at index 3 or later (past <key> <value>); a match at
+    // index 1 or 2 is the key name or the value, not a directive.
+    if (timestampLoc <= 2) {
+        timestampLoc = -1;
+    }
     if (labelsLoc > 2 && timestampLoc > labelsLoc) {
         // "TIMESTAMP" matched here is actually a label key/value inside the LABELS tail, not
         // a real TIMESTAMP directive, since LABELS greedily consumes every token after it.
@@ -1543,23 +1548,29 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         if (useLocalTimestamp) {
             const char *replCmd = isIncr ? "TS.INCRBY" : "TS.DECRBY";
             if (timestampLoc == -1) {
-                // TIMESTAMP must go right after <key> <value> (index 3): a trailing LABELS
-                // clause greedily consumes every token after it, so appending TIMESTAMP at
-                // the end would replicate a bogus "TIMESTAMP <ts>" label pair instead. Index
-                // 3 is always just past <key> <value>, so every optional clause (LABELS
-                // included) keeps its original order, and this stays correct for any future
-                // greedy trailing clause.
-                const size_t preArgc = 2;         // key + value
-                const size_t postArgc = argc - 3; // every optional clause, unchanged
-                RedisModule_Replicate(ctx,
-                                      replCmd,
-                                      "vclv",
-                                      argv + 1, // key, value
-                                      preArgc,
-                                      "TIMESTAMP",
-                                      currentUpdatedTime,
-                                      argv + 3, // remaining clauses, unchanged
-                                      postArgc);
+                // A real LABELS clause can only start at index 3 (past <key> <value>), and it
+                // greedily consumes every token after it, so the resolved TIMESTAMP has to be
+                // inserted before it. With no LABELS clause, keep appending at the end:
+                // inserting at index 3 would shift the operands of any other clause whose
+                // keyword collides with the key name (e.g. a key named IGNORE, whose second
+                // operand sits at index 3), and the replica would then fail to parse it.
+                if (labelsLoc > 2) {
+                    const size_t preArgc = labelsLoc - 1;
+                    const size_t postArgc = argc - labelsLoc;
+                    RedisModule_Replicate(ctx,
+                                          replCmd,
+                                          "vclv",
+                                          argv + 1, // args before the LABELS clause
+                                          preArgc,
+                                          "TIMESTAMP",
+                                          currentUpdatedTime,
+                                          argv + labelsLoc, // the LABELS clause, unchanged
+                                          postArgc);
+                } else {
+                    const size_t replArgc = argc - 1;
+                    RedisModule_Replicate(
+                        ctx, replCmd, "vcl", argv + 1, replArgc, "TIMESTAMP", currentUpdatedTime);
+                }
             } else {
                 // number of args, until the TIMESTAMP argument (included)
                 const size_t preArgc = timestampLoc;

--- a/src/module.c
+++ b/src/module.c
@@ -1488,12 +1488,17 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     }
 
     long long currentUpdatedTime = -1;
-    int timestampLoc = RMUtil_ArgIndex("TIMESTAMP", argv, argc);
-    int labelsLoc = RMUtil_ArgIndex("LABELS", argv, argc);
-    // Both keywords can only appear at index 3 or later (past <key> <value>); a match at
-    // index 1 or 2 is the key name or the value, not a directive.
-    if (timestampLoc <= 2) {
-        timestampLoc = -1;
+    // Both keywords can only appear at index 3 or later (past <key> <value>), so scan only
+    // from there. Zeroing a late match instead would also discard the real directive when the
+    // key name is itself "TIMESTAMP" or "LABELS" - RMUtil_ArgIndex returns the FIRST match,
+    // which for those key names is argv[1], not the directive.
+    int timestampLoc = RMUtil_ArgIndex("TIMESTAMP", argv + 3, argc - 3);
+    if (timestampLoc != -1) {
+        timestampLoc += 3;
+    }
+    int labelsLoc = RMUtil_ArgIndex("LABELS", argv + 3, argc - 3);
+    if (labelsLoc != -1) {
+        labelsLoc += 3;
     }
     if (labelsLoc > 2 && timestampLoc > labelsLoc) {
         // "TIMESTAMP" matched here is actually a label key/value inside the LABELS tail, not

--- a/src/module.c
+++ b/src/module.c
@@ -1489,6 +1489,15 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     long long currentUpdatedTime = -1;
     int timestampLoc = RMUtil_ArgIndex("TIMESTAMP", argv, argc);
+    int labelsLoc = RMUtil_ArgIndex("LABELS", argv, argc);
+    if (labelsLoc > 2 && timestampLoc > labelsLoc) {
+        // "TIMESTAMP" matched here is actually a label key/value inside the LABELS tail, not
+        // a real TIMESTAMP directive, since LABELS greedily consumes every token after it.
+        timestampLoc = -1;
+    }
+    if (timestampLoc != -1 && timestampLoc + 1 >= argc) {
+        return RedisModule_WrongArity(ctx);
+    }
     const bool useLocalTimestamp =
         timestampLoc == -1 || RMUtil_StringEqualsC(argv[timestampLoc + 1], "*");
     if (useLocalTimestamp) {
@@ -1530,48 +1539,46 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     int rv = internalAdd(ctx, series, currentUpdatedTime, result, DP_LAST, true);
 
-    if (useLocalTimestamp) {
-        const char *replCmd = isIncr ? "TS.INCRBY" : "TS.DECRBY";
-        if (timestampLoc == -1) {
-            // LABELS greedily consumes every token after it as a label/value pair, so it must
-            // stay the last clause; insert TIMESTAMP before it instead of after, or a create-on-
-            // write TS.INCRBY/TS.DECRBY with LABELS would replicate a bogus "TIMESTAMP" label.
-            int labelsLoc = RMUtil_ArgIndex("LABELS", argv, argc);
-            if (labelsLoc == -1) {
-                const size_t replArgc = argc - 1;
-                RedisModule_Replicate(
-                    ctx, replCmd, "vcl", argv + 1, replArgc, "TIMESTAMP", currentUpdatedTime);
-            } else {
-                const size_t preArgc = labelsLoc - 1;
-                const size_t postArgc = argc - labelsLoc;
+    if (rv == REDISMODULE_OK) {
+        if (useLocalTimestamp) {
+            const char *replCmd = isIncr ? "TS.INCRBY" : "TS.DECRBY";
+            if (timestampLoc == -1) {
+                // TIMESTAMP must go right after <key> <value> (index 3): a trailing LABELS
+                // clause greedily consumes every token after it, so appending TIMESTAMP at
+                // the end would replicate a bogus "TIMESTAMP <ts>" label pair instead. Index
+                // 3 is always just past <key> <value>, so every optional clause (LABELS
+                // included) keeps its original order, and this stays correct for any future
+                // greedy trailing clause.
+                const size_t preArgc = 2;         // key + value
+                const size_t postArgc = argc - 3; // every optional clause, unchanged
                 RedisModule_Replicate(ctx,
                                       replCmd,
                                       "vclv",
-                                      argv + 1, // start after the command name
+                                      argv + 1, // key, value
                                       preArgc,
                                       "TIMESTAMP",
                                       currentUpdatedTime,
-                                      argv + labelsLoc, // the LABELS clause, unchanged
+                                      argv + 3, // remaining clauses, unchanged
                                       postArgc);
+            } else {
+                // number of args, until the TIMESTAMP argument (included)
+                const size_t preArgc = timestampLoc;
+                // number of args, after the TIMESTAMP argument
+                const size_t postArgc = argc - timestampLoc - 2;
+                RedisModule_Replicate(
+                    ctx,
+                    replCmd,
+                    "vlv",
+                    argv + 1, // start after the command name
+                    preArgc,
+                    currentUpdatedTime, // the timestamp value
+                    argv + timestampLoc +
+                        2, // start after the TIMESTAMP argument, rest of the arguments
+                    postArgc);
             }
         } else {
-            // number of args, until the TIMESTAMP argument (included)
-            const size_t preArgc = timestampLoc;
-            // number of args, after the TIMESTAMP argument
-            const size_t postArgc = argc - timestampLoc - 2;
-            RedisModule_Replicate(
-                ctx,
-                replCmd,
-                "vlv",
-                argv + 1, // start after the command name
-                preArgc,
-                currentUpdatedTime, // the timestamp value
-                argv + timestampLoc +
-                    2, // start after the TIMESTAMP argument, rest of the arguments
-                postArgc);
+            RedisModule_ReplicateVerbatim(ctx);
         }
-    } else {
-        RedisModule_ReplicateVerbatim(ctx);
     }
     RedisModule_CloseKey(key);
 

--- a/src/module.c
+++ b/src/module.c
@@ -1533,9 +1533,27 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (useLocalTimestamp) {
         const char *replCmd = isIncr ? "TS.INCRBY" : "TS.DECRBY";
         if (timestampLoc == -1) {
-            const size_t replArgc = argc - 1;
-            RedisModule_Replicate(
-                ctx, replCmd, "vcl", argv + 1, replArgc, "TIMESTAMP", currentUpdatedTime);
+            // LABELS greedily consumes every token after it as a label/value pair, so it must
+            // stay the last clause; insert TIMESTAMP before it instead of after, or a create-on-
+            // write TS.INCRBY/TS.DECRBY with LABELS would replicate a bogus "TIMESTAMP" label.
+            int labelsLoc = RMUtil_ArgIndex("LABELS", argv, argc);
+            if (labelsLoc == -1) {
+                const size_t replArgc = argc - 1;
+                RedisModule_Replicate(
+                    ctx, replCmd, "vcl", argv + 1, replArgc, "TIMESTAMP", currentUpdatedTime);
+            } else {
+                const size_t preArgc = labelsLoc - 1;
+                const size_t postArgc = argc - labelsLoc;
+                RedisModule_Replicate(ctx,
+                                       replCmd,
+                                       "vclv",
+                                       argv + 1, // start after the command name
+                                       preArgc,
+                                       "TIMESTAMP",
+                                       currentUpdatedTime,
+                                       argv + labelsLoc, // the LABELS clause, unchanged
+                                       postArgc);
+            }
         } else {
             // number of args, until the TIMESTAMP argument (included)
             const size_t preArgc = timestampLoc;

--- a/src/module.c
+++ b/src/module.c
@@ -1545,14 +1545,14 @@ int TSDB_incrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                 const size_t preArgc = labelsLoc - 1;
                 const size_t postArgc = argc - labelsLoc;
                 RedisModule_Replicate(ctx,
-                                       replCmd,
-                                       "vclv",
-                                       argv + 1, // start after the command name
-                                       preArgc,
-                                       "TIMESTAMP",
-                                       currentUpdatedTime,
-                                       argv + labelsLoc, // the LABELS clause, unchanged
-                                       postArgc);
+                                      replCmd,
+                                      "vclv",
+                                      argv + 1, // start after the command name
+                                      preArgc,
+                                      "TIMESTAMP",
+                                      currentUpdatedTime,
+                                      argv + labelsLoc, // the LABELS clause, unchanged
+                                      postArgc);
             }
         } else {
             // number of args, until the TIMESTAMP argument (included)

--- a/tests/flow/test_ts_incrby.py
+++ b/tests/flow/test_ts_incrby.py
@@ -198,7 +198,8 @@ def test_incrby_create_with_labels_replicates_correctly():
     else:
         raise Exception('replica never caught up with warmup key')
     with env.getConnection() as master:
-        master.execute_command('ts.incrby', key, 1, 'LABELS', 'region', 'us')
+        master_ts = master.execute_command('ts.incrby', key, 1, 'LABELS', 'region', 'us')
+        master_sample = master.execute_command('ts.get', key)
     for _ in range(100):
         with env.getSlaveConnection() as slave:
             if slave.execute_command('exists', key):
@@ -208,4 +209,7 @@ def test_incrby_create_with_labels_replicates_correctly():
         raise Exception('replica never caught up with initial ts.incrby')
     with env.getSlaveConnection() as slave:
         info = _get_ts_info(slave, key)
+        slave_sample = slave.execute_command('ts.get', key)
     env.assertEqual(info.labels, {b'region': b'us'})
+    env.assertEqual(master_ts, slave_sample[0])
+    env.assertEqual(master_sample, slave_sample)

--- a/tests/flow/test_ts_incrby.py
+++ b/tests/flow/test_ts_incrby.py
@@ -172,18 +172,16 @@ def test_incrby_no_timestamp_replicates_diverging_timestamp():
 
 
 def test_incrby_create_with_labels_replicates_correctly():
-    # When TIMESTAMP is omitted, replication rewrites the command by
-    # appending "TIMESTAMP <ts>" (see
-    # test_incrby_no_timestamp_replicates_diverging_timestamp). If the
-    # create-on-write command also carries a trailing LABELS clause,
-    # appending TIMESTAMP after it gets swallowed as a bogus label/value
-    # pair on replicas and AOF-replay, since LABELS greedily consumes every
-    # token that follows it.
+    # When TIMESTAMP is omitted, replication rewrites the command with a
+    # resolved "TIMESTAMP <ts>" (see
+    # test_incrby_no_timestamp_replicates_diverging_timestamp). Because
+    # LABELS greedily consumes every token that follows it, TIMESTAMP has to
+    # be inserted *before* a trailing LABELS clause - appending it would be
+    # swallowed as a bogus label/value pair on replicas and in AOF replay.
     if not Env().useSlaves:
         Env().skip()
     Env().skipOnCluster()
     env = Env()
-    key = 'incrby_create_with_labels'
     warmup_key = 'incrby_create_with_labels_warmup'
     with env.getConnection() as master:
         master.execute_command('ts.create', warmup_key)
@@ -197,8 +195,53 @@ def test_incrby_create_with_labels_replicates_correctly():
         time.sleep(0.1)
     else:
         raise Exception('replica never caught up with warmup key')
+
+    for cmd in ('ts.incrby', 'ts.decrby'):
+        key = 'incrby_create_with_labels_%s' % cmd
+        with env.getConnection() as master:
+            master.execute_command(cmd, key, 1, 'LABELS', 'region', 'us')
+            master_sample = master.execute_command('ts.get', key)
+        for _ in range(100):
+            with env.getSlaveConnection() as slave:
+                if slave.execute_command('exists', key):
+                    break
+            time.sleep(0.1)
+        else:
+            raise Exception('replica never caught up with initial %s' % cmd)
+        with env.getSlaveConnection() as slave:
+            info = _get_ts_info(slave, key)
+            slave_sample = slave.execute_command('ts.get', key)
+        env.assertEqual(info.labels, {b'region': b'us'})
+        env.assertEqual(master_sample, slave_sample)
+
+    # Also exercise the AOF-replay path (not just the live replication
+    # stream): restart master and replica and reload from AOF/RDB, then
+    # verify the data survived intact.
+    env.restartAndReload()
+    for cmd in ('ts.incrby', 'ts.decrby'):
+        key = 'incrby_create_with_labels_%s' % cmd
+        with env.getConnection() as master:
+            master_info = _get_ts_info(master, key)
+            master_sample = master.execute_command('ts.get', key)
+        with env.getSlaveConnection() as slave:
+            slave_info = _get_ts_info(slave, key)
+            slave_sample = slave.execute_command('ts.get', key)
+        env.assertEqual(master_info.labels, {b'region': b'us'})
+        env.assertEqual(slave_info.labels, {b'region': b'us'})
+        env.assertEqual(master_sample, slave_sample)
+
+
+def test_incrby_create_with_key_named_labels_replicates_correctly():
+    # RMUtil_ArgIndex scans the whole argv, so a key literally named
+    # "LABELS" (case-insensitively) must not be mistaken for a LABELS
+    # clause when deciding where to insert the resolved TIMESTAMP.
+    if not Env().useSlaves:
+        Env().skip()
+    Env().skipOnCluster()
+    env = Env()
+    key = 'LABELS'
     with env.getConnection() as master:
-        master_ts = master.execute_command('ts.incrby', key, 1, 'LABELS', 'region', 'us')
+        master.execute_command('ts.incrby', key, 1)
         master_sample = master.execute_command('ts.get', key)
     for _ in range(100):
         with env.getSlaveConnection() as slave:
@@ -208,8 +251,43 @@ def test_incrby_create_with_labels_replicates_correctly():
     else:
         raise Exception('replica never caught up with initial ts.incrby')
     with env.getSlaveConnection() as slave:
-        info = _get_ts_info(slave, key)
         slave_sample = slave.execute_command('ts.get', key)
-    env.assertEqual(info.labels, {b'region': b'us'})
-    env.assertEqual(master_ts, slave_sample[0])
     env.assertEqual(master_sample, slave_sample)
+
+
+def test_incrby_labels_key_named_timestamp_replicates_correctly():
+    # A label whose key is literally "TIMESTAMP" collides with the reserved
+    # keyword: RMUtil_ArgIndex's naive scan for "TIMESTAMP" would otherwise
+    # match this label key instead of a real TIMESTAMP directive, and the
+    # resulting rewritten command must still parse to the same labels on
+    # replicas as it did on the primary.
+    if not Env().useSlaves:
+        Env().skip()
+    Env().skipOnCluster()
+    env = Env()
+    key = 'incrby_labels_key_named_timestamp'
+    with env.getConnection() as master:
+        master.execute_command('ts.incrby', key, 1, 'LABELS', 'a', 'b', 'TIMESTAMP', '*')
+        master_info = _get_ts_info(master, key)
+        master_sample = master.execute_command('ts.get', key)
+    for _ in range(100):
+        with env.getSlaveConnection() as slave:
+            if slave.execute_command('exists', key):
+                break
+        time.sleep(0.1)
+    else:
+        raise Exception('replica never caught up with initial ts.incrby')
+    with env.getSlaveConnection() as slave:
+        slave_info = _get_ts_info(slave, key)
+        slave_sample = slave.execute_command('ts.get', key)
+    env.assertEqual(master_info.labels, slave_info.labels)
+    env.assertEqual(master_sample, slave_sample)
+
+
+def test_incrby_timestamp_missing_value_returns_error():
+    # TIMESTAMP as the very last token has no value after it; this must be
+    # rejected cleanly instead of reading one RedisModuleString past the end
+    # of argv.
+    with Env().getClusterConnectionIfNeeded() as r:
+        with pytest.raises(redis.ResponseError):
+            r.execute_command('TS.INCRBY', 'incrby_timestamp_missing_value', '5', 'TIMESTAMP')

--- a/tests/flow/test_ts_incrby.py
+++ b/tests/flow/test_ts_incrby.py
@@ -171,6 +171,44 @@ def test_incrby_no_timestamp_replicates_diverging_timestamp():
     env.assertEqual(master_ts, slave_sample[0])
 
 
+def test_incrby_key_named_timestamp_replicates_correctly():
+    # RMUtil_ArgIndex returns the FIRST match scanning from argv[0], so a
+    # key literally named "TIMESTAMP" (case-insensitively) matches at the
+    # key's own position. The resolved timestamp computed on the primary
+    # must still reach the replica intact - not re-resolved to the
+    # replica's own, later wall-clock instant - even under replication
+    # delay. Without the injected stall below this passes by luck: on an
+    # idle loopback the gap can be as little as 1ms.
+    if not Env().useSlaves:
+        Env().skip()
+    Env().skipOnCluster()
+    env = Env()
+    key = 'TIMESTAMP'
+    with env.getConnection() as master:
+        master.execute_command('ts.create', key)
+    for _ in range(100):
+        with env.getSlaveConnection() as slave:
+            if slave.execute_command('exists', key):
+                break
+        time.sleep(0.1)
+    else:
+        raise Exception('replica never caught up with initial ts.create')
+    slave_sleep_secs = 2
+    def block_slave_main_thread():
+        with env.getSlaveConnection() as slave:
+            slave.execute_command('DEBUG', 'SLEEP', slave_sleep_secs)
+    blocker = threading.Thread(target=block_slave_main_thread)
+    blocker.start()
+    time.sleep(0.3)  # let DEBUG SLEEP actually start running on the slave
+    with env.getConnection() as master:
+        master_ts = master.execute_command('ts.incrby', key, 5)
+    blocker.join()
+    time.sleep(1)  # give the replica time to apply the now-unblocked command
+    with env.getSlaveConnection() as slave:
+        slave_sample = slave.execute_command('ts.get', key)
+    env.assertEqual(master_ts, slave_sample[0])
+
+
 def test_incrby_create_with_labels_replicates_correctly():
     # When TIMESTAMP is omitted, replication rewrites the command with a
     # resolved "TIMESTAMP <ts>" (see

--- a/tests/flow/test_ts_incrby.py
+++ b/tests/flow/test_ts_incrby.py
@@ -201,20 +201,33 @@ def test_incrby_key_named_timestamp_replicates_correctly():
     with env.getConnection() as master:
         master.execute_command('ts.create', key)
     _wait_for_replica_key(env, key, 'initial ts.create')
+    before_ms = int(time.time() * 1000)
     slave_sleep_secs = 2
+    stall_error = []
     def block_slave_main_thread():
-        with env.getSlaveConnection() as slave:
-            slave.execute_command('DEBUG', 'SLEEP', slave_sleep_secs)
+        # A failure in here cannot fail the test on its own - the stall would
+        # silently vanish and the assertions below would pass trivially - so
+        # record it and re-raise on the main thread.
+        try:
+            with env.getSlaveConnection() as slave:
+                slave.execute_command('DEBUG', 'SLEEP', slave_sleep_secs)
+        except Exception as e:
+            stall_error.append(e)
     blocker = threading.Thread(target=block_slave_main_thread)
     blocker.start()
     time.sleep(0.3)  # let DEBUG SLEEP actually start running on the slave
     with env.getConnection() as master:
         master_ts = master.execute_command('ts.incrby', key, 5)
     blocker.join()
+    if stall_error:
+        raise stall_error[0]
     time.sleep(1)  # give the replica time to apply the now-unblocked command
     with env.getSlaveConnection() as slave:
         slave_sample = slave.execute_command('ts.get', key)
     env.assertEqual(master_ts, slave_sample[0])
+    # The resolved timestamp must be wall-clock "now". Before the fix a key
+    # named TIMESTAMP made argv[2] the timestamp, storing the sample at ts=5.
+    env.assertGreaterEqual(master_ts, before_ms)
 
 
 def test_incrby_create_with_labels_replicates_correctly():

--- a/tests/flow/test_ts_incrby.py
+++ b/tests/flow/test_ts_incrby.py
@@ -9,6 +9,26 @@ from includes import *
 from test_helper_classes import _get_ts_info
 
 
+def _wait_for_replica_key(env, key, what):
+    for _ in range(100):
+        with env.getSlaveConnection() as slave:
+            if slave.execute_command('exists', key):
+                return
+        time.sleep(0.1)
+    raise Exception('replica never caught up with %s' % what)
+
+
+def _wait_for_replica_online(env, warmup_key):
+    # The replica only joins the live propagation stream once its initial full
+    # sync completes (repl-diskless-sync-delay defaults to 5s). Until then a
+    # create-on-write key arrives inside the full-sync RDB and the rewritten
+    # command is never parsed by the replica at all - which would make these
+    # tests pass vacuously.
+    with env.getConnection() as master:
+        master.execute_command('ts.create', warmup_key)
+    _wait_for_replica_key(env, warmup_key, 'warmup key')
+
+
 def test_incrby():
     with Env().getClusterConnectionIfNeeded() as r:
         r.execute_command('ts.create', 'tester')
@@ -144,13 +164,7 @@ def test_incrby_no_timestamp_replicates_diverging_timestamp():
     # Make sure the initial replica sync has caught up with the key creation
     # before we start controlling timing below, so the only delay measured
     # is the one we inject, not leftover initial-sync latency.
-    for _ in range(100):
-        with env.getSlaveConnection() as slave:
-            if slave.execute_command('exists', key):
-                break
-        time.sleep(0.1)
-    else:
-        raise Exception('replica never caught up with initial ts.create')
+    _wait_for_replica_key(env, key, 'initial ts.create')
     slave_sleep_secs = 2
     def block_slave_main_thread():
         # DEBUG SLEEP blocks the replica's single event loop entirely, so it
@@ -186,13 +200,7 @@ def test_incrby_key_named_timestamp_replicates_correctly():
     key = 'TIMESTAMP'
     with env.getConnection() as master:
         master.execute_command('ts.create', key)
-    for _ in range(100):
-        with env.getSlaveConnection() as slave:
-            if slave.execute_command('exists', key):
-                break
-        time.sleep(0.1)
-    else:
-        raise Exception('replica never caught up with initial ts.create')
+    _wait_for_replica_key(env, key, 'initial ts.create')
     slave_sleep_secs = 2
     def block_slave_main_thread():
         with env.getSlaveConnection() as slave:
@@ -221,18 +229,7 @@ def test_incrby_create_with_labels_replicates_correctly():
     Env().skipOnCluster()
     env = Env()
     warmup_key = 'incrby_create_with_labels_warmup'
-    with env.getConnection() as master:
-        master.execute_command('ts.create', warmup_key)
-    # Make sure the replica is already online and streaming live-propagated
-    # commands (rather than picking up our key via a fresh full RDB sync)
-    # before we issue the create-on-write TS.INCRBY below.
-    for _ in range(100):
-        with env.getSlaveConnection() as slave:
-            if slave.execute_command('exists', warmup_key):
-                break
-        time.sleep(0.1)
-    else:
-        raise Exception('replica never caught up with warmup key')
+    _wait_for_replica_online(env, warmup_key)
 
     pre_restart_sample = {}
     for cmd in ('ts.incrby', 'ts.decrby'):
@@ -240,13 +237,7 @@ def test_incrby_create_with_labels_replicates_correctly():
         with env.getConnection() as master:
             master.execute_command(cmd, key, 1, 'LABELS', 'region', 'us')
             master_sample = master.execute_command('ts.get', key)
-        for _ in range(100):
-            with env.getSlaveConnection() as slave:
-                if slave.execute_command('exists', key):
-                    break
-            time.sleep(0.1)
-        else:
-            raise Exception('replica never caught up with initial %s' % cmd)
+        _wait_for_replica_key(env, key, 'initial %s' % cmd)
         with env.getSlaveConnection() as slave:
             info = _get_ts_info(slave, key)
             slave_sample = slave.execute_command('ts.get', key)
@@ -287,30 +278,11 @@ def test_incrby_create_with_key_named_labels_replicates_correctly():
     env = Env()
     key = 'LABELS'
     warmup_key = 'incrby_key_named_labels_warmup'
-    with env.getConnection() as master:
-        master.execute_command('ts.create', warmup_key)
-    # Make sure the replica has finished its initial full sync and is
-    # applying live-propagated commands before we issue the create-on-write
-    # TS.INCRBY - otherwise the key arrives inside the full-sync RDB and the
-    # rewritten command is never parsed by the replica (see
-    # repl-diskless-sync-delay).
-    for _ in range(100):
-        with env.getSlaveConnection() as slave:
-            if slave.execute_command('exists', warmup_key):
-                break
-        time.sleep(0.1)
-    else:
-        raise Exception('replica never caught up with warmup key')
+    _wait_for_replica_online(env, warmup_key)
     with env.getConnection() as master:
         master.execute_command('ts.incrby', key, 1)
         master_sample = master.execute_command('ts.get', key)
-    for _ in range(100):
-        with env.getSlaveConnection() as slave:
-            if slave.execute_command('exists', key):
-                break
-        time.sleep(0.1)
-    else:
-        raise Exception('replica never caught up with initial ts.incrby')
+    _wait_for_replica_key(env, key, 'initial ts.incrby')
     with env.getSlaveConnection() as slave:
         slave_sample = slave.execute_command('ts.get', key)
     env.assertEqual(master_sample, slave_sample)
@@ -329,25 +301,11 @@ def test_incrby_create_with_key_named_ignore_replicates_correctly():
     env = Env()
     key = 'IGNORE'
     warmup_key = 'incrby_key_named_ignore_warmup'
-    with env.getConnection() as master:
-        master.execute_command('ts.create', warmup_key)
-    for _ in range(100):
-        with env.getSlaveConnection() as slave:
-            if slave.execute_command('exists', warmup_key):
-                break
-        time.sleep(0.1)
-    else:
-        raise Exception('replica never caught up with warmup key')
+    _wait_for_replica_online(env, warmup_key)
     with env.getConnection() as master:
         master.execute_command('ts.incrby', key, 1, 5)
         master_sample = master.execute_command('ts.get', key)
-    for _ in range(100):
-        with env.getSlaveConnection() as slave:
-            if slave.execute_command('exists', key):
-                break
-        time.sleep(0.1)
-    else:
-        raise Exception('replica never caught up with initial ts.incrby')
+    _wait_for_replica_key(env, key, 'initial ts.incrby')
     with env.getSlaveConnection() as slave:
         slave_sample = slave.execute_command('ts.get', key)
     env.assertEqual(master_sample, slave_sample)
@@ -365,31 +323,12 @@ def test_incrby_labels_key_named_timestamp_replicates_correctly():
     env = Env()
     key = 'incrby_labels_key_named_timestamp'
     warmup_key = 'incrby_labels_key_named_timestamp_warmup'
-    with env.getConnection() as master:
-        master.execute_command('ts.create', warmup_key)
-    # Make sure the replica has finished its initial full sync and is
-    # applying live-propagated commands before we issue the create-on-write
-    # TS.INCRBY - otherwise the key arrives inside the full-sync RDB and the
-    # rewritten command is never parsed by the replica (see
-    # repl-diskless-sync-delay).
-    for _ in range(100):
-        with env.getSlaveConnection() as slave:
-            if slave.execute_command('exists', warmup_key):
-                break
-        time.sleep(0.1)
-    else:
-        raise Exception('replica never caught up with warmup key')
+    _wait_for_replica_online(env, warmup_key)
     with env.getConnection() as master:
         master.execute_command('ts.incrby', key, 1, 'LABELS', 'a', 'b', 'TIMESTAMP', '*')
         master_info = _get_ts_info(master, key)
         master_sample = master.execute_command('ts.get', key)
-    for _ in range(100):
-        with env.getSlaveConnection() as slave:
-            if slave.execute_command('exists', key):
-                break
-        time.sleep(0.1)
-    else:
-        raise Exception('replica never caught up with initial ts.incrby')
+    _wait_for_replica_key(env, key, 'initial ts.incrby')
     with env.getSlaveConnection() as slave:
         slave_info = _get_ts_info(slave, key)
         slave_sample = slave.execute_command('ts.get', key)

--- a/tests/flow/test_ts_incrby.py
+++ b/tests/flow/test_ts_incrby.py
@@ -196,6 +196,7 @@ def test_incrby_create_with_labels_replicates_correctly():
     else:
         raise Exception('replica never caught up with warmup key')
 
+    pre_restart_sample = {}
     for cmd in ('ts.incrby', 'ts.decrby'):
         key = 'incrby_create_with_labels_%s' % cmd
         with env.getConnection() as master:
@@ -213,10 +214,12 @@ def test_incrby_create_with_labels_replicates_correctly():
             slave_sample = slave.execute_command('ts.get', key)
         env.assertEqual(info.labels, {b'region': b'us'})
         env.assertEqual(master_sample, slave_sample)
+        pre_restart_sample[cmd] = master_sample
 
     # Also exercise the AOF-replay path (not just the live replication
     # stream): restart master and replica and reload from AOF/RDB, then
-    # verify the data survived intact.
+    # verify the data survived intact against what was captured before
+    # the restart.
     env.restartAndReload()
     for cmd in ('ts.incrby', 'ts.decrby'):
         key = 'incrby_create_with_labels_%s' % cmd
@@ -228,20 +231,77 @@ def test_incrby_create_with_labels_replicates_correctly():
             slave_sample = slave.execute_command('ts.get', key)
         env.assertEqual(master_info.labels, {b'region': b'us'})
         env.assertEqual(slave_info.labels, {b'region': b'us'})
-        env.assertEqual(master_sample, slave_sample)
+        env.assertEqual(master_sample, pre_restart_sample[cmd])
+        env.assertEqual(slave_sample, pre_restart_sample[cmd])
 
 
 def test_incrby_create_with_key_named_labels_replicates_correctly():
     # RMUtil_ArgIndex scans the whole argv, so a key literally named
     # "LABELS" (case-insensitively) must not be mistaken for a LABELS
     # clause when deciding where to insert the resolved TIMESTAMP.
+    #
+    # Note: this only checks the sample, not labels - a key named LABELS
+    # also confuses parseLabelsFromArgs itself (which scans from argv[0],
+    # same as here), a separate, pre-existing bug outside this fix's scope.
     if not Env().useSlaves:
         Env().skip()
     Env().skipOnCluster()
     env = Env()
     key = 'LABELS'
+    warmup_key = 'incrby_key_named_labels_warmup'
+    with env.getConnection() as master:
+        master.execute_command('ts.create', warmup_key)
+    # Make sure the replica has finished its initial full sync and is
+    # applying live-propagated commands before we issue the create-on-write
+    # TS.INCRBY - otherwise the key arrives inside the full-sync RDB and the
+    # rewritten command is never parsed by the replica (see
+    # repl-diskless-sync-delay).
+    for _ in range(100):
+        with env.getSlaveConnection() as slave:
+            if slave.execute_command('exists', warmup_key):
+                break
+        time.sleep(0.1)
+    else:
+        raise Exception('replica never caught up with warmup key')
     with env.getConnection() as master:
         master.execute_command('ts.incrby', key, 1)
+        master_sample = master.execute_command('ts.get', key)
+    for _ in range(100):
+        with env.getSlaveConnection() as slave:
+            if slave.execute_command('exists', key):
+                break
+        time.sleep(0.1)
+    else:
+        raise Exception('replica never caught up with initial ts.incrby')
+    with env.getSlaveConnection() as slave:
+        slave_sample = slave.execute_command('ts.get', key)
+    env.assertEqual(master_sample, slave_sample)
+
+
+def test_incrby_create_with_key_named_ignore_replicates_correctly():
+    # A key literally named "IGNORE" (case-insensitively) makes
+    # parseIgnoreArgs match the key instead of a real IGNORE clause, so its
+    # two operands land right after the key. Inserting the resolved
+    # TIMESTAMP at a fixed index would shift those operands and break
+    # replica/AOF parsing entirely - this is why the insert must stay
+    # gated on an actual LABELS clause (labelsLoc > 2) instead.
+    if not Env().useSlaves:
+        Env().skip()
+    Env().skipOnCluster()
+    env = Env()
+    key = 'IGNORE'
+    warmup_key = 'incrby_key_named_ignore_warmup'
+    with env.getConnection() as master:
+        master.execute_command('ts.create', warmup_key)
+    for _ in range(100):
+        with env.getSlaveConnection() as slave:
+            if slave.execute_command('exists', warmup_key):
+                break
+        time.sleep(0.1)
+    else:
+        raise Exception('replica never caught up with warmup key')
+    with env.getConnection() as master:
+        master.execute_command('ts.incrby', key, 1, 5)
         master_sample = master.execute_command('ts.get', key)
     for _ in range(100):
         with env.getSlaveConnection() as slave:
@@ -266,6 +326,21 @@ def test_incrby_labels_key_named_timestamp_replicates_correctly():
     Env().skipOnCluster()
     env = Env()
     key = 'incrby_labels_key_named_timestamp'
+    warmup_key = 'incrby_labels_key_named_timestamp_warmup'
+    with env.getConnection() as master:
+        master.execute_command('ts.create', warmup_key)
+    # Make sure the replica has finished its initial full sync and is
+    # applying live-propagated commands before we issue the create-on-write
+    # TS.INCRBY - otherwise the key arrives inside the full-sync RDB and the
+    # rewritten command is never parsed by the replica (see
+    # repl-diskless-sync-delay).
+    for _ in range(100):
+        with env.getSlaveConnection() as slave:
+            if slave.execute_command('exists', warmup_key):
+                break
+        time.sleep(0.1)
+    else:
+        raise Exception('replica never caught up with warmup key')
     with env.getConnection() as master:
         master.execute_command('ts.incrby', key, 1, 'LABELS', 'a', 'b', 'TIMESTAMP', '*')
         master_info = _get_ts_info(master, key)

--- a/tests/flow/test_ts_incrby.py
+++ b/tests/flow/test_ts_incrby.py
@@ -6,6 +6,7 @@ import time
 # import redis
 # from utils import Env
 from includes import *
+from test_helper_classes import _get_ts_info
 
 
 def test_incrby():
@@ -168,3 +169,43 @@ def test_incrby_no_timestamp_replicates_diverging_timestamp():
     with env.getSlaveConnection() as slave:
         slave_sample = slave.execute_command('ts.get', key)
     env.assertEqual(master_ts, slave_sample[0])
+
+
+def test_incrby_create_with_labels_replicates_correctly():
+    # When TIMESTAMP is omitted, replication rewrites the command by
+    # appending "TIMESTAMP <ts>" (see
+    # test_incrby_no_timestamp_replicates_diverging_timestamp). If the
+    # create-on-write command also carries a trailing LABELS clause,
+    # appending TIMESTAMP after it gets swallowed as a bogus label/value
+    # pair on replicas and AOF-replay, since LABELS greedily consumes every
+    # token that follows it.
+    if not Env().useSlaves:
+        Env().skip()
+    Env().skipOnCluster()
+    env = Env()
+    key = 'incrby_create_with_labels'
+    warmup_key = 'incrby_create_with_labels_warmup'
+    with env.getConnection() as master:
+        master.execute_command('ts.create', warmup_key)
+    # Make sure the replica is already online and streaming live-propagated
+    # commands (rather than picking up our key via a fresh full RDB sync)
+    # before we issue the create-on-write TS.INCRBY below.
+    for _ in range(100):
+        with env.getSlaveConnection() as slave:
+            if slave.execute_command('exists', warmup_key):
+                break
+        time.sleep(0.1)
+    else:
+        raise Exception('replica never caught up with warmup key')
+    with env.getConnection() as master:
+        master.execute_command('ts.incrby', key, 1, 'LABELS', 'region', 'us')
+    for _ in range(100):
+        with env.getSlaveConnection() as slave:
+            if slave.execute_command('exists', key):
+                break
+        time.sleep(0.1)
+    else:
+        raise Exception('replica never caught up with initial ts.incrby')
+    with env.getSlaveConnection() as slave:
+        info = _get_ts_info(slave, key)
+    env.assertEqual(info.labels, {b'region': b'us'})


### PR DESCRIPTION
## Summary
- When `TIMESTAMP` is omitted, `TSDB_incrby`/`TSDB_decrby` rewrite the replicated command by appending `TIMESTAMP <ts>` at the end.
- If the create-on-write command also carries a trailing `LABELS` clause, appending `TIMESTAMP` after it gets swallowed as a bogus label/value pair on replicas and AOF-replay, since `LABELS` greedily consumes every token that follows it.
- Fix: insert `TIMESTAMP <ts>` before the `LABELS` clause instead of after it (only affects the create-on-write, no-explicit-TIMESTAMP path).

## Test plan
- [x] Added `test_incrby_create_with_labels_replicates_correctly` in `tests/flow/test_ts_incrby.py`, reproducing the bug on a replica before the fix, passing after.
- [x] `TEST=test_ts_incrby make flow_tests` — 8/8 pass across all 5 configs (general, slaves, AOF, AOF+slaves, cluster).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes replication and argv parsing for TS.INCRBY/DECRBY, which affects replica and AOF consistency; scope is limited to those commands but mistakes would corrupt timestamps or labels on secondaries.
> 
> **Overview**
> Fixes **TS.INCRBY** / **TS.DECRBY** so replicas and AOF replay apply the same sample timestamp and labels as the primary when `TIMESTAMP` is omitted or keywords collide with key/label names.
> 
> **Argument parsing** in `TSDB_incrby` now locates `TIMESTAMP` and `LABELS` only from index 3 onward (past key and increment), ignores a `TIMESTAMP` token inside a trailing `LABELS` block, and returns wrong arity when `TIMESTAMP` has no following value.
> 
> **Replication** runs only after a successful write. If the command used implicit or `*` timestamps, the primary rewrites the propagated command with the resolved millisecond timestamp—inserting `TIMESTAMP <ts>` **before** a real `LABELS` clause (so it is not eaten as a label pair), appending at the end when there is no `LABELS`, or replacing `TIMESTAMP *` inline; explicit numeric timestamps still replicate verbatim.
> 
> **Tests** add replica/AOF coverage (including keys named `TIMESTAMP`, `LABELS`, or `IGNORE`, label key `TIMESTAMP`, create-on-write with `LABELS`, and trailing `TIMESTAMP` without a value), plus shared helpers to wait for replica sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fe7148af421482575744c0fabef6763cc53c240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->