### PR TITLE
MOD-17439 Better handling of timeouts

### DIFF
--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -78,7 +78,7 @@ def verifyClusterInitialized(env):
     for conn in shardsConnections(env):
         try:
             conn.execute_command('debug', 'MARK-INTERNAL-CLIENT')
-        except Exception:
+        except redis.exceptions.ResponseError:
             pass # in case we run on older version of redis
         allConnected = False
         while not allConnected:

--- a/tests/flow/test_acls.py
+++ b/tests/flow/test_acls.py
@@ -6,6 +6,7 @@ import redis
 from includes import Env
 import redis.exceptions
 from includes import *
+from utils import get_timeout
 
 
 def _shard_for_slot(env, slot):
@@ -196,7 +197,7 @@ def do_test_libmr(env):
         # or mac, it is needed.
         conn.execute_command('CONFIG', 'set', 'cluster-node-timeout', '120000')
         conn.execute_command('timeseries.FORCESHARDSCONNECTION')
-    with TimeLimit(2):
+    with TimeLimit(get_timeout()):
         verifyClusterInitialized(env)
 
     with env.getClusterConnectionIfNeeded() as r, env.getConnection(1) as r1:


### PR DESCRIPTION
Only ignore `redis.exceptions.ResponseError` when trying `debug MARK-INTERNAL-CLIENT`. This keeps the logic of "work with older redis versions" but will not swallow other types of exceptions (e.g., timeouts).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to exception handling and wait limits; no production code paths affected.
> 
> **Overview**
> Tightens test harness behavior around cluster setup so real failures (especially **timeouts**) are not hidden, while still tolerating older Redis builds that reject `DEBUG MARK-INTERNAL-CLIENT`.
> 
> In **`verifyClusterInitialized`**, the broad `except Exception` around `debug MARK-INTERNAL-CLIENT` is replaced with **`except redis.exceptions.ResponseError`**, so only expected “command not available” style errors are ignored; connection timeouts and other issues can surface.
> 
> In the libmr ACL helper **`do_test_libmr`**, the fixed **`TimeLimit(2)`** around **`verifyClusterInitialized`** is replaced with **`TimeLimit(get_timeout())`** (10s normally, 60s under Valgrind/sanitizer), reducing flaky failures on slow CI or macOS without masking genuine hangs indefinitely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5b481dcd93cd0a27e4d57b7f9d75fa0605bcd07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->