### PR TITLE
MOD-17281 Tolerate connection reset during demotion in test_failover

### DIFF
--- a/tests/flow/test_topology_events.py
+++ b/tests/flow/test_topology_events.py
@@ -199,6 +199,7 @@ SLOT_RANGES_ERROR = "Query requires unavailable slots"
 # While a peer master is down its slots go unreachable, so the fan-out can time out waiting for that shard:
 # This error is currently swallowed when a node comes down and up again, but should be removed as part of MOD-17548.
 SHARD_TIMEOUT_ERROR = "A multi-keys command failed because at least one shard did not reply within the given timeframe."
+CONNECTION_RESET_ERROR = "Connection reset by peer"
 
 
 def skip_if_needed(env):
@@ -247,6 +248,9 @@ def validate_queries_during_failovers(env, post_failover, command, validate_resu
             result = connection_of(node.ip, node.port).execute_command(command)
         except redis.exceptions.ResponseError as x:
             assert str(x) in (TOPOLOGY_CHANGED_ERROR, UNBLOCKED_ERROR, CLUSTERDOWN_ERROR, SLOT_RANGES_ERROR), str(x)
+            return
+        except redis.exceptions.ConnectionError as x:
+            assert CONNECTION_RESET_ERROR in str(x), str(x)
             return
         validate_result(result)
 


### PR DESCRIPTION
`test_topology_events:test_failover` failed on the public Event Nightly, weekend build 7806 (2026-08-28), leg `build-linux-arm64 / arm64-alma10, unstable` — the only failure of 496 (495 passed):

[run 33215015567](https://github.com/RedisTimeSeries/RedisTimeSeries/actions/runs/33215015567) / [job 98996653669](https://github.com/RedisTimeSeries/RedisTimeSeries/actions/runs/33215015567/job/98996653669)

```
----- master 127.0.0.1:6410 failed over to replica 127.0.0.1:6409 -----
test_topology_events:test_failover:
	[ERROR]
	Unhandled exception: Error while reading from 127.0.0.1:6410 : (104, 'Connection reset by peer')
...
  test_topology_events.py:247 tolerable_validation -> execute_command
redis.exceptions.ConnectionError: Error while reading from 127.0.0.1:6410 : (104, 'Connection reset by peer')
```

The loop client was waiting for its `TS.MRANGE` reply from `6410` at the moment `6410` was demoted master -> replica, and the node dropped the in-flight connection instead of replying. No crash: the job log has no bug report, signal, backtrace or sanitizer output.

`tolerable_validation` only tolerated `redis.exceptions.ResponseError`, and `redis.exceptions.ConnectionError` is not one of those (both derive directly from `RedisError`), so a disconnect - which is a legitimate outcome of a demotion - failed the test.

This adds a second, deliberately narrow handler: `redis.exceptions.ConnectionError` whose message contains `Connection reset by peer`. Everything else still fails, e.g. `Connection refused` (node never came back), `Connection closed by server.`, `Broken pipe`, `TimeoutError`, and any unexpected `ResponseError` - and the `assert ..., str(x)` keeps the message in the output when it does. Substring matching is used because redis-py interpolates host/port/errno into that message and the suite does not pin a redis-py version.

No cache invalidation is needed for `connection_of`: `execute_command` disconnects the dead socket before raising, so the next iteration reconnects through the same cached client.

Not verified against a live cluster (needs a 3-master/3-replica oss-cluster run); the handler logic was exercised against the exception shapes above.

Open product question, deliberately not addressed here: whether a demoted node should be dropping an in-flight client at all instead of replying `-UNBLOCKED` / `-CLUSTERDOWN` / `-MOVED`. Tracked in MOD-17281.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to expected-exception handling; no production or cluster behavior changes.
> 
> **Overview**
> **Fixes flaky `test_failover`** by treating a narrow class of disconnects as acceptable while multi-shard queries run during master demotion.
> 
> Adds `CONNECTION_RESET_ERROR` and extends `tolerable_validation` so that, in addition to expected `ResponseError` messages, a `redis.exceptions.ConnectionError` whose message includes `Connection reset by peer` is accepted. Other connection failures and unexpected errors still fail the test via the existing assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cae3a17016484356e79053fbe0ae4b7161557f89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->