### PR TITLE
MOD-18192 - leak ssl in cluster err

### DIFF
--- a/tests/flow/test_tls_leak.py
+++ b/tests/flow/test_tls_leak.py
@@ -1,0 +1,55 @@
+import socketserver
+import threading
+import time
+
+from RLTest.debuggers import Valgrind
+from includes import Env, is_line_in_server_log
+from test_clusterset_noop import _long_form_clusterset
+
+
+def test_tls_initialization_failure():
+    """Run with --tls -V: Valgrind detects the SSL object lost on REDIS_ERR."""
+    env = Env(moduleArgs="ts-topology-events no")
+    env.skipOnCluster()
+    env.skipOnSlave()
+    if not env.useTLS or not isinstance(env.debugger, Valgrind):
+        env.skip()
+
+    class RejectTLS(socketserver.BaseRequestHandler):
+        def handle(self):
+            # Queue an invalid TLS record before the client's first SSL_connect.
+            self.request.sendall(b"not a TLS server\r\n")
+
+    conn = env.getConnection()
+    try:
+        conn.execute_command("DEBUG", "MARK-INTERNAL-CLIENT")
+    except Exception:
+        pass  # Older Redis versions do not have internal clients.
+    old_tls_cluster = conn.execute_command("CONFIG", "GET", "tls-cluster")[1]
+    conn.config_set("tls-cluster", "yes")
+    try:
+        with socketserver.TCPServer(("127.0.0.1", 0), RejectTLS) as peer:
+            worker = threading.Thread(target=peer.serve_forever, daemon=True)
+            worker.start()
+            try:
+                port = peer.server_address[1]
+                my_port = conn.connection_pool.connection_kwargs["port"]
+                conn.execute_command("timeseries.CLUSTERSET",
+                                     *_long_form_clusterset(my_port, port))
+                # Give the peer time to reject while checkTLS waits for Redis's
+                # main-thread lock. Reconnects cover scheduling variations.
+                with conn.pipeline(transaction=False) as pipe:
+                    pipe.execute_command("timeseries.FORCESHARDSCONNECTION")
+                    pipe.execute_command("DEBUG", "SLEEP", "0.1")
+                    pipe.execute()
+                deadline = time.monotonic() + 30
+                while not is_line_in_server_log(env, f"SSL auth to 127.0.0.1:{port} failed"):
+                    assert time.monotonic() < deadline, "Initial TLS failure path was not reached"
+                    time.sleep(0.1)
+                assert conn.ping()
+                # Leak detection happens when RLTest stops Redis under Valgrind.
+            finally:
+                peer.shutdown()
+                worker.join()
+    finally:
+        conn.config_set("tls-cluster", old_tls_cluster)

--- a/tests/flow/test_tls_leak.py
+++ b/tests/flow/test_tls_leak.py
@@ -10,8 +10,6 @@ from test_clusterset_noop import _long_form_clusterset
 def test_tls_initialization_failure():
     """Run with --tls -V: Valgrind detects the SSL object lost on REDIS_ERR."""
     env = Env(moduleArgs="ts-topology-events no")
-    env.skipOnCluster()
-    env.skipOnSlave()
     if not env.useTLS or not isinstance(env.debugger, Valgrind):
         env.skip()
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change with no production code in the diff; slightly increases CI surface when TLS and Valgrind are enabled.
> 
> **Overview**
> Adds **`test_tls_initialization_failure`** in `test_tls_leak.py` to guard **MOD-18192** (SSL not freed when cluster TLS setup fails).
> 
> The test runs only under **RLTest with `--tls` and Valgrind**. It turns on **`tls-cluster`**, registers a second shard via **`timeseries.CLUSTERSET`** at a local TCP server that sends non-TLS bytes, then drives **`timeseries.FORCESHARDSCONNECTION`** so Redis hits the failed **`SSL_connect`** path. It waits for the **`SSL auth to … failed`** log line, checks the main client still **`PING`**s, and relies on Valgrind at teardown to fail if an **`SSL`** object leaks on **`REDIS_ERR`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42226ccffefd2ae8f973e11646cdb0e5359adaea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->